### PR TITLE
Test illustrating bug in Array insertion

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -530,21 +530,24 @@ describe('Automerge', () => {
       assert.deepEqual(s2._conflicts, {})
     })
 
-    it('should handle insertion', () => {
-      for (let i = 1; i < 10; i++) {
-        try {
-          s1 = Automerge.init()
-          s2 = Automerge.init()
+    it('should handle insertion AB', () => {
+      s1 = Automerge.init('A')
+      s2 = Automerge.init('B')
 
-          s1 = Automerge.changeset(s1, doc => doc.list = ['one', 'three'])
-          s2 = Automerge.merge(s2, s1)
-          s2 = Automerge.changeset(s2, doc => doc.list.splice(1, 0, 'two'))
-          assert.deepEqual(s2.list, ['one', 'two', 'three'])
-        } catch (err) {
-          err.message += `\nFailed on iteration ${i}`
-          throw err
-        }
-      }
+      s1 = Automerge.changeset(s1, doc => doc.list = ['two'])
+      s2 = Automerge.merge(s2, s1)
+      s2 = Automerge.changeset(s2, doc => doc.list.splice(0, 0, 'one'))
+      assert.deepEqual(s2.list, ['one', 'two'])
+    })
+
+    it('should handle insertion BA', () => {
+      s1 = Automerge.init('B')
+      s2 = Automerge.init('A')
+
+      s1 = Automerge.changeset(s1, doc => doc.list = ['two'])
+      s2 = Automerge.merge(s2, s1)
+      s2 = Automerge.changeset(s2, doc => doc.list.splice(0, 0, 'one'))
+      assert.deepEqual(s2.list, ['one', 'two'])
     })
 
     it('should handle concurrent insertions at different list positions', () => {

--- a/test/test.js
+++ b/test/test.js
@@ -530,6 +530,7 @@ describe('Automerge', () => {
       assert.deepEqual(s2._conflicts, {})
     })
 
+    // Passes
     it('should handle insertion AB', () => {
       s1 = Automerge.init('A')
       s2 = Automerge.init('B')
@@ -540,9 +541,21 @@ describe('Automerge', () => {
       assert.deepEqual(s2.list, ['one', 'two'])
     })
 
+    // Fails
     it('should handle insertion BA', () => {
       s1 = Automerge.init('B')
       s2 = Automerge.init('A')
+
+      s1 = Automerge.changeset(s1, doc => doc.list = ['two'])
+      s2 = Automerge.merge(s2, s1)
+      s2 = Automerge.changeset(s2, doc => doc.list.splice(0, 0, 'one'))
+      assert.deepEqual(s2.list, ['one', 'two'])
+    })
+
+    // Fails 50% of the time
+    it('should handle insertion', () => {
+      s1 = Automerge.init()
+      s2 = Automerge.init()
 
       s1 = Automerge.changeset(s1, doc => doc.list = ['two'])
       s2 = Automerge.merge(s2, s1)

--- a/test/test.js
+++ b/test/test.js
@@ -530,6 +530,23 @@ describe('Automerge', () => {
       assert.deepEqual(s2._conflicts, {})
     })
 
+    it('should handle insertion', () => {
+      for (let i = 1; i < 10; i++) {
+        try {
+          s1 = Automerge.init()
+          s2 = Automerge.init()
+
+          s1 = Automerge.changeset(s1, doc => doc.list = ['one', 'three'])
+          s2 = Automerge.merge(s2, s1)
+          s2 = Automerge.changeset(s2, doc => doc.list.splice(1, 0, 'two'))
+          assert.deepEqual(s2.list, ['one', 'two', 'three'])
+        } catch (err) {
+          err.message += `\nFailed on iteration ${i}`
+          throw err
+        }
+      }
+    })
+
     it('should handle concurrent insertions at different list positions', () => {
       s1 = Automerge.changeset(s1, doc => doc.list = ['one', 'three'])
       s2 = Automerge.merge(s2, s1)


### PR DESCRIPTION
I believe I've found a bug in Array insertion following a merge. It seems like the `actorId` affects the behaviour - with some values it works as expected, with others it doesn't.

The `lamportCompare` function sorts ops based on the `actorId`, and the result of `insertionsAfter` seems to be missing some ops depending on the alphabetical order of the two actors' `actorId`. When the `actorId` isn't specified, the behaviour is non-deterministic (because the `actorId`s are random uuids).

I haven't been able to find a fix, but hopefully these pointers will help someone more familiar with the algorithm and code find and fix the bug quicker!

Cheers,
Aslak