### PR TITLE
CRDT increment operation

### DIFF
--- a/frontend/index.js
+++ b/frontend/index.js
@@ -48,13 +48,16 @@ function ensureSingleAssignment(ops) {
 
   for (let i = ops.length - 1; i >= 0; i--) {
     const op = ops[i], { obj, key, action } = op
-    if (['set', 'del', 'link'].includes(action)) {
+    if (['set', 'del', 'link', 'inc'].includes(action)) {
       if (!assignments[obj]) {
-        assignments[obj] = {[key]: true}
+        assignments[obj] = {[key]: op}
         result.push(op)
       } else if (!assignments[obj][key]) {
-        assignments[obj][key] = true
+        assignments[obj][key] = op
         result.push(op)
+      } else if (assignments[obj][key].action === 'inc' && ['set', 'inc'].includes(action)) {
+        assignments[obj][key].action = action
+        assignments[obj][key].value += op.value
       }
     } else {
       result.push(op)

--- a/test/backend_test.js
+++ b/test/backend_test.js
@@ -19,6 +19,23 @@ describe('Backend', () => {
       })
     })
 
+    it('should increment a key in a map', () => {
+      const actor = uuid()
+      const change1 = {actor, seq: 1, deps: {}, ops: [
+        {action: 'set', obj: ROOT_ID, key: 'counter', value: 1}
+      ]}
+      const change2 = {actor, seq: 2, deps: {}, ops: [
+        {action: 'inc', obj: ROOT_ID, key: 'counter', value: 2}
+      ]}
+      const s0 = Backend.init()
+      const [s1, patch1] = Backend.applyChanges(s0, [change1])
+      const [s2, patch2] = Backend.applyChanges(s1, [change2])
+      assert.deepEqual(patch2, {
+        canUndo: false, canRedo: false, clock: {[actor]: 2}, deps: {[actor]: 2},
+        diffs: [{action: 'set', obj: ROOT_ID, path: [], type: 'map', key: 'counter', value: 3}]
+      })
+    })
+
     it('should make a conflict on assignment to the same key', () => {
       const change1 = {actor: 'actor1', seq: 1, deps: {}, ops: [
         {action: 'set', obj: ROOT_ID, key: 'bird', value: 'magpie'}
@@ -213,6 +230,22 @@ describe('Backend', () => {
         diffs: [{action: 'set', obj: ROOT_ID, type: 'map', key: 'bird', value: 'blackbird',
           conflicts: [{actor: 'actor1', value: 'magpie'}]}
       ]})
+    })
+
+    it('should handle increments for a key in a map', () => {
+      const actor = uuid()
+      const change1 = {actor, seq: 1, deps: {}, ops: [
+        {action: 'set', obj: ROOT_ID, key: 'counter', value: 1}
+      ]}
+      const change2 = {actor, seq: 2, deps: {}, ops: [
+        {action: 'inc', obj: ROOT_ID, key: 'counter', value: 2}
+      ]}
+      const s0 = Backend.init()
+      const [s1, patch] = Backend.applyChanges(s0, [change1, change2])
+      assert.deepEqual(Backend.getPatch(s1), {
+        canUndo: false, canRedo: false, clock: {[actor]: 2}, deps: {[actor]: 2},
+        diffs: [{action: 'set', obj: ROOT_ID, type: 'map', key: 'counter', value: 3}]
+      })
     })
 
     it('should create nested maps', () => {

--- a/test/test.js
+++ b/test/test.js
@@ -67,23 +67,23 @@ describe('Automerge', () => {
 
       it('should allow repeated reading and writing of values', () => {
         s2 = Automerge.change(s1, 'change message', doc => {
-          doc.counter = 1
-          assert.strictEqual(doc.counter, 1)
-          doc.counter += 1
-          doc.counter += 1
-          assert.strictEqual(doc.counter, 3)
+          doc.value = 'a'
+          assert.strictEqual(doc.value, 'a')
+          doc.value = 'b'
+          doc.value = 'c'
+          assert.strictEqual(doc.value, 'c')
         })
         assert.deepEqual(s1, {})
-        assert.deepEqual(s2, {counter: 3})
+        assert.deepEqual(s2, {value: 'c'})
       })
 
       it('should not record conflicts when writing the same field several times within one change', () => {
         s1 = Automerge.change(s1, 'change message', doc => {
-          doc.counter = 1
-          doc.counter += 1
-          doc.counter += 1
+          doc.value = 'a'
+          doc.value = 'b'
+          doc.value = 'c'
         })
-        assert.strictEqual(s1.counter, 3)
+        assert.strictEqual(s1.value, 'c')
         assert.deepEqual(s1._conflicts, {})
       })
 

--- a/test/test.js
+++ b/test/test.js
@@ -570,6 +570,33 @@ describe('Automerge', () => {
       assert.deepEqual(s3._conflicts, {})
     })
 
+    it('should add concurrent increments of the same property', () => {
+      s1 = Automerge.change(s1, doc => doc.counter = 0)
+      s2 = Automerge.merge(s2, s1)
+      s1 = Automerge.change(s1, doc => doc.counter++)
+      s2 = Automerge.change(s2, doc => doc.counter += 2)
+      s3 = Automerge.merge(s1, s2)
+      assert.strictEqual(s1.counter, 1)
+      assert.strictEqual(s2.counter, 2)
+      assert.strictEqual(s3.counter, 3)
+      assert.deepEqual(s3._conflicts, {})
+    })
+
+    it('should add increments only to the values they precede', () => {
+      s1 = Automerge.change(s1, doc => doc.counter = 0)
+      s1 = Automerge.change(s1, doc => doc.counter++)
+      s2 = Automerge.change(s2, doc => doc.counter = 100)
+      s2 = Automerge.change(s2, doc => doc.counter += 3)
+      s3 = Automerge.merge(s1, s2)
+      if (s1._actorId > s2._actorId) {
+        assert.deepEqual(s3, {counter: 1})
+        assert.deepEqual(s3._conflicts, {counter: {[s2._actorId]: 103}})
+      } else {
+        assert.deepEqual(s3, {counter: 103})
+        assert.deepEqual(s3._conflicts, {counter: {[s1._actorId]: 1}})
+      }
+    })
+
     it('should detect concurrent updates of the same field', () => {
       s1 = Automerge.change(s1, doc => doc.field = 'one')
       s2 = Automerge.change(s2, doc => doc.field = 'two')


### PR DESCRIPTION
A counter is the most frequently cited and most trivial example of a CRDT, because addition of integers is naturally commutative. So far, Automerge hasn't supported counters, since we haven't actually needed them, but it does seem like a missing feature that ought to be there.

So, in theory, a counter is trivial. In practice, some interesting questions arise, such as: How do we handle the case where one user assigns a conflicting value (that may not even be a number) concurrently to another user incrementing a number? And, how do we handle undo of an increment (do we produce a matching decrement operation, or do we reset to the old value)?

Moreover, there an important API design question arises: how does the application indicate that it wants to increment a value, as opposed to overwriting the old value with a new value? One option would be to introduce a very explicit API, for example:

```js
after = Automerge.change(before, doc => {
  Automerge.increment(doc, 'counter', 1) // increases the value of doc.counter by 1
})
```

…but that feels quite ugly to me. I would like to be able to write the following code, and have it perform a CRDT increment operation, because that's clearly the intent:

```js
after = Automerge.change(before, doc => {
  doc.counter++
})
```

However, the JavaScript [Proxy](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy) feature that we use to capture modifications in the change callback does not allow us to override the `++` or `+=` operators, so from the point of view of Automerge, the code above is indistinguishable from:

```js
after = Automerge.change(before, doc => {
  doc.counter = doc.counter + 1
})
```

The proxy *can*, however, detect that the counter was first read, and then written. Thus, we can distinguish between the code above and the following code:

```js
oldValue = doc.counter
after = Automerge.change(before, doc => {
  doc.counter = oldValue + 1
})
```

In this last example we can detect that the counter was written but not read within the change callback. We can't detect any reads outside of the change callback, so the last example is indistinguishable from just assigning any numeric constant to the `counter` property.

So, the implementation in this PR takes the following approach:

* If a field has a numeric value, and it has no conflicts, and it is read within the change callback, and it is assigned another number value within that change callback, then the write is treated as an increment (where the increment magnitude is the difference between the new and the old value).
* In all other cases, the assignment is treated as an overwrite of the previous value.

This has the advantage that code like the following produces a commutative increment operation:

```js
after = Automerge.change(before, doc => {
  doc.counter += 5
})
```

while the following code produces a regular assignment operation:

```js
after = Automerge.change(before, doc => {
  doc.positionX = 102
  doc.positionY = 321
})
```

This seems nice to me, but it runs the risk of being a bit too "magic". While I think the above heuristic will work in the common case, there may be situations where it guesses wrongly. For example, the following code (which snaps the x/y position of a graphical object to the nearest multiple of 100 pixels) should use assignment, but it incorrectly guesses that you want to increment the x and y coordinates, since each coordinate is first read and then written:

```js
after = Automerge.change(before, doc => {
  doc.positionX = Math.round(doc.positionX / 100) * 100
  doc.positionY = Math.round(doc.positionY / 100) * 100
})
```

Guessing the wrong operation type will have undesirable merge semantics (the when merged, objects will most likely no longer be snapped to the 100 pixel grid). However, if your code produces an increment when you wanted an assignment, or vice versa, the mistake is not very visible: assignment and increment behave identically in the absence of concurrency, and only differ when there are concurrent changes.

So, how do we design the API to minimise the risk that application developers end up with the wrong semantics? Even introducing an explicit API, like in the first code example above, does not guarantee that people will actually use it; I'm sure people will be very tempted to just write `+= 1`, no matter how much we document that doing so is unsafe. So my inclination is to try to make the `+= 1` case safe by guessing that it should be an increment. For cases like the snapping-to-grid example, which I think will be rarer, the workaround would be to perform the calculation outside of the change callback, and to perform an unconditional assignment within the change callback:

```js
const positionX = Math.round(before.positionX / 100) * 100
const positionY = Math.round(before.positionY / 100) * 100
after = Automerge.change(before, doc => {
  doc.positionX = positionX
  doc.positionY = positionY
})
```

Thoughts?