### PR TITLE
Support replacing UUID implementation

### DIFF
--- a/src/automerge.js
+++ b/src/automerge.js
@@ -1,5 +1,5 @@
 const { Map, List, fromJS } = require('immutable')
-const uuid = require('uuid/v4')
+const uuid = require('./uuid')
 const { rootObjectProxy } = require('./proxies')
 const OpSet = require('./op_set')
 const {isObject, checkTarget, makeChange, merge, applyChanges} = require('./auto_api')

--- a/src/automerge.js
+++ b/src/automerge.js
@@ -280,7 +280,7 @@ function getMissingDeps(doc) {
 module.exports = {
   init, change, merge, diff, assign, load, save, equals, inspect, getHistory,
   initImmutable, loadImmutable, getConflicts,
-  getChanges, getChangesForActor, applyChanges, getMissingDeps, Text,
+  getChanges, getChangesForActor, applyChanges, getMissingDeps, Text, uuid,
   DocSet: require('./doc_set'),
   WatchableDoc: require('./watchable_doc'),
   Connection: require('./connection')

--- a/src/doc_set.js
+++ b/src/doc_set.js
@@ -1,5 +1,5 @@
 const { Map, Set } = require('immutable')
-const uuid = require('uuid/v4')
+const uuid = require('./uuid')
 const FreezeAPI = require('./freeze_api')
 
 class DocSet {

--- a/src/uuid.js
+++ b/src/uuid.js
@@ -1,0 +1,12 @@
+const uuid = require('uuid/v4')
+
+let factory = uuid
+
+function makeUuid() {
+  return factory()
+}
+
+makeUuid.setFactory = newFactory => factory = newFactory
+makeUuid.reset = () => factory = uuid
+
+module.exports = makeUuid

--- a/test/test_uuid.js
+++ b/test/test_uuid.js
@@ -1,5 +1,5 @@
 const assert = require('assert')
-const uuid = process.env.TEST_DIST === '1' ? require('../dist/uuid') : require('../src/uuid')
+const uuid = require('../src/uuid')
 
 describe('uuid', () => {
   afterEach(() => {

--- a/test/test_uuid.js
+++ b/test/test_uuid.js
@@ -1,5 +1,7 @@
 const assert = require('assert')
-const uuid = require('../src/uuid')
+const Automerge = process.env.TEST_DIST === '1' ? require('../dist/automerge') : require('../src/automerge')
+
+const uuid = Automerge.uuid
 
 describe('uuid', () => {
   afterEach(() => {

--- a/test/test_uuid.js
+++ b/test/test_uuid.js
@@ -1,0 +1,32 @@
+const assert = require('assert')
+const uuid = process.env.TEST_DIST === '1' ? require('../dist/uuid') : require('../src/uuid')
+
+describe('uuid', () => {
+  afterEach(() => {
+    uuid.reset()
+  })
+
+  describe('default implementation', () => {
+    it('generates unique values', () => {
+      assert.notEqual(uuid(), uuid())
+    })
+  })
+
+  describe('custom implementation', () => {
+    let counter
+
+    function customUuid() {
+      console.log('customUuid called!');
+      return `custom-uuid-${counter++}`
+    }
+
+    before(() => uuid.setFactory(customUuid))
+    beforeEach(() => counter = 0)
+
+    it('invokes the custom factory', () => {
+      console.log('in test!');
+      assert.equal(uuid(), 'custom-uuid-0');
+      assert.equal(uuid(), 'custom-uuid-1');
+    })
+  })
+})


### PR DESCRIPTION
Provide a way for replacing the UUID implementation at runtime.
This is useful for writing repeatable tests, and for contexts
where an alternative source of unique IDs is prefferred.