### PR TITLE
Calling applyChanges twice with unresolved dependencies would throw

### DIFF
--- a/src/freeze_api.js
+++ b/src/freeze_api.js
@@ -246,6 +246,10 @@ function applyChanges(root, changes, incremental) {
   } else {
     [opSet, newRoot] = materialize(opSet)
   }
+  if (Object.isFrozen(Object.getPrototypeOf(newRoot))) {
+    const newPrototype = Object.assign({}, Object.getPrototypeOf(newRoot))
+    newRoot = Object.assign(Object.create(newPrototype), newRoot)
+  }
   return rootObject(root._state.set('opSet', opSet), newRoot)
 }
 

--- a/test/test.js
+++ b/test/test.js
@@ -847,5 +847,18 @@ describe('Automerge', () => {
       assert.deepEqual(s3.birds, ['Chaffinch', 'Bullfinch'])
       assert.deepEqual(Automerge.getMissingDeps(s3), {})
     })
+
+    it('should report missing dependencies with out-of-order applyChanges', () => {
+      let s0 = Automerge.init()
+      let s1 = Automerge.change(s0, doc => doc.test = ['a'])
+      let s2 = Automerge.change(s1, doc => doc.test = ['b'])
+      let s3 = Automerge.change(s2, doc => doc.test = ['c'])
+      let changes1to2 = Automerge.getChanges(s1, s2)
+      let changes2to3 = Automerge.getChanges(s2, s3)
+      let s4 = Automerge.init()
+      let s5 = Automerge.applyChanges(s4, changes2to3)
+      let s6 = Automerge.applyChanges(s5, changes1to2)
+      assert.deepEqual(Automerge.getMissingDeps(s6), {[s0._actorId]: 2})
+    })
   })
 })


### PR DESCRIPTION
Here is a test case, and a workaround.