### PR TITLE
Add Node v11 and v12 to the CI test matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ node_js:
 - '8'
 - '9'
 - '10'
+- '11'
+- '12'
 script: 'yarn test && yarn build && TEST_DIST=1 yarn test && node -e "const Automerge = require(\"./dist/automerge\")"'
 jobs:
   include:


### PR DESCRIPTION
Both of these have been out for a little while now, and Travis looks to be free, may as well get more information about if the build is working for common platforms. v12 is the latest LTS so it seems especially important.

Note: The `fsevents` native extensions don't build on node v12 because the series of dependencies hasn't updated to the fsevents v3 series, which does indeed build on node v12 fine. It's dependend on via webpack, and because it's an optional dependency I feel it best to just leave it alone for now and wait for Webpack to upgrade to a v12 compatible version.