### PR TITLE
Counter CRDT (second attempt)

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,6 +291,42 @@ unmodified. The only special things about it are:
 * Objects also have a `_conflicts` property, which is used when several users make conflicting
   changes at the same time (see below).
 
+### Counters
+
+If you have a numeric value that is only ever changed by adding or subtracting (e.g. counting how
+many times the user has done a particular thing), it is recommmended that you use the
+`Automerge.Counter` datatype instead of a plain number. You set it up like this:
+
+```js
+state = Automerge.change(state, doc => {
+  // The counter is initialized to 0 by default. You can pass a number to the
+  // Automerge.Counter constructor if you want a different initial value.
+  doc.buttonClicks = new Automerge.Counter()
+})
+```
+
+To get the current counter value, use `doc.buttonClicks.value`.
+Whenever you want to increase or decrease the counter value, you can use the `.increment()`
+or `.decrement()` method:
+
+```js
+state = Automerge.change(state, doc => {
+  doc.buttonClicks.increment()  // Add 1 to counter value
+  doc.buttonClicks.increment(4) // Add 4 to counter value
+  doc.buttonClicks.decrement(3) // Subtract 3 from counter value
+})
+```
+
+Using the `Automerge.Counter` datatype is safer than changing a number value using the `++` or
+`+= 1` operators: if several users concurrently change a `Automerge.Counter` value, all the
+changes are added up as you'd expect, whereas concurrent `++` or `+= 1` operations will result
+in conflicts that need to be resolved (see "Conflicting changes" below).
+
+Another note: in relational databases it is common to use an auto-incrementing counter to generate
+primary keys for rows in a table, but this is not safe in Automerge, since several users may end
+up generating the same counter value! See the section "Relational table support" below for
+implementing a relational-like table with a primary key.
+
 ### Text editing support
 
 `Automerge.Text` provides experimental support for collaborative text editing.

--- a/backend/op_set.js
+++ b/backend/op_set.js
@@ -98,7 +98,12 @@ function getConflicts(ops) {
   const conflicts = []
   for (let op of ops.shift()) {
     let conflict = {actor: op.get('actor'), value: op.get('value')}
-    if (op.get('action') === 'link') conflict.link = true
+    if (op.get('action') === 'link') {
+      conflict.link = true
+    }
+    if (op.get('datatype')) {
+      conflict.datatype = op.get('datatype')
+    }
     conflicts.push(conflict)
   }
   return conflicts
@@ -184,7 +189,7 @@ function updateMapKey(opSet, objectId, type, key) {
   return [opSet, [edit]]
 }
 
-// Processes a 'set', 'del', or 'link' operation
+// Processes a 'set', 'del', 'link', or 'inc' operation
 function applyAssign(opSet, op, topLevel) {
   const objectId = op.get('obj')
   const objType = opSet.getIn(['byObject', objectId, '_init', 'action'])
@@ -199,11 +204,24 @@ function applyAssign(opSet, op, topLevel) {
     opSet = opSet.update('undoLocal', undoLocal => undoLocal.concat(undoOps))
   }
 
-  const priorOpsConcurrent = opSet
-    .getIn(['byObject', objectId, op.get('key')], List())
-    .groupBy(other => !!isConcurrent(opSet, other, op))
-  let overwritten = priorOpsConcurrent.get(false, List())
-  let remaining   = priorOpsConcurrent.get(true,  List())
+  const ops = opSet.getIn(['byObject', objectId, op.get('key')], List())
+  let overwritten, remaining
+
+  if (op.get('action') === 'inc') {
+    overwritten = List()
+    remaining = ops.map(other => {
+      if (other.get('action') === 'set' && typeof other.get('value') === 'number' &&
+          other.get('datatype') === 'counter' && !isConcurrent(opSet, other, op)) {
+        return other.set('value', other.get('value') + op.get('value'))
+      } else {
+        return other
+      }
+    })
+  } else {
+    const priorOpsConcurrent = ops.groupBy(other => !!isConcurrent(opSet, other, op))
+    overwritten = priorOpsConcurrent.get(false, List())
+    remaining   = priorOpsConcurrent.get(true,  List())
+  }
 
   // If any links were overwritten, remove them from the index of inbound links
   for (let op of overwritten.filter(op => op.get('action') === 'link')) {
@@ -213,7 +231,7 @@ function applyAssign(opSet, op, topLevel) {
   if (op.get('action') === 'link') {
     opSet = opSet.updateIn(['byObject', op.get('value'), '_inbound'], Set(), ops => ops.add(op))
   }
-  if (op.get('action') !== 'del') {
+  if (['set', 'link'].includes(op.get('action'))) {
     remaining = remaining.push(op)
   }
   remaining = remaining.sortBy(op => op.get('actor')).reverse()
@@ -239,7 +257,7 @@ function applyOps(opSet, ops) {
       ;[opSet, diffs] = applyMake(opSet, op)
     } else if (action === 'ins') {
       ;[opSet, diffs] = applyInsert(opSet, op)
-    } else if (action === 'set' || action === 'del' || action === 'link') {
+    } else if (['set', 'del', 'link', 'inc'].includes(action)) {
       ;[opSet, diffs] = applyAssign(opSet, op, !newObjects.contains(op.get('obj')))
     } else {
       throw new RangeError(`Unknown operation type ${action}`)

--- a/frontend/apply_patch.js
+++ b/frontend/apply_patch.js
@@ -2,6 +2,7 @@ const { ROOT_ID, isObject } = require('../src/common')
 const { OBJECT_ID, CONFLICTS, ELEM_IDS, MAX_ELEM } = require('./constants')
 const { Text } = require('./text')
 const { Table, instantiateTable } = require('./table')
+const { Counter } = require('./counter')
 
 /**
  * Takes a string in the form that is used to identify list elements (an actor
@@ -26,6 +27,8 @@ function getValue(diff, cache, updated) {
   } else if (diff.datatype === 'timestamp') {
     // Timestamp: value is milliseconds since 1970 epoch
     return new Date(diff.value)
+  } else if (diff.datatype === 'counter') {
+    return new Counter(diff.value)
   } else if (diff.datatype !== undefined) {
     throw new TypeError(`Unknown datatype: ${diff.datatype}`)
   } else {
@@ -43,7 +46,7 @@ function childReferences(object, key) {
   let refs = {}, conflicts = object[CONFLICTS][key] || {}
   let children = [object[key]].concat(Object.values(conflicts))
   for (let child of children) {
-    if (isObject(child)) {
+    if (isObject(child) && child[OBJECT_ID]) {
       refs[child[OBJECT_ID]] = true
     }
   }

--- a/frontend/counter.js
+++ b/frontend/counter.js
@@ -1,0 +1,75 @@
+/**
+ * The most basic CRDT: an integer value that can be changed only by
+ * incrementing and decrementing. Since addition of integers is commutative,
+ * the value trivially converges.
+ */
+class Counter {
+  constructor(value) {
+    this.value = value || 0
+    Object.freeze(this)
+  }
+
+  /**
+   * A peculiar JavaScript language feature from its early days: if the object
+   * `x` has a `valueOf()` method that returns a number, you can use numerical
+   * operators on the object `x` directly, such as `x + 1` or `x < 4`.
+   * This method is also called when coercing a value to a string by
+   * concatenating it with another string, as in `x + ''`.
+   * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/valueOf
+   */
+  valueOf() {
+    return this.value
+  }
+
+  /**
+   * Returns the counter value as a decimal string. If `x` is a counter object,
+   * this method is called e.g. when you do `['value: ', x].join('')` or when
+   * you use string interpolation: `value: ${x}`.
+   */
+  toString() {
+    return this.valueOf().toString()
+  }
+}
+
+/**
+ * An instance of this class is used when a counter is accessed within a change
+ * callback.
+ */
+class WriteableCounter extends Counter {
+  /**
+   * Increases the value of the counter by `delta`. If `delta` is not given,
+   * increases the value of the counter by 1.
+   */
+  increment(delta) {
+    delta = typeof delta === 'number' ? delta : 1
+    this.context.increment(this.objectId, this.key, delta)
+    this.value += delta
+    return this.value
+  }
+
+  /**
+   * Decreases the value of the counter by `delta`. If `delta` is not given,
+   * decreases the value of the counter by 1.
+   */
+  decrement(delta) {
+    return this.increment(typeof delta === 'number' ? -delta : -1)
+  }
+}
+
+/**
+ * Returns an instance of `WriteableCounter` for use in a change callback.
+ * `context` is the proxy context that keeps track of the mutations.
+ * `objectId` is the ID of the object containing the counter, and `key` is
+ * the property name (key in map, or index in list) where the counter is
+ * located.
+*/
+function getWriteableCounter(value, context, objectId, key) {
+  const instance = Object.create(WriteableCounter.prototype)
+  instance.value = value
+  instance.context = context
+  instance.objectId = objectId
+  instance.key = key
+  return instance
+}
+
+module.exports = { Counter, getWriteableCounter }

--- a/frontend/index.js
+++ b/frontend/index.js
@@ -6,6 +6,7 @@ const { rootObjectProxy } = require('./proxies')
 const { Context } = require('./context')
 const { Text } = require('./text')
 const { Table } = require('./table')
+const { Counter } = require('./counter')
 
 /**
  * Takes a set of objects that have been updated (in `updated`) and an updated
@@ -55,13 +56,16 @@ function ensureSingleAssignment(ops) {
 
   for (let i = ops.length - 1; i >= 0; i--) {
     const op = ops[i], { obj, key, action } = op
-    if (['set', 'del', 'link'].includes(action)) {
+    if (['set', 'del', 'link', 'inc'].includes(action)) {
       if (!assignments[obj]) {
-        assignments[obj] = {[key]: true}
+        assignments[obj] = {[key]: op}
         result.push(op)
       } else if (!assignments[obj][key]) {
-        assignments[obj][key] = true
+        assignments[obj][key] = op
         result.push(op)
+      } else if (assignments[obj][key].action === 'inc' && ['set', 'inc'].includes(action)) {
+        assignments[obj][key].action = action
+        assignments[obj][key].value += op.value
       }
     } else {
       result.push(op)
@@ -446,5 +450,5 @@ module.exports = {
   init, change, emptyChange, applyPatch,
   canUndo, undo, canRedo, redo,
   getObjectId, getActorId, setActorId, getConflicts, getBackendState, getElementIds,
-  Text, Table
+  Text, Table, Counter
 }

--- a/src/automerge.js
+++ b/src/automerge.js
@@ -129,6 +129,7 @@ module.exports = {
   Connection: require('./connection')
 }
 
-for (let name of ['canUndo', 'canRedo', 'getActorId', 'setActorId', 'getConflicts', 'Text', 'Table']) {
+for (let name of ['canUndo', 'canRedo', 'getActorId', 'setActorId',
+     'getConflicts', 'Text', 'Table', 'Counter']) {
   module.exports[name] = Frontend[name]
 }

--- a/test/frontend_test.js
+++ b/test/frontend_test.js
@@ -196,6 +196,18 @@ describe('Frontend', () => {
         assert.throws(() => Frontend.change(doc1, doc => doc.counter++), /Cannot overwrite a Counter object/)
         assert.throws(() => Frontend.change(doc1, doc => doc.list[0] = 3), /Cannot overwrite a Counter object/)
       })
+
+      it('should make counter objects behave like primitive numbers', () => {
+        const [doc1, req1] = Frontend.change(Frontend.init(), doc => doc.birds = new Frontend.Counter(3))
+        assert.equal(doc1.birds, 3) // they are equal according to ==, but not strictEqual according to ===
+        assert.notStrictEqual(doc1.birds, 3)
+        assert(doc1.birds < 4)
+        assert(doc1.birds >= 0)
+        assert(!(doc1.birds <= 2))
+        assert.strictEqual(doc1.birds + 10, 13)
+        assert.strictEqual(`I saw ${doc1.birds} birds`, 'I saw 3 birds')
+        assert.strictEqual(['I saw', doc1.birds, 'birds'].join(' '), 'I saw 3 birds')
+      })
     })
   })
 


### PR DESCRIPTION
This is a second implementation of a counter datatype in Automerge (a numeric value that can be incremented or decremented). The first attempt was in #140, but we decided the API in that implementation was too "magic". This PR uses a more explicit API.

To create a counter:

```js
state = Automerge.change(state, doc => {
  // The counter is initialized to 0 by default. You can pass a number to the
  // Automerge.Counter constructor if you want a different initial value.
  doc.buttonClicks = new Automerge.Counter()
})
```

To get the current counter value, use `doc.buttonClicks.value`. Whenever you want to increase or decrease the counter value, you can use the `.increment()` or `.decrement()` method:

```js
state = Automerge.change(state, doc => {
  doc.buttonClicks.increment()  // Add 1 to counter value
  doc.buttonClicks.increment(4) // Add 4 to counter value
  doc.buttonClicks.decrement(3) // Subtract 3 from counter value
})
```

