### PR TITLE
Fix Text update when mixed with other object updates

### DIFF
--- a/frontend/apply_patch.js
+++ b/frontend/apply_patch.js
@@ -251,7 +251,7 @@ function parentListObject(objectId, cache, updated) {
  * and the updated object is written to `updated`.
  */
 function updateTextObject(diffs, startIndex, endIndex, cache, updated) {
-  const objectId = diffs[0].obj
+  const objectId = diffs[startIndex].obj
   if (!updated[objectId]) {
     if (cache[objectId]) {
       const elems = cache[objectId].elems.slice()


### PR DESCRIPTION
The `updateTextObject` function is called with a `startIndex` and an `endIndex` parameter.

All diffs between these indexes should refer to the same object.

However we use the first diff (Is there a reason?) which can refer to a completely different object, thus the function will crash