### PR TITLE
Performance: use a skip list for list element indexing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,15 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "JSONStream": {
+      "version": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.1.tgz",
+      "integrity": "sha1-cH92HgHa6eFvG8+TcDt4xwlmV5o=",
+      "dev": true,
+      "requires": {
+        "jsonparse": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
+        "through": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
+      }
+    },
     "accepts": {
       "version": "https://registry.npmjs.org/accepts/-/accepts-1.3.3.tgz",
       "integrity": "sha1-w8p0NJOGSMPg2cHjKN1otiLChMo=",
@@ -291,9 +300,9 @@
       "integrity": "sha1-+GzWzvT1MAyOY+B6TVEvZfv/RTE=",
       "dev": true,
       "requires": {
+        "JSONStream": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.1.tgz",
         "combine-source-map": "https://registry.npmjs.org/combine-source-map/-/combine-source-map-0.7.2.tgz",
         "defined": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
-        "JSONStream": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.1.tgz",
         "through2": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
         "umd": "https://registry.npmjs.org/umd/-/umd-3.0.1.tgz"
       }
@@ -323,6 +332,7 @@
       "integrity": "sha1-CJo0Y69Y0OSNjNQHCz90ZU1avKk=",
       "dev": true,
       "requires": {
+        "JSONStream": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.1.tgz",
         "assert": "https://registry.npmjs.org/assert/-/assert-1.4.1.tgz",
         "browser-pack": "https://registry.npmjs.org/browser-pack/-/browser-pack-6.0.2.tgz",
         "browser-resolve": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.11.2.tgz",
@@ -344,7 +354,6 @@
         "https-browserify": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
         "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
         "insert-module-globals": "https://registry.npmjs.org/insert-module-globals/-/insert-module-globals-7.0.1.tgz",
-        "JSONStream": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.1.tgz",
         "labeled-stream-splicer": "https://registry.npmjs.org/labeled-stream-splicer/-/labeled-stream-splicer-2.0.0.tgz",
         "module-deps": "https://registry.npmjs.org/module-deps/-/module-deps-4.1.1.tgz",
         "os-browserify": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.1.2.tgz",
@@ -2194,15 +2203,6 @@
             }
           }
         },
-        "string_decoder": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.1.tgz",
-          "integrity": "sha1-YuIA8DmVWmgQ2N8KM//A8BNmLZg=",
-          "dev": true,
-          "requires": {
-            "safe-buffer": "5.0.1"
-          }
-        },
         "string-width": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
@@ -2212,6 +2212,15 @@
             "code-point-at": "1.1.0",
             "is-fullwidth-code-point": "1.0.0",
             "strip-ansi": "3.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.1.tgz",
+          "integrity": "sha1-YuIA8DmVWmgQ2N8KM//A8BNmLZg=",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "5.0.1"
           }
         },
         "stringstream": {
@@ -2541,10 +2550,10 @@
       "integrity": "sha1-wDv04BywhtW15azorQr+eInWOMM=",
       "dev": true,
       "requires": {
+        "JSONStream": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.1.tgz",
         "combine-source-map": "https://registry.npmjs.org/combine-source-map/-/combine-source-map-0.7.2.tgz",
         "concat-stream": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.2.tgz",
         "is-buffer": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
-        "JSONStream": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.1.tgz",
         "lexical-scope": "https://registry.npmjs.org/lexical-scope/-/lexical-scope-1.2.0.tgz",
         "process": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
         "through2": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
@@ -2745,13 +2754,16 @@
       "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=",
       "dev": true
     },
-    "JSONStream": {
-      "version": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.1.tgz",
-      "integrity": "sha1-cH92HgHa6eFvG8+TcDt4xwlmV5o=",
+    "jsverify": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/jsverify/-/jsverify-0.8.3.tgz",
+      "integrity": "sha1-AukXjhkktar5WcAjmvhO1cbQc4w=",
       "dev": true,
       "requires": {
-        "jsonparse": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
-        "through": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
+        "lazy-seq": "1.0.0",
+        "rc4": "0.1.5",
+        "trampa": "1.0.0",
+        "typify-parser": "1.1.0"
       }
     },
     "just-extend": {
@@ -2878,6 +2890,12 @@
     "lazy-cache": {
       "version": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
       "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
+      "dev": true
+    },
+    "lazy-seq": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/lazy-seq/-/lazy-seq-1.0.0.tgz",
+      "integrity": "sha1-iAy4qrJWAmOC4C9T7AiWgqdMW2o=",
       "dev": true
     },
     "lcid": {
@@ -3160,6 +3178,7 @@
       "integrity": "sha1-IyFYM/HaE/1gbMuAh7RIUty4If0=",
       "dev": true,
       "requires": {
+        "JSONStream": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.1.tgz",
         "browser-resolve": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.11.2.tgz",
         "cached-path-relative": "https://registry.npmjs.org/cached-path-relative/-/cached-path-relative-1.0.1.tgz",
         "concat-stream": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.0.tgz",
@@ -3167,7 +3186,6 @@
         "detective": "https://registry.npmjs.org/detective/-/detective-4.5.0.tgz",
         "duplexer2": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
         "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-        "JSONStream": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.1.tgz",
         "parents": "https://registry.npmjs.org/parents/-/parents-1.0.1.tgz",
         "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.2.tgz",
         "resolve": "https://registry.npmjs.org/resolve/-/resolve-1.3.3.tgz",
@@ -3640,6 +3658,12 @@
         "unpipe": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz"
       }
     },
+    "rc4": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/rc4/-/rc4-0.1.5.tgz",
+      "integrity": "sha1-CMbgSgFo9utiHCKrbLEVG9n0pk0=",
+      "dev": true
+    },
     "read-only-stream": {
       "version": "https://registry.npmjs.org/read-only-stream/-/read-only-stream-2.0.0.tgz",
       "integrity": "sha1-JyT9aoET1zdkrCiNQ4YnDB2/F/A=",
@@ -4047,14 +4071,6 @@
         "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.2.tgz"
       }
     },
-    "string_decoder": {
-      "version": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha1-D8Z9fBQYJd6UKC3VNr7GubzoYKs=",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz"
-      }
-    },
     "string-width": {
       "version": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
       "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
@@ -4063,6 +4079,14 @@
         "code-point-at": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
         "is-fullwidth-code-point": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
         "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz"
+      }
+    },
+    "string_decoder": {
+      "version": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha1-D8Z9fBQYJd6UKC3VNr7GubzoYKs=",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz"
       }
     },
     "strip-ansi": {
@@ -4170,6 +4194,12 @@
       "integrity": "sha1-fSKbH8xjfkZsoIEYCDanqr/4P0M=",
       "dev": true
     },
+    "trampa": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/trampa/-/trampa-1.0.0.tgz",
+      "integrity": "sha1-Ukc0esM0gH+mwAAERMuRtjmECtU=",
+      "dev": true
+    },
     "transit-immutable-js": {
       "version": "https://registry.npmjs.org/transit-immutable-js/-/transit-immutable-js-0.7.0.tgz",
       "integrity": "sha1-mT4lCJtjEf9AIUD1VidtbSUwBdk="
@@ -4195,6 +4225,12 @@
     "typedarray": {
       "version": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+      "dev": true
+    },
+    "typify-parser": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/typify-parser/-/typify-parser-1.1.0.tgz",
+      "integrity": "sha1-rHO/pfJTQ0aOLQ8zRsYRe8A9PJk=",
       "dev": true
     },
     "uglify-js": {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   },
   "devDependencies": {
     "browserify": "^14.4.0",
+    "jsverify": "^0.8.3",
     "karma": "^1.7.0",
     "karma-browserify": "^5.1.1",
     "karma-chrome-launcher": "^2.2.0",

--- a/src/automerge.js
+++ b/src/automerge.js
@@ -66,7 +66,7 @@ function setField(state, objectId, key, value) {
 function splice(state, objectId, start, deletions, insertions) {
   let elemIds = state.getIn(['opSet', 'byObject', objectId, '_elemIds'])
   for (let i = 0; i < deletions; i++) {
-    let elemId = elemIds.get(start)
+    let elemId = elemIds.keyOf(start)
     if (elemId) {
       state = makeOp(state, {action: 'del', obj: objectId, key: elemId})
       elemIds = state.getIn(['opSet', 'byObject', objectId, '_elemIds'])
@@ -74,7 +74,7 @@ function splice(state, objectId, start, deletions, insertions) {
   }
 
   // Apply insertions
-  let prev = (start === 0) ? '_head' : elemIds.get(start - 1)
+  let prev = (start === 0) ? '_head' : elemIds.keyOf(start - 1)
   if (!prev && insertions.length > 0) {
     throw new RangeError('Cannot insert at index ' + start + ', which is past the end of the list')
   }

--- a/src/skip_list.js
+++ b/src/skip_list.js
@@ -1,0 +1,171 @@
+const { Map, List } = require('immutable')
+
+// Returns a random number from the geometric distribution with p = 0.75.
+// That is, returns k with probability p * (1 - p)^(k - 1).
+// For example, returns 1 with probability 3/4, returns 2 with probability 3/16,
+// returns 3 with probability 3/64, and so on.
+function* randomLevel() {
+  while (true) {
+    const rand = Math.floor(Math.random() * 4294967296)
+    let level = 1
+    while (rand < 1 << (32 - 2 * level) && level < 16) level += 1
+    yield level
+  }
+}
+
+class Node {
+  constructor (key, value, level, prevKey, nextKey, prevCount, nextCount) {
+    this.key = key
+    this.value = value
+    this.level = level
+    this.prevKey = Object.freeze(prevKey)
+    this.nextKey = Object.freeze(nextKey)
+    this.prevCount = Object.freeze(prevCount)
+    this.nextCount = Object.freeze(nextCount)
+    Object.freeze(this)
+  }
+
+  insertAfter (newKey, newLevel, fromLevel, distance) {
+    if (newLevel > this.level && this.key !== null) {
+      throw new RangeError('Cannot increase the level of a non-head node')
+    }
+    const maxLevel = Math.max(this.level, newLevel)
+    const nextKey = this.nextKey.slice()
+    const nextCount = this.nextCount.slice()
+
+    for (let level = fromLevel; level < maxLevel; level++) {
+      if (level < newLevel) {
+        nextKey[level] = newKey
+        nextCount[level] = distance
+      } else {
+        nextCount[level] += 1
+      }
+    }
+
+    return new Node(this.key, this.value, maxLevel,
+                    this.prevKey, nextKey, this.prevCount, nextCount)
+  }
+
+  insertBefore (newKey, newLevel, fromLevel, distance) {
+    if (newLevel > this.level) throw new RangeError('Cannot increase node level')
+    const prevKey = this.prevKey.slice()
+    const prevCount = this.prevCount.slice()
+
+    for (let level = fromLevel; level < this.level; level++) {
+      if (level < newLevel) {
+        prevKey[level] = newKey
+        prevCount[level] = distance
+      } else {
+        prevCount[level] += 1
+      }
+    }
+
+    return new Node(this.key, this.value, this.level,
+                    prevKey, this.nextKey, prevCount, this.nextCount)
+  }
+}
+
+class SkipList {
+  constructor (randomSource) {
+    const head = new Node(null, null, 1, [], [null], [], [null])
+    const random = randomSource ? randomSource() : randomLevel()
+    return makeInstance(Map().set(null, head), random)
+  }
+
+  get headNode () {
+    return this._nodes.get(null)
+  }
+
+  predecessors (predecessor, maxLevel) {
+    const preKeys = [predecessor], preCounts = [1]
+
+    for (let level = 1; level < maxLevel; level++) {
+      let preKey = preKeys[level - 1]
+      let count = preCounts[level - 1]
+      while (preKey) {
+        let node = this._nodes.get(preKey)
+        if (node.level > level) break
+        if (node.level < level) {
+          throw new RangeError('Node ' + preKey + ' below expected level ' + (level - 1))
+        }
+        count += node.prevCount[level - 1]
+        preKey = node.prevKey[level - 1]
+      }
+      preKeys[level] = preKey
+      preCounts[level] = count
+    }
+
+    return {preKeys, preCounts}
+  }
+
+  successors (successor, maxLevel) {
+    const sucKeys = [successor], sucCounts = [1]
+
+    for (let level = 1; level < maxLevel; level++) {
+      let sucKey = sucKeys[level - 1]
+      let count = sucCounts[level - 1]
+      while (sucKey) {
+        let node = this._nodes.get(sucKey)
+        if (node.level > level) break
+        if (node.level < level) {
+          throw new RangeError('Node ' + sucKey + ' below expected level ' + (level - 1))
+        }
+        count += node.nextCount[level - 1]
+        sucKey = node.nextKey[level - 1]
+      }
+      sucKeys[level] = sucKey
+      sucCounts[level] = count
+    }
+
+    return {sucKeys, sucCounts}
+  }
+
+  // Inserts a new list element immediately after the element with key `predecessor`.
+  // If predecessor === null, inserts at the head of the list.
+  insertAfter (predecessor, key, value) {
+    if (!this._nodes.has(predecessor)) {
+      throw new RangeError('The referenced predecessor key does not exist')
+    }
+    if (this._nodes.has(key)) {
+      throw new RangeError('Cannot insert a key that already exists')
+    }
+
+    const newLevel = this._randomSource.next().value
+    const maxLevel = Math.max(newLevel, this.headNode.level)
+    const successor = this._nodes.get(predecessor).nextKey[0] || null
+    const { preKeys, preCounts } = this.predecessors(predecessor, maxLevel)
+    const { sucKeys, sucCounts } = this.successors(successor, maxLevel)
+
+    return makeInstance(this._nodes.withMutations(nodes => {
+      let preLevel = 0, sucLevel = 0
+      for (let level = 1; level <= maxLevel; level++) {
+        const updateLevel = Math.min(level, newLevel)
+        if (level === maxLevel || preKeys[level] !== preKeys[preLevel]) {
+          nodes.update(preKeys[preLevel],
+                       node => node.insertAfter(key, updateLevel, preLevel, preCounts[preLevel]))
+          preLevel = level
+        }
+        if (sucKeys[sucLevel] && (level === maxLevel || sucKeys[level] !== sucKeys[sucLevel])) {
+          nodes.update(sucKeys[sucLevel],
+                       node => node.insertBefore(key, updateLevel, sucLevel, sucCounts[sucLevel]))
+          sucLevel = level
+        }
+      }
+
+      nodes.set(key, new Node(key, value, newLevel,
+                              preKeys.slice(0, newLevel),
+                              sucKeys.slice(0, newLevel),
+                              preCounts.slice(0, newLevel),
+                              sucCounts.slice(0, newLevel)))
+    }), this._randomSource)
+  }
+}
+
+function makeInstance(nodes, randomSource) {
+  const instance = Object.create(SkipList.prototype)
+  instance._nodes = nodes
+  instance._randomSource = randomSource
+  return instance
+}
+
+module.exports = {SkipList}

--- a/src/skip_list.js
+++ b/src/skip_list.js
@@ -1,4 +1,4 @@
-const { Map, List } = require('immutable')
+const { Map } = require('immutable')
 
 // Returns a random number from the geometric distribution with p = 0.75.
 // That is, returns k with probability p * (1 - p)^(k - 1).

--- a/test/skip_list_test.js
+++ b/test/skip_list_test.js
@@ -1,0 +1,102 @@
+const assert = require('assert')
+const { SkipList } = require('../src/skip_list')
+
+describe('SkipList', () => {
+  describe('internal structure', () => {
+    it('should have a head node when initialized', () => {
+      let s = new SkipList()
+      assert.deepEqual(s._nodes.get(null),
+                       {key: null, value: null, level: 1,
+                        prevKey: [], prevCount: [], nextKey: [null], nextCount: [null]})
+    })
+
+    it('should link to a new level-1 node', () => {
+      let s = new SkipList(function* () { yield 1 })
+      s = s.insertAfter(null, 'a', 'aaa')
+      assert.deepEqual(s._nodes.get(null),
+                       {key: null, value: null, level: 1,
+                        prevKey: [], prevCount: [], nextKey: ['a'], nextCount: [1]})
+      assert.deepEqual(s._nodes.get('a'),
+                       {key: 'a', value: 'aaa', level: 1,
+                        prevKey: [null], prevCount: [1], nextKey: [null], nextCount: [1]})
+    })
+
+    it('should raise the head to the maximum level', () => {
+      let s = new SkipList(function* () {
+        for (let level of [1, 1, 1, 3]) yield level
+      })
+      s = s.insertAfter(null, 'a', 'aaa').insertAfter('a', 'b', 'bbb').insertAfter('b', 'd', 'ddd')
+      s = s.insertAfter('b', 'c', 'ccc') // this is the level-3 node
+
+      assert.deepEqual(s._nodes.get(null),
+                       {key: null, value: null, level: 3,
+                        prevKey: [], prevCount: [], nextKey: ['a', 'c', 'c'], nextCount: [1, 3, 3]})
+      assert.deepEqual(s._nodes.get('a'),
+                       {key: 'a', value: 'aaa', level: 1,
+                        prevKey: [null], prevCount: [1], nextKey: ['b'], nextCount: [1]})
+      assert.deepEqual(s._nodes.get('b'),
+                       {key: 'b', value: 'bbb', level: 1,
+                        prevKey: ['a'], prevCount: [1], nextKey: ['c'], nextCount: [1]})
+      assert.deepEqual(s._nodes.get('c'),
+                       {key: 'c', value: 'ccc', level: 3,
+                        prevKey: ['b', null, null], prevCount: [1, 3, 3],
+                        nextKey: ['d', null, null], nextCount: [1, 2, 2]})
+      assert.deepEqual(s._nodes.get('d'),
+                       {key: 'd', value: 'ddd', level: 1,
+                        prevKey: ['c'], nextKey: [null], prevCount: [1], nextCount: [1]})
+    })
+
+    it('should keep track of skip distances', () => {
+      let s = new SkipList(function* () {
+        for (let level of [1, 2, 1, 3, 1, 2, 1, 4]) yield level
+      })
+      s = s.insertAfter(null, '1', '1').insertAfter('1', '2', '2').insertAfter('2', '3', '3').insertAfter('3', '4', '4')
+      s = s.insertAfter('4', '5', '5').insertAfter('5', '6', '6').insertAfter('6', '7', '7').insertAfter('7', '8', '8')
+
+      assert.deepEqual(s._nodes.get(null),
+                       {key: null, value: null, level: 4,
+                        prevKey: [], prevCount: [], nextKey: ['1', '2', '4', '8'], nextCount: [1, 2, 4, 8]})
+      assert.deepEqual(s._nodes.get('2'),
+                       {key: '2', value: '2', level: 2,
+                        prevKey: ['1', null], prevCount: [1, 2], nextKey: ['3', '4'], nextCount: [1, 2]})
+      assert.deepEqual(s._nodes.get('4'),
+                       {key: '4', value: '4', level: 3,
+                        prevKey: ['3', '2', null], prevCount: [1, 2, 4], nextKey: ['5', '6', '8'], nextCount: [1, 2, 4]})
+      assert.deepEqual(s._nodes.get('6'),
+                       {key: '6', value: '6', level: 2,
+                        prevKey: ['5', '4'], prevCount: [1, 2], nextKey: ['7', '8'], nextCount: [1, 2]})
+      assert.deepEqual(s._nodes.get('8'),
+                       {key: '8', value: '8', level: 4,
+                        prevKey: [ '7',  '6',  '4', null], prevCount: [1, 2, 4, 8],
+                        nextKey: [null, null, null, null], nextCount: [1, 1, 1, 1]})
+    })
+
+    it('should update preceding and succeeding nodes at the appropriate levels', () => {
+      let s = new SkipList(function* () {
+        for (let level of [5, 2, 1, 1, 1, 2, 5, 4]) yield level
+      })
+      s = s.insertAfter(null, '1', '1').insertAfter('1', '2', '2').insertAfter('2', '3', '3').insertAfter('3', '4', '4')
+      s = s.insertAfter('4', '5', '5').insertAfter('5', '6', '6').insertAfter('6', '7', '7')
+      s = s.insertAfter('4', 'x', 'x') // insert x at level 4
+
+      assert.deepEqual(s._nodes.get('1'),
+                       {key: '1', value: '1', level: 5,
+                        prevKey: [null, null, null, null, null], prevCount: [1, 1, 1, 1, 1],
+                        nextKey: [ '2',  '2',  'x',  'x',  '7'], nextCount: [1, 1, 4, 4, 7]})
+      assert.deepEqual(s._nodes.get('2'),
+                       {key: '2', value: '2', level: 2,
+                        prevKey: ['1', '1'], prevCount: [1, 1], nextKey: ['3', 'x'], nextCount: [1, 3]})
+      assert.deepEqual(s._nodes.get('x'),
+                       {key: 'x', value: 'x', level: 4,
+                        prevKey: ['4', '2', '1', '1'], prevCount: [1, 3, 4, 4],
+                        nextKey: ['5', '6', '7', '7'], nextCount: [1, 2, 3, 3]})
+      assert.deepEqual(s._nodes.get('6'),
+                       {key: '6', value: '6', level: 2,
+                        prevKey: ['5', 'x'], prevCount: [1, 2], nextKey: ['7', '7'], nextCount: [1, 1]})
+      assert.deepEqual(s._nodes.get('7'),
+                       {key: '7', value: '7', level: 5,
+                        prevKey: [ '6',  '6',  'x',  'x',  '1'], prevCount: [1, 1, 3, 3, 7],
+                        nextKey: [null, null, null, null, null], nextCount: [1, 1, 1, 1, 1]})
+    })
+  })
+})

--- a/test/skip_list_test.js
+++ b/test/skip_list_test.js
@@ -1,6 +1,10 @@
 const assert = require('assert')
 const { SkipList } = require('../src/skip_list')
 
+function iter(array) {
+  return array[Symbol.iterator].bind(array)
+}
+
 describe('SkipList', () => {
   describe('internal structure', () => {
     it('should have a head node when initialized', () => {
@@ -11,7 +15,7 @@ describe('SkipList', () => {
     })
 
     it('should link to a new level-1 node', () => {
-      let s = new SkipList(function* () { yield 1 })
+      let s = new SkipList(iter([1]))
       s = s.insertAfter(null, 'a', 'aaa')
       assert.deepEqual(s._nodes.get(null),
                        {key: null, value: null, level: 1,
@@ -22,9 +26,7 @@ describe('SkipList', () => {
     })
 
     it('should raise the head to the maximum level', () => {
-      let s = new SkipList(function* () {
-        for (let level of [1, 1, 1, 3]) yield level
-      })
+      let s = new SkipList(iter([1, 1, 1, 3]))
       s = s.insertAfter(null, 'a', 'aaa').insertAfter('a', 'b', 'bbb').insertAfter('b', 'd', 'ddd')
       s = s.insertAfter('b', 'c', 'ccc') // this is the level-3 node
 
@@ -47,9 +49,7 @@ describe('SkipList', () => {
     })
 
     it('should keep track of skip distances', () => {
-      let s = new SkipList(function* () {
-        for (let level of [1, 2, 1, 3, 1, 2, 1, 4]) yield level
-      })
+      let s = new SkipList(iter([1, 2, 1, 3, 1, 2, 1, 4]))
       s = s.insertAfter(null, '1', '1').insertAfter('1', '2', '2').insertAfter('2', '3', '3').insertAfter('3', '4', '4')
       s = s.insertAfter('4', '5', '5').insertAfter('5', '6', '6').insertAfter('6', '7', '7').insertAfter('7', '8', '8')
 
@@ -72,9 +72,7 @@ describe('SkipList', () => {
     })
 
     it('should update preceding and succeeding nodes at the appropriate levels', () => {
-      let s = new SkipList(function* () {
-        for (let level of [5, 2, 1, 1, 1, 2, 5, 4]) yield level
-      })
+      let s = new SkipList(iter([5, 2, 1, 1, 1, 2, 5, 4]))
       s = s.insertAfter(null, '1', '1').insertAfter('1', '2', '2').insertAfter('2', '3', '3').insertAfter('3', '4', '4')
       s = s.insertAfter('4', '5', '5').insertAfter('5', '6', '6').insertAfter('6', '7', '7')
       s = s.insertAfter('4', 'x', 'x') // insert x at level 4


### PR DESCRIPTION
I have been working for a while on improving the performance of large lists (as needed for text editing = a long list of characters). This PR checkpoints the current state.

The major addition is a new data structure, an [indexed skip list](http://cglab.ca/~morin/teaching/5408/refs/p90b.pdf). The implementation here is immutable and is based on Immutable.js. Its main feature is that it gives each list element a unique ID (like our CRDT list does), and it can efficiently translate between those IDs and list indexes. All the main operations you need are O(log n): inserting a list element, deleting a list element, getting the element ID for a list index, and getting the index for an element ID.

So far, I have used the skip list only for the internal elemIds list that is part of the CRDT metadata. On my text-editing benchmark this brings roughly a 2x speedup (time to process 10,000 operations goes from 73 sec to 40 sec on my laptop).

Once the skip list is used for the actual list object, I expect a significantly larger speedup, but that will require some more code restructuring, so I will do that in a future PR.