### PR TITLE
Allow actorId assignment to be deferred

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -124,12 +124,8 @@ class MaterializationContext {
 /**
  * Returns an empty node state.
  */
-function init(actorId) {
-  if (typeof actorId !== 'string') {
-    throw new TypeError('init() requires an actorId')
-  }
-  const opSet = OpSet.init()
-  return Map({actorId, opSet})
+function init() {
+  return Map({opSet: OpSet.init()})
 }
 
 /**
@@ -229,11 +225,15 @@ function getMissingDeps(state) {
   return OpSet.getMissingDeps(state.get('opSet'))
 }
 
+/**
+ * Takes any changes that appear in `remote` but not in `local`, and applies
+ * them to `local`, returning a two-element list `[state, patch]` where `state`
+ * is the updated version of `local`, and `patch` describes the modifications
+ * that need to be made to the document objects to reflect these changes.
+ * Note that this function does not detect if the same sequence number has been
+ * reused for different changes in `local` and `remote` respectively.
+ */
 function merge(local, remote) {
-  if (local.get('actorId') === remote.get('actorId')) {
-    throw new RangeError('Cannot merge an actor with itself')
-  }
-
   const changes = OpSet.getMissingChanges(remote.get('opSet'), local.getIn(['opSet', 'clock']))
   return applyChanges(local, changes)
 }

--- a/backend/index.js
+++ b/backend/index.js
@@ -133,23 +133,15 @@ function init(actorId) {
 }
 
 /**
- * Returns the current dependencies map in the form required by patch objects.
- */
-function getDeps(state) {
-  let actorId = state.get('actorId'), opSet = state.get('opSet')
-  return opSet.get('deps')
-    .set(actorId, opSet.getIn(['clock', actorId], 0))
-}
-
-/**
  * Constructs a patch object from the current node state `state` and the list
  * of object modifications `diffs`.
  */
 function makePatch(state, diffs) {
   const canUndo = state.getIn(['opSet', 'undoPos']) > 0
   const canRedo = !state.getIn(['opSet', 'redoStack']).isEmpty()
-  const deps = getDeps(state).toJS()
-  return {deps, canUndo, canRedo, diffs}
+  const clock = state.getIn(['opSet', 'clock']).toJS()
+  const deps = state.getIn(['opSet', 'deps']).toJS()
+  return {clock, deps, canUndo, canRedo, diffs}
 }
 
 /**

--- a/frontend/context.js
+++ b/frontend/context.js
@@ -10,8 +10,8 @@ const uuid = require('../src/uuid')
  * and to apply the requested changes.
  */
 class Context {
-  constructor (doc) {
-    this.actorId = doc[OPTIONS].actorId
+  constructor (doc, actorId) {
+    this.actorId = actorId
     this.cache = doc[CACHE]
     this.updated = {}
     this.inbound = Object.assign({}, doc[INBOUND])

--- a/frontend/context.js
+++ b/frontend/context.js
@@ -1,4 +1,4 @@
-const { OPTIONS, CACHE, INBOUND, OBJECT_ID, CONFLICTS, MAX_ELEM } = require('./constants')
+const { CACHE, INBOUND, OBJECT_ID, CONFLICTS, MAX_ELEM } = require('./constants')
 const { applyDiffs } = require('./apply_patch')
 const { Text, getElemId } = require('./text')
 const { isObject } = require('../src/common')

--- a/frontend/index.js
+++ b/frontend/index.js
@@ -202,7 +202,7 @@ function init(options) {
   const root = {}, cache = {[ROOT_ID]: root}
   const state = {seq: 0, requests: [], deps: {}, canUndo: false, canRedo: false}
   if (options.backend) {
-    state.backendState = options.backend.init(options.actorId)
+    state.backendState = options.backend.init()
   }
   Object.defineProperty(root, '_actorId', {value: options.actorId})
   Object.defineProperty(root, OBJECT_ID, {value: ROOT_ID})

--- a/src/automerge.js
+++ b/src/automerge.js
@@ -41,6 +41,9 @@ function save(doc) {
 }
 
 function merge(localDoc, remoteDoc) {
+  if (Frontend.getActorId(localDoc) === Frontend.getActorId(remoteDoc)) {
+    throw new RangeError('Cannot merge an actor with itself')
+  }
   const localState  = Frontend.getBackendState(localDoc)
   const remoteState = Frontend.getBackendState(remoteDoc)
   const [state, patch] = Backend.merge(localState, remoteState)
@@ -91,6 +94,7 @@ function inspect(doc) {
 
 function getHistory(doc) {
   const state = Frontend.getBackendState(doc)
+  const actor = Frontend.getActorId(doc)
   const history = state.getIn(['opSet', 'history'])
   return history.map((change, index) => {
     return {
@@ -98,7 +102,7 @@ function getHistory(doc) {
         return change.toJS()
       },
       get snapshot () {
-        return docFromChanges(state.get('actorId'), history.slice(0, index + 1))
+        return docFromChanges(actor, history.slice(0, index + 1))
       }
     }
   }).toArray()

--- a/src/automerge.js
+++ b/src/automerge.js
@@ -23,14 +23,6 @@ function init(actorId) {
   return Frontend.init({actorId, backend: Backend})
 }
 
-function change(doc, message, callback) {
-  return Frontend.change(doc, message, callback)
-}
-
-function emptyChange(doc, message) {
-  return Frontend.emptyChange(doc, message)
-}
-
 function load(string, actorId) {
   return docFromChanges(actorId || uuid(), transit.fromJSON(string))
 }
@@ -108,17 +100,16 @@ function getHistory(doc) {
   }).toArray()
 }
 
-function getConflicts(doc, list) {
-  return Frontend.getConflicts(list)
-}
-
 module.exports = {
-  init, change, emptyChange, load, save, merge, diff, getChanges, applyChanges, getMissingDeps,
-  equals, inspect, getHistory, getConflicts, uuid,
-  canUndo: Frontend.canUndo, undo: Frontend.undo, canRedo: Frontend.canRedo, redo: Frontend.redo,
+  init, load, save, merge, diff, getChanges, applyChanges, getMissingDeps,
+  equals, inspect, getHistory, uuid,
   Frontend, Backend,
-  Text: Frontend.Text,
   DocSet: require('./doc_set'),
   WatchableDoc: require('./watchable_doc'),
   Connection: require('./connection')
+}
+
+for (let name of ['change', 'emptyChange', 'canUndo', 'undo', 'canRedo', 'redo',
+     'getActorId', 'setActorId', 'getConflicts', 'Text']) {
+  module.exports[name] = Frontend[name]
 }

--- a/test/backend_test.js
+++ b/test/backend_test.js
@@ -13,9 +13,10 @@ describe('Backend', () => {
       ]}
       const s0 = Backend.init(actor)
       const [s1, patch1] = Backend.applyChanges(s0, [change1])
-      assert.deepEqual(patch1, {canUndo: false, canRedo: false, deps: {[actor]: 1}, diffs: [
-        {action: 'set', obj: ROOT_ID, path: [], type: 'map', key: 'bird', value: 'magpie'}
-      ]})
+      assert.deepEqual(patch1, {
+        canUndo: false, canRedo: false, clock: {[actor]: 1}, deps: {[actor]: 1},
+        diffs: [{action: 'set', obj: ROOT_ID, path: [], type: 'map', key: 'bird', value: 'magpie'}]
+      })
     })
 
     it('should make a conflict on assignment to the same key', () => {
@@ -28,8 +29,9 @@ describe('Backend', () => {
       const s0 = Backend.init('actor1')
       const [s1, patch1] = Backend.applyChanges(s0, [change1])
       const [s2, patch2] = Backend.applyChanges(s1, [change2])
-      assert.deepEqual(patch2, {canUndo: false, canRedo: false, deps: {actor1: 1, actor2: 1}, diffs: [
-        {action: 'set', obj: ROOT_ID, path: [], type: 'map', key: 'bird', value: 'blackbird',
+      assert.deepEqual(patch2, {
+        canUndo: false, canRedo: false, clock: {actor1: 1, actor2: 1}, deps: {actor1: 1, actor2: 1},
+        diffs: [{action: 'set', obj: ROOT_ID, path: [], type: 'map', key: 'bird', value: 'blackbird',
           conflicts: [{actor: 'actor1', value: 'magpie'}]}
       ]})
     })
@@ -45,9 +47,10 @@ describe('Backend', () => {
       const s0 = Backend.init(actor)
       const [s1, patch1] = Backend.applyChanges(s0, [change1])
       const [s2, patch2] = Backend.applyChanges(s1, [change2])
-      assert.deepEqual(patch2, {canUndo: false, canRedo: false, deps: {[actor]: 2}, diffs: [
-        {action: 'remove', obj: ROOT_ID, path: [], type: 'map', key: 'bird'}
-      ]})
+      assert.deepEqual(patch2, {
+        canUndo: false, canRedo: false, clock: {[actor]: 2}, deps: {[actor]: 2},
+        diffs: [{action: 'remove', obj: ROOT_ID, path: [], type: 'map', key: 'bird'}]
+      })
     })
 
     it('should create nested maps', () => {
@@ -59,11 +62,14 @@ describe('Backend', () => {
       ]}
       const s0 = Backend.init(actor)
       const [s1, patch1] = Backend.applyChanges(s0, [change1])
-      assert.deepEqual(patch1, {canUndo: false, canRedo: false, deps: {[actor]: 1}, diffs: [
-        {action: 'create', obj: birds,   type: 'map'},
-        {action: 'set',    obj: birds,   type: 'map', path: null, key: 'wrens', value: 3},
-        {action: 'set',    obj: ROOT_ID, type: 'map', path: [],   key: 'birds', value: birds, link: true}
-      ]})
+      assert.deepEqual(patch1, {
+        canUndo: false, canRedo: false, clock: {[actor]: 1}, deps: {[actor]: 1},
+        diffs: [
+          {action: 'create', obj: birds,   type: 'map'},
+          {action: 'set',    obj: birds,   type: 'map', path: null, key: 'wrens', value: 3},
+          {action: 'set',    obj: ROOT_ID, type: 'map', path: [],   key: 'birds', value: birds, link: true}
+        ]
+      })
     })
 
     it('should assign to keys in nested maps', () => {
@@ -79,9 +85,10 @@ describe('Backend', () => {
       const s0 = Backend.init(actor)
       const [s1, patch1] = Backend.applyChanges(s0, [change1])
       const [s2, patch2] = Backend.applyChanges(s1, [change2])
-      assert.deepEqual(patch2, {canUndo: false, canRedo: false, deps: {[actor]: 2}, diffs: [
-        {action: 'set', obj: birds, type: 'map', path: ['birds'], key: 'sparrows', value: 15}
-      ]})
+      assert.deepEqual(patch2, {
+        canUndo: false, canRedo: false, clock: {[actor]: 2}, deps: {[actor]: 2},
+        diffs: [{action: 'set', obj: birds, type: 'map', path: ['birds'], key: 'sparrows', value: 15}]
+      })
     })
 
     it('should create lists', () => {
@@ -94,11 +101,14 @@ describe('Backend', () => {
       ]}
       const s0 = Backend.init(actor)
       const [s1, patch1] = Backend.applyChanges(s0, [change1])
-      assert.deepEqual(patch1, {canUndo: false, canRedo: false, deps: {[actor]: 1}, diffs: [
-        {action: 'create', obj: birds,   type: 'list'},
-        {action: 'insert', obj: birds,   type: 'list', path: null, index: 0, value: 'chaffinch', elemId: `${actor}:1`},
-        {action: 'set',    obj: ROOT_ID, type: 'map',  path: [],   key: 'birds', value: birds, link: true}
-      ]})
+      assert.deepEqual(patch1, {
+        canUndo: false, canRedo: false, clock: {[actor]: 1}, deps: {[actor]: 1},
+        diffs: [
+          {action: 'create', obj: birds,   type: 'list'},
+          {action: 'insert', obj: birds,   type: 'list', path: null, index: 0, value: 'chaffinch', elemId: `${actor}:1`},
+          {action: 'set',    obj: ROOT_ID, type: 'map',  path: [],   key: 'birds', value: birds, link: true}
+        ]
+      })
     })
 
     it('should apply updates inside lists', () => {
@@ -115,9 +125,10 @@ describe('Backend', () => {
       const s0 = Backend.init(actor)
       const [s1, patch1] = Backend.applyChanges(s0, [change1])
       const [s2, patch2] = Backend.applyChanges(s1, [change2])
-      assert.deepEqual(patch2, {canUndo: false, canRedo: false, deps: {[actor]: 2}, diffs: [
-        {action: 'set', obj: birds, type: 'list', path: ['birds'], index: 0, value: 'greenfinch'}
-      ]})
+      assert.deepEqual(patch2, {
+        canUndo: false, canRedo: false, clock: {[actor]: 2}, deps: {[actor]: 2},
+        diffs: [{action: 'set', obj: birds, type: 'list', path: ['birds'], index: 0, value: 'greenfinch'}]
+      })
     })
 
     it('should delete list elements', () => {
@@ -134,9 +145,10 @@ describe('Backend', () => {
       const s0 = Backend.init(actor)
       const [s1, patch1] = Backend.applyChanges(s0, [change1])
       const [s2, patch2] = Backend.applyChanges(s1, [change2])
-      assert.deepEqual(patch2, {canUndo: false, canRedo: false, deps: {[actor]: 2}, diffs: [
-        {action: 'remove', obj: birds, type: 'list', path: ['birds'], index: 0}
-      ]})
+      assert.deepEqual(patch2, {
+        canUndo: false, canRedo: false, clock: {[actor]: 2}, deps: {[actor]: 2},
+        diffs: [{action: 'remove', obj: birds, type: 'list', path: ['birds'], index: 0}]
+      })
     })
   })
 
@@ -151,9 +163,10 @@ describe('Backend', () => {
       ]}
       const s0 = Backend.init(actor)
       const [s1, patch] = Backend.applyChanges(s0, [change1, change2])
-      assert.deepEqual(Backend.getPatch(s1), {canUndo: false, canRedo: false, deps: {[actor]: 2}, diffs: [
-        {action: 'set', obj: ROOT_ID, type: 'map', key: 'bird', value: 'blackbird'}
-      ]})
+      assert.deepEqual(Backend.getPatch(s1), {
+        canUndo: false, canRedo: false, clock: {[actor]: 2}, deps: {[actor]: 2},
+        diffs: [{action: 'set', obj: ROOT_ID, type: 'map', key: 'bird', value: 'blackbird'}]
+      })
     })
 
     it('should include conflicting values for a key', () => {
@@ -165,8 +178,9 @@ describe('Backend', () => {
       ]}
       const s0 = Backend.init('actor1')
       const [s1, patch] = Backend.applyChanges(s0, [change1, change2])
-      assert.deepEqual(Backend.getPatch(s1), {canUndo: false, canRedo: false, deps: {actor1: 1, actor2: 1}, diffs: [
-        {action: 'set', obj: ROOT_ID, type: 'map', key: 'bird', value: 'blackbird',
+      assert.deepEqual(Backend.getPatch(s1), {
+        canUndo: false, canRedo: false, clock: {actor1: 1, actor2: 1}, deps: {actor1: 1, actor2: 1},
+        diffs: [{action: 'set', obj: ROOT_ID, type: 'map', key: 'bird', value: 'blackbird',
           conflicts: [{actor: 'actor1', value: 'magpie'}]}
       ]})
     })
@@ -184,11 +198,14 @@ describe('Backend', () => {
       ]}
       const s0 = Backend.init(actor)
       const [s1, patch] = Backend.applyChanges(s0, [change1, change2])
-      assert.deepEqual(Backend.getPatch(s1), {canUndo: false, canRedo: false, deps: {[actor]: 2}, diffs: [
-        {action: 'create', obj: birds,   type: 'map'},
-        {action: 'set',    obj: birds,   type: 'map', key: 'sparrows', value: 15},
-        {action: 'set',    obj: ROOT_ID, type: 'map', key: 'birds',    value: birds, link: true}
-      ]})
+      assert.deepEqual(Backend.getPatch(s1), {
+        canUndo: false, canRedo: false, clock: {[actor]: 2}, deps: {[actor]: 2},
+        diffs: [
+          {action: 'create', obj: birds,   type: 'map'},
+          {action: 'set',    obj: birds,   type: 'map', key: 'sparrows', value: 15},
+          {action: 'set',    obj: ROOT_ID, type: 'map', key: 'birds',    value: birds, link: true}
+        ]
+      })
     })
 
     it('should create lists', () => {
@@ -201,11 +218,14 @@ describe('Backend', () => {
       ]}
       const s0 = Backend.init(actor)
       const [s1, patch] = Backend.applyChanges(s0, [change1])
-      assert.deepEqual(Backend.getPatch(s1), {canUndo: false, canRedo: false, deps: {[actor]: 1}, diffs: [
-        {action: 'create', obj: birds,   type: 'list'},
-        {action: 'insert', obj: birds,   type: 'list', index: 0, value: 'chaffinch', elemId: `${actor}:1`},
-        {action: 'set',    obj: ROOT_ID, type: 'map',  key: 'birds', value: birds, link: true}
-      ]})
+      assert.deepEqual(Backend.getPatch(s1), {
+        canUndo: false, canRedo: false, clock: {[actor]: 1}, deps: {[actor]: 1},
+        diffs: [
+          {action: 'create', obj: birds,   type: 'list'},
+          {action: 'insert', obj: birds,   type: 'list', index: 0, value: 'chaffinch', elemId: `${actor}:1`},
+          {action: 'set',    obj: ROOT_ID, type: 'map',  key: 'birds', value: birds, link: true}
+        ]
+      })
     })
 
     it('should include the latest state of a list', () => {
@@ -226,12 +246,15 @@ describe('Backend', () => {
       ]}
       const s0 = Backend.init(actor)
       const [s1, patch] = Backend.applyChanges(s0, [change1, change2])
-      assert.deepEqual(Backend.getPatch(s1), {canUndo: false, canRedo: false, deps: {[actor]: 2}, diffs: [
-        {action: 'create', obj: birds,   type: 'list'},
-        {action: 'insert', obj: birds,   type: 'list', index: 0, value: 'greenfinch',    elemId: `${actor}:3`},
-        {action: 'insert', obj: birds,   type: 'list', index: 1, value: 'goldfinches!!', elemId: `${actor}:2`},
-        {action: 'set',    obj: ROOT_ID, type: 'map',  key: 'birds', value: birds, link: true}
-      ]})
+      assert.deepEqual(Backend.getPatch(s1), {
+        canUndo: false, canRedo: false, clock: {[actor]: 2}, deps: {[actor]: 2},
+        diffs: [
+          {action: 'create', obj: birds,   type: 'list'},
+          {action: 'insert', obj: birds,   type: 'list', index: 0, value: 'greenfinch',    elemId: `${actor}:3`},
+          {action: 'insert', obj: birds,   type: 'list', index: 1, value: 'goldfinches!!', elemId: `${actor}:2`},
+          {action: 'set',    obj: ROOT_ID, type: 'map',  key: 'birds', value: birds, link: true}
+        ]
+      })
     })
   })
 

--- a/test/frontend_test.js
+++ b/test/frontend_test.js
@@ -6,7 +6,18 @@ const uuid = require('../src/uuid')
 
 describe('Frontend', () => {
   it('should be an empty object by default', () => {
-    assert.deepEqual(Frontend.init(), {})
+    const doc = Frontend.init()
+    assert.deepEqual(doc, {})
+    assert(!!Frontend.getActorId(doc).match(/^[0-9a-f]{8}(-[0-9a-f]{4}){3}-[0-9a-f]{12}$/))
+  })
+
+  it('should allow actorId assignment to be deferred', () => {
+    let doc = Frontend.init({deferActorId: true})
+    assert.strictEqual(Frontend.getActorId(doc), undefined)
+    assert.throws(() => { Frontend.change(doc, doc => doc.foo = 'bar') }, /Actor ID must be initialized with setActorId/)
+    doc = Frontend.setActorId(doc, uuid())
+    doc = Frontend.change(doc, doc => doc.foo = 'bar')
+    assert.deepEqual(doc, {foo: 'bar'})
   })
 
   describe('performing changes', () => {

--- a/test/frontend_test.js
+++ b/test/frontend_test.js
@@ -96,13 +96,15 @@ describe('Frontend', () => {
   describe('backend concurrency', () => {
     it('should use dependencies and sequence number from the backend', () => {
       const local = uuid(), remote1 = uuid(), remote2 = uuid()
-      const patch1 = {deps: {[local]: 4, [remote1]: 11, [remote2]: 41}, diffs: [
-        {action: 'set', obj: ROOT_ID, type: 'map', key: 'blackbirds', value: 24}
-      ]}
+      const patch1 = {
+        clock: {[local]: 4, [remote1]: 11, [remote2]: 41},
+        deps: {[local]: 4, [remote2]: 41},
+        diffs: [{action: 'set', obj: ROOT_ID, type: 'map', key: 'blackbirds', value: 24}]
+      }
       let doc1 = Frontend.applyPatch(Frontend.init(local), patch1)
       let doc2 = Frontend.change(doc1, doc => doc.partridges = 1)
       assert.deepEqual(Frontend.getRequests(doc2), [
-        {requestType: 'change', actor: local, seq: 5, deps: {[remote1]: 11, [remote2]: 41}, ops: [
+        {requestType: 'change', actor: local, seq: 5, deps: {[remote2]: 41}, ops: [
           {obj: ROOT_ID, action: 'set', key: 'partridges', value: 1}
         ]}
       ])


### PR DESCRIPTION
In the context of [Hypermerge](https://github.com/automerge/hypermerge), the actorId is defined to be a hypercore name, which in turn is the public key of an elliptic curve keypair and which corresponds to some files on disk. In this case, there is a noticeable cost to creating a new actorId.

For nodes that only read a document but never modify it, there is no reason to incur the cost of creating an actorId. This PR allows an Automerge document to be instantiated without assigning an actorId, as long as an actorId is assigned with `setActorId()` before any change is made to the document. To indicate that actorId assignment should be deferred, use `Automerge.init({deferActorId: true})` (if the option is not given, an actorId is automatically generated to be a random UUID, to maintain compatibility with the existing API).

This PR also removes the need for the backend to know its own actorId at all. Only the frontend now needs to know its actorId, and it only needs to know it if you make any changes.