### PR TITLE
Test illustrating non deterministic string array merge

### DIFF
--- a/src/automerge.js
+++ b/src/automerge.js
@@ -1,5 +1,7 @@
 const { Map, List, fromJS } = require('immutable')
 const uuid = require('uuid/v4')
+// let n=0
+// const uuid = () => "UUID-" + n++
 const { rootObjectProxy } = require('./proxies')
 const OpSet = require('./op_set')
 const transit = require('transit-immutable-js')

--- a/test/test.js
+++ b/test/test.js
@@ -464,27 +464,34 @@ describe('Automerge', () => {
     })
 
     it('merges string arrays', () => {
-      s1 = Automerge.changeset(s1, doc => (doc.body = 'ABCD'.split('')))
-      assert.strictEqual(s1.body.join(''), 'ABCD')
+      for(let x=0; x<1000; x++) {
+        console.log(x)
+        s1 = Automerge.init()
+        s2 = Automerge.init()
+        s3 = Automerge.init()
 
-      s2 = Automerge.merge(s2, s1)
-      assert.strictEqual(s2.body.join(''), 'ABCD')
-      s2 = Automerge.changeset(s2, doc =>
-        doc.body.insertAt(1, ...'joe'.split(''))
-      )
-      assert.strictEqual(s2.body.join(''), 'AjoeBCD') // Sometimes 'Ajoe' ???
+        s1 = Automerge.changeset(s1, doc => (doc.body = 'ABCD'.split('')))
+        assert.strictEqual(s1.body.join(''), 'ABCD')
 
-      s3 = Automerge.merge(s3, s1)
-      assert.strictEqual(s3.body.join(''), 'ABCD')
-      s3 = Automerge.changeset(s3, doc =>
-        doc.body.insertAt(2, ...'lisa'.split(''))
-      )
-      assert.strictEqual(s3.body.join(''), 'ABlisaCD') // Sometimes 'ABlisa' ???
+        s2 = Automerge.merge(s2, s1)
+        assert.strictEqual(s2.body.join(''), 'ABCD')
+        s2 = Automerge.changeset(s2, doc =>
+          doc.body.insertAt(1, ...'joe'.split(''))
+        )
+        assert.strictEqual(s2.body.join(''), 'AjoeBCD') // Sometimes 'Ajoe' ???
 
-      s1 = Automerge.merge(s1, s2)
-      assert.strictEqual(s1.body.join(''), 'AjoeBCD')
-      s1 = Automerge.merge(s1, s3)
-      assert.strictEqual(s1.body.join(''), 'AjoeBlisaCD')
+        s3 = Automerge.merge(s3, s1)
+        assert.strictEqual(s3.body.join(''), 'ABCD')
+        s3 = Automerge.changeset(s3, doc =>
+          doc.body.insertAt(2, ...'lisa'.split(''))
+        )
+        assert.strictEqual(s3.body.join(''), 'ABlisaCD') // Sometimes 'ABlisa' ???
+
+        s1 = Automerge.merge(s1, s2)
+        assert.strictEqual(s1.body.join(''), 'AjoeBCD')
+        s1 = Automerge.merge(s1, s3)
+        assert.strictEqual(s1.body.join(''), 'AjoeBlisaCD')
+      }
     })
 
     it('should merge concurrent updates of different properties', () => {

--- a/test/test.js
+++ b/test/test.js
@@ -463,6 +463,30 @@ describe('Automerge', () => {
       s3 = Automerge.init()
     })
 
+    it('merges string arrays', () => {
+      s1 = Automerge.changeset(s1, doc => (doc.body = 'ABCD'.split('')))
+      assert.strictEqual(s1.body.join(''), 'ABCD')
+
+      s2 = Automerge.merge(s2, s1)
+      assert.strictEqual(s2.body.join(''), 'ABCD')
+      s2 = Automerge.changeset(s2, doc =>
+        doc.body.insertAt(1, ...'joe'.split(''))
+      )
+      assert.strictEqual(s2.body.join(''), 'AjoeBCD') // Sometimes 'Ajoe' ???
+
+      s3 = Automerge.merge(s3, s1)
+      assert.strictEqual(s3.body.join(''), 'ABCD')
+      s3 = Automerge.changeset(s3, doc =>
+        doc.body.insertAt(2, ...'lisa'.split(''))
+      )
+      assert.strictEqual(s3.body.join(''), 'ABlisaCD') // Sometimes 'ABlisa' ???
+
+      s1 = Automerge.merge(s1, s2)
+      assert.strictEqual(s1.body.join(''), 'AjoeBCD')
+      s1 = Automerge.merge(s1, s3)
+      assert.strictEqual(s1.body.join(''), 'AjoeBlisaCD')
+    })
+
     it('should merge concurrent updates of different properties', () => {
       s1 = Automerge.changeset(s1, doc => doc.foo = 'bar')
       s2 = Automerge.changeset(s2, doc => doc.hello = 'world')


### PR DESCRIPTION
I'm experimenting with text (as an array of characters) and discovered that merging of concurrent updates to a string array is non deterministic. The test in this PR runs the same test 1000 times:

```
./node_modules/.bin/mocha -g "merges string arrays"
```

On my machine (Node 8.2.1, OS X), the test usually fails within the first 1-3 iterations. However, if you uncomment the deterministic `uuid` function in `automerge.js`, it deterministically fails on iteration 24. Try initialising `n` to a different value than `0`, and it will deterministically fail after a different number of iterations (!)
