### PR TITLE
Fix sequence number assignment

### DIFF
--- a/frontend/constants.js
+++ b/frontend/constants.js
@@ -17,5 +17,5 @@ const ELEM_IDS  = Symbol('_elemIds')   // list containing the element ID of each
 const MAX_ELEM  = Symbol('_maxElem')   // maximum element counter value in this list (number)
 
 module.exports = {
-  OPTIONS, CACHE, INBOUND, REQUESTS, MAX_SEQ, DEPS, OBJECT_ID, CONFLICTS, CHANGE, ELEM_IDS, MAX_ELEM
+  OPTIONS, CACHE, INBOUND, REQUESTS, MAX_SEQ, DEPS, STATE, OBJECT_ID, CONFLICTS, CHANGE, ELEM_IDS, MAX_ELEM
 }

--- a/frontend/constants.js
+++ b/frontend/constants.js
@@ -2,10 +2,7 @@
 const OPTIONS   = Symbol('_options')   // object containing options passed to init()
 const CACHE     = Symbol('_cache')     // map from objectId to immutable object
 const INBOUND   = Symbol('_inbound')   // map from child objectId to parent objectId
-const REQUESTS  = Symbol('_requests')  // list of changes applied locally but not yet confirmed by backend
-const MAX_SEQ   = Symbol('_maxSeq')    // maximum sequence number generated so far
-const DEPS      = Symbol('_deps')      // map from actorId to max sequence number received from that actor
-const STATE     = Symbol('_state')     // backend state object (if an immediate backend is provided)
+const STATE     = Symbol('_state')     // object containing metadata about current state (e.g. sequence numbers)
 
 // Properties of all Automerge objects
 const OBJECT_ID = '_objectId'          // the object ID of the current object (string)
@@ -17,5 +14,5 @@ const ELEM_IDS  = Symbol('_elemIds')   // list containing the element ID of each
 const MAX_ELEM  = Symbol('_maxElem')   // maximum element counter value in this list (number)
 
 module.exports = {
-  OPTIONS, CACHE, INBOUND, REQUESTS, MAX_SEQ, DEPS, STATE, OBJECT_ID, CONFLICTS, CHANGE, ELEM_IDS, MAX_ELEM
+  OPTIONS, CACHE, INBOUND, STATE, OBJECT_ID, CONFLICTS, CHANGE, ELEM_IDS, MAX_ELEM
 }

--- a/frontend/index.js
+++ b/frontend/index.js
@@ -273,7 +273,7 @@ function applyPatch(doc, patch) {
 
   const actor = doc[OPTIONS].actorId
   const deps = patch.deps || {}
-  const maxSeq = deps[actor] || doc[MAX_SEQ]
+  const maxSeq = Math.max(deps[actor] || 0, doc[MAX_SEQ])
 
   if (doc[OPTIONS].backend) {
     if (!patch.state) {

--- a/frontend/index.js
+++ b/frontend/index.js
@@ -1,4 +1,4 @@
-const { OPTIONS, CACHE, INBOUND, REQUESTS, MAX_SEQ, DEPS, STATE, OBJECT_ID, CONFLICTS, CHANGE, ELEM_IDS } = require('./constants')
+const { OPTIONS, CACHE, INBOUND, STATE, OBJECT_ID, CONFLICTS, CHANGE, ELEM_IDS } = require('./constants')
 const { ROOT_ID, isObject } = require('../src/common')
 const uuid = require('../src/uuid')
 const { applyDiffs, updateParentObjects, cloneRootObject } = require('./apply_patch')
@@ -10,11 +10,9 @@ const { Text } = require('./text')
  * Takes a set of objects that have been updated (in `updated`) and an updated
  * mapping from child objectId to parent objectId (in `inbound`), and returns
  * a new immutable document root object based on `doc` that reflects those
- * updates. The request queue `requests`, the sequence number `maxSeq`, the
- * dependencies map `deps`, and the optional backend state `state` are
- * attached to the new root object.
+ * updates. The state object `state` is attached to the new root object.
  */
-function updateRootObject(doc, updated, inbound, requests, maxSeq, deps, state) {
+function updateRootObject(doc, updated, inbound, state) {
   let newDoc = updated[ROOT_ID]
   if (!newDoc) {
     newDoc = cloneRootObject(doc[CACHE][ROOT_ID])
@@ -24,9 +22,6 @@ function updateRootObject(doc, updated, inbound, requests, maxSeq, deps, state) 
   Object.defineProperty(newDoc, OPTIONS,  {value: doc[OPTIONS]})
   Object.defineProperty(newDoc, CACHE,    {value: updated})
   Object.defineProperty(newDoc, INBOUND,  {value: inbound})
-  Object.defineProperty(newDoc, REQUESTS, {value: requests})
-  Object.defineProperty(newDoc, MAX_SEQ,  {value: maxSeq})
-  Object.defineProperty(newDoc, DEPS,     {value: deps})
   Object.defineProperty(newDoc, STATE,    {value: state})
 
   for (let objectId of Object.keys(doc[CACHE])) {
@@ -69,44 +64,46 @@ function ensureSingleAssignment(ops) {
 }
 
 /**
- * Adds a new change request to the list of requests `doc[REQUESTS]`, and returns
- * an updated document root object. The details of the change are taken from the
+ * Adds a new change request to the list of pending requests, and returns an
+ * updated document root object. The details of the change are taken from the
  * context object `context`, and `message` is an optional human-readable string
  * describing the change.
  */
 function makeChange(doc, context, message) {
   const actor = doc[OPTIONS].actorId
-  const seq = doc[MAX_SEQ] + 1
-  const deps = Object.assign({}, doc[DEPS])
+  const state = Object.assign({}, doc[STATE])
+  state.seq += 1
+  const deps = Object.assign({}, state.deps)
   delete deps[actor]
 
   const ops = ensureSingleAssignment(context.ops)
 
   if (doc[OPTIONS].backend) {
-    const request = {actor, seq, deps, message, ops}
-    const [state, patch] = doc[OPTIONS].backend.applyChange(doc[STATE], request)
-    return applyPatchToDoc(doc, patch, [], seq, patch.deps, state)
+    const request = {actor, seq: state.seq, deps, message, ops}
+    const [backendState, patch] = doc[OPTIONS].backend.applyChange(state.backendState, request)
+    state.deps = patch.deps
+    state.backendState = backendState
+    state.requests = []
+    return applyPatchToDoc(doc, patch, state)
 
   } else {
-    const request = {actor, seq, deps, message, before: doc, ops, diffs: context.diffs}
-    const requests = doc[REQUESTS].slice() // shallow clone
-    requests.push(request)
-    return updateRootObject(doc, context.updated, context.inbound, requests, seq, doc[DEPS])
+    const request = {actor, seq: state.seq, deps, message, before: doc, ops, diffs: context.diffs}
+    state.requests = state.requests.slice() // shallow clone
+    state.requests.push(request)
+    return updateRootObject(doc, context.updated, context.inbound, state)
   }
 }
 
 /**
  * Applies the changes described in `patch` to the document with root object
- * `doc`. The request queue `requests`, the sequence number `maxSeq`, the
- * dependencies map `deps`, and the optional backend state `state` are
- * attached to the new root object.
+ * `doc`. The state object `state` is attached to the new root object.
  */
-function applyPatchToDoc(doc, patch, requests, maxSeq, deps, state) {
+function applyPatchToDoc(doc, patch, state) {
   let inbound = Object.assign({}, doc[INBOUND])
   let updated = {}
   applyDiffs(patch.diffs, doc[CACHE], updated, inbound)
   updateParentObjects(doc[CACHE], updated, inbound)
-  return updateRootObject(doc, updated, inbound, requests, maxSeq, deps, state)
+  return updateRootObject(doc, updated, inbound, state)
 }
 
 /**
@@ -187,18 +184,18 @@ function init(options) {
     options.actorId = uuid()
   }
 
-  let root = {}, cache = {[ROOT_ID]: root}
-  let state = options.backend ? options.backend.init(options.actorId) : undefined
+  const root = {}, cache = {[ROOT_ID]: root}
+  const state = {seq: 0, requests: [], deps: {}}
+  if (options.backend) {
+    state.backendState = options.backend.init(options.actorId)
+  }
   Object.defineProperty(root, '_actorId', {value: options.actorId})
   Object.defineProperty(root, OBJECT_ID, {value: ROOT_ID})
   Object.defineProperty(root, OPTIONS,   {value: Object.freeze(options)})
   Object.defineProperty(root, CONFLICTS, {value: Object.freeze({})})
   Object.defineProperty(root, CACHE,     {value: Object.freeze(cache)})
   Object.defineProperty(root, INBOUND,   {value: Object.freeze({})})
-  Object.defineProperty(root, REQUESTS,  {value: Object.freeze([])})
-  Object.defineProperty(root, MAX_SEQ,   {value: 0})
-  Object.defineProperty(root, DEPS,      {value: Object.freeze({})})
-  Object.defineProperty(root, STATE,     {value: state})
+  Object.defineProperty(root, STATE,     {value: Object.freeze(state)})
   return Object.freeze(root)
 }
 
@@ -254,39 +251,45 @@ function emptyChange(doc, message) {
  * request should be included in the patch, so that we can match them up here.
  */
 function applyPatch(doc, patch) {
-  let baseDoc, remainingRequests
-  if (doc[REQUESTS].length > 0) {
+  const actor = doc[OPTIONS].actorId
+  const deps = patch.deps || {}
+  const state = Object.assign({}, doc[STATE])
+  let baseDoc
+  if (state.requests.length > 0) {
     if (patch.actor === getActorId(doc) && patch.seq !== undefined) {
-      if (doc[REQUESTS][0].seq !== patch.seq) {
-        throw new RangeError(`Mismatched sequence number: patch ${patch.seq} does not match next request ${doc[REQUESTS][0].seq}`)
+      if (state.requests[0].seq !== patch.seq) {
+        throw new RangeError(`Mismatched sequence number: patch ${patch.seq} does not match next request ${state.requests[0].seq}`)
       }
-      baseDoc = doc[REQUESTS][0].before
-      remainingRequests = doc[REQUESTS].slice(1).map(req => Object.assign({}, req))
+      baseDoc = state.requests[0].before
+      state.requests = state.requests.slice(1).map(req => Object.assign({}, req))
     } else {
-      baseDoc = doc[REQUESTS][0].before
-      remainingRequests = doc[REQUESTS].slice().map(req => Object.assign({}, req))
+      baseDoc = state.requests[0].before
+      state.requests = state.requests.slice().map(req => Object.assign({}, req))
     }
   } else {
     baseDoc = doc
-    remainingRequests = []
+    state.requests = []
   }
 
-  const actor = doc[OPTIONS].actorId
-  const deps = patch.deps || {}
-  const maxSeq = Math.max(deps[actor] || 0, doc[MAX_SEQ])
+  state.deps = deps
+  if (deps[actor] && deps[actor] > state.seq) {
+    state.seq = deps[actor]
+  }
 
   if (doc[OPTIONS].backend) {
     if (!patch.state) {
       throw new RangeError('When an immediate backend is used, a patch must contain the new backend state')
     }
-    return applyPatchToDoc(doc, patch, [], maxSeq, patch.deps, patch.state)
+    state.backendState = patch.state
+    state.requests = []
+    return applyPatchToDoc(doc, patch, state)
   }
 
-  let newDoc = applyPatchToDoc(baseDoc, patch, remainingRequests, maxSeq, patch.deps)
-  for (let request of remainingRequests) {
+  let newDoc = applyPatchToDoc(baseDoc, patch, state)
+  for (let request of state.requests) {
     request.before = newDoc
     transformRequest(request, patch)
-    newDoc = applyPatchToDoc(request.before, request, remainingRequests, maxSeq, patch.deps)
+    newDoc = applyPatchToDoc(request.before, request, state)
   }
   return newDoc
 }
@@ -320,7 +323,7 @@ function getConflicts(object) {
  * Returns the list of change requests pending on the document `doc`.
  */
 function getRequests(doc) {
-  return doc[REQUESTS].map(req => {
+  return doc[STATE].requests.map(req => {
     const { actor, seq, deps, message, ops } = req
     const change = { actor, seq, deps }
     if (message !== undefined) {
@@ -336,7 +339,7 @@ function getRequests(doc) {
  * a backend implementation is passed to `init()`).
  */
 function getBackendState(doc) {
-  return doc[STATE]
+  return doc[STATE].backendState
 }
 
 function getElementIds(list) {

--- a/src/automerge.js
+++ b/src/automerge.js
@@ -108,24 +108,10 @@ function getConflicts(doc, list) {
   return Frontend.getConflicts(list)
 }
 
-function undo(doc, message) {
-  const oldState = Frontend.getBackendState(doc)
-  const [newState, patch] = Backend.undo(oldState, message)
-  patch.state = newState
-  return Frontend.applyPatch(doc, patch)
-}
-
-function redo(doc, message) {
-  const oldState = Frontend.getBackendState(doc)
-  const [newState, patch] = Backend.redo(oldState, message)
-  patch.state = newState
-  return Frontend.applyPatch(doc, patch)
-}
-
 module.exports = {
   init, change, emptyChange, load, save, merge, diff, getChanges, applyChanges, getMissingDeps,
   equals, inspect, getHistory, getConflicts, uuid,
-  canUndo: Frontend.canUndo, undo, canRedo: Frontend.canRedo, redo,
+  canUndo: Frontend.canUndo, undo: Frontend.undo, canRedo: Frontend.canRedo, redo: Frontend.redo,
   Frontend, Backend,
   Text: Frontend.Text,
   DocSet: require('./doc_set'),

--- a/src/automerge.js
+++ b/src/automerge.js
@@ -108,19 +108,11 @@ function getConflicts(doc, list) {
   return Frontend.getConflicts(list)
 }
 
-function canUndo(doc) {
-  return Backend.canUndo(Frontend.getBackendState(doc))
-}
-
 function undo(doc, message) {
   const oldState = Frontend.getBackendState(doc)
   const [newState, patch] = Backend.undo(oldState, message)
   patch.state = newState
   return Frontend.applyPatch(doc, patch)
-}
-
-function canRedo(doc) {
-  return Backend.canRedo(Frontend.getBackendState(doc))
 }
 
 function redo(doc, message) {
@@ -133,7 +125,7 @@ function redo(doc, message) {
 module.exports = {
   init, change, emptyChange, load, save, merge, diff, getChanges, applyChanges, getMissingDeps,
   equals, inspect, getHistory, getConflicts, uuid,
-  canUndo, undo, canRedo, redo,
+  canUndo: Frontend.canUndo, undo, canRedo: Frontend.canRedo, redo,
   Frontend, Backend,
   Text: Frontend.Text,
   DocSet: require('./doc_set'),

--- a/test/backend_test.js
+++ b/test/backend_test.js
@@ -13,7 +13,7 @@ describe('Backend', () => {
       ]}
       const s0 = Backend.init(actor)
       const [s1, patch1] = Backend.applyChanges(s0, [change1])
-      assert.deepEqual(patch1, {actor, seq: 1, deps: {[actor]: 1}, diffs: [
+      assert.deepEqual(patch1, {canUndo: false, canRedo: false, deps: {[actor]: 1}, diffs: [
         {action: 'set', obj: ROOT_ID, path: [], type: 'map', key: 'bird', value: 'magpie'}
       ]})
     })
@@ -28,7 +28,7 @@ describe('Backend', () => {
       const s0 = Backend.init('actor1')
       const [s1, patch1] = Backend.applyChanges(s0, [change1])
       const [s2, patch2] = Backend.applyChanges(s1, [change2])
-      assert.deepEqual(patch2, {actor: 'actor2', seq: 1, deps: {actor1: 1, actor2: 1}, diffs: [
+      assert.deepEqual(patch2, {canUndo: false, canRedo: false, deps: {actor1: 1, actor2: 1}, diffs: [
         {action: 'set', obj: ROOT_ID, path: [], type: 'map', key: 'bird', value: 'blackbird',
           conflicts: [{actor: 'actor1', value: 'magpie'}]}
       ]})
@@ -45,7 +45,7 @@ describe('Backend', () => {
       const s0 = Backend.init(actor)
       const [s1, patch1] = Backend.applyChanges(s0, [change1])
       const [s2, patch2] = Backend.applyChanges(s1, [change2])
-      assert.deepEqual(patch2, {actor, seq: 2, deps: {[actor]: 2}, diffs: [
+      assert.deepEqual(patch2, {canUndo: false, canRedo: false, deps: {[actor]: 2}, diffs: [
         {action: 'remove', obj: ROOT_ID, path: [], type: 'map', key: 'bird'}
       ]})
     })
@@ -59,7 +59,7 @@ describe('Backend', () => {
       ]}
       const s0 = Backend.init(actor)
       const [s1, patch1] = Backend.applyChanges(s0, [change1])
-      assert.deepEqual(patch1, {actor, seq: 1, deps: {[actor]: 1}, diffs: [
+      assert.deepEqual(patch1, {canUndo: false, canRedo: false, deps: {[actor]: 1}, diffs: [
         {action: 'create', obj: birds,   type: 'map'},
         {action: 'set',    obj: birds,   type: 'map', path: null, key: 'wrens', value: 3},
         {action: 'set',    obj: ROOT_ID, type: 'map', path: [],   key: 'birds', value: birds, link: true}
@@ -79,7 +79,7 @@ describe('Backend', () => {
       const s0 = Backend.init(actor)
       const [s1, patch1] = Backend.applyChanges(s0, [change1])
       const [s2, patch2] = Backend.applyChanges(s1, [change2])
-      assert.deepEqual(patch2, {actor, seq: 2, deps: {[actor]: 2}, diffs: [
+      assert.deepEqual(patch2, {canUndo: false, canRedo: false, deps: {[actor]: 2}, diffs: [
         {action: 'set', obj: birds, type: 'map', path: ['birds'], key: 'sparrows', value: 15}
       ]})
     })
@@ -94,7 +94,7 @@ describe('Backend', () => {
       ]}
       const s0 = Backend.init(actor)
       const [s1, patch1] = Backend.applyChanges(s0, [change1])
-      assert.deepEqual(patch1, {actor, seq: 1, deps: {[actor]: 1}, diffs: [
+      assert.deepEqual(patch1, {canUndo: false, canRedo: false, deps: {[actor]: 1}, diffs: [
         {action: 'create', obj: birds,   type: 'list'},
         {action: 'insert', obj: birds,   type: 'list', path: null, index: 0, value: 'chaffinch', elemId: `${actor}:1`},
         {action: 'set',    obj: ROOT_ID, type: 'map',  path: [],   key: 'birds', value: birds, link: true}
@@ -115,7 +115,7 @@ describe('Backend', () => {
       const s0 = Backend.init(actor)
       const [s1, patch1] = Backend.applyChanges(s0, [change1])
       const [s2, patch2] = Backend.applyChanges(s1, [change2])
-      assert.deepEqual(patch2, {actor, seq: 2, deps: {[actor]: 2}, diffs: [
+      assert.deepEqual(patch2, {canUndo: false, canRedo: false, deps: {[actor]: 2}, diffs: [
         {action: 'set', obj: birds, type: 'list', path: ['birds'], index: 0, value: 'greenfinch'}
       ]})
     })
@@ -134,7 +134,7 @@ describe('Backend', () => {
       const s0 = Backend.init(actor)
       const [s1, patch1] = Backend.applyChanges(s0, [change1])
       const [s2, patch2] = Backend.applyChanges(s1, [change2])
-      assert.deepEqual(patch2, {actor, seq: 2, deps: {[actor]: 2}, diffs: [
+      assert.deepEqual(patch2, {canUndo: false, canRedo: false, deps: {[actor]: 2}, diffs: [
         {action: 'remove', obj: birds, type: 'list', path: ['birds'], index: 0}
       ]})
     })
@@ -151,7 +151,7 @@ describe('Backend', () => {
       ]}
       const s0 = Backend.init(actor)
       const [s1, patch] = Backend.applyChanges(s0, [change1, change2])
-      assert.deepEqual(Backend.getPatch(s1), {deps: {[actor]: 2}, diffs: [
+      assert.deepEqual(Backend.getPatch(s1), {canUndo: false, canRedo: false, deps: {[actor]: 2}, diffs: [
         {action: 'set', obj: ROOT_ID, type: 'map', key: 'bird', value: 'blackbird'}
       ]})
     })
@@ -165,7 +165,7 @@ describe('Backend', () => {
       ]}
       const s0 = Backend.init('actor1')
       const [s1, patch] = Backend.applyChanges(s0, [change1, change2])
-      assert.deepEqual(Backend.getPatch(s1), {deps: {actor1: 1, actor2: 1}, diffs: [
+      assert.deepEqual(Backend.getPatch(s1), {canUndo: false, canRedo: false, deps: {actor1: 1, actor2: 1}, diffs: [
         {action: 'set', obj: ROOT_ID, type: 'map', key: 'bird', value: 'blackbird',
           conflicts: [{actor: 'actor1', value: 'magpie'}]}
       ]})
@@ -184,7 +184,7 @@ describe('Backend', () => {
       ]}
       const s0 = Backend.init(actor)
       const [s1, patch] = Backend.applyChanges(s0, [change1, change2])
-      assert.deepEqual(Backend.getPatch(s1), {deps: {[actor]: 2}, diffs: [
+      assert.deepEqual(Backend.getPatch(s1), {canUndo: false, canRedo: false, deps: {[actor]: 2}, diffs: [
         {action: 'create', obj: birds,   type: 'map'},
         {action: 'set',    obj: birds,   type: 'map', key: 'sparrows', value: 15},
         {action: 'set',    obj: ROOT_ID, type: 'map', key: 'birds',    value: birds, link: true}
@@ -201,7 +201,7 @@ describe('Backend', () => {
       ]}
       const s0 = Backend.init(actor)
       const [s1, patch] = Backend.applyChanges(s0, [change1])
-      assert.deepEqual(Backend.getPatch(s1), {deps: {[actor]: 1}, diffs: [
+      assert.deepEqual(Backend.getPatch(s1), {canUndo: false, canRedo: false, deps: {[actor]: 1}, diffs: [
         {action: 'create', obj: birds,   type: 'list'},
         {action: 'insert', obj: birds,   type: 'list', index: 0, value: 'chaffinch', elemId: `${actor}:1`},
         {action: 'set',    obj: ROOT_ID, type: 'map',  key: 'birds', value: birds, link: true}
@@ -226,7 +226,7 @@ describe('Backend', () => {
       ]}
       const s0 = Backend.init(actor)
       const [s1, patch] = Backend.applyChanges(s0, [change1, change2])
-      assert.deepEqual(Backend.getPatch(s1), {deps: {[actor]: 2}, diffs: [
+      assert.deepEqual(Backend.getPatch(s1), {canUndo: false, canRedo: false, deps: {[actor]: 2}, diffs: [
         {action: 'create', obj: birds,   type: 'list'},
         {action: 'insert', obj: birds,   type: 'list', index: 0, value: 'greenfinch',    elemId: `${actor}:3`},
         {action: 'insert', obj: birds,   type: 'list', index: 1, value: 'goldfinches!!', elemId: `${actor}:2`},

--- a/test/frontend_test.js
+++ b/test/frontend_test.js
@@ -198,7 +198,7 @@ describe('Frontend', () => {
       assert.deepEqual(req1, {actor, seq: 1, deps: {}, ops: [{obj: ROOT_ID, action: 'set', key: 'number', value: 1}]})
       assert.deepEqual(req2, {actor, seq: 2, deps: {}, ops: [{obj: ROOT_ID, action: 'set', key: 'number', value: 2}]})
       const state0 = Backend.init(actor)
-      const [state1, patch1] = Backend.applyChange(state0, req1)
+      const [state1, patch1] = Backend.applyLocalChange(state0, req1)
       const doc2a = Frontend.applyPatch(doc2, patch1)
       const doc3 = Frontend.change(doc2a, doc => doc.number = 3)
       const [req2a, req3] = Frontend.getRequests(doc3)

--- a/test/test.js
+++ b/test/test.js
@@ -934,12 +934,12 @@ describe('Automerge', () => {
     it('should allow redo if the last change was an undo', () => {
       let s1 = Automerge.change(Automerge.init(), doc => doc.birds = ['peregrine falcon'])
       assert.strictEqual(Automerge.canRedo(s1), false)
-      assert.throws(() => Automerge.redo(s1), /the last change was not an undo/)
+      assert.throws(() => Automerge.redo(s1), /there is no prior undo/)
       s1 = Automerge.undo(s1)
       assert.strictEqual(Automerge.canRedo(s1), true)
       s1 = Automerge.redo(s1)
       assert.strictEqual(Automerge.canRedo(s1), false)
-      assert.throws(() => Automerge.redo(s1), /the last change was not an undo/)
+      assert.throws(() => Automerge.redo(s1), /there is no prior undo/)
     })
 
     it('should allow several undos to be matched by several redos', () => {


### PR DESCRIPTION
This PR fixes a bug in which sequence numbers would inadvertently get reused in the case of certain concurrency patterns between frontend and backend (see commit message on 97b9dfd6ae67ec927c846b135c399076d9284e88 for details).

Relatedly, this PR changes the data flow for undo/redo: while the actual logic remains on the backend, the responsibility for assigning sequence numbers to the undo/redo changes is moved to the frontend. This has the advantage that the frontend is now the sole authority for assigning sequence numbers, reducing the risk of further race conditions between frontend and backend.