### PR TITLE
Minor Babel tooling change.

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "babel-polyfill": "^6.26.0",
+    "idempotent-babel-polyfill": "^0.1.1",
     "immutable": "^3.8.2",
     "transit-immutable-js": "^0.7.0",
     "transit-js": "^0.8.861",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,7 +1,7 @@
 var path = require('path');
 
 module.exports = {
-  entry: ['babel-polyfill', './src/automerge.js'],
+  entry: ['idempotent-babel-polyfill', './src/automerge.js'],
   output: {
     filename: 'automerge.js',
     library: 'Automerge',


### PR DESCRIPTION
Switched from babel-polyfill to idempotent-babel-polyfill, a thin
wrapper that simply checks to see if there's a polyfill instance already
before adding it, preventing frustrating collisions when using two
packages which both depend on Automerge.