### PR TITLE
Incremental cache maintenance & Automerge state diffing

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,11 +161,21 @@ state2 = Automerge.changeset(state2, 'Delete card', doc => {
 // Haskell' was set to true, and that 'Rewrite everything in Clojure' was
 // deleted:
 
-state1 = Automerge.merge(state1, state2)
+let finalState = Automerge.merge(state1, state2)
 
 // { cards:
 //    [ { title: 'Rewrite everything in Haskell', done: true },
 //      { title: 'Reticulate splines', done: false } ] }
+
+// If you want to know what changed from one version to another, you can get a
+// diff describing the changes (the objectId is a unique identifier for a
+// particular card object):
+
+Automerge.diff(state2, finalState)
+// [ { action: 'set',
+//     objectId: 'ef794659-d8fa-4e89-8605-06dff020513d',
+//     key: 'done',
+//     value: true } ]
 
 // As our final trick, we can inspect the change history. Automerge
 // automatically keeps track of every change, along with the "commit message"
@@ -174,7 +184,7 @@ state1 = Automerge.merge(state1, state2)
 // can also see a snapshot of the application state at any moment in time in the
 // past. For example, we can count how many cards there were at each point:
 
-Automerge.getHistory(state1)
+Automerge.getHistory(finalState)
   .map(state => [state.changeset.message, state.snapshot.cards.length])
 // [ [ 'Initialize card list', 0 ],
 //   [ 'Add card', 1 ],

--- a/src/automerge.js
+++ b/src/automerge.js
@@ -249,6 +249,15 @@ function merge(local, remote) {
   return applyChangesets(local, changes)
 }
 
+function diff(oldState, newState) {
+  checkTarget('diff', oldState)
+  let root, opSet = oldState._state.get('opSet').set('diff', List())
+  const changes = OpSet.getMissingChanges(newState._state.get('opSet'), opSet.get('clock'))
+
+  for (let change of changes) [opSet, root] = OpSet.addChangeset(opSet, change)
+  return opSet.get('diff').toJS()
+}
+
 module.exports = {
-  init, changeset, assign, load, save, equals, inspect, getHistory, DocSet, Connection, merge
+  init, changeset, assign, load, save, equals, inspect, getHistory, DocSet, Connection, merge, diff
 }

--- a/src/op_set.js
+++ b/src/op_set.js
@@ -437,23 +437,16 @@ function getObjectConflicts(opSet, objectId, context) {
     ])
 }
 
-function listElemByIndex(opSet, listId, index, context) {
-  let i = -1, elem = getNext(opSet, listId, '_head')
-  while (elem) {
-    const ops = getFieldOps(opSet, listId, elem)
-    if (!ops.isEmpty()) i += 1
-    if (i === index) return getOpValue(opSet, ops.first(), context)
-    elem = getNext(opSet, listId, elem)
+function listElemByIndex(opSet, objectId, index, context) {
+  const elemId = opSet.getIn(['byObject', objectId, '_elemIds', index])
+  if (elemId) {
+    const ops = getFieldOps(opSet, objectId, elemId)
+    if (!ops.isEmpty()) return getOpValue(opSet, ops.first(), context)
   }
 }
 
-function listLength(opSet, listId) {
-  let length = 0, elem = getNext(opSet, listId, '_head')
-  while (elem) {
-    if (!getFieldOps(opSet, listId, elem).isEmpty()) length += 1
-    elem = getNext(opSet, listId, elem)
-  }
-  return length
+function listLength(opSet, objectId) {
+  return opSet.getIn(['cache', objectId]).length
 }
 
 function listIterator(opSet, listId, mode, context) {

--- a/src/op_set.js
+++ b/src/op_set.js
@@ -47,7 +47,9 @@ function applyMake(opSet, op) {
     opSet = opSet.setIn(['cache', objectId], Object.freeze({_objectId: objectId}))
   } else {
     edit.value = []
-    opSet = opSet.setIn(['cache', objectId], Object.freeze([]))
+    let array = []
+    Object.defineProperty(array, '_objectId', {value: objectId})
+    opSet = opSet.setIn(['cache', objectId], Object.freeze(array))
     object = object.set('_elemIds', List())
   }
 
@@ -75,6 +77,7 @@ function patchList(opSet, objectId, index, action, op, withDiff) {
   let elemIds = opSet.getIn(['byObject', objectId, '_elemIds'])
   let value = op ? op.get('value') : null
   let edit = {action, objectId, index, value}
+  Object.defineProperty(list, '_objectId', {value: objectId})
 
   if (op && op.get('action') === 'link') {
     value = opSet.getIn(['cache', value])
@@ -301,6 +304,7 @@ function instantiateImmutable(opSet, objectId) {
     })
   } else if (objType === 'makeList') {
     obj = [...listIterator(opSet, objectId, 'values', this)]
+    Object.defineProperty(obj, '_objectId', {value: objectId})
   } else {
     throw 'Unknown object type: ' + objType
   }

--- a/src/op_set.js
+++ b/src/op_set.js
@@ -323,8 +323,15 @@ function init() {
 }
 
 function addLocalOp(opSet, op, actor) {
-  opSet = opSet.update('local', ops => ops.push(op))
-  return applyOp(opSet, op.set('actor', actor))
+  const objectId = op.get('obj'), action = op.get('action'), key = op.get('key')
+  let ops = opSet.get('local')
+
+  // Override any prior assignment operations for the same object and key
+  if (action === 'set' || action === 'del' || action === 'link') {
+    ops = ops.filter(prev => prev.get('obj') != objectId || prev.get('key') != key)
+  }
+  ops = ops.push(op)
+  return applyOp(opSet.set('local', ops), op.set('actor', actor))
 }
 
 function addChangeset(opSet, changeset) {

--- a/test/test.js
+++ b/test/test.js
@@ -76,9 +76,15 @@ describe('Automerge', () => {
         assert.deepEqual(s2, {_objectId: '00000000-0000-0000-0000-000000000000', counter: 3})
       })
 
-      /* FIXME: the example in the previous test case actually creates spurious conflicts,
-       * but the deepEqual comparison doesn't detect them */
-      it('should not record conflicts when writing the same field several times within one changeset')
+      it('should not record conflicts when writing the same field several times within one changeset', () => {
+        s1 = Automerge.changeset(s1, 'changeset message', doc => {
+          doc.counter = 1
+          doc.counter += 1
+          doc.counter += 1
+        })
+        assert.strictEqual(s1.counter, 3)
+        assert.deepEqual(s1._conflicts, {})
+      })
 
       it('should sanity-check arguments', () => {
         s1 = Automerge.changeset(s1, doc => doc.nested = {})


### PR DESCRIPTION
This branch introduces two things that might not seem like they should be related, but actually are closely related:

1. Incremental cache maintenance: for example, if a change is made to a list, we make only the minimal modification to the cached list object, rather than rebuilding the whole thing after every changeset. This brings a significant performance improvement: in my test on a 1,000-element list, single-element insertion or deletion becomes about 20x faster (from about 40ms down to 2ms per operation). Still not blazingly fast, but let's just say… it's much less bad now than it was previously.

2. Computing the diff between two Automerge objects, in terms of the edits that you would need to make in order to transform the old state into the new state. This is useful for integrating Automerge with existing editor components, as in aslakhellesoy/automerge-codemirror#1 for example.

This branch still needs some tests, which I'll add next week. I just wanted to share something quickly now since I just got it working. The diff functionality isn't documented yet, but this is what it looks like, in a nutshell:

```js
let state1 = Automerge.changeset(Automerge.init(), doc => doc.text = [])
let state2 = Automerge.changeset(state1, doc => doc.text.push("a"))
let state3 = Automerge.changeset(state2, doc => doc.text.push('b'))

Automerge.diff(state1, state2)
// [ { action: 'insert',
//     objectId: '9ad394d7-8e4a-498f-af47-2e9d1266e2ae',
//     index: 0,
//     value: 'a' } ]

Automerge.diff(state1, state3)
// [ { action: 'insert',
//     objectId: '9ad394d7-8e4a-498f-af47-2e9d1266e2ae',
//     index: 0,
//     value: 'a' },
//   { action: 'insert',
//     objectId: '9ad394d7-8e4a-498f-af47-2e9d1266e2ae',
//     index: 1,
//     value: 'b' } ]
```

I have probably introduced exciting new bugs as well. Let me know if you find any…