### PR TITLE
Use explicit exponentiation instead of literal int in randomLevel()

### DIFF
--- a/backend/skip_list.js
+++ b/backend/skip_list.js
@@ -10,7 +10,7 @@ function randomLevel() {
   // generator polyfills in the distribution build.
   return {
     next() {
-      const rand = Math.floor(Math.random() * 4294967296)
+      const rand = Math.floor(Math.random() * 2**32)
       let level = 1
       while (rand < 1 << (32 - 2 * level) && level < 16) level += 1
       return { value: level, done: false }


### PR DESCRIPTION
This replaces the magic literal int (4294967296) with explicit exponentiation (`2**32`), which should be a little more intention-revealing.

Babel will transpile this to `Math.pow(2, 32)`, but in all cases perf is basically indistinguishable from the integer constant:

https://jsperf.com/pow-vs-exp-vs-raw/1