### PR TITLE
Expose getter for specific objects

### DIFF
--- a/src/proxies.js
+++ b/src/proxies.js
@@ -102,6 +102,7 @@ const MapHandler = {
     if (key === '_actorId') return context.state.get('actorId')
     if (key === '_conflicts') return OpSet.getObjectConflicts(context.state.get('opSet'), objectId, context).toJS()
     if (key === '_change') return context
+    if (key === '_get') return context._get
     return OpSet.getObjectField(context.state.get('opSet'), objectId, key, context)
   },
 
@@ -219,7 +220,7 @@ function listProxy(context, objectId) {
 }
 
 function instantiateProxy(opSet, objectId) {
-  const objectType = opSet.getIn(['byObject', objectId, '_init', 'action'])
+  const objectType = OpSet.ROOT_ID === objectId ? 'makeMap' : opSet.getIn(['byObject', objectId, '_init', 'action'])
   if (objectType === 'makeMap') {
     return mapProxy(this, objectId)
   } else if (objectType === 'makeList' || objectType === 'makeText') {
@@ -229,7 +230,8 @@ function instantiateProxy(opSet, objectId) {
 
 function rootObjectProxy(context) {
   context.instantiateObject = instantiateProxy
-  return mapProxy(context, '00000000-0000-0000-0000-000000000000')
+  context._get = (objId) => instantiateProxy.call(context, context.state.get('opSet'), objId)
+  return mapProxy(context, OpSet.ROOT_ID)
 }
 
 module.exports = { rootObjectProxy }

--- a/test/proxies_test.js
+++ b/test/proxies_test.js
@@ -102,6 +102,28 @@ describe('Automerge proxy API', () => {
     })
   })
 
+  it('should allow access to an object by id', () => {
+    Automerge.change(Automerge.init(), doc => {
+      const rootObj = doc._get(ROOT_ID)
+      assert.strictEqual(rootObj._objectId, doc._objectId)
+
+      rootObj.deepObj = {}
+      const deepObjId = doc.deepObj._objectId
+      const deepObj = doc._get(deepObjId)
+      assert.strictEqual(deepObj._objectId, deepObjId)
+
+      deepObj.deepList = []
+      const deepListId = doc.deepObj.deepList._objectId
+      const deepList = doc._get(deepListId)
+      assert.strictEqual(deepList._objectId, deepListId)
+
+      deepList.insertAt(0, {})
+      const deepItemId = doc.deepObj.deepList[0]._objectId
+      const deepItem = doc._get(deepItemId)
+      assert.strictEqual(deepItem._objectId, deepItemId)
+    })
+  })
+
   describe('list object', () => {
     let root
     beforeEach(() => {


### PR DESCRIPTION
fix #106.
This is useful in cases where I know which object I'd like to mutate, but I'm not sure where that object lives in the tree.