### PR TITLE
Fixes #151: reuse of list element IDs

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -547,6 +547,21 @@ describe('Automerge', () => {
         assert.strictEqual(s1.letters[1], 'd')
       })
 
+      it('should allow adding and removing list elements in the same change callback', () => {
+        s1 = Automerge.change(Automerge.init(), doc => doc.noodles = [])
+        s1 = Automerge.change(s1, doc => {
+          doc.noodles.push('udon')
+          doc.noodles.deleteAt(0)
+        })
+        assert.deepEqual(s1, {noodles: []})
+        // do the add-remove cycle twice, test for #151 (https://github.com/automerge/automerge/issues/151)
+        s1 = Automerge.change(s1, doc => {
+          doc.noodles.push('soba')
+          doc.noodles.deleteAt(0)
+        })
+        assert.deepEqual(s1, {noodles: []})
+      })
+
       it('should handle arbitrary-depth nesting', () => {
         s1 = Automerge.change(s1, doc => doc.maze = [[[[[[[['noodles', ['here']]]]]]]]])
         s1 = Automerge.change(s1, doc => doc.maze[0][0][0][0][0][0][0][1].unshift('found'))


### PR DESCRIPTION
This PR fixes bug #151.

If a list element was added and then removed again in the same change block, then after the change came back from the backend, the frontend would forget about the element ID it had allocated. Then, on the next inserted list element, it would incorrectly reuse the same ID again. This change uses the existing maxElem action type in a patch to ensure the frontend's elemId counter is kept up-to-date.