### PR TITLE
Allow Text instatiation with preset value

### DIFF
--- a/frontend/apply_patch.js
+++ b/frontend/apply_patch.js
@@ -1,6 +1,6 @@
 const { ROOT_ID, isObject, copyObject, parseElemId } = require('../src/common')
 const { OPTIONS, OBJECT_ID, CONFLICTS, ELEM_IDS, MAX_ELEM } = require('./constants')
-const { Text, makeTextInstance } = require('./text')
+const { Text, instantiateText } = require('./text')
 const { Table, instantiateTable } = require('./table')
 const { Counter } = require('./counter')
 
@@ -320,9 +320,9 @@ function updateTextObject(diffs, startIndex, endIndex, cache, updated) {
     if (cache[objectId]) {
       const elems = cache[objectId].elems.slice()
       const maxElem = cache[objectId][MAX_ELEM]
-      updated[objectId] = makeTextInstance(objectId, elems, maxElem)
+      updated[objectId] = instantiateText(objectId, elems, maxElem)
     } else {
-      updated[objectId] = makeTextInstance(objectId)
+      updated[objectId] = instantiateText(objectId, [], 0)
     }
   }
 
@@ -379,7 +379,7 @@ function updateTextObject(diffs, startIndex, endIndex, cache, updated) {
 
     startIndex += 1
   }
-  updated[objectId] = makeTextInstance(objectId, elems, maxElem)
+  updated[objectId] = instantiateText(objectId, elems, maxElem)
 }
 
 /**

--- a/frontend/apply_patch.js
+++ b/frontend/apply_patch.js
@@ -1,6 +1,6 @@
 const { ROOT_ID, isObject, copyObject, parseElemId } = require('../src/common')
 const { OPTIONS, OBJECT_ID, CONFLICTS, ELEM_IDS, MAX_ELEM } = require('./constants')
-const { Text } = require('./text')
+const { Text, makeTextInstance } = require('./text')
 const { Table, instantiateTable } = require('./table')
 const { Counter } = require('./counter')
 
@@ -320,9 +320,9 @@ function updateTextObject(diffs, startIndex, endIndex, cache, updated) {
     if (cache[objectId]) {
       const elems = cache[objectId].elems.slice()
       const maxElem = cache[objectId][MAX_ELEM]
-      updated[objectId] = new Text(objectId, elems, maxElem)
+      updated[objectId] = makeTextInstance(objectId, elems, maxElem)
     } else {
-      updated[objectId] = new Text(objectId)
+      updated[objectId] = makeTextInstance(objectId)
     }
   }
 
@@ -379,7 +379,7 @@ function updateTextObject(diffs, startIndex, endIndex, cache, updated) {
 
     startIndex += 1
   }
-  updated[objectId] = new Text(objectId, elems, maxElem)
+  updated[objectId] = makeTextInstance(objectId, elems, maxElem)
 }
 
 /**

--- a/frontend/context.js
+++ b/frontend/context.js
@@ -77,11 +77,17 @@ class Context {
 
     if (value instanceof Text) {
       // Create a new Text object
-      if (value.length > 0) {
-        throw new RangeError('Assigning a non-empty Text object is not supported')
-      }
       this.apply({action: 'create', type: 'text', obj: objectId})
       this.addOp({action: 'makeText', obj: objectId})
+      // If non empty Text instance that has no objectId it was initialized
+      // with preset elements which are inserted.
+      if (value.length > 0) {
+        const [...elems] = value
+        this.splice(objectId, 0, 0, elems)
+        // Get rid of preset elems.
+        value.elems.length = elems.length
+        value.maxElem = elems.length
+      }
 
     } else if (value instanceof Table) {
       // Create a new Table object

--- a/frontend/context.js
+++ b/frontend/context.js
@@ -79,14 +79,9 @@ class Context {
       // Create a new Text object
       this.apply({action: 'create', type: 'text', obj: objectId})
       this.addOp({action: 'makeText', obj: objectId})
-      // If non empty Text instance that has no objectId it was initialized
-      // with preset elements which are inserted.
+
       if (value.length > 0) {
-        const [...elems] = value
-        this.splice(objectId, 0, 0, elems)
-        // Get rid of preset elems.
-        value.elems.length = elems.length
-        value.maxElem = elems.length
+        this.splice(objectId, 0, 0, [...value])
       }
 
     } else if (value instanceof Table) {

--- a/frontend/context.js
+++ b/frontend/context.js
@@ -84,6 +84,14 @@ class Context {
         this.splice(objectId, 0, 0, [...value])
       }
 
+      // Set object properties so that any subsequent modifications of the Text
+      // object can be applied to the context
+      let text = this.getObject(objectId)
+      value[OBJECT_ID] = objectId
+      value.elems = text.elems
+      value[MAX_ELEM] = text.maxElem
+      value.context = this
+
     } else if (value instanceof Table) {
       // Create a new Table object
       if (value.count > 0) {

--- a/frontend/proxies.js
+++ b/frontend/proxies.js
@@ -205,9 +205,9 @@ function listProxy(context, objectId) {
  */
 function instantiateProxy(objectId) {
   const object = this.getObject(objectId)
-  if (Array.isArray(object) || (object instanceof Text)) {
+  if (Array.isArray(object)) {
     return listProxy(this, objectId)
-  } else if (object instanceof Table) {
+  } else if (object instanceof Text || object instanceof Table) {
     return object.getWriteable(this)
   } else {
     return mapProxy(this, objectId)

--- a/frontend/text.js
+++ b/frontend/text.js
@@ -1,8 +1,15 @@
 const { OBJECT_ID, ELEM_IDS, MAX_ELEM } = require('./constants')
+const uuid = require('../src/uuid')
+
 
 class Text {
-  constructor (objectId, elems, maxElem) {
-    return makeInstance(objectId, elems, maxElem)
+  constructor (text) {
+    if (text) {
+      const elems = text.split("").map(value => ({value}))
+      return makeTextInstance(undefined, elems, elems.length)
+    } else {
+      return makeTextInstance()
+    }
   }
 
   get length () {
@@ -50,7 +57,7 @@ for (let method of ['concat', 'every', 'filter', 'find', 'findIndex', 'forEach',
   }
 }
 
-function makeInstance(objectId, elems, maxElem) {
+function makeTextInstance(objectId, elems, maxElem) {
   const instance = Object.create(Text.prototype)
   instance[OBJECT_ID] = objectId
   instance.elems = elems || []
@@ -66,4 +73,4 @@ function getElemId(object, index) {
   return (object instanceof Text) ? object.getElemId(index) : object[ELEM_IDS][index]
 }
 
-module.exports = { Text, getElemId }
+module.exports = { Text, getElemId, makeTextInstance }

--- a/frontend/text.js
+++ b/frontend/text.js
@@ -48,6 +48,64 @@ class Text {
   toJSON() {
     return this.join('')
   }
+
+  /**
+   * Returns a writeable instance of this object. This instance is returned when
+   * the text object is accessed within a change callback. `context` is the
+   * proxy context that keeps track of the mutations.
+   */
+  getWriteable(context) {
+    if (!this[OBJECT_ID]) {
+      throw new RangeError('getWriteable() requires the objectId to be set')
+    }
+
+    const instance = instantiateText(this[OBJECT_ID], this.elems, this[MAX_ELEM])
+    instance.context = context
+    return instance
+  }
+
+  /**
+   * Updates the list item at position `index` to a new value `value`.
+   */
+  set (index, value) {
+    if (this.context) {
+      this.context.setListIndex(this[OBJECT_ID], index, value)
+    } else if (!this[OBJECT_ID]) {
+      this.elems[index].value = value
+    } else {
+      throw new TypeError('Automerge.Text object cannot be modified outside of a change block')
+    }
+    return this
+  }
+
+  /**
+   * Inserts new list items `values` starting at position `index`.
+   */
+  insertAt(index, ...values) {
+    if (this.context) {
+      this.context.splice(this[OBJECT_ID], index, 0, values)
+    } else if (!this[OBJECT_ID]) {
+      this.elems.splice(index, 0, ...values.map(value => ({value})))
+    } else {
+      throw new TypeError('Automerge.Text object cannot be modified outside of a change block')
+    }
+    return this
+  }
+
+  /**
+   * Deletes `numDelete` list items starting at position `index`.
+   * if `numDelete` is not given, one item is deleted.
+   */
+  deleteAt(index, numDelete) {
+    if (this.context) {
+      this.context.splice(this[OBJECT_ID], index, numDelete || 1, [])
+    } else if (!this[OBJECT_ID]) {
+      this.elems.splice(index, numDelete || 1)
+    } else {
+      throw new TypeError('Automerge.Text object cannot be modified outside of a change block')
+    }
+    return this
+  }
 }
 
 // Read-only methods that can delegate to the JavaScript built-in array

--- a/frontend/text.js
+++ b/frontend/text.js
@@ -1,14 +1,17 @@
 const { OBJECT_ID, ELEM_IDS, MAX_ELEM } = require('./constants')
-const uuid = require('../src/uuid')
-
 
 class Text {
   constructor (text) {
-    if (text) {
-      const elems = text.split("").map(value => ({value}))
-      return makeTextInstance(undefined, elems, elems.length)
+    if (typeof text === 'string') {
+      const elems = text.split('').map(value => ({value}))
+      return instantiateText(undefined, elems, undefined)
+    } else if (Array.isArray(text)) {
+      const elems = text.map(value => ({value}))
+      return instantiateText(undefined, elems, undefined)
+    } else if (text === undefined) {
+      return instantiateText(undefined, [], 0)
     } else {
-      return makeTextInstance()
+      throw new TypeError(`Unsupported initial value for Text: ${text}`)
     }
   }
 
@@ -57,11 +60,11 @@ for (let method of ['concat', 'every', 'filter', 'find', 'findIndex', 'forEach',
   }
 }
 
-function makeTextInstance(objectId, elems, maxElem) {
+function instantiateText(objectId, elems, maxElem) {
   const instance = Object.create(Text.prototype)
   instance[OBJECT_ID] = objectId
-  instance.elems = elems || []
-  instance[MAX_ELEM] = maxElem || 0
+  instance.elems = elems
+  instance[MAX_ELEM] = maxElem
   return instance
 }
 
@@ -73,4 +76,4 @@ function getElemId(object, index) {
   return (object instanceof Text) ? object.getElemId(index) : object[ELEM_IDS][index]
 }
 
-module.exports = { Text, getElemId, makeTextInstance }
+module.exports = { Text, getElemId, instantiateText }

--- a/test/text_test.js
+++ b/test/text_test.js
@@ -45,3 +45,51 @@ describe('Automerge.Text', () => {
     assert.strictEqual(JSON.stringify(s1), '{"text":"a\\"b"}')
   })
 })
+
+describe('Automerge.Text("init")', () => {
+  let s1, s2
+  beforeEach(() => {
+    s1 = Automerge.change(Automerge.init(), doc => doc.text = new Automerge.Text("init"))
+    s2 = Automerge.merge(Automerge.init(), s1)
+  })
+
+  it('should support insertion', () => {
+    s1 = Automerge.change(s1, doc => doc.text.insertAt(0, 'a'))
+    assert.strictEqual(s1.text.length, 5)
+    assert.strictEqual(s1.text.get(0), 'a')
+    assert.strictEqual(s1.text.get(1), 'i')
+    assert.strictEqual(s1.text.get(2), 'n')
+    assert.strictEqual(s1.text.get(3), 'i')
+    assert.strictEqual(s1.text.get(4), 't')
+  })
+
+  it('should support deletion', () => {
+    s1 = Automerge.change(s1, doc => doc.text.deleteAt(1, 1))
+    assert.strictEqual(s1.text.length, 3)
+    assert.strictEqual(s1.text.get(0), 'i')
+    assert.strictEqual(s1.text.get(1), 'i')
+    assert.strictEqual(s1.text.get(2), 't')
+  })
+
+  it('should handle concurrent insertion', () => {
+    s1 = Automerge.change(s1, doc => doc.text.insertAt(1, 'a', 'b', 'c'))
+    s2 = Automerge.change(s2, doc => doc.text.insertAt(1, 'x', 'y', 'z'))
+    s1 = Automerge.merge(s1, s2)
+    assert.strictEqual(s1.text.length, 10)
+    assertEqualsOneOf(s1.text.join(''), 'iabcxyznit', 'ixyzabcnit')
+  })
+
+  it('should handle text and other ops in the same change', () => {
+    s1 = Automerge.change(s1, doc => {
+      doc.foo = 'bar'
+      doc.text.insertAt(0, 'a')
+    })
+    assert.strictEqual(s1.foo, 'bar')
+    assert.strictEqual(s1.text.join(''), 'ainit')
+  })
+
+  it('should serialize to JSON as a simple string', () => {
+    s1 = Automerge.change(s1, doc => doc.text.insertAt(0, 'a', '"', 'b'))
+    assert.strictEqual(JSON.stringify(s1), '{"text":"a\\"binit"}')
+  })
+})

--- a/test/text_test.js
+++ b/test/text_test.js
@@ -44,52 +44,53 @@ describe('Automerge.Text', () => {
     s1 = Automerge.change(s1, doc => doc.text.insertAt(0, 'a', '"', 'b'))
     assert.strictEqual(JSON.stringify(s1), '{"text":"a\\"b"}')
   })
-})
 
-describe('Automerge.Text("init")', () => {
-  let s1, s2
-  beforeEach(() => {
-    s1 = Automerge.change(Automerge.init(), doc => doc.text = new Automerge.Text("init"))
-    s2 = Automerge.merge(Automerge.init(), s1)
-  })
-
-  it('should support insertion', () => {
-    s1 = Automerge.change(s1, doc => doc.text.insertAt(0, 'a'))
-    assert.strictEqual(s1.text.length, 5)
-    assert.strictEqual(s1.text.get(0), 'a')
-    assert.strictEqual(s1.text.get(1), 'i')
-    assert.strictEqual(s1.text.get(2), 'n')
-    assert.strictEqual(s1.text.get(3), 'i')
-    assert.strictEqual(s1.text.get(4), 't')
-  })
-
-  it('should support deletion', () => {
-    s1 = Automerge.change(s1, doc => doc.text.deleteAt(1, 1))
-    assert.strictEqual(s1.text.length, 3)
-    assert.strictEqual(s1.text.get(0), 'i')
-    assert.strictEqual(s1.text.get(1), 'i')
-    assert.strictEqual(s1.text.get(2), 't')
-  })
-
-  it('should handle concurrent insertion', () => {
-    s1 = Automerge.change(s1, doc => doc.text.insertAt(1, 'a', 'b', 'c'))
-    s2 = Automerge.change(s2, doc => doc.text.insertAt(1, 'x', 'y', 'z'))
-    s1 = Automerge.merge(s1, s2)
-    assert.strictEqual(s1.text.length, 10)
-    assertEqualsOneOf(s1.text.join(''), 'iabcxyznit', 'ixyzabcnit')
-  })
-
-  it('should handle text and other ops in the same change', () => {
-    s1 = Automerge.change(s1, doc => {
-      doc.foo = 'bar'
-      doc.text.insertAt(0, 'a')
+  describe('with initial value', () => {
+    it('should accept a string as initial value', () => {
+      let s1 = Automerge.change(Automerge.init(), doc => doc.text = new Automerge.Text('init'))
+      assert.strictEqual(s1.text.length, 4)
+      assert.strictEqual(s1.text.get(0), 'i')
+      assert.strictEqual(s1.text.get(1), 'n')
+      assert.strictEqual(s1.text.get(2), 'i')
+      assert.strictEqual(s1.text.get(3), 't')
     })
-    assert.strictEqual(s1.foo, 'bar')
-    assert.strictEqual(s1.text.join(''), 'ainit')
-  })
 
-  it('should serialize to JSON as a simple string', () => {
-    s1 = Automerge.change(s1, doc => doc.text.insertAt(0, 'a', '"', 'b'))
-    assert.strictEqual(JSON.stringify(s1), '{"text":"a\\"binit"}')
+    it('should accept an array as initial value', () => {
+      let s1 = Automerge.change(Automerge.init(), doc => doc.text = new Automerge.Text(['i', 'n', 'i', 't']))
+      assert.strictEqual(s1.text.length, 4)
+      assert.strictEqual(s1.text.get(0), 'i')
+      assert.strictEqual(s1.text.get(1), 'n')
+      assert.strictEqual(s1.text.get(2), 'i')
+      assert.strictEqual(s1.text.get(3), 't')
+    })
+
+    it('should initialize text in Automerge.from()', () => {
+      let s1 = Automerge.from({text: new Automerge.Text('init')})
+      assert.strictEqual(s1.text.length, 4)
+      assert.strictEqual(s1.text.get(0), 'i')
+      assert.strictEqual(s1.text.get(1), 'n')
+      assert.strictEqual(s1.text.get(2), 'i')
+      assert.strictEqual(s1.text.get(3), 't')
+    })
+
+    it('should encode the initial value as a change', () => {
+      const s1 = Automerge.from({text: new Automerge.Text('init')})
+      const changes = Automerge.getChanges(Automerge.init(), s1)
+      assert.strictEqual(changes.length, 1)
+      const s2 = Automerge.applyChanges(Automerge.init(), changes)
+      assert.strictEqual(s2.text instanceof Automerge.Text, true)
+      assert.strictEqual(s2.text.join(''), 'init')
+    })
+
+    it('should allow immediate access to the value', () => {
+      let s1 = Automerge.change(Automerge.init(), doc => {
+        const text = new Automerge.Text('init')
+        assert.strictEqual(text.length, 4)
+        assert.strictEqual(text.get(0), 'i')
+        doc.text = text
+        assert.strictEqual(doc.text.length, 4)
+        //assert.strictEqual(doc.text.get(0), 'i') // FIXME
+      })
+    })
   })
 })


### PR DESCRIPTION
Attempt to fix #170

I'm not super happy about how code turned out as `elems` / `maxElem` are being mutated afterwards, but I also could not figure any better option. I have considered using separate field instead but that had it's own drawbacks, specifically `new Text("hello")` would have appeared as empty text.