### PR TITLE
Improved (published) package compatibility.

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,1 @@
+{"presets": ["env"]}

--- a/package.json
+++ b/package.json
@@ -2,21 +2,26 @@
   "name": "automerge",
   "version": "0.7.1",
   "description": "Data structures for building collaborative applications",
-  "main": "src/automerge.js",
+  "main": "dist/automerge.js",
   "scripts": {
     "browsertest": "karma start karma.conf.js",
     "test": "mocha",
-    "webpack": "webpack --config webpack.config.js"
+    "build": "webpack",
+    "prepublishOnly": "webpack"
   },
   "author": "",
   "license": "MIT",
   "dependencies": {
+    "babel-polyfill": "^6.26.0",
     "immutable": "^3.8.1",
     "transit-immutable-js": "^0.7.0",
     "transit-js": "^0.8.846",
     "uuid": "^3.1.0"
   },
   "devDependencies": {
+    "babel-core": "^6.26.0",
+    "babel-loader": "^7.1.4",
+    "babel-preset-env": "^1.6.1",
     "browserify": "^14.4.0",
     "jsverify": "^0.8.3",
     "karma": "^1.7.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,10 +1,17 @@
 var path = require('path');
 
 module.exports = {
-  entry: './src/automerge.js',
+  entry: ['babel-polyfill', './src/automerge.js'],
   output: {
     filename: 'automerge.js',
     library: 'Automerge',
+    libraryTarget: 'umd',
     path: path.resolve(__dirname, 'dist')
+  },
+  devtool: 'source-map',
+  module: {
+    rules: [
+      { test: /\.js$/, exclude: /node_modules/, loader: "babel-loader" }
+    ]
   }
 }


### PR DESCRIPTION
* Configured webpack to target `umd`, which covers Node (CommonJS), global browser
use (yuck), and use with ESM (`require`)
* Configured webpack to transcompile with Babel (using `env` preset),
making suitable for use with `create-react-app`, and to generally improve
compatibility
* Configured webpack to generate source map
* Modified scripts to be more standard ("build" instead of "webpack")
* Added `prepublishOnly` script to prevent forgetful publishing of stale build (note npm 5 has deprecated `prepublish` in favor of `prepublishOnly`)

Note that without these changes, Automerge will prevent the build script in `create-react-app` from working.  That is, the following will happen:

```
$ create-react-app demo
$ cd demo
$ yarn add automerge       # or npm i
$ # edit src/App.js to "import Automerge from 'automerge'" and use Automerge
$ yarn build

Creating an optimized production build...
Failed to compile.

Failed to minify the code from this file: 

    ./node_modules/automerge/src/op_set.js:1 
```
