### PR TITLE
Make use of Object.freeze optional to improve performance

### DIFF
--- a/backend/skip_list.js
+++ b/backend/skip_list.js
@@ -25,11 +25,10 @@ class Node {
     this.key = key
     this.value = value
     this.level = level
-    this.prevKey = Object.freeze(prevKey)
-    this.nextKey = Object.freeze(nextKey)
-    this.prevCount = Object.freeze(prevCount)
-    this.nextCount = Object.freeze(nextCount)
-    Object.freeze(this)
+    this.prevKey = prevKey
+    this.nextKey = nextKey
+    this.prevCount = prevCount
+    this.nextCount = nextCount
   }
 
   setValue (key, value) {
@@ -338,7 +337,7 @@ function makeInstance(length, nodes, randomSource) {
   instance.length = length
   instance._nodes = nodes
   instance._randomSource = randomSource
-  return Object.freeze(instance)
+  return instance
 }
 
 module.exports = {SkipList}

--- a/frontend/apply_patch.js
+++ b/frontend/apply_patch.js
@@ -1,5 +1,5 @@
 const { ROOT_ID, isObject, parseElemId } = require('../src/common')
-const { OBJECT_ID, CONFLICTS, ELEM_IDS, MAX_ELEM } = require('./constants')
+const { OPTIONS, OBJECT_ID, CONFLICTS, ELEM_IDS, MAX_ELEM } = require('./constants')
 const { Text } = require('./text')
 const { Table, instantiateTable } = require('./table')
 const { Counter } = require('./counter')
@@ -142,7 +142,7 @@ function parentMapObject(objectId, cache, updated) {
       }
     }
 
-    if (conflictsUpdate) {
+    if (conflictsUpdate && cache[ROOT_ID][OPTIONS].freeze) {
       Object.freeze(conflictsUpdate)
     }
   }
@@ -302,7 +302,7 @@ function parentListObject(objectId, cache, updated) {
       }
     }
 
-    if (conflictsUpdate) {
+    if (conflictsUpdate && cache[ROOT_ID][OPTIONS].freeze) {
       Object.freeze(conflictsUpdate)
     }
   }

--- a/frontend/index.js
+++ b/frontend/index.js
@@ -25,12 +25,14 @@ function updateRootObject(doc, updated, inbound, state) {
   Object.defineProperty(newDoc, INBOUND,  {value: inbound})
   Object.defineProperty(newDoc, STATE,    {value: state})
 
-  for (let objectId of Object.keys(updated)) {
-    if (updated[objectId] instanceof Table) {
-      updated[objectId]._freeze()
-    } else {
-      Object.freeze(updated[objectId])
-      Object.freeze(updated[objectId][CONFLICTS])
+  if (doc[OPTIONS].freeze) {
+    for (let objectId of Object.keys(updated)) {
+      if (updated[objectId] instanceof Table) {
+        updated[objectId]._freeze()
+      } else {
+        Object.freeze(updated[objectId])
+        Object.freeze(updated[objectId][CONFLICTS])
+      }
     }
   }
 
@@ -40,8 +42,10 @@ function updateRootObject(doc, updated, inbound, state) {
     }
   }
 
-  Object.freeze(updated)
-  Object.freeze(inbound)
+  if (doc[OPTIONS].freeze) {
+    Object.freeze(updated)
+    Object.freeze(inbound)
+  }
   return newDoc
 }
 

--- a/src/automerge.js
+++ b/src/automerge.js
@@ -7,9 +7,8 @@ const { isObject } = require('./common')
 /**
  * Constructs a new frontend document that reflects the given list of changes.
  */
-function docFromChanges(actorId, changes) {
-  if (!actorId) throw new RangeError('actorId is required in docFromChanges')
-  const doc = Frontend.init({actorId, backend: Backend})
+function docFromChanges(options, changes) {
+  const doc = init(options)
   const [state, _] = Backend.applyChanges(Backend.init(), changes)
   const patch = Backend.getPatch(state)
   patch.state = state
@@ -18,12 +17,19 @@ function docFromChanges(actorId, changes) {
 
 ///// Automerge.* API
 
-function init(actorId) {
-  return Frontend.init({actorId, backend: Backend})
+function init(options) {
+  if (typeof options === 'string') {
+    options = {actorId: options}
+  } else if (typeof options === 'undefined') {
+    options = {}
+  } else if (!isObject(options)) {
+    throw new TypeError(`Unsupported options for init(): ${options}`)
+  }
+  return Frontend.init(Object.assign({backend: Backend}, options))
 }
 
-function from(initialState) {
-  return change(init(), 'Initialization', doc => Object.assign(doc, initialState))
+function from(initialState, options) {
+  return change(init(options), 'Initialization', doc => Object.assign(doc, initialState))
 }
 
 function change(doc, message, callback) {
@@ -46,8 +52,8 @@ function redo(doc, message) {
   return newDoc
 }
 
-function load(string, actorId) {
-  return docFromChanges(actorId || uuid(), transit.fromJSON(string))
+function load(string, options) {
+  return docFromChanges(options, transit.fromJSON(string))
 }
 
 function save(doc) {

--- a/test/table_test.js
+++ b/test/table_test.js
@@ -62,7 +62,7 @@ describe('Automerge.Table', () => {
     let s1, rowId
 
     beforeEach(() => {
-      s1 = Automerge.change(Automerge.init(), doc => {
+      s1 = Automerge.change(Automerge.init({freeze: true}), doc => {
         doc.books = new Automerge.Table(['authors', 'title', 'isbn'])
         rowId = doc.books.add(DDIA)
       })

--- a/test/test.js
+++ b/test/test.js
@@ -66,7 +66,8 @@ describe('Automerge', () => {
         assert.deepEqual(s2, {first: 'one', second: 'two'})
       })
 
-      it('should prevent mutations outside of a change block', () => {
+      it('should freeze objects if desired', () => {
+        s1 = Automerge.init({freeze: true})
         s2 = Automerge.change(s1, doc => doc.foo = 'bar')
         try {
           s2.foo = 'lemon'


### PR DESCRIPTION
As discovered by @izuchukwu in #177, our use of `Object.freeze` has a big negative performance impact on Automerge. In particular, in Chrome and Node (i.e. V8), copying a frozen array is [awfully slow](https://jsperf.com/cloning-frozen-array/1) (on the order of 100x slower than copying a non-frozen array of the same size), and copying a frozen object [isn't great either](https://jsperf.com/cloning-frozen-object/1). I have [filed a Chromium bug](https://bugs.chromium.org/p/chromium/issues/detail?id=980227) that will hopefully cause this issue to be fixed, but we don't know how long it will take.

In the meantime, this PR disables the use of `Object.freeze` by default. It doesn't remove all calls to that function, but it does remove those that are on the critical path performance-wise. If you want to keep the use of `Object.freeze`, e.g. in order to avoid inadvertently modifying an Automerge document outside of `Automerge.change()`, you can pass in an option when constructing the document object: `Automerge.init({freeze: true})` or `Automerge.load(string, {freeze: true})`.

With these changes, Automerge achieves the same performance as the "hot-automerge" fork in @izuchukwu's [benchmark](https://github.com/izuchukwu/experiments-automerge).