### PR TITLE
refactor: Remove unused `local` list

### DIFF
--- a/backend/op_set.js
+++ b/backend/op_set.js
@@ -364,7 +364,6 @@ function init() {
     .set('byObject', Map().set(ROOT_ID, Map().set('_keys', Map())))
     .set('clock',    Map())
     .set('deps',     Map())
-    .set('local',    List())
     .set('undoPos',   0)
     .set('undoStack', List())
     .set('redoStack', List())


### PR DESCRIPTION
This pull request removes the `local` list from the backend. As far as I can tell, this isn't actually used anymore (I searched the codebase for `'local'`, and this was the only occurrence). If I've missed something, please help me understand what this does!