### PR TITLE
Remove Frontend.getRequests()

### DIFF
--- a/frontend/index.js
+++ b/frontend/index.js
@@ -95,7 +95,8 @@ function makeChange(doc, requestType, context, message) {
     return [applyPatchToDoc(doc, patch, state, true), request]
 
   } else {
-    const queuedRequest = {...request, before: doc}
+    const queuedRequest = Object.assign({}, request)
+    queuedRequest.before = doc
     if (context) queuedRequest.diffs = context.diffs
     state.requests = state.requests.slice() // shallow clone
     state.requests.push(queuedRequest)

--- a/frontend/index.js
+++ b/frontend/index.js
@@ -95,8 +95,7 @@ function makeChange(doc, requestType, context, message) {
     return [applyPatchToDoc(doc, patch, state, true), request]
 
   } else {
-    const queuedRequest = Object.assign({}, request)
-    queuedRequest.before = doc
+    const queuedRequest = {...request, before: doc}
     if (context) queuedRequest.diffs = context.diffs
     state.requests = state.requests.slice() // shallow clone
     state.requests.push(queuedRequest)

--- a/src/automerge.js
+++ b/src/automerge.js
@@ -22,6 +22,26 @@ function init(actorId) {
   return Frontend.init({actorId, backend: Backend})
 }
 
+function change(doc, message, callback) {
+  const [newDoc, change] = Frontend.change(doc, message, callback)
+  return newDoc
+}
+
+function emptyChange(doc, message) {
+  const [newDoc, change] = Frontend.emptyChange(doc, message)
+  return newDoc
+}
+
+function undo(doc, message) {
+  const [newDoc, change] = Frontend.undo(doc, message)
+  return newDoc
+}
+
+function redo(doc, message) {
+  const [newDoc, change] = Frontend.redo(doc, message)
+  return newDoc
+}
+
 function load(string, actorId) {
   return docFromChanges(actorId || uuid(), transit.fromJSON(string))
 }
@@ -100,7 +120,8 @@ function getHistory(doc) {
 }
 
 module.exports = {
-  init, load, save, merge, diff, getChanges, applyChanges, getMissingDeps,
+  init, change, emptyChange, undo, redo,
+  load, save, merge, diff, getChanges, applyChanges, getMissingDeps,
   equals, inspect, getHistory, uuid,
   Frontend, Backend,
   DocSet: require('./doc_set'),
@@ -108,7 +129,6 @@ module.exports = {
   Connection: require('./connection')
 }
 
-for (let name of ['change', 'emptyChange', 'canUndo', 'undo', 'canRedo', 'redo',
-     'getActorId', 'setActorId', 'getConflicts', 'Text']) {
+for (let name of ['canUndo', 'canRedo', 'getActorId', 'setActorId', 'getConflicts', 'Text']) {
   module.exports[name] = Frontend[name]
 }

--- a/test/frontend_test.js
+++ b/test/frontend_test.js
@@ -3,6 +3,7 @@ const Frontend = require('../frontend')
 const Backend = require('../backend')
 const ROOT_ID = '00000000-0000-0000-0000-000000000000'
 const uuid = require('../src/uuid')
+const { STATE } = require('../frontend/constants')
 
 describe('Frontend', () => {
   it('should be an empty object by default', () => {
@@ -12,99 +13,108 @@ describe('Frontend', () => {
   })
 
   it('should allow actorId assignment to be deferred', () => {
-    let doc = Frontend.init({deferActorId: true})
-    assert.strictEqual(Frontend.getActorId(doc), undefined)
-    assert.throws(() => { Frontend.change(doc, doc => doc.foo = 'bar') }, /Actor ID must be initialized with setActorId/)
-    doc = Frontend.setActorId(doc, uuid())
-    doc = Frontend.change(doc, doc => doc.foo = 'bar')
-    assert.deepEqual(doc, {foo: 'bar'})
+    let doc0 = Frontend.init({deferActorId: true})
+    assert.strictEqual(Frontend.getActorId(doc0), undefined)
+    assert.throws(() => { Frontend.change(doc0, doc => doc.foo = 'bar') }, /Actor ID must be initialized with setActorId/)
+    const doc1 = Frontend.setActorId(doc0, uuid())
+    const [doc2, req] = Frontend.change(doc1, doc => doc.foo = 'bar')
+    assert.deepEqual(doc2, {foo: 'bar'})
   })
 
   describe('performing changes', () => {
     it('should return the unmodified document if nothing changed', () => {
       const doc0 = Frontend.init()
-      const doc1 = Frontend.change(doc0, doc => {})
+      const [doc1, req] = Frontend.change(doc0, doc => {})
       assert.strictEqual(doc1, doc0)
     })
 
     it('should set root object properties', () => {
       const actor = uuid()
-      const doc = Frontend.change(Frontend.init(actor), doc => doc.bird = 'magpie')
+      const [doc, req] = Frontend.change(Frontend.init(actor), doc => doc.bird = 'magpie')
       assert.deepEqual(doc, {bird: 'magpie'})
-      assert.deepEqual(Frontend.getRequests(doc), [{requestType: 'change', actor, seq: 1, deps: {}, ops: [
+      assert.deepEqual(req, {requestType: 'change', actor, seq: 1, deps: {}, ops: [
         {obj: ROOT_ID, action: 'set', key: 'bird', value: 'magpie'}
-      ]}])
+      ]})
     })
 
     it('should create nested maps', () => {
-      const doc = Frontend.change(Frontend.init(), doc => doc.birds = {wrens: 3})
+      const [doc, req] = Frontend.change(Frontend.init(), doc => doc.birds = {wrens: 3})
       const birds = Frontend.getObjectId(doc.birds), actor = Frontend.getActorId(doc)
       assert.deepEqual(doc, {birds: {wrens: 3}})
-      assert.deepEqual(Frontend.getRequests(doc), [{requestType: 'change', actor, seq: 1, deps: {}, ops: [
+      assert.deepEqual(req, {requestType: 'change', actor, seq: 1, deps: {}, ops: [
         {obj: birds,   action: 'makeMap'},
         {obj: birds,   action: 'set',  key: 'wrens', value: 3},
         {obj: ROOT_ID, action: 'link', key: 'birds', value: birds}
-      ]}])
+      ]})
     })
 
     it('should apply updates inside nested maps', () => {
-      const doc1 = Frontend.change(Frontend.init(), doc => doc.birds = {wrens: 3})
-      const doc2 = Frontend.change(doc1, doc => doc.birds.sparrows = 15)
+      const [doc1, req1] = Frontend.change(Frontend.init(), doc => doc.birds = {wrens: 3})
+      const [doc2, req2] = Frontend.change(doc1, doc => doc.birds.sparrows = 15)
       const birds = Frontend.getObjectId(doc2.birds), actor = Frontend.getActorId(doc1)
       assert.deepEqual(doc1, {birds: {wrens: 3}})
       assert.deepEqual(doc2, {birds: {wrens: 3, sparrows: 15}})
-      assert.deepEqual(Frontend.getRequests(doc2)[1], {requestType: 'change', actor, seq: 2, deps: {}, ops: [
+      assert.deepEqual(req2, {requestType: 'change', actor, seq: 2, deps: {}, ops: [
         {obj: birds, action: 'set', key: 'sparrows', value: 15}
       ]})
     })
 
     it('should delete keys in maps', () => {
       const actor = uuid()
-      const doc1 = Frontend.change(Frontend.init(actor), doc => { doc.magpies = 2; doc.sparrows = 15 })
-      const doc2 = Frontend.change(doc1, doc => delete doc['magpies'])
+      const [doc1, req1] = Frontend.change(Frontend.init(actor), doc => { doc.magpies = 2; doc.sparrows = 15 })
+      const [doc2, req2] = Frontend.change(doc1, doc => delete doc['magpies'])
       assert.deepEqual(doc1, {magpies: 2, sparrows: 15})
       assert.deepEqual(doc2, {sparrows: 15})
-      assert.deepEqual(Frontend.getRequests(doc2)[1], {requestType: 'change', actor, seq: 2, deps: {}, ops: [
+      assert.deepEqual(req2, {requestType: 'change', actor, seq: 2, deps: {}, ops: [
         {obj: ROOT_ID, action: 'del', key: 'magpies'}
       ]})
     })
 
     it('should create lists', () => {
-      const doc = Frontend.change(Frontend.init(), doc => doc.birds = ['chaffinch'])
+      const [doc, req] = Frontend.change(Frontend.init(), doc => doc.birds = ['chaffinch'])
       const birds = Frontend.getObjectId(doc.birds), actor = Frontend.getActorId(doc)
       assert.deepEqual(doc, {birds: ['chaffinch']})
-      assert.deepEqual(Frontend.getRequests(doc), [{requestType: 'change', actor, seq: 1, deps: {}, ops: [
+      assert.deepEqual(req, {requestType: 'change', actor, seq: 1, deps: {}, ops: [
         {obj: birds,   action: 'makeList'},
         {obj: birds,   action: 'ins',  key: '_head', elem: 1},
         {obj: birds,   action: 'set',  key: `${actor}:1`, value: 'chaffinch'},
         {obj: ROOT_ID, action: 'link', key: 'birds', value: birds}
-      ]}])
+      ]})
     })
 
     it('should apply updates inside lists', () => {
-      const doc1 = Frontend.change(Frontend.init(), doc => doc.birds = ['chaffinch'])
-      const doc2 = Frontend.change(doc1, doc => doc.birds[0] = 'greenfinch')
+      const [doc1, req1] = Frontend.change(Frontend.init(), doc => doc.birds = ['chaffinch'])
+      const [doc2, req2] = Frontend.change(doc1, doc => doc.birds[0] = 'greenfinch')
       const birds = Frontend.getObjectId(doc2.birds), actor = Frontend.getActorId(doc2)
       assert.deepEqual(doc1, {birds: ['chaffinch']})
       assert.deepEqual(doc2, {birds: ['greenfinch']})
-      assert.deepEqual(Frontend.getRequests(doc2)[1], {requestType: 'change', actor, seq: 2, deps: {}, ops: [
+      assert.deepEqual(req2, {requestType: 'change', actor, seq: 2, deps: {}, ops: [
         {obj: birds, action: 'set', key: `${actor}:1`, value: 'greenfinch'}
       ]})
     })
 
     it('should delete list elements', () => {
-      const doc1 = Frontend.change(Frontend.init(), doc => doc.birds = ['chaffinch', 'goldfinch'])
-      const doc2 = Frontend.change(doc1, doc => doc.birds.deleteAt(0))
+      const [doc1, req1] = Frontend.change(Frontend.init(), doc => doc.birds = ['chaffinch', 'goldfinch'])
+      const [doc2, req2] = Frontend.change(doc1, doc => doc.birds.deleteAt(0))
       const birds = Frontend.getObjectId(doc2.birds), actor = Frontend.getActorId(doc2)
       assert.deepEqual(doc1, {birds: ['chaffinch', 'goldfinch']})
       assert.deepEqual(doc2, {birds: ['goldfinch']})
-      assert.deepEqual(Frontend.getRequests(doc2)[1], {requestType: 'change', actor, seq: 2, deps: {}, ops: [
+      assert.deepEqual(req2, {requestType: 'change', actor, seq: 2, deps: {}, ops: [
         {obj: birds, action: 'del', key: `${actor}:1`}
       ]})
     })
   })
 
   describe('backend concurrency', () => {
+    function getRequests(doc) {
+      return doc[STATE].requests.map(req => {
+        req = Object.assign({}, req)
+        delete req['before']
+        delete req['diffs']
+        return req
+      })
+    }
+
     it('should use dependencies and sequence number from the backend', () => {
       const local = uuid(), remote1 = uuid(), remote2 = uuid()
       const patch1 = {
@@ -113,8 +123,8 @@ describe('Frontend', () => {
         diffs: [{action: 'set', obj: ROOT_ID, type: 'map', key: 'blackbirds', value: 24}]
       }
       let doc1 = Frontend.applyPatch(Frontend.init(local), patch1)
-      let doc2 = Frontend.change(doc1, doc => doc.partridges = 1)
-      assert.deepEqual(Frontend.getRequests(doc2), [
+      let [doc2, req] = Frontend.change(doc1, doc => doc.partridges = 1)
+      assert.deepEqual(getRequests(doc2), [
         {requestType: 'change', actor: local, seq: 5, deps: {[remote2]: 41}, ops: [
           {obj: ROOT_ID, action: 'set', key: 'partridges', value: 1}
         ]}
@@ -123,9 +133,9 @@ describe('Frontend', () => {
 
     it('should remove pending requests once handled', () => {
       const actor = uuid()
-      let doc1 = Frontend.change(Frontend.init(actor), doc => doc.blackbirds = 24)
-      let doc2 = Frontend.change(doc1, doc => doc.partridges = 1)
-      assert.deepEqual(Frontend.getRequests(doc2), [
+      let [doc1, change1] = Frontend.change(Frontend.init(actor), doc => doc.blackbirds = 24)
+      let [doc2, change2] = Frontend.change(doc1, doc => doc.partridges = 1)
+      assert.deepEqual(getRequests(doc2), [
         {requestType: 'change', actor, seq: 1, deps: {}, ops: [{obj: ROOT_ID, action: 'set', key: 'blackbirds', value: 24}]},
         {requestType: 'change', actor, seq: 2, deps: {}, ops: [{obj: ROOT_ID, action: 'set', key: 'partridges', value: 1}]}
       ])
@@ -133,46 +143,46 @@ describe('Frontend', () => {
       const diffs1 = [{obj: ROOT_ID, type: 'map', action: 'set', key: 'blackbirds', value: 24}]
       doc2 = Frontend.applyPatch(doc2, {actor, seq: 1, diffs: diffs1})
       assert.deepEqual(doc2, {blackbirds: 24, partridges: 1})
-      assert.deepEqual(Frontend.getRequests(doc2), [
+      assert.deepEqual(getRequests(doc2), [
         {requestType: 'change', actor, seq: 2, deps: {}, ops: [{obj: ROOT_ID, action: 'set', key: 'partridges', value: 1}]}
       ])
 
       const diffs2 = [{obj: ROOT_ID, type: 'map', action: 'set', key: 'partridges', value: 1}]
       doc2 = Frontend.applyPatch(doc2, {actor, seq: 2, diffs: diffs2})
       assert.deepEqual(doc2, {blackbirds: 24, partridges: 1})
-      assert.deepEqual(Frontend.getRequests(doc2), [])
+      assert.deepEqual(getRequests(doc2), [])
     })
 
     it('should leave the request queue unchanged on remote patches', () => {
       const actor = uuid(), other = uuid()
-      let doc = Frontend.change(Frontend.init(actor), doc => doc.blackbirds = 24)
-      assert.deepEqual(Frontend.getRequests(doc), [
+      let [doc, req] = Frontend.change(Frontend.init(actor), doc => doc.blackbirds = 24)
+      assert.deepEqual(getRequests(doc), [
         {requestType: 'change', actor, seq: 1, deps: {}, ops: [{obj: ROOT_ID, action: 'set', key: 'blackbirds', value: 24}]}
       ])
 
       const diffs1 = [{obj: ROOT_ID, type: 'map', action: 'set', key: 'pheasants', value: 2}]
       doc = Frontend.applyPatch(doc, {actor: other, seq: 1, diffs: diffs1})
       assert.deepEqual(doc, {blackbirds: 24, pheasants: 2})
-      assert.deepEqual(Frontend.getRequests(doc), [
+      assert.deepEqual(getRequests(doc), [
         {requestType: 'change', actor, seq: 1, deps: {}, ops: [{obj: ROOT_ID, action: 'set', key: 'blackbirds', value: 24}]}
       ])
 
       const diffs2 = [{obj: ROOT_ID, type: 'map', action: 'set', key: 'blackbirds', value: 24}]
       doc = Frontend.applyPatch(doc, {actor, seq: 1, diffs: diffs2})
       assert.deepEqual(doc, {blackbirds: 24, pheasants: 2})
-      assert.deepEqual(Frontend.getRequests(doc), [])
+      assert.deepEqual(getRequests(doc), [])
     })
 
     it('should not allow request patches to be applied out-of-order', () => {
-      const doc1 = Frontend.change(Frontend.init(), doc => doc.blackbirds = 24)
-      const doc2 = Frontend.change(doc1, doc => doc.partridges = 1)
+      const [doc1, req1] = Frontend.change(Frontend.init(), doc => doc.blackbirds = 24)
+      const [doc2, req2] = Frontend.change(doc1, doc => doc.partridges = 1)
       const actor = Frontend.getActorId(doc2)
       const diffs = [{obj: ROOT_ID, type: 'map', action: 'set', key: 'partridges', value: 1}]
       assert.throws(() => { Frontend.applyPatch(doc2, {actor, seq: 2, diffs}) }, /Mismatched sequence number/)
     })
 
     it('should transform concurrent insertions', () => {
-      let doc1 = Frontend.change(Frontend.init(), doc => doc.birds = ['goldfinch'])
+      let [doc1, req1] = Frontend.change(Frontend.init(), doc => doc.birds = ['goldfinch'])
       const birds = Frontend.getObjectId(doc1.birds), actor = Frontend.getActorId(doc1)
       const diffs1 = [
         {obj: birds,   type: 'list', action: 'create'},
@@ -181,9 +191,9 @@ describe('Frontend', () => {
       ]
       doc1 = Frontend.applyPatch(doc1, {actor, seq: 1, diffs: diffs1})
       assert.deepEqual(doc1, {birds: ['goldfinch']})
-      assert.deepEqual(Frontend.getRequests(doc1), [])
+      assert.deepEqual(getRequests(doc1), [])
 
-      const doc2 = Frontend.change(doc1, doc => {
+      const [doc2, req2] = Frontend.change(doc1, doc => {
         doc.birds.insertAt(0, 'chaffinch')
         doc.birds.insertAt(2, 'greenfinch')
       })
@@ -200,21 +210,19 @@ describe('Frontend', () => {
       ]
       const doc4 = Frontend.applyPatch(doc3, {actor, seq: 2, diffs: diffs4})
       assert.deepEqual(doc4, {birds: ['chaffinch', 'goldfinch', 'greenfinch', 'bullfinch']})
-      assert.deepEqual(Frontend.getRequests(doc4), [])
+      assert.deepEqual(getRequests(doc4), [])
     })
 
     it('should allow interleaving of patches and changes', () => {
       const actor = uuid()
-      const doc1 = Frontend.change(Frontend.init(actor), doc => doc.number = 1)
-      const doc2 = Frontend.change(doc1, doc => doc.number = 2)
-      const [req1, req2] = Frontend.getRequests(doc2)
+      const [doc1, req1] = Frontend.change(Frontend.init(actor), doc => doc.number = 1)
+      const [doc2, req2] = Frontend.change(doc1, doc => doc.number = 2)
       assert.deepEqual(req1, {requestType: 'change', actor, seq: 1, deps: {}, ops: [{obj: ROOT_ID, action: 'set', key: 'number', value: 1}]})
       assert.deepEqual(req2, {requestType: 'change', actor, seq: 2, deps: {}, ops: [{obj: ROOT_ID, action: 'set', key: 'number', value: 2}]})
       const state0 = Backend.init(actor)
       const [state1, patch1] = Backend.applyLocalChange(state0, req1)
       const doc2a = Frontend.applyPatch(doc2, patch1)
-      const doc3 = Frontend.change(doc2a, doc => doc.number = 3)
-      const [req2a, req3] = Frontend.getRequests(doc3)
+      const [doc3, req3] = Frontend.change(doc2a, doc => doc.number = 3)
       assert.deepEqual(req3, {requestType: 'change', actor, seq: 3, deps: {}, ops: [{obj: ROOT_ID, action: 'set', key: 'number', value: 3}]})
     })
   })


### PR DESCRIPTION
The functions that generate requests (`Frontend.change()`, `Frontend.emptyChange()`, `Frontend.undo()`, and `Frontend.redo()`) now return a two-element array consisting of the new document state and the request object. Previously they would only return the new document state, and the request object was added to a queue that could be queried with `Frontend.getRequests()`. Since the request-generating functions now return the request directly, `Frontend.getRequests()` can be removed.

This API change encourages users of the API to send a request from the frontend to the backend only once, avoiding duplicate requests.

The `Automerge.*` public API is not affected by this change; the change is only on Frontend.