### PR TITLE
Fix "Duplicate list element ID" error

### DIFF
--- a/backend/op_set.js
+++ b/backend/op_set.js
@@ -1,6 +1,6 @@
 const { Map, List, Set } = require('immutable')
 const { SkipList } = require('./skip_list')
-const ROOT_ID = '00000000-0000-0000-0000-000000000000'
+const { ROOT_ID, parseElemId } = require('../src/common')
 
 // Returns true if the two operations are concurrent, that is, they happened without being aware of
 // each other (neither happened before the other). Returns false if one supersedes the other.
@@ -412,8 +412,11 @@ function lamportCompare(op1, op2) {
 }
 
 function insertionsAfter(opSet, objectId, parentId, childId) {
-  const match = /^(.*):(\d+)$/.exec(childId || '')
-  const childKey = match ? Map({actor: match[1], elem: parseInt(match[2])}) : null
+  let childKey = null
+  if (childId) {
+    const parsedId = parseElemId(childId)
+    childKey = Map({actor: parsedId.actorId, elem: parsedId.counter})
+  }
 
   return opSet
     .getIn(['byObject', objectId, '_following', parentId], List())

--- a/frontend/apply_patch.js
+++ b/frontend/apply_patch.js
@@ -1,21 +1,8 @@
-const { ROOT_ID, isObject } = require('../src/common')
+const { ROOT_ID, isObject, parseElemId } = require('../src/common')
 const { OBJECT_ID, CONFLICTS, ELEM_IDS, MAX_ELEM } = require('./constants')
 const { Text } = require('./text')
 const { Table, instantiateTable } = require('./table')
 const { Counter } = require('./counter')
-
-/**
- * Takes a string in the form that is used to identify list elements (an actor
- * ID concatenated with a counter, separated by a colon) and returns a
- * two-element array, `[counter, actorId]`.
- */
-function parseElemId(elemId) {
-  const match = /^(.*):(\d+)$/.exec(elemId || '')
-  if (!match) {
-    throw new RangeError(`Not a valid elemId: ${elemId}`)
-  }
-  return [parseInt(match[2]), match[1]]
-}
 
 /**
  * Reconstructs the value from the diff object `diff`.
@@ -262,7 +249,7 @@ function updateListObject(diff, cache, updated, inbound) {
   if (diff.action === 'create') {
     // do nothing
   } else if (diff.action === 'insert') {
-    list[MAX_ELEM] = Math.max(list[MAX_ELEM], parseElemId(diff.elemId)[0])
+    list[MAX_ELEM] = Math.max(list[MAX_ELEM], parseElemId(diff.elemId).counter)
     list.splice(diff.index, 0, value)
     conflicts.splice(diff.index, 0, conflict)
     elemIds.splice(diff.index, 0, diff.elemId)
@@ -351,7 +338,7 @@ function updateTextObject(diffs, startIndex, endIndex, cache, updated) {
         deletions = 0
         insertions = []
       }
-      maxElem = Math.max(maxElem, parseElemId(diff.elemId)[0])
+      maxElem = Math.max(maxElem, parseElemId(diff.elemId).counter)
       insertions.push({elemId: diff.elemId, value: diff.value, conflicts: diff.conflicts})
 
       if (startIndex === endIndex || diffs[startIndex + 1].action !== 'insert' ||

--- a/frontend/apply_patch.js
+++ b/frontend/apply_patch.js
@@ -264,6 +264,8 @@ function updateListObject(diff, cache, updated, inbound) {
     list.splice(diff.index, 1)
     conflicts.splice(diff.index, 1) || {}
     elemIds.splice(diff.index, 1)
+  } else if (diff.action === 'maxElem') {
+    list[MAX_ELEM] = Math.max(list[MAX_ELEM], diff.value)
   } else {
     throw new RangeError('Unknown action type: ' + diff.action)
   }
@@ -368,6 +370,9 @@ function updateTextObject(diffs, startIndex, endIndex, cache, updated) {
         elems.splice(splicePos, deletions)
         splicePos = -1
       }
+
+    } else if (diff.action === 'maxElem') {
+      maxElem = Math.max(maxElem, diff.value)
     } else {
       throw new RangeError('Unknown action type: ' + diff.action)
     }

--- a/src/common.js
+++ b/src/common.js
@@ -17,6 +17,19 @@ function lessOrEqual(clock1, clock2) {
     true)
 }
 
+/**
+ * Takes a string in the form that is used to identify list elements (an actor
+ * ID concatenated with a counter, separated by a colon) and returns an object
+ * of the structure `{counter, actorId}`.
+ */
+function parseElemId(elemId) {
+  const match = /^(.*):(\d+)$/.exec(elemId || '')
+  if (!match) {
+    throw new RangeError(`Not a valid elemId: ${elemId}`)
+  }
+  return {counter: parseInt(match[2]), actorId: match[1]}
+}
+
 module.exports = {
-  ROOT_ID, isObject, lessOrEqual
+  ROOT_ID, isObject, lessOrEqual, parseElemId
 }

--- a/test/backend_test.js
+++ b/test/backend_test.js
@@ -318,9 +318,10 @@ describe('Backend', () => {
       assert.deepEqual(Backend.getPatch(s1), {
         canUndo: false, canRedo: false, clock: {[actor]: 1}, deps: {[actor]: 1},
         diffs: [
-          {action: 'create', obj: birds,   type: 'list'},
-          {action: 'insert', obj: birds,   type: 'list', index: 0, value: 'chaffinch', elemId: `${actor}:1`},
-          {action: 'set',    obj: ROOT_ID, type: 'map',  key: 'birds', value: birds, link: true}
+          {action: 'create',  obj: birds,   type: 'list'},
+          {action: 'insert',  obj: birds,   type: 'list', index: 0, value: 'chaffinch', elemId: `${actor}:1`},
+          {action: 'maxElem', obj: birds,   type: 'list', value: 1},
+          {action: 'set',     obj: ROOT_ID, type: 'map',  key: 'birds', value: birds, link: true}
         ]
       })
     })
@@ -346,10 +347,11 @@ describe('Backend', () => {
       assert.deepEqual(Backend.getPatch(s1), {
         canUndo: false, canRedo: false, clock: {[actor]: 2}, deps: {[actor]: 2},
         diffs: [
-          {action: 'create', obj: birds,   type: 'list'},
-          {action: 'insert', obj: birds,   type: 'list', index: 0, value: 'greenfinch',    elemId: `${actor}:3`},
-          {action: 'insert', obj: birds,   type: 'list', index: 1, value: 'goldfinches!!', elemId: `${actor}:2`},
-          {action: 'set',    obj: ROOT_ID, type: 'map',  key: 'birds', value: birds, link: true}
+          {action: 'create',  obj: birds,   type: 'list'},
+          {action: 'insert',  obj: birds,   type: 'list', index: 0, value: 'greenfinch',    elemId: `${actor}:3`},
+          {action: 'insert',  obj: birds,   type: 'list', index: 1, value: 'goldfinches!!', elemId: `${actor}:2`},
+          {action: 'maxElem', obj: birds,   type: 'list', value: 3},
+          {action: 'set',     obj: ROOT_ID, type: 'map',  key: 'birds', value: birds, link: true}
         ]
       })
     })
@@ -370,12 +372,13 @@ describe('Backend', () => {
       assert.deepEqual(Backend.getPatch(s1), {
         canUndo: false, canRedo: false, clock: {[actor]: 1}, deps: {[actor]: 1},
         diffs: [
-          {action: 'create', obj: item,    type: 'map'},
-          {action: 'set',    obj: item,    type: 'map',  key: 'title', value: 'water plants'},
-          {action: 'set',    obj: item,    type: 'map',  key: 'done',  value: false},
-          {action: 'create', obj: todos,   type: 'list'},
-          {action: 'insert', obj: todos,   type: 'list', index: 0,     value: item,  link: true, elemId: `${actor}:1`},
-          {action: 'set',    obj: ROOT_ID, type: 'map',  key: 'todos', value: todos, link: true}
+          {action: 'create',  obj: item,    type: 'map'},
+          {action: 'set',     obj: item,    type: 'map',  key: 'title', value: 'water plants'},
+          {action: 'set',     obj: item,    type: 'map',  key: 'done',  value: false},
+          {action: 'create',  obj: todos,   type: 'list'},
+          {action: 'insert',  obj: todos,   type: 'list', index: 0,     value: item,  link: true, elemId: `${actor}:1`},
+          {action: 'maxElem', obj: todos,   type: 'list', value: 1},
+          {action: 'set',     obj: ROOT_ID, type: 'map',  key: 'todos', value: todos, link: true}
         ]
       })
     })
@@ -406,9 +409,10 @@ describe('Backend', () => {
       assert.deepEqual(Backend.getPatch(s1), {
         canUndo: false, canRedo: false, clock: {[actor]: 1}, deps: {[actor]: 1},
         diffs: [
-          {action: 'create', obj: list,    type: 'list'},
-          {action: 'insert', obj: list,    type: 'list', index: 0, value: now.getTime(), elemId: `${actor}:1`, datatype: 'timestamp'},
-          {action: 'set',    obj: ROOT_ID, type: 'map',  key: 'list', value: list, link: true}
+          {action: 'create',  obj: list,    type: 'list'},
+          {action: 'insert',  obj: list,    type: 'list', index: 0, value: now.getTime(), elemId: `${actor}:1`, datatype: 'timestamp'},
+          {action: 'maxElem', obj: list,    type: 'list', value: 1},
+          {action: 'set',     obj: ROOT_ID, type: 'map',  key: 'list', value: list, link: true}
         ]
       })
     })

--- a/test/test.js
+++ b/test/test.js
@@ -1212,6 +1212,17 @@ describe('Automerge', () => {
       assert.deepEqual(s3._conflicts, {x: {actor1: 3}})
     })
 
+    it('should reconstitute element ID counters', () => {
+      let s = Automerge.init('actorid')
+      s = Automerge.change(s, doc => doc.list = ['a'])
+      assert.strictEqual(Automerge.Frontend.getElementIds(s.list)[0], 'actorid:1')
+      s = Automerge.change(s, doc => doc.list.deleteAt(0))
+      s = Automerge.load(Automerge.save(s), 'actorid')
+      s = Automerge.change(s, doc => doc.list.push('b'))
+      assert.deepEqual(s, {list: ['b']})
+      assert.strictEqual(Automerge.Frontend.getElementIds(s.list)[0], 'actorid:2')
+    })
+
     it('should allow a reloaded list to be mutated', () => {
       let doc = Automerge.change(Automerge.init(), doc => doc.foo = [])
       doc = Automerge.load(Automerge.save(doc))


### PR DESCRIPTION
This PR fixes the error reported in #145. It was caused by the MAX_ELEM list metadata being lost when a document was saved to disk and reloaded, leading to list element IDs potentially being reused.