### PR TITLE
Connection and DocSet serialization

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "license": "MIT",
   "dependencies": {
     "immutable": "^3.8.1",
+    "serialize-javascript": "^1.4.0",
     "transit-immutable-js": "^0.7.0",
     "transit-js": "^0.8.846",
     "uuid": "^3.1.0"

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
   "license": "MIT",
   "dependencies": {
     "immutable": "^3.8.1",
-    "serialize-javascript": "^1.4.0",
     "transit-immutable-js": "^0.7.0",
     "transit-js": "^0.8.846",
     "uuid": "^3.1.0"

--- a/src/automerge.js
+++ b/src/automerge.js
@@ -237,6 +237,8 @@ function getHistory(doc) {
 const DocSet = require('./doc_set')
 const Connection = require('./connection')
 DocSet.prototype._applyChanges = applyChanges
+DocSet.prototype._saveDoc = save
+DocSet.prototype._loadDoc = load
 
 function merge(local, remote) {
   checkTarget('merge', local)

--- a/src/connection.js
+++ b/src/connection.js
@@ -2,6 +2,7 @@ const { Map, fromJS } = require('immutable')
 const transit = require('transit-immutable-js')
 const serialize = require('serialize-javascript')
 const OpSet = require('./op_set')
+const DocSet = require('./doc_set')
 
 // Returns true if all components of clock1 are less than or equal to those of clock2.
 // Returns false if there is at least one component in which clock1 is greater than clock2

--- a/src/connection.js
+++ b/src/connection.js
@@ -123,10 +123,14 @@ class Connection {
   }
 
   toJSON () {
+    let serializedSendMsg = null
+
+    try { serializedSendMsg = serialize(this._sendMsg) } catch(ex) {}
+
     return {
       _type: 'Connection',
       docSet: this._docSet.toJSON(),
-      sendMsg: serialize(this._sendMsg),
+      sendMsg: serializedSendMsg,
       theirClock: transit.toJSON(this._theirClock),
       ourClock: transit.toJSON(this._ourClock),
     }

--- a/src/connection.js
+++ b/src/connection.js
@@ -1,6 +1,5 @@
 const { Map, fromJS } = require('immutable')
 const transit = require('transit-immutable-js')
-const serialize = require('serialize-javascript')
 const OpSet = require('./op_set')
 const DocSet = require('./doc_set')
 
@@ -125,14 +124,9 @@ class Connection {
   }
 
   toJSON () {
-    let serializedSendMsg = null
-
-    try { serializedSendMsg = serialize(this._sendMsg) } catch(ex) {}
-
     return {
       _type: 'Connection',
       docSet: this._docSet.toJSON(),
-      sendMsg: serializedSendMsg,
       clientId: this._clientId,
       theirClock: transit.toJSON(this._theirClock),
       ourClock: transit.toJSON(this._ourClock),
@@ -140,11 +134,10 @@ class Connection {
   }
 }
 
-Connection.fromJSON = (json) => {
+Connection.fromJSON = (json, sendMsg, docSetHandlers = []) => {
   if (json._type != 'Connection') return null
 
-  const docSet = DocSet.fromJSON(json.docSet)
-  const sendMsg = eval(json.sendMsg)
+  const docSet = DocSet.fromJSON(json.docSet, docSetHandlers)
   const connection = new Connection(docSet, sendMsg, json.clientId)
 
   connection.setTheirClock(transit.fromJSON(json.theirClock))

--- a/src/connection.js
+++ b/src/connection.js
@@ -143,7 +143,7 @@ Connection.fromJSON = (json) => {
   if (json._type != 'Connection') return null
 
   const docSet = DocSet.fromJSON(json.docSet)
-  const sendMsg = eval('(' + json.sendMsg + ')')
+  const sendMsg = eval(json.sendMsg)
   const connection = new Connection(docSet, sendMsg, json.clientId)
 
   connection.setTheirClock(transit.fromJSON(json.theirClock))

--- a/src/connection.js
+++ b/src/connection.js
@@ -149,6 +149,7 @@ Connection.fromJSON = (json) => {
 
   connection.setTheirClock(transit.fromJSON(json.theirClock))
   connection.setOurClock(transit.fromJSON(json.ourClock))
+  connection.open()
 
   return connection
 }

--- a/src/doc_set.js
+++ b/src/doc_set.js
@@ -1,4 +1,5 @@
 const { Map, Set } = require('immutable')
+const transit = require('transit-immutable-js')
 
 class DocSet {
   constructor () {
@@ -32,6 +33,28 @@ class DocSet {
   unregisterHandler (handler) {
     this.handlers = this.handlers.remove(handler)
   }
+
+  toJSON () {
+    return {
+      _type: 'DocSet',
+      docs: transit.toJSON(this.docs),
+      handlers: transit.toJSON(this.handlers)
+    }
+  }
+}
+
+DocSet.fromJSON = (json) => {
+  if (json._type != 'DocSet') return null
+
+  const docSet = new DocSet()
+
+  const docs = transit.fromJSON(json.docs)
+  const handlers = transit.fromJSON(json.handlers)
+
+  handlers.forEach(handler => docSet.registerHandler(handler))
+  docs.keySeq().forEach(docId => docSet.setDoc(docId, docs.get(docId)))
+
+  return docSet
 }
 
 module.exports = DocSet

--- a/src/doc_set.js
+++ b/src/doc_set.js
@@ -1,5 +1,4 @@
 const { Map, Set } = require('immutable')
-const serialize = require('serialize-javascript')
 
 class DocSet {
   constructor () {
@@ -36,7 +35,6 @@ class DocSet {
 
   toJSON () {
     const allDocs = []
-    const allHandlers = []
 
     this.docs.keySeq().forEach((docId) => {
       allDocs.push({
@@ -45,19 +43,14 @@ class DocSet {
       })
     })
 
-    this.handlers.forEach((handler) => {
-      try { allHandlers.push(serialize(handler)) } catch(ex) {}
-    })
-
     return {
       _type: 'DocSet',
-      docs: allDocs,
-      handlers: allHandlers
+      docs: allDocs
     }
   }
 }
 
-DocSet.fromJSON = (json) => {
+DocSet.fromJSON = (json, handlers = []) => {
   if (json._type != 'DocSet') return null
 
   const docSet = new DocSet()
@@ -66,9 +59,8 @@ DocSet.fromJSON = (json) => {
     docSet.setDoc(item.id, docSet._loadDoc(item.doc))
   })
 
-  json.handlers.forEach((handler) => {
-    const func = eval(handler)
-    docSet.registerHandler(func)
+  handlers.forEach((handler) => {
+    docSet.registerHandler(handler)
   })
 
   return docSet

--- a/src/doc_set.js
+++ b/src/doc_set.js
@@ -55,10 +55,13 @@ DocSet.fromJSON = (json) => {
 
   const docSet = new DocSet()
 
-  json.handlers.forEach(handler => docSet.registerHandler(eval('(' + handler + ')')))
-
   const docs = transit.fromJSON(json.docs)
   docs.keySeq().forEach(docId => docSet.setDoc(docId, docs.get(docId)))
+
+  json.handlers.forEach((handler) => {
+    const func = eval(handler)
+    docSet.registerHandler(func)
+  })
 
   return docSet
 }

--- a/src/doc_set.js
+++ b/src/doc_set.js
@@ -38,7 +38,9 @@ class DocSet {
   toJSON () {
     const allHandlers = []
 
-    this.handlers.forEach(handler => allHandlers.push(serialize(handler)))
+    this.handlers.forEach((handler) => {
+      try { allHandlers.push(serialize(handler)) } catch(ex) {}
+    })
 
     return {
       _type: 'DocSet',


### PR DESCRIPTION
This PR adds `toJSON` and `fromJSON` to the `Connection` and `DocSet` classes, to enable serialization/deserialization on them, which is mostly useful when working on a serverless context.

It's also adding a `clientId` attribute to the `Connection` which is passed as a second parameter to the `sendMsg` callback. This is useful in cases where each connection has a unique device identifier, like in an IoT context.