### PR TITLE
Fix undo/redo when using separate frontend and backend

### DIFF
--- a/frontend/index.js
+++ b/frontend/index.js
@@ -105,9 +105,10 @@ function makeChange(doc, requestType, context, message) {
     return [applyPatchToDoc(doc, patch, state, true), request]
 
   } else {
+    if (!context) context = new Context(doc, actor)
     const queuedRequest = Object.assign({}, request)
     queuedRequest.before = doc
-    if (context) queuedRequest.diffs = context.diffs
+    queuedRequest.diffs = context.diffs
     state.requests = state.requests.slice() // shallow clone
     state.requests.push(queuedRequest)
     return [updateRootObject(doc, context.updated, context.inbound, state), request]


### PR DESCRIPTION
Bug: when using Automerge in a configuration with separate frontend and backend, attempting to perform `Frontend.undo()` would result in the following exception:

    TypeError: Cannot read property 'updated' of null
      at makeChange (frontend/index.js:113:43)

Fixed the bug and added tests that exercise undo/redo in the case where frontend and backend are separate.