### PR TITLE
Require that the change message must be a string

### DIFF
--- a/src/automerge.js
+++ b/src/automerge.js
@@ -140,6 +140,9 @@ function change(doc, message, callback) {
   if (typeof message === 'function' && callback === undefined) {
     [message, callback] = [callback, message]
   }
+  if (message !== undefined && typeof message !== 'string') {
+    throw new TypeError('Change message must be a string')
+  }
 
   const context = {state: doc._state, mutable: true, setField, splice, setListIndex, deleteField}
   callback(rootObjectProxy(context))

--- a/test/test.js
+++ b/test/test.js
@@ -102,6 +102,12 @@ describe('Automerge', () => {
         }, /Calls to Automerge.change cannot be nested/)
       })
 
+      it('should not allow objects as change message', () => {
+        assert.throws(() => {
+          Automerge.change(s1, {key: 'value'}, doc => doc.foo = 'bar')
+        }, /Change message must be a string/)
+      })
+
       it('should not interfere with each other when forking', () => {
         s1 = Automerge.change(s1, doc1 => {
           s2 = Automerge.change(s1, doc2 => doc2.two = 2)


### PR DESCRIPTION
At the moment, the second argument to `Automerge.change()` can be not just a message describing the change, but it can in fact be any JavaScript object, and it is encoded as JSON in the serialised change data.

I am proposing changing the behaviour such that `Automerge.change()` only accepts a string as change message, and throws an error otherwise. This will pave the way towards supporting a richer API in the future, e.g. using an options object. This change also helps with the binary encoding of changes.

If you want to continue using the change message for arbitrary structured metadata can do so by doing `JSON.stringify` and passing in the result as change message.

Does anyone object to this change?