### PR TITLE
Deduplicate requests in Backend.applyLocalChange

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -171,6 +171,14 @@ function applyChanges(state, changes) {
  * and `patch` confirms the modifications to the document objects.
  */
 function applyLocalChange(state, change) {
+  if (typeof change.actor !== 'string' || typeof change.seq !== 'number') {
+    throw new TypeError('Change request requries `actor` and `seq` properties')
+  }
+  // If we have already applied this change request, return a null patch
+  if (change.seq <= state.getIn(['opSet', 'clock', change.actor], 0)) {
+    return [state, null]
+  }
+
   let patch
   if (change.requestType === 'change') {
     ;[state, patch] = apply(state, [change], true)


### PR DESCRIPTION
If `Backend.applyLocalChange()` is called with a change request that has already been applied, it now returns a `null` patch. Previously it would return a patch with no `diffs` but with the `seq` from the request, which would throw an exception when applied to the frontend, due to the reuse of the same sequence number in different patches.