### PR TITLE
feat(signing): Add support for signing each change.

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -677,6 +677,17 @@ describe('Automerge', () => {
                         birds: ['oystercatcher', 'mallard']}])
     })
 
+    it('should support signing', () => {
+      let s = Automerge.init()
+      let sign = () => 'test-signing'
+      s = Automerge.change(s, doc => doc.config = {background: 'blue'}, sign)
+      s = Automerge.change(s, doc => doc.birds = ['mallard'], sign)
+      s = Automerge.change(s, doc => doc.birds.unshift('oystercatcher'), sign)
+      assert.deepEqual(
+        Automerge.getHistory(s).map(state => state.change.signature),
+        ['test-signing', 'test-signing', 'test-signing'])
+    })
+
     it('should reuse unmodified portions of past documents', () => {
       let s = Automerge.init()
       s = Automerge.change(s, doc => doc.config = {background: 'blue'})


### PR DESCRIPTION
In p2p and offline systems it's often necessary to sign each change so that the "actor" noted in the
change can be validated at any time by any participant. Rather than add a bunch of crypto and strong
opinions about *how* to sign I added support for an additional function in the change method that
can be used to return a signature for any change object. This will allow people to implement their
own signing and validation methods without any additional features in automerge.