### PR TITLE
Attach a sequential ID to patches

### DIFF
--- a/frontend/constants.js
+++ b/frontend/constants.js
@@ -5,6 +5,7 @@ const INBOUND   = Symbol('_inbound')   // map from child objectId to parent obje
 const REQUESTS  = Symbol('_requests')  // list of changes applied locally but not yet confirmed by backend
 const MAX_SEQ   = Symbol('_maxSeq')    // maximum sequence number generated so far
 const DEPS      = Symbol('_deps')      // map from actorId to max sequence number received from that actor
+const PATCH_ID  = Symbol('_patchId')   // number of patches from the backend we have applied
 const STATE     = Symbol('_state')     // backend state object (if an immediate backend is provided)
 
 // Properties of all Automerge objects
@@ -17,5 +18,5 @@ const ELEM_IDS  = Symbol('_elemIds')   // list containing the element ID of each
 const MAX_ELEM  = Symbol('_maxElem')   // maximum element counter value in this list (number)
 
 module.exports = {
-  OPTIONS, CACHE, INBOUND, REQUESTS, MAX_SEQ, DEPS, OBJECT_ID, CONFLICTS, CHANGE, ELEM_IDS, MAX_ELEM
+  OPTIONS, CACHE, INBOUND, REQUESTS, MAX_SEQ, DEPS, PATCH_ID, STATE, OBJECT_ID, CONFLICTS, CHANGE, ELEM_IDS, MAX_ELEM
 }

--- a/src/automerge.js
+++ b/src/automerge.js
@@ -8,11 +8,10 @@ const { isObject } = require('./common')
 /**
  * Constructs a new frontend document that reflects the given list of changes.
  */
-function docFromChanges(actorId, changes) {
+function docFromChanges(changes, actorId) {
   if (!actorId) throw new RangeError('actorId is required in docFromChanges')
   const doc = Frontend.init({actorId, backend: Backend})
-  const [state, _] = Backend.applyChanges(Backend.init(actorId), changes)
-  const patch = Backend.getPatch(state)
+  const [state, patch] = Backend.load(changes, actorId)
   patch.state = state
   return Frontend.applyPatch(doc, patch)
 }
@@ -32,7 +31,7 @@ function emptyChange(doc, message) {
 }
 
 function load(string, actorId) {
-  return docFromChanges(actorId || uuid(), transit.fromJSON(string))
+  return docFromChanges(transit.fromJSON(string), actorId || uuid())
 }
 
 function save(doc) {
@@ -98,7 +97,7 @@ function getHistory(doc) {
         return change.toJS()
       },
       get snapshot () {
-        return docFromChanges(state.get('actorId'), history.slice(0, index + 1))
+        return docFromChanges(history.slice(0, index + 1), state.get('actorId'))
       }
     }
   }).toArray()

--- a/test/frontend_test.js
+++ b/test/frontend_test.js
@@ -95,7 +95,7 @@ describe('Frontend', () => {
   describe('backend concurrency', () => {
     it('should use dependencies and sequence number from the backend', () => {
       const local = uuid(), remote1 = uuid(), remote2 = uuid()
-      const patch1 = {deps: {[local]: 4, [remote1]: 11, [remote2]: 41}, diffs: [
+      const patch1 = {patchId: 1, deps: {[local]: 4, [remote1]: 11, [remote2]: 41}, diffs: [
         {action: 'set', obj: ROOT_ID, type: 'map', key: 'blackbirds', value: 24}
       ]}
       let doc1 = Frontend.applyPatch(Frontend.init(local), patch1)
@@ -117,14 +117,14 @@ describe('Frontend', () => {
       ])
 
       const diffs1 = [{obj: ROOT_ID, type: 'map', action: 'set', key: 'blackbirds', value: 24}]
-      doc2 = Frontend.applyPatch(doc2, {actor, seq: 1, diffs: diffs1})
+      doc2 = Frontend.applyPatch(doc2, {actor, seq: 1, patchId: 1, diffs: diffs1})
       assert.deepEqual(doc2, {blackbirds: 24, partridges: 1})
       assert.deepEqual(Frontend.getRequests(doc2), [
         {actor, seq: 2, deps: {}, ops: [{obj: ROOT_ID, action: 'set', key: 'partridges', value: 1}]}
       ])
 
       const diffs2 = [{obj: ROOT_ID, type: 'map', action: 'set', key: 'partridges', value: 1}]
-      doc2 = Frontend.applyPatch(doc2, {actor, seq: 2, diffs: diffs2})
+      doc2 = Frontend.applyPatch(doc2, {actor, seq: 2, patchId: 2, diffs: diffs2})
       assert.deepEqual(doc2, {blackbirds: 24, partridges: 1})
       assert.deepEqual(Frontend.getRequests(doc2), [])
     })
@@ -137,14 +137,14 @@ describe('Frontend', () => {
       ])
 
       const diffs1 = [{obj: ROOT_ID, type: 'map', action: 'set', key: 'pheasants', value: 2}]
-      doc = Frontend.applyPatch(doc, {actor: other, seq: 1, diffs: diffs1})
+      doc = Frontend.applyPatch(doc, {actor: other, seq: 1, patchId: 1, diffs: diffs1})
       assert.deepEqual(doc, {blackbirds: 24, pheasants: 2})
       assert.deepEqual(Frontend.getRequests(doc), [
         {actor, seq: 1, deps: {}, ops: [{obj: ROOT_ID, action: 'set', key: 'blackbirds', value: 24}]}
       ])
 
       const diffs2 = [{obj: ROOT_ID, type: 'map', action: 'set', key: 'blackbirds', value: 24}]
-      doc = Frontend.applyPatch(doc, {actor, seq: 1, diffs: diffs2})
+      doc = Frontend.applyPatch(doc, {actor, seq: 1, patchId: 2, diffs: diffs2})
       assert.deepEqual(doc, {blackbirds: 24, pheasants: 2})
       assert.deepEqual(Frontend.getRequests(doc), [])
     })
@@ -154,7 +154,7 @@ describe('Frontend', () => {
       const doc2 = Frontend.change(doc1, doc => doc.partridges = 1)
       const actor = Frontend.getActorId(doc2)
       const diffs = [{obj: ROOT_ID, type: 'map', action: 'set', key: 'partridges', value: 1}]
-      assert.throws(() => { Frontend.applyPatch(doc2, {actor, seq: 2, diffs}) }, /Mismatched sequence number/)
+      assert.throws(() => { Frontend.applyPatch(doc2, {actor, seq: 2, patchId: 2, diffs}) }, /Mismatched sequence number/)
     })
 
     it('should transform concurrent insertions', () => {
@@ -165,7 +165,7 @@ describe('Frontend', () => {
         {obj: birds,   type: 'list', action: 'insert', index: 0, value: 'goldfinch', elemId: `${actor}:1`},
         {obj: ROOT_ID, type: 'map',  action: 'set',    key: 'birds', value: birds, link: true}
       ]
-      doc1 = Frontend.applyPatch(doc1, {actor, seq: 1, diffs: diffs1})
+      doc1 = Frontend.applyPatch(doc1, {actor, seq: 1, patchId: 1, diffs: diffs1})
       assert.deepEqual(doc1, {birds: ['goldfinch']})
       assert.deepEqual(Frontend.getRequests(doc1), [])
 
@@ -176,7 +176,7 @@ describe('Frontend', () => {
       assert.deepEqual(doc2, {birds: ['chaffinch', 'goldfinch', 'greenfinch']})
 
       const diffs3 = [{obj: birds, type: 'list', action: 'insert', index: 1, value: 'bullfinch', elemId: `${uuid()}:2`}]
-      const doc3 = Frontend.applyPatch(doc2, {actor: uuid(), seq: 1, diffs: diffs3})
+      const doc3 = Frontend.applyPatch(doc2, {actor: uuid(), seq: 1, patchId: 2, diffs: diffs3})
       // TODO this is not correct: order of 'bullfinch' and 'greenfinch' should depend on thier elemIds
       assert.deepEqual(doc3, {birds: ['chaffinch', 'goldfinch', 'bullfinch', 'greenfinch']})
 
@@ -184,7 +184,7 @@ describe('Frontend', () => {
         {obj: birds, type: 'list', action: 'insert', index: 0, value: 'chaffinch',  elemId: `${actor}:2`},
         {obj: birds, type: 'list', action: 'insert', index: 2, value: 'greenfinch', elemId: `${actor}:3`}
       ]
-      const doc4 = Frontend.applyPatch(doc3, {actor, seq: 2, diffs: diffs4})
+      const doc4 = Frontend.applyPatch(doc3, {actor, seq: 2, patchId: 3, diffs: diffs4})
       assert.deepEqual(doc4, {birds: ['chaffinch', 'goldfinch', 'greenfinch', 'bullfinch']})
       assert.deepEqual(Frontend.getRequests(doc4), [])
     })
@@ -195,7 +195,7 @@ describe('Frontend', () => {
       const diffs = [
         {obj: ROOT_ID, type: 'map', action: 'set', key: 'bird', value: 'magpie'}
       ]
-      const doc = Frontend.applyPatch(Frontend.init(), {diffs})
+      const doc = Frontend.applyPatch(Frontend.init(), {patchId: 1, diffs})
       assert.deepEqual(doc, {bird: 'magpie'})
     })
 
@@ -204,7 +204,7 @@ describe('Frontend', () => {
       const diffs = [
         {obj: ROOT_ID, type: 'map', action: 'set', key: 'favoriteBird', value: 'wagtail', conflicts: [{actor, value: 'robin'}]}
       ]
-      const doc = Frontend.applyPatch(Frontend.init(), {diffs})
+      const doc = Frontend.applyPatch(Frontend.init(), {patchId: 1, diffs})
       assert.deepEqual(doc, {favoriteBird: 'wagtail'})
       assert.deepEqual(Frontend.getConflicts(doc), {favoriteBird: {[actor]: 'robin'}})
     })
@@ -216,7 +216,7 @@ describe('Frontend', () => {
         {obj: birds,   type: 'map', action: 'set', key: 'wrens', value: 3},
         {obj: ROOT_ID, type: 'map', action: 'set', key: 'birds', value: birds, link: true}
       ]
-      const doc = Frontend.applyPatch(Frontend.init(), {diffs})
+      const doc = Frontend.applyPatch(Frontend.init(), {patchId: 1, diffs})
       assert.deepEqual(doc, {birds: {wrens: 3}})
     })
 
@@ -230,8 +230,8 @@ describe('Frontend', () => {
       const diffs2 = [
         {obj: birds, type: 'map', action: 'set', key: 'sparrows', value: 15}
       ]
-      const doc1 = Frontend.applyPatch(Frontend.init(), {diffs: diffs1})
-      const doc2 = Frontend.applyPatch(doc1, {diffs: diffs2})
+      const doc1 = Frontend.applyPatch(Frontend.init(), {patchId: 1, diffs: diffs1})
+      const doc2 = Frontend.applyPatch(doc1, {patchId: 2, diffs: diffs2})
       assert.deepEqual(doc1, {birds: {wrens: 3}})
       assert.deepEqual(doc2, {birds: {wrens: 3, sparrows: 15}})
     })
@@ -249,8 +249,8 @@ describe('Frontend', () => {
       const diffs2 = [
         {obj: birds2, type: 'map', action: 'set', key: 'blackbirds', value: 2}
       ]
-      const doc1 = Frontend.applyPatch(Frontend.init(), {diffs: diffs1})
-      const doc2 = Frontend.applyPatch(doc1, {diffs: diffs2})
+      const doc1 = Frontend.applyPatch(Frontend.init(), {patchId: 1, diffs: diffs1})
+      const doc2 = Frontend.applyPatch(doc1, {patchId: 2, diffs: diffs2})
       assert.deepEqual(doc1, {favoriteBirds: {wrens: 3}})
       assert.deepEqual(doc2, {favoriteBirds: {wrens: 3}})
       assert.deepEqual(Frontend.getConflicts(doc1), {favoriteBirds: {[actor]: {blackbirds: 1}}})
@@ -270,8 +270,8 @@ describe('Frontend', () => {
       const diffs2 = [
         {obj: birds, type: 'map', action: 'set', key: 'sparrows', value: 15}
       ]
-      const doc1 = Frontend.applyPatch(Frontend.init(), {diffs: diffs1})
-      const doc2 = Frontend.applyPatch(doc1, {diffs: diffs2})
+      const doc1 = Frontend.applyPatch(Frontend.init(), {patchId: 1, diffs: diffs1})
+      const doc2 = Frontend.applyPatch(doc1, {patchId: 2, diffs: diffs2})
       assert.deepEqual(doc1, {birds: {wrens: 3}, mammals: {badgers: 1}})
       assert.deepEqual(doc2, {birds: {wrens: 3, sparrows: 15}, mammals: {badgers: 1}})
       assert.strictEqual(doc1.mammals, doc2.mammals)
@@ -285,8 +285,8 @@ describe('Frontend', () => {
       const diffs2 = [
         {obj: ROOT_ID, type: 'map', action: 'remove', key: 'magpies'}
       ]
-      const doc1 = Frontend.applyPatch(Frontend.init(), {diffs: diffs1})
-      const doc2 = Frontend.applyPatch(doc1, {diffs: diffs2})
+      const doc1 = Frontend.applyPatch(Frontend.init(), {patchId: 1, diffs: diffs1})
+      const doc2 = Frontend.applyPatch(doc1, {patchId: 2, diffs: diffs2})
       assert.deepEqual(doc1, {magpies: 2, sparrows: 15})
       assert.deepEqual(doc2, {sparrows: 15})
     })
@@ -298,7 +298,7 @@ describe('Frontend', () => {
         {obj: birds,   type: 'list', action: 'insert', index: 0, value: 'chaffinch', elemId: `${actor}:1`},
         {obj: ROOT_ID, type: 'map',  action: 'set',    key: 'birds', value: birds, link: true}
       ]
-      const doc = Frontend.applyPatch(Frontend.init(), {diffs})
+      const doc = Frontend.applyPatch(Frontend.init(), {patchId: 1, diffs})
       assert.deepEqual(doc, {birds: ['chaffinch']})
     })
 
@@ -312,8 +312,8 @@ describe('Frontend', () => {
       const diffs2 = [
         {obj: birds,   type: 'list', action: 'set',    index: 0, value: 'greenfinch'}
       ]
-      const doc1 = Frontend.applyPatch(Frontend.init(), {diffs: diffs1})
-      const doc2 = Frontend.applyPatch(doc1, {diffs: diffs2})
+      const doc1 = Frontend.applyPatch(Frontend.init(), {patchId: 1, diffs: diffs1})
+      const doc2 = Frontend.applyPatch(doc1, {patchId: 2, diffs: diffs2})
       assert.deepEqual(doc1, {birds: ['chaffinch']})
       assert.deepEqual(doc2, {birds: ['greenfinch']})
     })
@@ -335,8 +335,8 @@ describe('Frontend', () => {
       const diffs2 = [
         {obj: item2, type: 'map', action: 'set', key: 'numSeen', value: 2}
       ]
-      const doc1 = Frontend.applyPatch(Frontend.init(), {diffs: diffs1})
-      const doc2 = Frontend.applyPatch(doc1, {diffs: diffs2})
+      const doc1 = Frontend.applyPatch(Frontend.init(), {patchId: 1, diffs: diffs1})
+      const doc2 = Frontend.applyPatch(doc1, {patchId: 2, diffs: diffs2})
       assert.deepEqual(doc1, {birds: [{species: 'lapwing', numSeen: 2}]})
       assert.deepEqual(doc2, {birds: [{species: 'lapwing', numSeen: 2}]})
       assert.strictEqual(doc1.birds[0], doc2.birds[0])
@@ -355,8 +355,8 @@ describe('Frontend', () => {
       const diffs2 = [
         {obj: birds,   type: 'list', action: 'remove', index: 0}
       ]
-      const doc1 = Frontend.applyPatch(Frontend.init(), {diffs: diffs1})
-      const doc2 = Frontend.applyPatch(doc1, {diffs: diffs2})
+      const doc1 = Frontend.applyPatch(Frontend.init(), {patchId: 1, diffs: diffs1})
+      const doc2 = Frontend.applyPatch(doc1, {patchId: 2, diffs: diffs2})
       assert.deepEqual(doc1, {birds: ['chaffinch', 'goldfinch']})
       assert.deepEqual(doc2, {birds: ['goldfinch']})
     })
@@ -378,8 +378,8 @@ describe('Frontend', () => {
         {obj: counts,  type: 'map',  action: 'set', key: 'magpies', value: 3},
         {obj: detail1, type: 'map',  action: 'set', key: 'species', value: 'Eurasian magpie'}
       ]
-      const doc1 = Frontend.applyPatch(Frontend.init(), {diffs: diffs1})
-      const doc2 = Frontend.applyPatch(doc1, {diffs: diffs2})
+      const doc1 = Frontend.applyPatch(Frontend.init(), {patchId: 1, diffs: diffs1})
+      const doc2 = Frontend.applyPatch(doc1, {patchId: 2, diffs: diffs2})
       assert.deepEqual(doc1, {counts: {magpies: 2}, details: [{species: 'magpie', family: 'corvidae'}]})
       assert.deepEqual(doc2, {counts: {magpies: 3}, details: [{species: 'Eurasian magpie', family: 'corvidae'}]})
     })


### PR DESCRIPTION
The frontend checks that patches are applied in strictly incrementing order. This prevents network implementations from accidentally applying patches in the wrong order, or skipping or duplicating patches.

Since `getPatch()` now requires a state update (namely incrementing the patch counter), I changed the API: instead of `getPatch()` there is now an integrated `load()` function that constructs a new backend document from a list of changes.