### PR TITLE
New API to get missing causal dependencies

### DIFF
--- a/src/automerge.js
+++ b/src/automerge.js
@@ -279,9 +279,14 @@ function applyChanges(doc, changes) {
   return FreezeAPI.applyChanges(doc, fromJS(changes), true)
 }
 
+function getMissingDeps(doc) {
+  checkTarget('getMissingDeps', doc)
+  return OpSet.getMissingDeps(doc._state.get('opSet'))
+}
+
 module.exports = {
   init, change, merge, diff, assign, load, save, equals, inspect, getHistory,
-  getChanges, applyChanges, Text,
+  getChanges, applyChanges, getMissingDeps, Text,
   DocSet: require('./doc_set'),
   Connection: require('./connection')
 }

--- a/src/op_set.js
+++ b/src/op_set.js
@@ -278,6 +278,19 @@ function getMissingChanges(opSet, haveDeps) {
     .map(state => state.get('change'))
 }
 
+function getMissingDeps(opSet) {
+  let missing = {}
+  for (let change of opSet.get('queue')) {
+    const deps = change.get('deps').set(change.get('actor'), change.get('seq') - 1)
+    deps.forEach((depSeq, depActor) => {
+      if (opSet.getIn(['clock', depActor], 0) < depSeq) {
+        missing[depActor] = Math.max(depSeq, missing[depActor] || 0)
+      }
+    })
+  }
+  return missing
+}
+
 function getFieldOps(opSet, objectId, key) {
   return opSet.getIn(['byObject', objectId, key], List())
 }
@@ -423,7 +436,7 @@ function listIterator(opSet, listId, mode, context) {
 }
 
 module.exports = {
-  init, addLocalOp, addChange, getMissingChanges,
+  init, addLocalOp, addChange, getMissingChanges, getMissingDeps,
   getObjectFields, getObjectField, getObjectConflicts,
   listElemByIndex, listLength, listIterator, ROOT_ID
 }

--- a/test/test.js
+++ b/test/test.js
@@ -815,5 +815,18 @@ describe('Automerge', () => {
       assert.deepEqual(s3.birds, ['Chaffinch'])
       assert.deepEqual(s4.birds, ['Chaffinch', 'Bullfinch'])
     })
+
+    it('should report missing dependencies', () => {
+      let s1 = Automerge.change(Automerge.init(), doc => doc.birds = ['Chaffinch'])
+      let s2 = Automerge.merge(Automerge.init(), s1)
+      s2 = Automerge.change(s2, doc => doc.birds.push('Bullfinch'))
+      let changes = Automerge.getChanges(Automerge.init(), s2)
+      let s3 = Automerge.applyChanges(Automerge.init(), [changes[1]])
+      assert.deepEqual(s3, {_objectId: '00000000-0000-0000-0000-000000000000'})
+      assert.deepEqual(Automerge.getMissingDeps(s3), {[s1._actorId]: 1})
+      s3 = Automerge.applyChanges(s3, [changes[0]])
+      assert.deepEqual(s3.birds, ['Chaffinch', 'Bullfinch'])
+      assert.deepEqual(Automerge.getMissingDeps(s3), {})
+    })
   })
 })


### PR DESCRIPTION
In some network protocols, changes are stored by actor ID. In this context, it's useful to be able to apply a change whose dependencies are not yet satisfied, and then query Automerge for the missing actor IDs and sequence numbers, so that they can be loaded and applied as well. This patch adds an API to do that: `Automerge.getMissingDeps(doc)` returns an object of actorId => seqNum.