### PR TITLE
generate actorId in Automerge.load when unspecified

### DIFF
--- a/src/automerge.js
+++ b/src/automerge.js
@@ -162,11 +162,11 @@ function assign(target, values) {
 }
 
 function load(string, actorId) {
-  return FreezeAPI.applyChanges(FreezeAPI.init(actorId), transit.fromJSON(string), false)
+  return FreezeAPI.applyChanges(FreezeAPI.init(actorId || uuid()), transit.fromJSON(string), false)
 }
 
 function loadImmutable(string, actorId) {
-  return ImmutableAPI.applyChanges(ImmutableAPI.init(actorId), transit.fromJSON(string), false)
+  return ImmutableAPI.applyChanges(ImmutableAPI.init(actorId || uuid()), transit.fromJSON(string), false)
 }
 
 function save(doc) {


### PR DESCRIPTION
While playing around with `Automerge.load`, I ran into the `actorId` being undefined when not specified explicitly (which is different from the `.init()` behavior). This branch should make the following true for `Automerge.load`/`Automerge.loadImmutable`:

> Each Automerge instance has an actor ID — a UUID that is generated randomly whenever you do Automerge.init() or Automerge.load() (unless you explicitly pass an actor ID into those functions).