### PR TITLE
Detect the current platform's behaviour for throwing on frozen object modification for the tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ node_js:
 - '8'
 - '9'
 - '10'
+- '11'
+- '12'
 script: 'yarn test && yarn build && TEST_DIST=1 yarn test && node -e "const Automerge = require(\"./dist/automerge\")"'
 jobs:
   include:

--- a/test/test.js
+++ b/test/test.js
@@ -42,10 +42,17 @@ describe('Automerge', () => {
         assert.deepEqual(s2, {first: 'one', second: 'two'})
       })
 
+      let platformIgnoresFrozenMutation = true;
+      try {
+        Object.freeze({}).foo = 1;
+      } catch (e) {
+        platformIgnoresFrozenMutation = false;
+      }
+
       it('should prevent mutations outside of a change block', () => {
         s2 = Automerge.change(s1, doc => doc.foo = 'bar')
-        if (typeof window === 'object') {
-          // Chrome and Firefox silently ignore modifications of a frozen object
+        if (platformIgnoresFrozenMutation) {
+          // Chrome, Firefox, and node >= 10 silently ignore modifications of a frozen object
           s2.foo = 'lemon'
           assert.strictEqual(s2.foo, 'bar')
           const deleted = delete s2['foo']


### PR DESCRIPTION
Different platforms sadly treat modifying a frozen object differently, so this test has to test different behaviour depending on the platform. Before this change, it hardcoded which behaviour to expect when based on the presence of the window object, but new node versions changed their behaviour to match that of the browsers, breaking this check. Instead of a hardcoded check, let's just detect the current platform's behaviour outside the test, and then make sure that automerge matches that behaviour.

This fixes the tests to run cleanly on node v10.x,  v11.x, and v12.x. It also adds v11 and v12 to be tested on Travis to prevent this in the future!   