### PR TITLE
Support Date objects in Automerge documents

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -9,16 +9,16 @@ class MaterializationContext {
   }
 
   /**
-   * Unpacks `value`: if it's an object of the form `{objectId: '...'}`, updates
-   * `diff` to link to that objectId. Otherwise uses `value` as a primitive.
+   * Updates `diff` with the properties from `data`. The object `data` should be
+   * of the form `{value: objectId, link: true}` if the value is a reference to
+   * another object, of the form `{value: timestamp, datatype: 'timestamp'}` if
+   * the value is a Date object, and of the form `{value: primitiveValue}`
+   * if the value is a primitive value.
    */
-  unpackValue(parentId, diff, value) {
-    if (isObject(value)) {
-      diff.value = value.objectId
-      diff.link = true
-      this.children[parentId].push(value.objectId)
-    } else {
-      diff.value = value
+  unpackValue(parentId, diff, data) {
+    Object.assign(diff, data)
+    if (data.link) {
+      this.children[parentId].push(data.value)
     }
   }
 
@@ -81,11 +81,11 @@ class MaterializationContext {
   /**
    * Called by OpSet.getOpValue() when recursively instantiating an object in
    * the document tree. Updates `this.diffs[objectId]` to contain the patch
-   * necessary to instantiate the object, and returns `{objectId: objectId}`
-   * (which is then interpreted by `this.unpackValue()`).
+   * necessary to instantiate the object, and returns
+   * `{value: objectId, link: true}` (which is used to update the parent object).
    */
   instantiateObject(opSet, objectId) {
-    if (this.diffs[objectId]) return {objectId}
+    if (this.diffs[objectId]) return {value: objectId, link: true}
 
     const isRoot = (objectId === OpSet.ROOT_ID)
     const objType = opSet.getIn(['byObject', objectId, '_init', 'action'])
@@ -101,7 +101,7 @@ class MaterializationContext {
     } else {
       throw new RangeError(`Unknown object type: ${objType}`)
     }
-    return {objectId}
+    return {value: objectId, link: true}
   }
 
   /**

--- a/frontend/apply_patch.js
+++ b/frontend/apply_patch.js
@@ -16,6 +16,24 @@ function parseElemId(elemId) {
 }
 
 /**
+ * Reconstructs the value from the diff object `diff`.
+ */
+function getValue(diff, cache, updated) {
+  if (diff.link) {
+    // Reference to another object; fetch it from the cache
+    return updated[diff.value] || cache[diff.value]
+  } else if (diff.datatype === 'timestamp') {
+    // Timestamp: value is milliseconds since 1970 epoch
+    return new Date(diff.value)
+  } else if (diff.datatype !== undefined) {
+    throw new TypeError(`Unknown datatype: ${diff.datatype}`)
+  } else {
+    // Primitive value (number, string, boolean, or null)
+    return diff.value
+  }
+}
+
+/**
  * Finds the object IDs of all child objects referenced under the key `key` of
  * `object` (both `object[key]` and any conflicts under that key). Returns a map
  * from those objectIds to the value `true`.
@@ -82,12 +100,11 @@ function updateMapObject(diff, cache, updated, inbound) {
     // do nothing
   } else if (diff.action === 'set') {
     refsBefore = childReferences(object, diff.key)
-    object[diff.key] = diff.link ? (updated[diff.value] || cache[diff.value]) : diff.value
+    object[diff.key] = getValue(diff, cache, updated)
     if (diff.conflicts) {
       conflicts[diff.key] = {}
       for (let conflict of diff.conflicts) {
-        const value = conflict.link ? (updated[conflict.value] || cache[conflict.value]) : conflict.value
-        conflicts[diff.key][conflict.actor] = value
+        conflicts[diff.key][conflict.actor] = getValue(conflict, cache, updated)
       }
       Object.freeze(conflicts[diff.key])
     } else {
@@ -173,11 +190,11 @@ function updateListObject(diff, cache, updated, inbound) {
   let value = null, conflict = null
 
   if (['insert', 'set'].includes(diff.action)) {
-    value = diff.link ? (updated[diff.value] || cache[diff.value]) : diff.value
+    value = getValue(diff, cache, updated)
     if (diff.conflicts) {
       conflict = {}
       for (let c of diff.conflicts) {
-        conflict[c.actor] = c.link ? (updated[c.value] || cache[c.value]) : c.value
+        conflict[c.actor] = getValue(c, cache, updated)
       }
       Object.freeze(conflict)
     }

--- a/frontend/context.js
+++ b/frontend/context.js
@@ -4,23 +4,6 @@ const { Text, getElemId } = require('./text')
 const { isObject } = require('../src/common')
 const uuid = require('../src/uuid')
 
-/**
- * Takes a value that a user may assign within a change callback, and turns it
- * into the value we actually want to store. Currently, turns JavaScript Date
- * objects into ISO 8601 strings (which is what JSON.stringify does).
- */
-function coerceValue(value) {
-  if (!['object', 'boolean', 'number', 'string'].includes(typeof value)) {
-    throw new TypeError(`Unsupported type of value: ${typeof value}`)
-  }
-
-  if ((typeof value === 'object') && (value instanceof Date)) {
-    return JSON.parse(JSON.stringify(value))
-  } else {
-    return value
-  }
-}
-
 
 /**
  * An instance of this class is passed to `rootObjectProxy()`. The methods are
@@ -112,6 +95,37 @@ class Context {
   }
 
   /**
+   * Records an operation to update the object with ID `obj`, setting `key`
+   * to `value`. Returns an object in which the value has been normalized: if it
+   * is a reference to another object, `{value: otherObjectId, link: true}` is
+   * returned; if it is a Date object, `{value: timestamp, datatype: 'timestamp'}`
+   * is returned; and if it is a primitive value, `{value}` is returned.
+   */
+  setValue(obj, key, value) {
+    if (!['object', 'boolean', 'number', 'string'].includes(typeof value)) {
+      throw new TypeError(`Unsupported type of value: ${typeof value}`)
+    }
+
+    if (isObject(value)) {
+      if (value instanceof Date) {
+        // Date object, translate to timestamp (milliseconds since epoch)
+        const timestamp = value.getTime()
+        this.addOp({action: 'set', obj, key, value: timestamp, datatype: 'timestamp'})
+        return {value: timestamp, datatype: 'timestamp'}
+      } else {
+        // Reference to another object
+        const childId = this.createNestedObjects(value)
+        this.addOp({action: 'link', obj, key, value: childId})
+        return {value: childId, link: true}
+      }
+    } else {
+      // Primitive value (number, string, boolean, or null)
+      this.addOp({action: 'set', obj, key, value})
+      return {value}
+    }
+  }
+
+  /**
    * Updates the map object with ID `objectId`, setting the property with name
    * `key` to `value`.
    */
@@ -126,19 +140,12 @@ class Context {
       throw new RangeError(`Map entries starting with underscore are not allowed: ${key}`)
     }
 
+    // If the assigned field value is the same as the existing value, and
+    // the assignment does not resolve a conflict, do nothing
     const object = this.getObject(objectId)
-    value = coerceValue(value)
-
-    if (isObject(value)) {
-      const childId = this.createNestedObjects(value)
-      this.apply({action: 'set', type: 'map', obj: objectId, key, value: childId, link: true})
-      this.addOp({action: 'link', obj: objectId, key, value: childId})
-
-    } else if (object[key] !== value || object[CONFLICTS][key]) {
-      // If the assigned field value is the same as the existing value, and
-      // the assignment does not resolve a conflict, do nothing
-      this.apply({action: 'set', type: 'map', obj: objectId, key, value})
-      this.addOp({action: 'set', obj: objectId, key, value})
+    if (object[key] !== value || object[CONFLICTS][key] || value === undefined) {
+      const valueObj = this.setValue(objectId, key, value)
+      this.apply(Object.assign({action: 'set', type: 'map', obj: objectId, key}, valueObj))
     }
   }
 
@@ -158,7 +165,6 @@ class Context {
    * ID `objectId`.
    */
   insertListItem(objectId, index, value) {
-    value = coerceValue(value)
     const list = this.getObject(objectId)
     if (index < 0 || index > list.length) {
       throw new RangeError(`List index ${index} is out of bounds for list of length ${list.length}`)
@@ -170,14 +176,8 @@ class Context {
     const elemId = `${this.actorId}:${maxElem}`
     this.addOp({action: 'ins', obj: objectId, key: prevId, elem: maxElem})
 
-    if (isObject(value)) {
-      const childId = this.createNestedObjects(value)
-      this.apply({action: 'insert', type, obj: objectId, index, value: childId, link: true, elemId})
-      this.addOp({action: 'link', obj: objectId, key: elemId, value: childId})
-    } else {
-      this.apply({action: 'insert', type, obj: objectId, index, value, elemId})
-      this.addOp({action: 'set', obj: objectId, key: elemId, value})
-    }
+    const valueObj = this.setValue(objectId, elemId, value)
+    this.apply(Object.assign({action: 'insert', type, obj: objectId, index, elemId}, valueObj))
     this.getObject(objectId)[MAX_ELEM] = maxElem
   }
 
@@ -186,7 +186,6 @@ class Context {
    * position `index` with the new value `value`.
    */
   setListIndex(objectId, index, value) {
-    value = coerceValue(value)
     const list = this.getObject(objectId)
     if (index === list.length) {
       this.insertListItem(objectId, index, value)
@@ -196,18 +195,13 @@ class Context {
       throw new RangeError(`List index ${index} is out of bounds for list of length ${list.length}`)
     }
 
-    const elemId = getElemId(list, index)
-    const type = (list instanceof Text) ? 'text' : 'list'
-
-    if (isObject(value)) {
-      const childId = this.createNestedObjects(value)
-      this.apply({action: 'set', type, obj: objectId, index, value: childId, link: true})
-      this.addOp({action: 'link', obj: objectId, key: elemId, value: childId})
-    } else if (list[index] !== value || list[CONFLICTS][index]) {
-      // If the assigned list element value is the same as the existing value, and
-      // the assignment does not resolve a conflict, do nothing
-      this.apply({action: 'set', type, obj: objectId, index, value})
-      this.addOp({action: 'set', obj: objectId, key: elemId, value})
+    // If the assigned list element value is the same as the existing value, and
+    // the assignment does not resolve a conflict, do nothing
+    if (list[index] !== value || list[CONFLICTS][index] || value === undefined) {
+      const elemId = getElemId(list, index)
+      const type = (list instanceof Text) ? 'text' : 'list'
+      const valueObj = this.setValue(objectId, elemId, value)
+      this.apply(Object.assign({action: 'set', type, obj: objectId, index}, valueObj))
     }
   }
 

--- a/test/frontend_test.js
+++ b/test/frontend_test.js
@@ -103,6 +103,17 @@ describe('Frontend', () => {
         {obj: birds, action: 'del', key: `${actor}:1`}
       ]})
     })
+
+    it('should store Date objects as timestamps', () => {
+      const now = new Date()
+      const [doc, req] = Frontend.change(Frontend.init(), doc => doc.now = now)
+      const actor = Frontend.getActorId(doc)
+      assert(doc.now instanceof Date)
+      assert.strictEqual(doc.now.getTime(), now.getTime())
+      assert.deepEqual(req, {requestType: 'change', actor, seq: 1, deps: {}, ops: [
+        {obj: ROOT_ID, action: 'set', key: 'now', value: now.getTime(), datatype: 'timestamp'}
+      ]})
+    })
   })
 
   describe('backend concurrency', () => {

--- a/test/test.js
+++ b/test/test.js
@@ -87,22 +87,6 @@ describe('Automerge', () => {
         assert.deepEqual(s1._conflicts, {})
       })
 
-      it('should turn Date objects into ISO8601 strings', () => {
-        const ISO8601 = /^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}/
-        s2 = Automerge.change(s1, doc => {
-          doc.now = new Date()
-          doc.object = {foo: new Date()}
-          assert.strictEqual(typeof doc.now, 'string')
-          assert.strictEqual(typeof doc.object.foo, 'string')
-          assert(ISO8601.test(doc.now))
-          assert(ISO8601.test(doc.object.foo))
-        })
-        assert.strictEqual(typeof s2.now, 'string')
-        assert.strictEqual(typeof s2.object.foo, 'string')
-        assert(ISO8601.test(s2.now))
-        assert(ISO8601.test(s2.object.foo))
-      })
-
       it('should return the unchanged state object if nothing changed', () => {
         s2 = Automerge.change(s1, doc => {})
         assert.strictEqual(s2, s1)
@@ -184,6 +168,26 @@ describe('Automerge', () => {
           doc1.stuff = Object.assign({}, doc1.stuff, {baz: 'updated!'})
         })
         assert.deepEqual(s1, {stuff: {foo: 'bar', baz: 'updated!'}})
+      })
+
+      it('should support Date objects in maps', () => {
+        const now = new Date()
+        s1 = Automerge.change(s1, doc => doc.now = now)
+        let changes = Automerge.getChanges(Automerge.init(), s1)
+        changes = JSON.parse(JSON.stringify(changes))
+        s2 = Automerge.applyChanges(Automerge.init(), changes)
+        assert(s2.now instanceof Date)
+        assert.strictEqual(s2.now.getTime(), now.getTime())
+      })
+
+      it('should support Date objects in lists', () => {
+        const now = new Date()
+        s1 = Automerge.change(s1, doc => doc.list = [now])
+        let changes = Automerge.getChanges(Automerge.init(), s1)
+        changes = JSON.parse(JSON.stringify(changes))
+        s2 = Automerge.applyChanges(Automerge.init(), changes)
+        assert(s2.list[0] instanceof Date)
+        assert.strictEqual(s2.list[0].getTime(), now.getTime())
       })
     })
 

--- a/test/test.js
+++ b/test/test.js
@@ -92,9 +92,13 @@ describe('Automerge', () => {
         s2 = Automerge.change(s1, doc => {
           doc.now = new Date()
           doc.object = {foo: new Date()}
+          assert.strictEqual(typeof doc.now, 'string')
+          assert.strictEqual(typeof doc.object.foo, 'string')
           assert(ISO8601.test(doc.now))
           assert(ISO8601.test(doc.object.foo))
         })
+        assert.strictEqual(typeof s2.now, 'string')
+        assert.strictEqual(typeof s2.object.foo, 'string')
         assert(ISO8601.test(s2.now))
         assert(ISO8601.test(s2.object.foo))
       })

--- a/test/test.js
+++ b/test/test.js
@@ -87,6 +87,18 @@ describe('Automerge', () => {
         assert.deepEqual(s1._conflicts, {})
       })
 
+      it('should turn Date objects into ISO8601 strings', () => {
+        const ISO8601 = /^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}/
+        s2 = Automerge.change(s1, doc => {
+          doc.now = new Date()
+          doc.object = {foo: new Date()}
+          assert(ISO8601.test(doc.now))
+          assert(ISO8601.test(doc.object.foo))
+        })
+        assert(ISO8601.test(s2.now))
+        assert(ISO8601.test(s2.object.foo))
+      })
+
       it('should return the unchanged state object if nothing changed', () => {
         s2 = Automerge.change(s1, doc => {})
         assert.strictEqual(s2, s1)


### PR DESCRIPTION
To address #138, this patch detects when a JavaScript Date() object is assigned to an Automerge document, and converts it to an [ISO 8601 string](https://en.wikipedia.org/wiki/ISO_8601). This behaviour matches that of `JSON.stringify()`.