### PR TITLE
splice in a change callback returns an array of deleted elements

### DIFF
--- a/src/proxies.js
+++ b/src/proxies.js
@@ -59,7 +59,12 @@ function listMethods(context, listId) {
       if (deleteCount === undefined) {
         deleteCount = OpSet.listLength(context.state.get('opSet'), listId) - start
       }
+      const deleted = []
+      for (let n = 0; n < deleteCount; n++) {
+        deleted.push(OpSet.listElemByIndex(context.state.get('opSet'), listId, start + n, context))
+      }
       context.state = context.splice(context.state, listId, start, deleteCount, values)
+      return deleted
     },
 
     unshift(...values) {

--- a/test/proxies_test.js
+++ b/test/proxies_test.js
@@ -413,11 +413,11 @@ describe('Automerge proxy API', () => {
       })
 
       it('splice()', () => {
-        root = Automerge.change(root, doc => doc.list.splice(1))
+        root = Automerge.change(root, doc => assert.deepEqual(doc.list.splice(1), [2, 3]))
         assert.deepEqual(root.list, [1])
-        root = Automerge.change(root, doc => doc.list.splice(0, 0, 'a', 'b', 'c'))
+        root = Automerge.change(root, doc => assert.deepEqual(doc.list.splice(0, 0, 'a', 'b', 'c'), []))
         assert.deepEqual(root.list, ['a', 'b', 'c', 1])
-        root = Automerge.change(root, doc => doc.list.splice(1, 2, '-->'))
+        root = Automerge.change(root, doc => assert.deepEqual(doc.list.splice(1, 2, '-->'), ['b', 'c']))
         assert.deepEqual(root.list, ['a', '-->', 1])
       })
 


### PR DESCRIPTION
This makes the proxy API behave like `Array#splice`