### PR TITLE
Add Automerge.Text datatype

### DIFF
--- a/src/automerge.js
+++ b/src/automerge.js
@@ -86,14 +86,8 @@ function splice(state, objectId, start, deletions, insertions) {
 }
 
 function setListIndex(state, listId, index, value) {
-  let i = -1, elem = OpSet.getNext(state.get('opSet'), listId, '_head')
-  index = parseListIndex(index)
-  while (elem) {
-    if (!OpSet.getFieldOps(state.get('opSet'), listId, elem).isEmpty()) i += 1
-    if (i === index) break
-    elem = OpSet.getNext(state.get('opSet'), listId, elem)
-  }
-
+  const elemIds = state.getIn(['opSet', 'byObject', listId, '_elemIds'])
+  const elem = elemIds.keyOf(parseListIndex(index))
   if (elem) {
     return setField(state, listId, elem, value)
   } else {

--- a/src/automerge.js
+++ b/src/automerge.js
@@ -2,6 +2,7 @@ const { Map, List, fromJS } = require('immutable')
 const uuid = require('uuid/v4')
 const { rootObjectProxy } = require('./proxies')
 const OpSet = require('./op_set')
+const FreezeAPI = require('./freeze_api')
 const transit = require('transit-immutable-js')
 
 function isObject(obj) {
@@ -10,7 +11,8 @@ function isObject(obj) {
 
 function makeOp(state, opProps) {
   const opSet = state.get('opSet'), actor = state.get('actorId'), op = fromJS(opProps)
-  return state.set('opSet', OpSet.addLocalOp(opSet, op, actor))
+  let [opSet2, diff] = OpSet.addLocalOp(opSet, op, actor)
+  return state.set('opSet', opSet2)
 }
 
 function insertAfter(state, listId, elemId) {
@@ -105,39 +107,19 @@ function deleteField(state, objectId, key) {
   return makeOp(state, { action: 'del', obj: objectId, key: key })
 }
 
-function rootObject(state, rootObj) {
-  Object.assign(Object.getPrototypeOf(rootObj), {_state: state, _actorId: state.get('actorId')})
-  Object.freeze(Object.getPrototypeOf(rootObj))
-  return rootObj
-}
-
-function applyChange(state, change) {
-  const [opSet, root] = OpSet.addChange(state.get('opSet'), change)
-  return rootObject(state.set('opSet', opSet), root)
-}
-
-function applyChanges(doc, changes) {
-  return changes.reduce(
-    (root, change) => applyChange(root._state, change),
-    doc || init()
-  )
-}
-
-function makeChange(oldState, newState, message) {
-  const actor = oldState.get('actorId')
-  const seq = oldState.getIn(['opSet', 'clock', actor], 0) + 1
-  const deps = oldState.getIn(['opSet', 'deps']).remove(actor)
+function makeChange(root, newState, message) {
+  const actor = root._state.get('actorId')
+  const seq = root._state.getIn(['opSet', 'clock', actor], 0) + 1
+  const deps = root._state.getIn(['opSet', 'deps']).remove(actor)
   const change = fromJS({actor, seq, deps, message})
     .set('ops', newState.getIn(['opSet', 'local']))
-  return applyChange(oldState, change)
+  return FreezeAPI.applyChanges(root, List.of(change), true)
 }
 
 ///// Automerge.* API
 
 function init(actorId) {
-  const [opSet, rootObj] = OpSet.materialize(OpSet.init())
-  const state = Map({actorId: actorId || uuid(), opSet})
-  return rootObject(state, rootObj)
+  return FreezeAPI.init(actorId || uuid())
 }
 
 function checkTarget(funcName, target, needMutable) {
@@ -174,10 +156,9 @@ function change(doc, message, callback) {
     [message, callback] = [callback, message]
   }
 
-  const oldState = doc._state
-  const context = {state: oldState, mutable: true, setField, splice, setListIndex, deleteField}
+  const context = {state: doc._state, mutable: true, setField, splice, setListIndex, deleteField}
   callback(rootObjectProxy(context))
-  return makeChange(oldState, context.state, message)
+  return makeChange(doc, context.state, message)
 }
 
 function assign(target, values) {
@@ -196,15 +177,12 @@ function assign(target, values) {
 }
 
 function load(string, actorId) {
-  return applyChanges(init(actorId), transit.fromJSON(string))
+  return FreezeAPI.applyChanges(FreezeAPI.init(actorId), transit.fromJSON(string), false)
 }
 
 function save(doc) {
   checkTarget('save', doc)
-  const history = doc._state
-    .getIn(['opSet', 'history'])
-    .map(state => state.get('change'))
-  return transit.toJSON(history)
+  return transit.toJSON(doc._state.getIn(['opSet', 'history']))
 }
 
 function equals(val1, val2) {
@@ -225,12 +203,19 @@ function inspect(doc) {
 
 function getHistory(doc) {
   checkTarget('inspect', doc)
-  return doc._state.getIn(['opSet', 'history']).toJS()
+  const history = doc._state.getIn(['opSet', 'history'])
+  return history.map((change, index) => {
+    return {
+      get change () {
+        return change.toJS()
+      },
+      get snapshot () {
+        const root = FreezeAPI.init(doc._state.get('actorId'))
+        return FreezeAPI.applyChanges(root, history.slice(0, index + 1), false)
+      }
+    }
+  }).toArray()
 }
-
-const DocSet = require('./doc_set')
-const Connection = require('./connection')
-DocSet.prototype._applyChanges = applyChanges
 
 function merge(local, remote) {
   checkTarget('merge', local)
@@ -240,7 +225,7 @@ function merge(local, remote) {
 
   const clock = local._state.getIn(['opSet', 'clock'])
   const changes = OpSet.getMissingChanges(remote._state.get('opSet'), clock)
-  return applyChanges(local, changes)
+  return FreezeAPI.applyChanges(local, changes, true)
 }
 
 // Returns true if all components of clock1 are less than or equal to those of clock2.
@@ -264,10 +249,16 @@ function diff(oldState, newState) {
   let root, opSet = oldState._state.get('opSet').set('diff', List())
   const changes = OpSet.getMissingChanges(newState._state.get('opSet'), oldClock)
 
-  for (let change of changes) [opSet, root] = OpSet.addChange(opSet, change)
-  return opSet.get('diff').toJS()
+  let diffs = [], diff
+  for (let change of changes) {
+    [opSet, diff] = OpSet.addChange(opSet, change)
+    diffs.push(...diff)
+  }
+  return diffs
 }
 
 module.exports = {
-  init, change, changeset: change, assign, load, save, equals, inspect, getHistory, DocSet, Connection, merge, diff
+  init, change, merge, diff, assign, load, save, equals, inspect, getHistory,
+  DocSet: require('./doc_set'),
+  Connection: require('./connection')
 }

--- a/src/doc_set.js
+++ b/src/doc_set.js
@@ -1,4 +1,6 @@
 const { Map, Set } = require('immutable')
+const uuid = require('uuid/v4')
+const FreezeAPI = require('./freeze_api')
 
 class DocSet {
   constructor () {
@@ -20,7 +22,8 @@ class DocSet {
   }
 
   applyChanges (docId, changes) {
-    const doc = this._applyChanges(this.docs.get(docId), changes)
+    let doc = this.docs.get(docId) || FreezeAPI.init(uuid())
+    doc = FreezeAPI.applyChanges(doc, changes, true)
     this.setDoc(docId, doc)
     return doc
   }

--- a/src/freeze_api.js
+++ b/src/freeze_api.js
@@ -1,0 +1,152 @@
+const { Map, List, Set } = require('immutable')
+const OpSet = require('./op_set')
+
+function updateMapObject(opSet, edit) {
+  if (edit.action === 'create') {
+    return opSet.setIn(['cache', edit.obj], Object.freeze({_objectId: edit.obj}))
+  }
+
+  const oldObject = opSet.getIn(['cache', edit.obj])
+  const conflicts = Object.assign({}, oldObject._conflicts)
+  const object = Object.assign(Object.create({_conflicts: conflicts}), oldObject)
+
+  if (edit.action === 'set') {
+    object[edit.key] = edit.link ? opSet.getIn(['cache', edit.value]) : edit.value
+    if (edit.conflicts) {
+      conflicts[edit.key] = {}
+      for (let conflict of edit.conflicts) {
+        const value = conflict.link ? opSet.getIn(['cache', conflict.value]) : conflict.value
+        conflicts[edit.key][conflict.actor] = value
+      }
+      Object.freeze(conflicts[edit.key])
+    } else {
+      delete conflicts[edit.key]
+    }
+  } else if (edit.action === 'remove') {
+    delete object[edit.key]
+    delete conflicts[edit.key]
+  } else throw 'Unknown action type: ' + edit.action
+
+  Object.freeze(conflicts)
+  return opSet.setIn(['cache', edit.obj], Object.freeze(object))
+}
+
+function updateListObject(opSet, edit) {
+  if (edit.action === 'create') {
+    let list = []
+    Object.defineProperty(list, '_objectId', {value: edit.obj})
+    return opSet.setIn(['cache', edit.obj], Object.freeze(list))
+  }
+
+  let value = edit.link ? opSet.getIn(['cache', edit.value]) : edit.value
+  let list = opSet.getIn(['cache', edit.obj]).slice()
+  Object.defineProperty(list, '_objectId', {value: edit.obj})
+
+  if (edit.action === 'insert') {
+    list.splice(edit.index, 0, value)
+  } else if (edit.action === 'set') {
+    list[edit.index] = value
+  } else if (edit.action === 'remove') {
+    list.splice(edit.index, 1)
+  } else throw 'Unknown action type: ' + edit.action
+  return opSet.setIn(['cache', edit.obj], Object.freeze(list))
+}
+
+function updateCache(opSet, diffs) {
+  let affected = Set()
+  for (let edit of diffs) {
+    affected = affected.add(edit.obj)
+    if (edit.type === 'map') {
+      opSet = updateMapObject(opSet, edit)
+    } else if (edit.type === 'list') {
+      opSet = updateListObject(opSet, edit)
+    } else throw 'Unknown object type: ' + edit.type
+  }
+
+  // Update cache entries on the path from the root to the modified object
+  while (!affected.isEmpty()) {
+    const parentOps = affected.flatMap(objectId => opSet.getIn(['byObject', objectId, '_inbound'], Set()))
+    affected = Set()
+    for (let ref of parentOps) {
+      const objectId = ref.get('obj')
+      const objType = opSet.getIn(['byObject', objectId, '_init', 'action'])
+      affected = affected.add(objectId)
+
+      if (objType === 'makeList') {
+        const index = opSet.getIn(['byObject', objectId, '_elemIds']).indexOf(ref.get('key'))
+        const edit = {action: 'set', obj: objectId, index, value: ref.get('value'), link: true}
+        opSet = updateListObject(opSet, edit)
+      } else {
+        const edit = {action: 'set', obj: objectId, key: ref.get('key'), value: ref.get('value'), link: true}
+        // TODO get conflicts
+        opSet = updateMapObject(opSet, edit)
+      }
+    }
+  }
+  return opSet
+}
+
+function instantiateImmutable(opSet, objectId) {
+  const isRoot = (objectId === OpSet.ROOT_ID)
+  const objType = opSet.getIn(['byObject', objectId, '_init', 'action'])
+
+  // Don't read the root object from cache, because it may reference an outdated state.
+  // The state may change without without invalidating the cache entry for the root object (for
+  // example, adding an item to the queue of operations that are not yet causally ready).
+  if (!isRoot && this.cache && this.cache[objectId]) return this.cache[objectId]
+
+  let obj
+  if (isRoot || objType === 'makeMap') {
+    const conflicts = OpSet.getObjectConflicts(opSet, objectId, this)
+    obj = Object.create({_conflicts: Object.freeze(conflicts.toJS())})
+
+    OpSet.getObjectFields(opSet, objectId).forEach(field => {
+      obj[field] = OpSet.getObjectField(opSet, objectId, field, this)
+    })
+  } else if (objType === 'makeList') {
+    obj = [...OpSet.listIterator(opSet, objectId, 'values', this)]
+    Object.defineProperty(obj, '_objectId', {value: objectId})
+  } else {
+    throw 'Unknown object type: ' + objType
+  }
+
+  Object.freeze(obj)
+  if (this.cache) this.cache[objectId] = obj
+  return obj
+}
+
+function materialize(opSet) {
+  opSet = opSet.set('cache', Map())
+  const context = {instantiateObject: instantiateImmutable, cache: {}}
+  const snapshot = context.instantiateObject(opSet, OpSet.ROOT_ID)
+  return [opSet.set('cache', Map(context.cache)), snapshot]
+}
+
+function rootObject(state, rootObj) {
+  Object.assign(Object.getPrototypeOf(rootObj), {_state: state, _actorId: state.get('actorId')})
+  Object.freeze(Object.getPrototypeOf(rootObj))
+  return rootObj
+}
+
+function init(actorId) {
+  const [opSet, rootObj] = materialize(OpSet.init())
+  const state = Map({actorId, opSet})
+  return rootObject(state, rootObj)
+}
+
+function applyChanges(root, changes, incremental) {
+  let opSet = root._state.get('opSet'), diffs = [], diff
+  for (let change of changes) {
+    [opSet, diff] = OpSet.addChange(opSet, change)
+    diffs.push(...diff)
+  }
+
+  if (incremental) opSet = updateCache(opSet, diffs)
+  let newRoot
+  [opSet, newRoot] = materialize(opSet)
+  return rootObject(root._state.set('opSet', opSet), newRoot)
+}
+
+module.exports = {
+  init, applyChanges
+}

--- a/src/freeze_api.js
+++ b/src/freeze_api.js
@@ -1,5 +1,6 @@
 const { Map, List, Set } = require('immutable')
 const OpSet = require('./op_set')
+const { Text } = require('./text')
 
 function isObject(obj) {
   return typeof obj === 'object' && obj !== null
@@ -108,6 +109,8 @@ function updateCache(opSet, diffs) {
       opSet = updateMapObject(opSet, edit)
     } else if (edit.type === 'list') {
       opSet = updateListObject(opSet, edit)
+    } else if (edit.type === 'text') {
+      opSet = opSet.setIn(['cache', edit.obj], new Text(opSet, edit.obj))
     } else throw 'Unknown object type: ' + edit.type
   }
 
@@ -122,6 +125,8 @@ function updateCache(opSet, diffs) {
         opSet = parentListObject(opSet, ref)
       } else if (objType === 'makeMap' || ref.get('obj') === OpSet.ROOT_ID) {
         opSet = parentMapObject(opSet, ref)
+      } else if (objType === 'makeText') {
+        opSet = opSet.setIn(['cache', ref.get('obj')], new Text(opSet, ref.get('obj')))
       } else {
         throw 'Unknown object type: ' + objType
       }
@@ -153,6 +158,8 @@ function instantiateImmutable(opSet, objectId) {
   } else if (objType === 'makeList') {
     obj = [...OpSet.listIterator(opSet, objectId, 'values', this)]
     Object.defineProperty(obj, '_objectId', {value: objectId})
+  } else if (objType === 'makeText') {
+    obj = new Text(opSet, objectId)
   } else {
     throw 'Unknown object type: ' + objType
   }

--- a/src/freeze_api.js
+++ b/src/freeze_api.js
@@ -147,9 +147,9 @@ function instantiateImmutable(opSet, objectId) {
     const conflicts = OpSet.getObjectConflicts(opSet, objectId, this)
     obj = Object.create({_conflicts: Object.freeze(conflicts.toJS())})
 
-    OpSet.getObjectFields(opSet, objectId).forEach(field => {
+    for (let field of OpSet.getObjectFields(opSet, objectId)) {
       obj[field] = OpSet.getObjectField(opSet, objectId, field, this)
-    })
+    }
   } else if (objType === 'makeList') {
     obj = [...OpSet.listIterator(opSet, objectId, 'values', this)]
     Object.defineProperty(obj, '_objectId', {value: objectId})

--- a/src/op_set.js
+++ b/src/op_set.js
@@ -502,6 +502,6 @@ function listIterator(opSet, listId, mode, context) {
 
 module.exports = {
   init, addLocalOp, addChange, materialize, getMissingChanges,
-  getFieldOps, getObjectFields, getObjectField, getObjectConflicts,
+  getObjectFields, getObjectField, getObjectConflicts,
   getNext, listElemByIndex, listLength, listIterator
 }

--- a/src/proxies.js
+++ b/src/proxies.js
@@ -214,10 +214,12 @@ function listProxy(context, objectId) {
 }
 
 function instantiateProxy(opSet, objectId) {
-  switch (opSet.getIn(['byObject', objectId, '_init', 'action'])) {
-    case 'makeMap':  return mapProxy(this, objectId)
-    case 'makeList': return listProxy(this, objectId)
-  }
+  const objectType = opSet.getIn(['byObject', objectId, '_init', 'action'])
+  if (objectType === 'makeMap') {
+    return mapProxy(this, objectId)
+  } else if (objectType === 'makeList' || objectType === 'makeText') {
+    return listProxy(this, objectId)
+  } else throw 'Unknown object type: ' + objectType
 }
 
 function rootObjectProxy(context) {

--- a/src/text.js
+++ b/src/text.js
@@ -1,0 +1,51 @@
+const { SkipList } = require('./skip_list')
+
+class Text {
+  constructor (opSet, objectId) {
+    return makeInstance(opSet, objectId)
+  }
+
+  get elemIds () {
+    if (this.opSet && this.objectId) {
+      return this.opSet.getIn(['byObject', this.objectId, '_elemIds'])
+    } else {
+      return new SkipList()
+    }
+  }
+
+  get length () {
+    return this.elemIds.length
+  }
+
+  get (index) {
+    const key = this.elemIds.keyOf(index)
+    if (key) return this.elemIds.getValue(key)
+  }
+
+  get _objectId () {
+    return this.objectId
+  }
+
+  [Symbol.iterator] () {
+    return this.elemIds.iterator('values')
+  }
+}
+
+// Read-only methods that can delegate to the JavaScript built-in array
+for (let method of ['concat', 'every', 'filter', 'find', 'findIndex', 'forEach', 'includes',
+                    'indexOf', 'join', 'lastIndexOf', 'map', 'reduce', 'reduceRight',
+                    'slice', 'some', 'toLocaleString', 'toString']) {
+  Text.prototype[method] = function (...args) {
+    const array = [...this.elemIds.iterator('values')]
+    return array[method].call(array, ...args)
+  }
+}
+
+function makeInstance(opSet, objectId) {
+  const instance = Object.create(Text.prototype)
+  instance.opSet = opSet
+  instance.objectId = objectId
+  return Object.freeze(instance)
+}
+
+module.exports = {Text}

--- a/test/test.js
+++ b/test/test.js
@@ -677,15 +677,6 @@ describe('Automerge', () => {
                         birds: ['oystercatcher', 'mallard']}])
     })
 
-    it('should reuse unmodified portions of past documents', () => {
-      let s = Automerge.init()
-      s = Automerge.change(s, doc => doc.config = {background: 'blue'})
-      s = Automerge.change(s, doc => doc.birds = ['mallard'])
-      s = Automerge.change(s, doc => doc.birds.unshift('oystercatcher'))
-      assert.strictEqual(Automerge.getHistory(s)[1].snapshot.config, Automerge.getHistory(s)[0].snapshot.config)
-      assert.strictEqual(Automerge.getHistory(s)[2].snapshot.config, Automerge.getHistory(s)[0].snapshot.config)
-    })
-
     it('should make change messages accessible', () => {
       let s = Automerge.init()
       s = Automerge.change(s, 'Empty Bookshelf', doc => doc.books = [])
@@ -716,11 +707,11 @@ describe('Automerge', () => {
       let s2 = Automerge.change(s1, doc => doc.birds.push('Robin'))
       let s3 = Automerge.change(s2, doc => doc.birds.push('Wagtail'))
       assert.deepEqual(Automerge.diff(s1, s2), [
-        {objectId: s1.birds._objectId, action: 'insert', index: 0, value: 'Robin'}
+        {obj: s1.birds._objectId, type: 'list', action: 'insert', index: 0, value: 'Robin'}
       ])
       assert.deepEqual(Automerge.diff(s1, s3), [
-        {objectId: s1.birds._objectId, action: 'insert', index: 0, value: 'Robin'},
-        {objectId: s1.birds._objectId, action: 'insert', index: 1, value: 'Wagtail'}
+        {obj: s1.birds._objectId, type: 'list', action: 'insert', index: 0, value: 'Robin'},
+        {obj: s1.birds._objectId, type: 'list', action: 'insert', index: 1, value: 'Wagtail'}
       ])
     })
 
@@ -728,8 +719,8 @@ describe('Automerge', () => {
       let s1 = Automerge.change(Automerge.init(), doc => doc.birds = ['Robin', 'Wagtail'])
       let s2 = Automerge.change(s1, doc => { doc.birds[1] = 'Pied Wagtail'; doc.birds.shift() })
       assert.deepEqual(Automerge.diff(s1, s2), [
-        {objectId: s1.birds._objectId, action: 'set',    index: 1, value: 'Pied Wagtail'},
-        {objectId: s1.birds._objectId, action: 'remove', index: 0}
+        {obj: s1.birds._objectId, type: 'list', action: 'set',    index: 1, value: 'Pied Wagtail'},
+        {obj: s1.birds._objectId, type: 'list', action: 'remove', index: 0}
       ])
     })
 
@@ -738,11 +729,11 @@ describe('Automerge', () => {
       let s2 = Automerge.change(s1, doc => doc.birds = [{name: 'Chaffinch'}])
       let rootId = '00000000-0000-0000-0000-000000000000'
       assert.deepEqual(Automerge.diff(s1, s2), [
-        {action: 'createObj', objectId: s2.birds._objectId,    value: []},
-        {action: 'createObj', objectId: s2.birds[0]._objectId, value: {}},
-        {action: 'set',       objectId: s2.birds[0]._objectId, key: 'name',  value: 'Chaffinch'},
-        {action: 'insert',    objectId: s2.birds._objectId,    index: 0,     value: s2.birds[0]._objectId, link: true},
-        {action: 'set',       objectId: rootId,                key: 'birds', value: s2.birds._objectId,    link: true}
+        {action: 'create', type: 'list', obj: s2.birds._objectId},
+        {action: 'create', type: 'map',  obj: s2.birds[0]._objectId},
+        {action: 'set',    type: 'map',  obj: s2.birds[0]._objectId, key: 'name',  value: 'Chaffinch'},
+        {action: 'insert', type: 'list', obj: s2.birds._objectId,    index: 0,     value: s2.birds[0]._objectId, link: true},
+        {action: 'set',    type: 'map',  obj: rootId,                key: 'birds', value: s2.birds._objectId,    link: true}
       ])
     })
   })

--- a/test/text_test.js
+++ b/test/text_test.js
@@ -1,0 +1,33 @@
+const assert = require('assert')
+const Automerge = require('../src/automerge')
+const { equalsOneOf } = require('./helpers')
+
+describe('Automerge.Text', () => {
+  let s1, s2
+  beforeEach(() => {
+    s1 = Automerge.change(Automerge.init(), doc => doc.text = new Automerge.Text())
+    s2 = Automerge.merge(Automerge.init(), s1)
+  })
+
+  it('should support insertion', () => {
+    s1 = Automerge.change(s1, doc => doc.text.insertAt(0, 'a'))
+    assert.strictEqual(s1.text.length, 1)
+    assert.strictEqual(s1.text.get(0), 'a')
+  })
+
+  it('should support deletion', () => {
+    s1 = Automerge.change(s1, doc => doc.text.insertAt(0, 'a', 'b', 'c'))
+    s1 = Automerge.change(s1, doc => doc.text.deleteAt(1, 1))
+    assert.strictEqual(s1.text.length, 2)
+    assert.strictEqual(s1.text.get(0), 'a')
+    assert.strictEqual(s1.text.get(1), 'c')
+  })
+
+  it('should handle concurrent insertion', () => {
+    s1 = Automerge.change(s1, doc => doc.text.insertAt(0, 'a', 'b', 'c'))
+    s2 = Automerge.change(s2, doc => doc.text.insertAt(0, 'x', 'y', 'z'))
+    s1 = Automerge.merge(s1, s2)
+    assert.strictEqual(s1.text.length, 6)
+    equalsOneOf(s1.text.join(''), 'abcxyz', 'xyzabc')
+  })
+})


### PR DESCRIPTION
This is the continuation of #40, improving the performance of text editing (a long list of characters). Before this PR, the slowest part of text editing was the shallow clone of the JS array holding the text that was required on every change (in order to keep it immutable). In this PR, I introduce a new datatype `Automerge.Text`, based on the skip list introduced in #40, which does not need to be cloned in order to be updated.

On a 10,000-operation text editing benchmark, the runtime is reduced to about 10 seconds, which is 7x better than the 73-second runtime before #40. The CPU time per operation is about 1 ms, which should be good enough for most practical purposes. At this point half the time is being spent in GC, and there are no obvious remaining bottlenecks in the code, so any future performance gains will probably have to come from being more careful with heap allocation.

Part of this PR is a significant refactoring that separates the cache maintenance of materialised JS objects from the CRDT internals. The OpSet now doesn't perform any cache maintenance, but instead returns a list of edits that need to be applied to cached objects. The FreezeAPI module applies these edits to the frozen (immutable) JavaScript objects that are returned to the application. This refactoring should also make it easier to support alternative APIs, e.g. an Immutable.js-based API, as suggested on Slack.

The API of `Automerge.Text` is very minimal right now. In the future we'll probably want to expand it to support access patterns that are needed in text editing (e.g. line-based access rather than character-based access; splitting strings into characters). But I want to understand the APIs of existing JS text editors first, and explore how best to integrate with them.