### PR TITLE
Add initialization options parameter to `automerge.from`

### DIFF
--- a/@types/automerge/index.d.ts
+++ b/@types/automerge/index.d.ts
@@ -15,9 +15,13 @@ declare module 'automerge' {
 
   // Automerge.* functions
 
-  function init<T>(actorId?: string): Doc<T>
-  function init<T>(options: any): Doc<T>
-  function from<T>(initialState: T | Doc<T>, options?: any): Doc<T>
+  function init<T>(options?: InitOptions): Doc<T>
+  function from<T>(initialState: T | Doc<T>, options?: InitOptions): Doc<T>
+
+  type InitOptions =
+    | string // = actorId
+    | { actorId?: string; deferActorId?: boolean }
+
   function merge<T>(localdoc: Doc<T>, remotedoc: Doc<T>): Doc<T>
 
   function change<D, T = Proxy<D>>(doc: D, message: string, callback: ChangeFn<T>): D

--- a/@types/automerge/index.d.ts
+++ b/@types/automerge/index.d.ts
@@ -20,7 +20,11 @@ declare module 'automerge' {
 
   type InitOptions =
     | string // = actorId
-    | { actorId?: string; deferActorId?: boolean }
+    | { 
+      actorId?: string
+      deferActorId?: boolean
+      freeze?: boolean 
+    }
 
   function merge<T>(localdoc: Doc<T>, remotedoc: Doc<T>): Doc<T>
 

--- a/frontend/index.js
+++ b/frontend/index.js
@@ -238,8 +238,8 @@ function init(options) {
 /**
  * Returns a new document object initialized with the given state.
  */
-function from(initialState) {
-  return change(init(), 'Initialization', doc => Object.assign(doc, initialState))
+function from(initialState, options) {
+  return change(init(options), 'Initialization', doc => Object.assign(doc, initialState))
 }
 
 

--- a/test/test.js
+++ b/test/test.js
@@ -31,14 +31,15 @@ describe('Automerge', () => {
       })
 
       it('should allow instantiating from an existing object', () => {
-        const initialState = {
-          birds: {
-            wrens: 3,
-            magpies: 4,
-          },
-        }
+        const initialState = { birds: { wrens: 3, magpies: 4 }}
         const doc = Automerge.from(initialState)
         assert.deepEqual(doc, initialState)
+      })
+
+      it('should allow passing an actorId when instantiating from an existing object', () => {
+        const actorId = '123'
+        let doc = Automerge.from({ foo: 1 }, actorId)
+        assert.strictEqual(Automerge.getActorId(doc), '123')
       })
 
       it('should accept an empty object as initial state', () => {

--- a/test/typescript_test.ts
+++ b/test/typescript_test.ts
@@ -57,6 +57,14 @@ describe('TypeScript support', () => {
       assert.strictEqual(s2.birds[0], 'magpie')
     })
 
+    it('should allow passing options when initializing with `from`', () => {
+      const actorId = '123'
+      const s1 = Automerge.from<BirdList>({ birds: [] }, actorId)
+      assert.strictEqual(Automerge.getActorId(s1), '123')
+      const s2 = Automerge.from<BirdList>({ birds: [] }, { actorId })
+      assert.strictEqual(Automerge.getActorId(s2), '123')
+    })
+
     it('should allow the actorId to be configured', () => {
       let s1 = Automerge.init<BirdList>('actor1')
       assert.strictEqual(Automerge.getActorId(s1), 'actor1')


### PR DESCRIPTION
Currently you can either call init with no arguments,
```js
const foo = automerge.init()
```
or you can pass some options around how `actorId` is set:
```js
const foo = automerge.init(actorId)
```
or
```
const foo = automerge.init({actorId, deferActorId})
```

This PR adds the (optional) options parameter to `automerge.from`, so you can do this:
```js
const foo = automerge.from(initialState, actorId)
```
or
```js
const foo = automerge.from(initialState, {actorId, deferActorId})
```

Still to do: 
- [x] add test coverage
