### PR TITLE
Immutable api

### DIFF
--- a/src/auto_api.js
+++ b/src/auto_api.js
@@ -1,0 +1,71 @@
+const { List, fromJS } = require('immutable')
+const OpSet = require('./op_set')
+const FreezeAPI = require('./freeze_api')
+const ImmutableAPI = require('./immutable_api')
+
+function isObject(obj) {
+  return typeof obj === 'object' && obj !== null
+}
+
+// TODO when we move to Immutable.js 4.0.0, this function is provided by Immutable.js itself
+function isImmutable(obj) {
+  return isObject(obj) && !!obj['@@__IMMUTABLE_ITERABLE__@@']
+}
+
+function checkTarget(funcName, target, needMutable) {
+  if (!target || !target._state || !target._objectId ||
+      !target._state.hasIn(['opSet', 'byObject', target._objectId])) {
+    throw new TypeError('The first argument to Automerge.' + funcName +
+                        ' must be the object to modify, but you passed ' + JSON.stringify(target))
+  }
+  if (needMutable && (!target._change || !target._change.mutable)) {
+    throw new TypeError('Automerge.' + funcName + ' requires a writable object as first argument, ' +
+                        'but the one you passed is read-only. Please use Automerge.change() ' +
+                        'to get a writable version.')
+  }
+}
+
+function makeChange(root, newState, message) {
+  const actor = root._state.get('actorId')
+  const seq = root._state.getIn(['opSet', 'clock', actor], 0) + 1
+  const deps = root._state.getIn(['opSet', 'deps']).remove(actor)
+  const change = fromJS({actor, seq, deps, message})
+    .set('ops', newState.getIn(['opSet', 'local']))
+
+  if (isImmutable(root)) {
+    return ImmutableAPI.applyChanges(root, List.of(change), true)
+  } else {
+    return FreezeAPI.applyChanges(root, List.of(change), true)
+  }
+}
+
+function applyChanges(doc, changes) {
+  checkTarget('applyChanges', doc)
+  if (isImmutable(doc)) {
+    return ImmutableAPI.applyChanges(doc, fromJS(changes), true)
+  } else {
+    return FreezeAPI.applyChanges(doc, fromJS(changes), true)
+  }
+}
+
+function merge(local, remote) {
+  checkTarget('merge', local)
+  if (local._state.get('actorId') === remote._state.get('actorId')) {
+    throw new RangeError('Cannot merge an actor with itself')
+  }
+
+  const clock = local._state.getIn(['opSet', 'clock'])
+  const changes = OpSet.getMissingChanges(remote._state.get('opSet'), clock)
+  if (isImmutable(local)) {
+    return ImmutableAPI.applyChanges(local, changes, true)
+  } else {
+    return FreezeAPI.applyChanges(local, changes, true)
+  }
+}
+
+module.exports = {
+  checkTarget, isObject, isImmutable,
+  makeChange,
+  applyChanges,
+  merge,
+}

--- a/src/automerge.js
+++ b/src/automerge.js
@@ -3,11 +3,17 @@ const uuid = require('uuid/v4')
 const { rootObjectProxy } = require('./proxies')
 const OpSet = require('./op_set')
 const FreezeAPI = require('./freeze_api')
+const ImmutableAPI = require('./immutable_api')
 const { Text } = require('./text')
 const transit = require('transit-immutable-js')
 
 function isObject(obj) {
   return typeof obj === 'object' && obj !== null
+}
+
+// TODO when we move to Immutable.js 4.0.0, this function is provided by Immutable.js itself
+function isImmutable(obj) {
+  return isObject(obj) && !!obj['@@__IMMUTABLE_ITERABLE__@@']
 }
 
 function makeOp(state, opProps) {
@@ -118,13 +124,22 @@ function makeChange(root, newState, message) {
   const deps = root._state.getIn(['opSet', 'deps']).remove(actor)
   const change = fromJS({actor, seq, deps, message})
     .set('ops', newState.getIn(['opSet', 'local']))
-  return FreezeAPI.applyChanges(root, List.of(change), true)
+
+  if (isImmutable(root)) {
+    return ImmutableAPI.applyChanges(root, List.of(change), true)
+  } else {
+    return FreezeAPI.applyChanges(root, List.of(change), true)
+  }
 }
 
 ///// Automerge.* API
 
 function init(actorId) {
   return FreezeAPI.init(actorId || uuid())
+}
+
+function initImmutable(actorId) {
+  return ImmutableAPI.init(actorId || uuid())
 }
 
 function checkTarget(funcName, target, needMutable) {
@@ -185,6 +200,10 @@ function load(string, actorId) {
   return FreezeAPI.applyChanges(FreezeAPI.init(actorId), transit.fromJSON(string), false)
 }
 
+function loadImmutable(string, actorId) {
+  return ImmutableAPI.applyChanges(ImmutableAPI.init(actorId), transit.fromJSON(string), false)
+}
+
 function save(doc) {
   checkTarget('save', doc)
   return transit.toJSON(doc._state.getIn(['opSet', 'history']))
@@ -230,7 +249,11 @@ function merge(local, remote) {
 
   const clock = local._state.getIn(['opSet', 'clock'])
   const changes = OpSet.getMissingChanges(remote._state.get('opSet'), clock)
-  return FreezeAPI.applyChanges(local, changes, true)
+  if (isImmutable(local)) {
+    return ImmutableAPI.applyChanges(local, changes, true)
+  } else {
+    return FreezeAPI.applyChanges(local, changes, true)
+  }
 }
 
 // Returns true if all components of clock1 are less than or equal to those of clock2.
@@ -284,7 +307,11 @@ function getChangesForActor(state, actorId) {
 
 function applyChanges(doc, changes) {
   checkTarget('applyChanges', doc)
-  return FreezeAPI.applyChanges(doc, fromJS(changes), true)
+  if (isImmutable(doc)) {
+    return ImmutableAPI.applyChanges(doc, fromJS(changes), true)
+  } else {
+    return FreezeAPI.applyChanges(doc, fromJS(changes), true)
+  }
 }
 
 function getMissingDeps(doc) {
@@ -294,6 +321,7 @@ function getMissingDeps(doc) {
 
 module.exports = {
   init, change, merge, diff, assign, load, save, equals, inspect, getHistory,
+  initImmutable, loadImmutable,
   getChanges, getChangesForActor, applyChanges, getMissingDeps, Text,
   DocSet: require('./doc_set'),
   WatchableDoc: require('./watchable_doc'),

--- a/src/automerge.js
+++ b/src/automerge.js
@@ -235,6 +235,23 @@ function diff(oldState, newState) {
   return diffs
 }
 
+function getConflicts(doc, list) {
+  checkTarget('getConflicts', doc)
+  const opSet = doc._state.get('opSet')
+  const objectId = list._objectId
+  if (!objectId || opSet.getIn(['byObject', objectId, '_init', 'action']) !== 'makeList') {
+    throw new TypeError('The second argument to Automerge.getConflicts must be a list object')
+  }
+
+  const context = {
+    cache: {},
+    instantiateObject (opSet, objectId) {
+      return opSet.getIn(['cache', objectId])
+    }
+  }
+  return List(OpSet.listIterator(opSet, objectId, 'conflicts', context))
+}
+
 function getChanges(oldState, newState) {
   checkTarget('getChanges', oldState)
 
@@ -262,7 +279,7 @@ function getMissingDeps(doc) {
 
 module.exports = {
   init, change, merge, diff, assign, load, save, equals, inspect, getHistory,
-  initImmutable, loadImmutable,
+  initImmutable, loadImmutable, getConflicts,
   getChanges, getChangesForActor, applyChanges, getMissingDeps, Text,
   DocSet: require('./doc_set'),
   WatchableDoc: require('./watchable_doc'),

--- a/src/immutable_api.js
+++ b/src/immutable_api.js
@@ -1,0 +1,169 @@
+const { Map, List, Set } = require('immutable')
+const OpSet = require('./op_set')
+const { Text } = require('./text')
+
+function instantiateImmutable(opSet, objectId) {
+  const isRoot = (objectId === OpSet.ROOT_ID)
+  const objType = opSet.getIn(['byObject', objectId, '_init', 'action'])
+
+  // Don't read the root object from cache, because it may reference an outdated state.
+  // The state may change without without invalidating the cache entry for the root object (for
+  // example, adding an item to the queue of operations that are not yet causally ready).
+  if (!isRoot) {
+    if (opSet.hasIn(['cache', objectId])) return opSet.getIn(['cache', objectId])
+    if (this.cache && this.cache[objectId]) return this.cache[objectId]
+  }
+
+  let obj
+  if (isRoot || objType === 'makeMap') {
+    const conflicts = OpSet.getObjectConflicts(opSet, objectId, this)
+    obj = Map().set('_conflicts', conflicts)
+
+    for (let field of OpSet.getObjectFields(opSet, objectId)) {
+      obj = obj.set(field, OpSet.getObjectField(opSet, objectId, field, this))
+    }
+  } else if (objType === 'makeList') {
+    obj = List(OpSet.listIterator(opSet, objectId, 'values', this))
+  } else if (objType === 'makeText') {
+    obj = new Text(opSet, objectId)
+  } else {
+    throw 'Unknown object type: ' + objType
+  }
+
+  obj._objectId = objectId
+  if (this.cache) this.cache[objectId] = obj
+  return obj
+}
+
+function materialize(opSet) {
+  opSet = opSet.set('cache', Map())
+  const context = {instantiateObject: instantiateImmutable, cache: {}}
+  const rootObj = context.instantiateObject(opSet, OpSet.ROOT_ID)
+  return [opSet.set('cache', Map(context.cache)), rootObj]
+}
+
+function refresh(opSet, objectId) {
+  opSet = opSet.deleteIn(['cache', objectId])
+  const context = {instantiateObject: instantiateImmutable, cache: {}}
+  const object = context.instantiateObject(opSet, objectId)
+  return opSet.setIn(['cache', objectId], object)
+}
+
+function updateMapObject(opSet, edit) {
+  if (edit.action === 'create') {
+    const object = Map({_objectId: edit.obj})
+    object._objectId = edit.obj
+    return opSet.setIn(['cache', edit.obj], object)
+  }
+
+  let object = opSet.getIn(['cache', edit.obj])
+  if (edit.action === 'set') {
+    let conflicts = null
+    if (edit.conflicts) {
+      conflicts = Map().withMutations(conflicts => {
+        for (let conflict of edit.conflicts) {
+          const value = conflict.link ? opSet.getIn(['cache', conflict.value]) : conflict.value
+          conflicts.set(conflict.actor, value)
+        }
+      })
+    }
+
+    object = object.withMutations(obj => {
+      obj.set(edit.key, edit.link ? opSet.getIn(['cache', edit.value]) : edit.value)
+      if (conflicts) {
+        obj.setIn(['_conflicts', edit.key], conflicts)
+      } else {
+        obj.deleteIn(['_conflicts', edit.key])
+      }
+    })
+  } else if (edit.action === 'remove') {
+    object = object.withMutations(obj => {
+      obj.delete(edit.key)
+      obj.deleteIn(['_conflicts', edit.key])
+    })
+  } else throw 'Unknown action type: ' + edit.action
+
+  object._objectId = edit.obj
+  return opSet.setIn(['cache', edit.obj], object)
+}
+
+function updateListObject(opSet, edit) {
+  if (edit.action === 'create') {
+    const list = List()
+    list._objectId = edit.obj
+    return opSet.setIn(['cache', edit.obj], list)
+  }
+
+  const value = edit.link ? opSet.getIn(['cache', edit.value]) : edit.value
+  let list = opSet.getIn(['cache', edit.obj])
+
+  if (edit.action === 'insert') {
+    list = list.insert(edit.index, value)
+  } else if (edit.action === 'set') {
+    list = list.set(edit.index, value)
+  } else if (edit.action === 'remove') {
+    list = list.delete(edit.index)
+  } else throw 'Unknown action type: ' + edit.action
+
+  list._objectId = edit.obj
+  return opSet.setIn(['cache', edit.obj], list)
+}
+
+function updateCache(opSet, diffs) {
+  let affected = Set()
+  for (let edit of diffs) {
+    affected = affected.add(edit.obj)
+    if (edit.type === 'map') {
+      opSet = updateMapObject(opSet, edit)
+    } else if (edit.type === 'list') {
+      opSet = updateListObject(opSet, edit)
+    } else if (edit.type === 'text') {
+      opSet = opSet.setIn(['cache', edit.obj], new Text(opSet, edit.obj))
+    } else throw 'Unknown object type: ' + edit.type
+  }
+
+  // Update cache entries on the path from the root to the modified object
+  while (!affected.isEmpty()) {
+    affected = affected.flatMap(objectId => {
+      return opSet
+        .getIn(['byObject', objectId, '_inbound'], Set())
+        .map(op => op.get('obj'))
+    })
+    for (let objectId of affected) opSet = refresh(opSet, objectId)
+  }
+  return opSet
+}
+
+function init(actorId) {
+  const [opSet, rootObj] = materialize(OpSet.init())
+  rootObj._state = Map({actorId, opSet})
+  rootObj._actorId = actorId
+  return rootObj
+}
+
+function applyChanges(root, changes, incremental) {
+  let opSet = root._state.get('opSet'), diffs = [], diff
+  for (let change of changes) {
+    [opSet, diff] = OpSet.addChange(opSet, change)
+    diffs.push(...diff)
+  }
+
+  let newRoot
+  if (incremental) {
+    opSet = updateCache(opSet, diffs)
+    newRoot = opSet.getIn(['cache', OpSet.ROOT_ID])
+    if (newRoot === root) {
+      // Ugly hack to get a clone of the root object (since we mutably assign _state below)
+      newRoot = root.set('_ignore', true).remove('_ignore')
+    }
+  } else {
+    [opSet, newRoot] = materialize(opSet)
+  }
+  newRoot._state = root._state.set('opSet', opSet)
+  newRoot._actorId = root._state.get('actorId')
+  return newRoot
+}
+
+module.exports = {
+  init, applyChanges
+}

--- a/src/immutable_api.js
+++ b/src/immutable_api.js
@@ -161,6 +161,7 @@ function applyChanges(root, changes, incremental) {
   }
   newRoot._state = root._state.set('opSet', opSet)
   newRoot._actorId = root._state.get('actorId')
+  newRoot._objectId = root._objectId
   return newRoot
 }
 

--- a/src/watchable_doc.js
+++ b/src/watchable_doc.js
@@ -1,9 +1,9 @@
 const { Map, Set, fromJS } = require('immutable')
-const uuid = require('uuid/v4')
-const ImmutableAPI = require('./immutable_api')
+const AutoAPI = require('./auto_api')
 
 class WatchableDoc {
   constructor (doc) {
+    if (!doc) throw new Error("doc argument is required")
     this.doc = doc
     this.handlers = Set()
   }
@@ -18,8 +18,8 @@ class WatchableDoc {
   }
 
   applyChanges (changes) {
-    let doc = this.doc || ImmutableAPI.init(uuid())
-    doc = ImmutableAPI.applyChanges(doc, fromJS(changes), true)
+    let doc = this.doc
+    doc = AutoAPI.applyChanges(doc, fromJS(changes), true)
     this.set(doc)
     return doc
   }

--- a/src/watchable_doc.js
+++ b/src/watchable_doc.js
@@ -1,6 +1,6 @@
 const { Map, Set, fromJS } = require('immutable')
 const uuid = require('uuid/v4')
-const FreezeAPI = require('./freeze_api')
+const ImmutableAPI = require('./immutable_api')
 
 class WatchableDoc {
   constructor (doc) {
@@ -18,8 +18,8 @@ class WatchableDoc {
   }
 
   applyChanges (changes) {
-    let doc = this.doc || FreezeAPI.init(uuid())
-    doc = FreezeAPI.applyChanges(doc, fromJS(changes), true)
+    let doc = this.doc || ImmutableAPI.init(uuid())
+    doc = ImmutableAPI.applyChanges(doc, fromJS(changes), true)
     this.set(doc)
     return doc
   }

--- a/test/immutable_test.js
+++ b/test/immutable_test.js
@@ -1,0 +1,26 @@
+const assert = require('assert')
+const sinon = require('sinon')
+const Immutable = require('immutable')
+const Automerge = require('../src/Automerge')
+
+describe('Automerge.initImmutable()', () => {
+  let beforeDoc, afterDoc, appliedDoc, changes
+
+  beforeEach(() => {
+    beforeDoc = Automerge.change(Automerge.initImmutable(), doc => doc.document = 'watch me now')
+    afterDoc = Automerge.change(beforeDoc, doc => doc.document = 'i can mash potato')
+    changes = Automerge.getChanges(beforeDoc, afterDoc)
+    appliedDoc = Automerge.applyChanges(beforeDoc, changes)
+  })
+
+  it('Uses Immutable.Map', () => {
+    assert(beforeDoc instanceof Immutable.Map)
+    assert(afterDoc instanceof Immutable.Map)
+    assert(appliedDoc instanceof Immutable.Map)
+  })
+
+  it('applies changes', () => {
+    assert.equal(Automerge.save(appliedDoc), Automerge.save(afterDoc))
+  })
+
+})

--- a/test/immutable_test.js
+++ b/test/immutable_test.js
@@ -26,4 +26,20 @@ describe('Automerge.initImmutable()', () => {
     assert.equal(Automerge.save(appliedDoc2), Automerge.save(afterDoc))
   })
 
+  it('supports fetching conflicts on lists', () => {
+    let s1 = Automerge.change(Automerge.initImmutable(), doc => doc.pixels = ['red'])
+    let s2 = Automerge.merge(Automerge.initImmutable(), s1)
+    s1 = Automerge.change(s1, doc => doc.pixels[0] = 'green')
+    s2 = Automerge.change(s2, doc => doc.pixels[0] = 'blue')
+    s1 = Automerge.merge(s1, s2)
+    if (s1._actorId > s2._actorId) {
+      assert(s1.get('pixels').equals(Immutable.List.of('green')))
+      assert(Automerge.getConflicts(s1, s1.get('pixels')).equals(
+        Immutable.List.of(Immutable.Map().set(s2._actorId, 'blue'))))
+    } else {
+      assert(s1.get('pixels').equals(Immutable.List.of('blue')))
+      assert(Automerge.getConflicts(s1, s1.get('pixels')).equals(
+        Immutable.List.of(Immutable.Map().set(s1._actorId, 'green'))))
+    }
+  })
 })

--- a/test/immutable_test.js
+++ b/test/immutable_test.js
@@ -4,23 +4,26 @@ const Immutable = require('immutable')
 const Automerge = require('../src/Automerge')
 
 describe('Automerge.initImmutable()', () => {
-  let beforeDoc, afterDoc, appliedDoc, changes
+  let beforeDoc, afterDoc, appliedDoc, appliedDoc2, changes
 
   beforeEach(() => {
     beforeDoc = Automerge.change(Automerge.initImmutable(), doc => doc.document = 'watch me now')
     afterDoc = Automerge.change(beforeDoc, doc => doc.document = 'i can mash potato')
     changes = Automerge.getChanges(beforeDoc, afterDoc)
     appliedDoc = Automerge.applyChanges(beforeDoc, changes)
+    appliedDoc2 = Automerge.applyChanges(appliedDoc, changes)
   })
 
   it('Uses Immutable.Map', () => {
     assert(beforeDoc instanceof Immutable.Map)
     assert(afterDoc instanceof Immutable.Map)
     assert(appliedDoc instanceof Immutable.Map)
+    assert(appliedDoc2 instanceof Immutable.Map)
   })
 
   it('applies changes', () => {
     assert.equal(Automerge.save(appliedDoc), Automerge.save(afterDoc))
+    assert.equal(Automerge.save(appliedDoc2), Automerge.save(afterDoc))
   })
 
 })


### PR DESCRIPTION
Pull request to merge in the initial version of the Immutable.js-compatible API, as discussed in #47. The feature is not complete; in particular, the Immutable.js mutation methods are not yet supported, and the feature is not yet documented. However, some intrepid early adopters are using the API, so I'm merging it so that they can depend on a released version of Automerge.