### PR TITLE
Improve performance of bulk assignments

### DIFF
--- a/src/op_set.js
+++ b/src/op_set.js
@@ -258,17 +258,8 @@ function init() {
 }
 
 function addLocalOp(opSet, op, actor) {
-  const objectId = op.get('obj'), action = op.get('action'), key = op.get('key')
-  let ops = opSet.get('local')
-
-  // Override any prior assignment operations for the same object and key
-  if (action === 'set' || action === 'del' || action === 'link') {
-    ops = ops.filter(prev =>
-      prev.get('obj') != objectId || prev.get('key') != key ||
-      (prev.get('action') !== 'set' && prev.get('action') !== 'del' && prev.get('action') !== 'link'))
-  }
-  ops = ops.push(op)
-  return applyOp(opSet.set('local', ops), op.set('actor', actor))
+  opSet = opSet.update('local', ops => ops.push(op))
+  return applyOp(opSet, op.set('actor', actor))
 }
 
 function addChange(opSet, change) {


### PR DESCRIPTION
This PR improves the performance of changes that affect a large number of elements (map keys or list elements) of a single object within a single change block. For example, assigning a 10,000-element list:

```js
let x = [];
for (let i = 0; i < 10000; i++) x.push(i);
let doc = Automerge.change(Automerge.init(), d => d.x = x)
```

Before this PR, the code above takes about 30 seconds to run; after this patch, it takes about 3 seconds. This improvement is by replacing two accidentally-quadratic algorithms with linear-time ones.