### PR TITLE
Replaced generators.

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "babel-polyfill": "^6.26.0",
     "immutable": "^3.8.2",
     "transit-immutable-js": "^0.7.0",
     "transit-js": "^0.8.861",

--- a/src/skip_list.js
+++ b/src/skip_list.js
@@ -4,12 +4,17 @@ const { Map } = require('immutable')
 // That is, returns k with probability p * (1 - p)^(k - 1).
 // For example, returns 1 with probability 3/4, returns 2 with probability 3/16,
 // returns 3 with probability 3/64, and so on.
-function* randomLevel() {
-  while (true) {
-    const rand = Math.floor(Math.random() * 4294967296)
-    let level = 1
-    while (rand < 1 << (32 - 2 * level) && level < 16) level += 1
-    yield level
+function randomLevel() {
+  // NOTE: this function used to be a generator; it has been converted to a regular
+  // function (that mimics the interface of a generator) to avoid having to include
+  // generator polyfills in the distribution build.
+  return {
+    next() {
+      const rand = Math.floor(Math.random() * 4294967296)
+      let level = 1
+      while (rand < 1 << (32 - 2 * level) && level < 16) level += 1
+      return { value: level, done: false }
+    }
   }
 }
 
@@ -298,16 +303,31 @@ class SkipList {
     return makeInstance(this.length, this._nodes.set(key, node), this._randomSource)
   }
 
-  *iterator (mode) {
+  iterator (mode) {
+    // NOTE: this method used to be a generator; it has been converted to a regular
+    // method (that mimics the interface of a generator) to avoid having to include
+    // generator polyfills in the distribution build.
     let key = this._nodes.get(null).nextKey[0]
-    while (key) {
-      const node = this._nodes.get(key)
-      switch (mode) {
-        case 'keys':    yield key; break;
-        case 'values':  yield node.value; break;
-        case 'entries': yield [key, node.value]; break;
-      }
-      key = node.nextKey[0]
+    return {
+      next: () => {
+        if(!key) return { value: undefined, done: true }
+        const node = this._nodes.get(key)
+        let rval = undefined
+        switch (mode) {
+          case 'keys':
+            rval = { value: key, done: false }
+            break
+          case 'values':
+            rval = { value: this._nodes.get(key).value, done: false }
+            break
+          case 'entries':
+            rval = { value: [key, node.value], done: false }
+            break
+        }
+        key = node.nextKey[0]
+        return rval
+      },
+      [Symbol.iterator]: () => this.iterator(mode),
     }
   }
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,7 +1,7 @@
 var path = require('path');
 
 module.exports = {
-  entry: ['babel-polyfill', './src/automerge.js'],
+  entry: './src/automerge.js',
   output: {
     filename: 'automerge.js',
     library: 'Automerge',


### PR DESCRIPTION
Refactored generators to regular functions to eliminate the necessity of
a generator polyfill, which causes a lot of unfortunate distribution
overhead (i.e. the use of Babel's transform-runtime, which I have been
unable to integrate successfuly).  It also reduces the size of the
generated bundle by ~260k (over the previous use of babel-polyfill,
which I have learned is a poor choice to use in libraries).