### PR TITLE
Fix equalsOneOf

### DIFF
--- a/test/helpers.js
+++ b/test/helpers.js
@@ -9,7 +9,7 @@ function equalsOneOf(actual, ...expected) {
       assert.deepEqual(actual, expected[i])
       return // if we get here without an exception, that means success
     } catch (e) {
-      if (e.name !== 'AssertionError' || i === expected.length - 1) throw e
+      if (!e.name.match(/^AssertionError/) || i === expected.length - 1) throw e
     }
   }
 }


### PR DESCRIPTION
A few tests were failing on Node v8.2.1, where the name of an Assertion Error isn't `AssertionError`, but `AssertionError [ERR_ASSERTION]`.

This fixes that.