### PR TITLE
Allow property names starting with underscore

### DIFF
--- a/backend/op_set.js
+++ b/backend/op_set.js
@@ -475,12 +475,8 @@ function getOpValue(opSet, op, context) {
   }
 }
 
-function validFieldName(key) {
-  return (typeof key === 'string' && key !== '' && !key.startsWith('_'))
-}
-
 function isFieldPresent(opSet, objectId, key) {
-  return validFieldName(key) && !getFieldOps(opSet, objectId, key).isEmpty()
+  return !getFieldOps(opSet, objectId, key).isEmpty()
 }
 
 function getObjectFields(opSet, objectId) {
@@ -491,14 +487,13 @@ function getObjectFields(opSet, objectId) {
 }
 
 function getObjectField(opSet, objectId, key, context) {
-  if (!validFieldName(key)) return undefined
   const ops = getFieldOps(opSet, objectId, key)
   if (!ops.isEmpty()) return getOpValue(opSet, ops.first(), context)
 }
 
 function getObjectConflicts(opSet, objectId, context) {
   return opSet.getIn(['byObject', objectId, '_keys'])
-    .filter((field, key) => validFieldName(key) && getFieldOps(opSet, objectId, key).size > 1)
+    .filter((field, key) => getFieldOps(opSet, objectId, key).size > 1)
     .mapEntries(([key, field]) => [key, field.shift().toMap()
       .mapEntries(([idx, op]) => [op.get('actor'), getOpValue(opSet, op, context)])
     ])

--- a/frontend/constants.js
+++ b/frontend/constants.js
@@ -5,8 +5,8 @@ const INBOUND   = Symbol('_inbound')   // map from child objectId to parent obje
 const STATE     = Symbol('_state')     // object containing metadata about current state (e.g. sequence numbers)
 
 // Properties of all Automerge objects
-const OBJECT_ID = '_objectId'          // the object ID of the current object (string)
-const CONFLICTS = '_conflicts'         // map or list (depending on object type) of conflicts
+const OBJECT_ID = Symbol('_objectId')  // the object ID of the current object (string)
+const CONFLICTS = Symbol('_conflicts') // map or list (depending on object type) of conflicts
 const CHANGE    = Symbol('_change')    // the context object on proxy objects used in change callback
 
 // Properties of Automerge list objects

--- a/frontend/context.js
+++ b/frontend/context.js
@@ -161,9 +161,6 @@ class Context {
     if (key === '') {
       throw new RangeError('The key of a map entry must not be an empty string')
     }
-    if (key.startsWith('_')) {
-      throw new RangeError(`Map entries starting with underscore are not allowed: ${key}`)
-    }
 
     const object = this.getObject(objectId)
     if (object[key] instanceof Counter) {

--- a/frontend/index.js
+++ b/frontend/index.js
@@ -424,14 +424,12 @@ function setActorId(doc, actorId) {
 }
 
 /**
- * Fetches the conflicts on `object`, which may be any object in a document.
- * If the object is a map, returns an object mapping keys to conflict sets
- * (only for those keys that actually have conflicts). If the object is a list,
- * returns a list that contains null for non-conflicting indexes and a conflict
- * set otherwise.
+ * Fetches the conflicts on the property `key` of `object`, which may be any
+ * object in a document. If `object` is a list, then `key` must be a list
+ * index; if `object` is a map, then `key` must be a property name.
  */
-function getConflicts(object) {
-  return object[CONFLICTS]
+function getConflicts(object, key) {
+  return object[CONFLICTS][key]
 }
 
 /**

--- a/frontend/index.js
+++ b/frontend/index.js
@@ -408,6 +408,19 @@ function getObjectId(object) {
 }
 
 /**
+ * Returns the object with the given Automerge object ID.
+ */
+function getObjectById(doc, objectId) {
+  const context = doc[CHANGE]
+  if (context) {
+    // If we're within a change callback, return a proxied object
+    return context.instantiateObject(objectId)
+  } else {
+    return doc[CACHE][objectId]
+  }
+}
+
+/**
  * Returns the Automerge actor ID of the given document.
  */
 function getActorId(doc) {
@@ -447,6 +460,7 @@ function getElementIds(list) {
 module.exports = {
   init, change, emptyChange, applyPatch,
   canUndo, undo, canRedo, redo,
-  getObjectId, getActorId, setActorId, getConflicts, getBackendState, getElementIds,
+  getObjectId, getObjectById, getActorId, setActorId, getConflicts,
+  getBackendState, getElementIds,
   Text, Table, Counter
 }

--- a/frontend/proxies.js
+++ b/frontend/proxies.js
@@ -98,8 +98,6 @@ function listMethods(context, listId) {
 const MapHandler = {
   get (target, key) {
     const { context, objectId } = target
-    if (key === '_inspect') return JSON.parse(JSON.stringify(mapProxy(context, objectId)))
-    if (key === '_type') return 'map'
     if (key === OBJECT_ID) return objectId
     if (key === CHANGE) return context
     if (key === '_get') return context._get
@@ -120,7 +118,7 @@ const MapHandler = {
 
   has (target, key) {
     const { context, objectId } = target
-    return ['_type', OBJECT_ID, CHANGE, '_get'].includes(key) || (key in context.getObject(objectId))
+    return [OBJECT_ID, CHANGE, '_get'].includes(key) || (key in context.getObject(objectId))
   },
 
   getOwnPropertyDescriptor (target, key) {
@@ -141,8 +139,6 @@ const ListHandler = {
   get (target, key) {
     const [context, objectId] = target
     if (key === Symbol.iterator) return context.getObject(objectId)[Symbol.iterator]
-    if (key === '_inspect') return JSON.parse(JSON.stringify(listProxy(context, objectId)))
-    if (key === '_type') return 'list'
     if (key === OBJECT_ID) return objectId
     if (key === CHANGE) return context
     if (key === 'length') return context.getObject(objectId).length
@@ -169,7 +165,7 @@ const ListHandler = {
     if (typeof key === 'string' && /^[0-9]+$/.test(key)) {
       return parseListIndex(key) < context.getObject(objectId).length
     }
-    return ['length', '_type', OBJECT_ID, CHANGE].includes(key)
+    return ['length', OBJECT_ID, CHANGE].includes(key)
   },
 
   getOwnPropertyDescriptor (target, key) {

--- a/frontend/proxies.js
+++ b/frontend/proxies.js
@@ -1,5 +1,5 @@
 const { ROOT_ID } = require('../src/common')
-const { CHANGE } = require('./constants')
+const { OBJECT_ID, CHANGE } = require('./constants')
 const { Text } = require('./text')
 const { Table } = require('./table')
 
@@ -100,7 +100,7 @@ const MapHandler = {
     const { context, objectId } = target
     if (key === '_inspect') return JSON.parse(JSON.stringify(mapProxy(context, objectId)))
     if (key === '_type') return 'map'
-    if (key === '_objectId') return objectId
+    if (key === OBJECT_ID) return objectId
     if (key === CHANGE) return context
     if (key === '_get') return context._get
     return context.getObjectField(objectId, key)
@@ -120,7 +120,7 @@ const MapHandler = {
 
   has (target, key) {
     const { context, objectId } = target
-    return ['_type', '_objectId', CHANGE, '_get'].includes(key) || (key in context.getObject(objectId))
+    return ['_type', OBJECT_ID, CHANGE, '_get'].includes(key) || (key in context.getObject(objectId))
   },
 
   getOwnPropertyDescriptor (target, key) {
@@ -143,7 +143,7 @@ const ListHandler = {
     if (key === Symbol.iterator) return context.getObject(objectId)[Symbol.iterator]
     if (key === '_inspect') return JSON.parse(JSON.stringify(listProxy(context, objectId)))
     if (key === '_type') return 'list'
-    if (key === '_objectId') return objectId
+    if (key === OBJECT_ID) return objectId
     if (key === CHANGE) return context
     if (key === 'length') return context.getObject(objectId).length
     if (typeof key === 'string' && /^[0-9]+$/.test(key)) {
@@ -169,12 +169,12 @@ const ListHandler = {
     if (typeof key === 'string' && /^[0-9]+$/.test(key)) {
       return parseListIndex(key) < context.getObject(objectId).length
     }
-    return ['length', '_type', '_objectId', CHANGE].includes(key)
+    return ['length', '_type', OBJECT_ID, CHANGE].includes(key)
   },
 
   getOwnPropertyDescriptor (target, key) {
     if (key === 'length') return {}
-    if (key === '_objectId') return {configurable: true, enumerable: false}
+    if (key === OBJECT_ID) return {configurable: false, enumerable: false}
 
     const [context, objectId] = target
     const object = context.getObject(objectId)
@@ -188,7 +188,7 @@ const ListHandler = {
   ownKeys (target) {
     const [context, objectId] = target
     const object = context.getObject(objectId)
-    let keys = ['length', '_objectId']
+    let keys = ['length']
     keys.push(...Object.keys(object))
     return keys
   }

--- a/frontend/proxies.js
+++ b/frontend/proxies.js
@@ -100,7 +100,6 @@ const MapHandler = {
     const { context, objectId } = target
     if (key === OBJECT_ID) return objectId
     if (key === CHANGE) return context
-    if (key === '_get') return context._get
     return context.getObjectField(objectId, key)
   },
 
@@ -118,7 +117,7 @@ const MapHandler = {
 
   has (target, key) {
     const { context, objectId } = target
-    return [OBJECT_ID, CHANGE, '_get'].includes(key) || (key in context.getObject(objectId))
+    return [OBJECT_ID, CHANGE].includes(key) || (key in context.getObject(objectId))
   },
 
   getOwnPropertyDescriptor (target, key) {
@@ -216,7 +215,6 @@ function instantiateProxy(objectId) {
 
 function rootObjectProxy(context) {
   context.instantiateObject = instantiateProxy
-  context._get = (objId) => instantiateProxy.call(context, objId)
   return mapProxy(context, ROOT_ID)
 }
 

--- a/src/automerge.js
+++ b/src/automerge.js
@@ -125,7 +125,7 @@ module.exports = {
   Connection: require('./connection')
 }
 
-for (let name of ['canUndo', 'canRedo', 'getActorId', 'setActorId',
+for (let name of ['canUndo', 'canRedo', 'getObjectId', 'getActorId', 'setActorId',
      'getConflicts', 'Text', 'Table', 'Counter']) {
   module.exports[name] = Frontend[name]
 }

--- a/src/automerge.js
+++ b/src/automerge.js
@@ -125,7 +125,7 @@ module.exports = {
   Connection: require('./connection')
 }
 
-for (let name of ['canUndo', 'canRedo', 'getObjectId', 'getActorId', 'setActorId',
-     'getConflicts', 'Text', 'Table', 'Counter']) {
+for (let name of ['canUndo', 'canRedo', 'getObjectId', 'getObjectById', 'getActorId',
+     'setActorId', 'getConflicts', 'Text', 'Table', 'Counter']) {
   module.exports[name] = Frontend[name]
 }

--- a/test/frontend_test.js
+++ b/test/frontend_test.js
@@ -349,7 +349,7 @@ describe('Frontend', () => {
       ]
       const doc = Frontend.applyPatch(Frontend.init(), {diffs})
       assert.deepEqual(doc, {favoriteBird: 'wagtail'})
-      assert.deepEqual(Frontend.getConflicts(doc), {favoriteBird: {[actor]: 'robin'}})
+      assert.deepEqual(Frontend.getConflicts(doc, 'favoriteBird'), {[actor]: 'robin'})
     })
 
     it('should create nested maps', () => {
@@ -396,8 +396,8 @@ describe('Frontend', () => {
       const doc2 = Frontend.applyPatch(doc1, {diffs: diffs2})
       assert.deepEqual(doc1, {favoriteBirds: {wrens: 3}})
       assert.deepEqual(doc2, {favoriteBirds: {wrens: 3}})
-      assert.deepEqual(Frontend.getConflicts(doc1), {favoriteBirds: {[actor]: {blackbirds: 1}}})
-      assert.deepEqual(Frontend.getConflicts(doc2), {favoriteBirds: {[actor]: {blackbirds: 2}}})
+      assert.deepEqual(Frontend.getConflicts(doc1, 'favoriteBirds'), {[actor]: {blackbirds: 1}})
+      assert.deepEqual(Frontend.getConflicts(doc2, 'favoriteBirds'), {[actor]: {blackbirds: 2}})
     })
 
     it('should structure-share unmodified objects', () => {
@@ -483,8 +483,8 @@ describe('Frontend', () => {
       assert.deepEqual(doc1, {birds: [{species: 'lapwing', numSeen: 2}]})
       assert.deepEqual(doc2, {birds: [{species: 'lapwing', numSeen: 2}]})
       assert.strictEqual(doc1.birds[0], doc2.birds[0])
-      assert.deepEqual(Frontend.getConflicts(doc1.birds), [{[actor]: {species: 'woodpecker', numSeen: 1}}])
-      assert.deepEqual(Frontend.getConflicts(doc2.birds), [{[actor]: {species: 'woodpecker', numSeen: 2}}])
+      assert.deepEqual(Frontend.getConflicts(doc1.birds, 0), {[actor]: {species: 'woodpecker', numSeen: 1}})
+      assert.deepEqual(Frontend.getConflicts(doc2.birds, 0), {[actor]: {species: 'woodpecker', numSeen: 2}})
     })
 
     it('should delete list elements', () => {

--- a/test/proxies_test.js
+++ b/test/proxies_test.js
@@ -8,8 +8,7 @@ describe('Automerge proxy API', () => {
     it('should have a fixed object ID', () => {
       Automerge.change(Automerge.init(), doc => {
         assert.strictEqual(doc._type, 'map')
-        assert.strictEqual(doc._objectId, ROOT_ID)
-        assert.strictEqual('_objectId' in doc, true)
+        assert.strictEqual(Automerge.getObjectId(doc), ROOT_ID)
       })
     })
 
@@ -87,22 +86,22 @@ describe('Automerge proxy API', () => {
     it('should allow access to an object by id', () => {
       Automerge.change(Automerge.init(), doc => {
         const rootObj = doc._get(ROOT_ID)
-        assert.strictEqual(rootObj._objectId, doc._objectId)
+        assert.strictEqual(Automerge.getObjectId(rootObj), Automerge.getObjectId(doc))
 
         rootObj.deepObj = {}
-        const deepObjId = doc.deepObj._objectId
+        const deepObjId = Automerge.getObjectId(doc.deepObj)
         const deepObj = doc._get(deepObjId)
-        assert.strictEqual(deepObj._objectId, deepObjId)
+        assert.strictEqual(Automerge.getObjectId(deepObj), deepObjId)
 
         deepObj.deepList = []
-        const deepListId = doc.deepObj.deepList._objectId
+        const deepListId = Automerge.getObjectId(doc.deepObj.deepList)
         const deepList = doc._get(deepListId)
-        assert.strictEqual(deepList._objectId, deepListId)
+        assert.strictEqual(Automerge.getObjectId(deepList), deepListId)
 
         deepList.insertAt(0, {})
-        const deepItemId = doc.deepObj.deepList[0]._objectId
+        const deepItemId = Automerge.getObjectId(doc.deepObj.deepList[0])
         const deepItem = doc._get(deepItemId)
-        assert.strictEqual(deepItem._objectId, deepItemId)
+        assert.strictEqual(Automerge.getObjectId(deepItem), deepItemId)
       })
     })
   })
@@ -163,7 +162,7 @@ describe('Automerge proxy API', () => {
 
     it('should support Object.getOwnPropertyNames()', () => {
       Automerge.change(root, doc => {
-        assert.deepEqual(Object.getOwnPropertyNames(doc.list), ['length', '_objectId', '0', '1', '2'])
+        assert.deepEqual(Object.getOwnPropertyNames(doc.list), ['length', '0', '1', '2'])
       })
     })
 

--- a/test/proxies_test.js
+++ b/test/proxies_test.js
@@ -7,7 +7,6 @@ describe('Automerge proxy API', () => {
   describe('root object', () => {
     it('should have a fixed object ID', () => {
       Automerge.change(Automerge.init(), doc => {
-        assert.strictEqual(doc._type, 'map')
         assert.strictEqual(Automerge.getObjectId(doc), ROOT_ID)
       })
     })

--- a/test/proxies_test.js
+++ b/test/proxies_test.js
@@ -83,25 +83,27 @@ describe('Automerge proxy API', () => {
     })
 
     it('should allow access to an object by id', () => {
-      Automerge.change(Automerge.init(), doc => {
-        const rootObj = doc._get(ROOT_ID)
+      let deepObjId, deepListId
+
+      const doc = Automerge.change(Automerge.init(), doc => {
+        const rootObj = Automerge.getObjectById(doc, ROOT_ID)
         assert.strictEqual(Automerge.getObjectId(rootObj), Automerge.getObjectId(doc))
 
         rootObj.deepObj = {}
-        const deepObjId = Automerge.getObjectId(doc.deepObj)
-        const deepObj = doc._get(deepObjId)
+        deepObjId = Automerge.getObjectId(doc.deepObj)
+        const deepObj = Automerge.getObjectById(doc, deepObjId)
         assert.strictEqual(Automerge.getObjectId(deepObj), deepObjId)
 
         deepObj.deepList = []
-        const deepListId = Automerge.getObjectId(doc.deepObj.deepList)
-        const deepList = doc._get(deepListId)
+        deepListId = Automerge.getObjectId(doc.deepObj.deepList)
+        const deepList = Automerge.getObjectById(doc, deepListId)
         assert.strictEqual(Automerge.getObjectId(deepList), deepListId)
-
-        deepList.insertAt(0, {})
-        const deepItemId = Automerge.getObjectId(doc.deepObj.deepList[0])
-        const deepItem = doc._get(deepItemId)
-        assert.strictEqual(Automerge.getObjectId(deepItem), deepItemId)
       })
+
+      const deepObj = Automerge.getObjectById(doc, deepObjId)
+      assert.strictEqual(Automerge.getObjectId(deepObj), Automerge.getObjectId(doc.deepObj))
+      const deepList = Automerge.getObjectById(doc, deepListId)
+      assert.strictEqual(Automerge.getObjectId(deepList), Automerge.getObjectId(doc.deepObj.deepList))
     })
   })
 

--- a/test/test.js
+++ b/test/test.js
@@ -270,9 +270,6 @@ describe('Automerge', () => {
         assert.throws(() => {
           Automerge.change(s1, 'foo', doc => doc[''] = 'x')
         }, /must not be an empty string/)
-        assert.throws(() => {
-          Automerge.change(s1, 'foo', doc => doc['_foo'] = 'x')
-        }, /Map entries starting with underscore are not allowed/)
       })
 
       it('should not allow assignment of unsupported datatypes', () => {
@@ -403,8 +400,6 @@ describe('Automerge', () => {
         s1 = Automerge.change(s1, doc => doc.nested = {})
         assert.throws(() => { Automerge.change(s1, doc => doc.nested[''] = 'x') }, /must not be an empty string/)
         assert.throws(() => { Automerge.change(s1, doc => doc.nested = {'': 'x'}) }, /must not be an empty string/)
-        assert.throws(() => { Automerge.change(s1, doc => doc.nested._foo = 'x') }, /Map entries starting with underscore are not allowed/)
-        assert.throws(() => { Automerge.change(s1, doc => doc.nested = {_foo: 'x'}) }, /Map entries starting with underscore are not allowed/)
       })
     })
 


### PR DESCRIPTION
This PR implements the long-standing request #94: Automerge map objects may now contain user-defined properties whose name begins with an underscore. Previously these properties had been reserved for Automerge-internal purposes, but now applications may use them as they see fit.

In order to enable this change, all APIs that were provided through underscore-prefixed properties or methods on document objects have now been replaced with functions in the Automerge namespace. In particular:

* `doc.object._objectId` is now `Automerge.getObjectId(doc.object)`
* `doc.object._conflicts.property` is now `Automerge.getConflicts(doc.object, 'property')`
* `doc._get(objectId)` is now `Automerge.getObjectById(doc, objectId)`
