### PR TITLE
Don't create a change record if nothing changed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,13 @@ is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - [#106]: New `doc._get(UUID)` method allows looking up an object by its `_objectId` inside
   an `Automerge.change()` callback ([@mattkrick])
 - [#109]: Export `OpSet.getMissingChanges` on the Automerge object ([@mattkrick])
+- [#111]: New `Automerge.emptyChange()` allows a "change" record to be created without actually
+  changing the document ([@ept])
 
 ### Changed
 - [#110]: Require that the change message in `Automerge.change()` must be a string ([@ept])
+- [#111]: If `Automerge.change()` does not modify the document, the function now returns the
+  original document object untouched ([@ept])
 
 ## [0.7.11] — 2018-06-26
 
@@ -166,6 +170,7 @@ is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 [0.4.0]: https://github.com/automerge/automerge/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/automerge/automerge/compare/v0.2.0...v0.3.0
 
+[#111]: https://github.com/automerge/automerge/pull/111
 [#110]: https://github.com/automerge/automerge/pull/110
 [#109]: https://github.com/automerge/automerge/pull/109
 [#106]: https://github.com/automerge/automerge/issues/106

--- a/src/automerge.js
+++ b/src/automerge.js
@@ -169,6 +169,14 @@ function change(doc, message, callback) {
   }
 }
 
+function emptyChange(doc, message) {
+  checkTarget('emptyChange', doc)
+  if (message !== undefined && typeof message !== 'string') {
+    throw new TypeError('Change message must be a string')
+  }
+  return makeChange(doc, doc._state, message)
+}
+
 function assign(target, values) {
   checkTarget('assign', target, true)
   if (!isObject(values)) throw new TypeError('The second argument to Automerge.assign must be an ' +
@@ -294,7 +302,7 @@ function getMissingDeps(doc) {
 }
 
 module.exports = {
-  init, change, merge, diff, assign, load, save, equals, inspect, getHistory,
+  init, change, emptyChange, merge, diff, assign, load, save, equals, inspect, getHistory,
   initImmutable, loadImmutable, getConflicts,
   getChanges, getChangesForActor, applyChanges, getMissingDeps, Text, uuid,
   getMissingChanges: OpSet.getMissingChanges,

--- a/src/automerge.js
+++ b/src/automerge.js
@@ -72,11 +72,13 @@ function setField(state, objectId, key, value) {
     const [newState, newId] = createNestedObjects(state, value)
     return makeOp(newState, { action: 'link', obj: objectId, key, value: newId })
   } else {
-    const oldValue = OpSet.getObjectField(state.get('opSet'), objectId, key, cachedContext())
-    if (value !== oldValue) {
-      return makeOp(state, { action: 'set', obj: objectId, key, value })
-    } else {
+    // If the assigned field value is the same as the existing value, do nothing
+    const fieldOps = OpSet.getFieldOps(state.get('opSet'), objectId, key)
+    if (fieldOps.size === 1 && fieldOps.get(0).get('action') === 'set' &&
+        fieldOps.get(0).get('value') === value) {
       return state
+    } else {
+      return makeOp(state, { action: 'set', obj: objectId, key, value })
     }
   }
 }

--- a/src/automerge.js
+++ b/src/automerge.js
@@ -146,7 +146,13 @@ function change(doc, message, callback) {
 
   const context = {state: doc._state, mutable: true, setField, splice, setListIndex, deleteField}
   callback(rootObjectProxy(context))
-  return makeChange(doc, context.state, message)
+
+  // If the callback didn't change anything, return the original document object unchanged
+  if (context.state.getIn(['opSet', 'local']).isEmpty()) {
+    return doc
+  } else {
+    return makeChange(doc, context.state, message)
+  }
 }
 
 function assign(target, values) {

--- a/src/op_set.js
+++ b/src/op_set.js
@@ -474,6 +474,6 @@ function listIterator(opSet, listId, mode, context) {
 
 module.exports = {
   init, addLocalOp, addChange, getMissingChanges, getChangesForActor, getMissingDeps,
-  getObjectFields, getObjectField, getObjectConflicts,
+  getObjectFields, getObjectField, getObjectConflicts, getFieldOps,
   listElemByIndex, listLength, listIterator, ROOT_ID
 }

--- a/test/test.js
+++ b/test/test.js
@@ -139,6 +139,26 @@ describe('Automerge', () => {
       })
     })
 
+    describe('emptyChange()', () => {
+      it('should append an empty change to the history', () => {
+        s1 = Automerge.change(s1, 'first change', doc => doc.field = 123)
+        s2 = Automerge.emptyChange(s1, 'empty change')
+        assert.notStrictEqual(s2, s1)
+        assert.deepEqual(s2, s1)
+        assert.deepEqual(Automerge.getHistory(s2).map(state => state.change.message),
+                         ['first change', 'empty change'])
+      })
+
+      it('should reference dependencies', () => {
+        s1 = Automerge.change(s1, doc => doc.field = 123)
+        s2 = Automerge.merge(Automerge.init(), s1)
+        s2 = Automerge.change(s2, doc => doc.other = 'hello')
+        s1 = Automerge.emptyChange(Automerge.merge(s1, s2))
+        const history = Automerge.getHistory(s1)
+        assert.deepEqual(history[history.length - 1].change.deps, {[s2._actorId]: 1})
+      })
+    })
+
     describe('root object', () => {
       it('should handle single-property assignment', () => {
         s1 = Automerge.change(s1, 'set bar', doc => doc.foo = 'bar')

--- a/test/test.js
+++ b/test/test.js
@@ -97,6 +97,18 @@ describe('Automerge', () => {
         assert.strictEqual(s2, s1)
       })
 
+      it('should not ignore field updates that resolve a conflict', () => {
+        s2 = Automerge.merge(Automerge.init(), s1)
+        s1 = Automerge.change(s1, doc => doc.field = 123)
+        s2 = Automerge.change(s2, doc => doc.field = 321)
+        s1 = Automerge.merge(s1, s2)
+        assert.deepEqual(Object.keys(s1._conflicts), ['field'])
+        const resolved = Automerge.change(s1, doc => doc.field = s1.field)
+        assert.notStrictEqual(resolved, s1)
+        assert.deepEqual(resolved, {field: s1.field})
+        assert.deepEqual(resolved._conflicts, {})
+      })
+
       it('should sanity-check arguments', () => {
         s1 = Automerge.change(s1, doc => doc.nested = {})
         assert.throws(() => { Automerge.change({},        doc => doc.foo = 'bar') }, /must be the object to modify/)

--- a/test/test.js
+++ b/test/test.js
@@ -86,6 +86,11 @@ describe('Automerge', () => {
         assert.deepEqual(s1._conflicts, {})
       })
 
+      it('should return the unchanged state object if nothing changed', () => {
+        s2 = Automerge.change(s1, doc => {})
+        assert.strictEqual(s2, s1)
+      })
+
       it('should sanity-check arguments', () => {
         s1 = Automerge.change(s1, doc => doc.nested = {})
         assert.throws(() => { Automerge.change({},        doc => doc.foo = 'bar') }, /must be the object to modify/)

--- a/test/test.js
+++ b/test/test.js
@@ -91,6 +91,12 @@ describe('Automerge', () => {
         assert.strictEqual(s2, s1)
       })
 
+      it('should ignore field updates that write the existing value', () => {
+        s1 = Automerge.change(s1, doc => doc.field = 123)
+        s2 = Automerge.change(s1, doc => doc.field = 123)
+        assert.strictEqual(s2, s1)
+      })
+
       it('should sanity-check arguments', () => {
         s1 = Automerge.change(s1, doc => doc.nested = {})
         assert.throws(() => { Automerge.change({},        doc => doc.foo = 'bar') }, /must be the object to modify/)

--- a/test/test.js
+++ b/test/test.js
@@ -167,7 +167,9 @@ describe('Automerge', () => {
         s2 = Automerge.change(s2, doc => doc.other = 'hello')
         s1 = Automerge.emptyChange(Automerge.merge(s1, s2))
         const history = Automerge.getHistory(s1)
-        assert.deepEqual(history[history.length - 1].change.deps, {[s2._actorId]: 1})
+        const emptyChange = history[history.length - 1].change
+        assert.deepEqual(emptyChange.deps, {[s2._actorId]: 1})
+        assert.deepEqual(emptyChange.ops, [])
       })
     })
 


### PR DESCRIPTION
This PR makes the changes discussed in #107:

* If the change callback doesn't actually change anything, `Automerge.change()` returns the original document object unmodified.
* If the change callback overwrites an object property with the same value, that is no longer logged as an operation.
* A new API function `Automerge.emptyChange()` exists to make a no-op change (like `git commit --allow-empty`), which can be used e.g. to capture the fact that remote changes were merged in.