### PR TITLE
docs: Add local state overview

### DIFF
--- a/INTERNALS.md
+++ b/INTERNALS.md
@@ -232,6 +232,36 @@ generates the following JSON object describing the change:
 Applying operations to the local state
 --------------------------------------
 
+The local state is comprised of a few different pieces:
+
+* `queue`: A list of pending changes.
+* `history`: A list of all applied changes.
+
+The two pieces of state above represent the single source-of-truth for every
+change that the system has observed. When saving and loading an Automerge CRDT,
+only the `history` is used. The pieces described in the next section below
+contain cached information that would otherwise have to be computed by iterating
+over the entire history.
+
+* `states`: A map keyed by actor IDs. The values are lists, where each element
+  is a change plus all of the changes dependencies, including transitive
+  dependencies. (Since each change only stores direct dependencies, this
+  essentially caches the transitive dependencies for each change.)
+* `byObject`: A map of object IDs to objects. An "object" is a map, a list, or a
+  text sequence.
+* `clock`: A map keyed by actor IDs, with sequence numbers as the values. This
+  represents the current vector clock of the local state.
+* `deps`: A map
+
+Finally, the pieces of state below store the information necessary to support
+undo and redo operations:
+
+* `undoPos`: An integer, representing the current place in the undo stack.
+* `undoStack`: A list of changes that, if applied to the state, would perform an
+  "undo".
+* `redoStack`: A list of changes that, if applied to the state, would perform a
+  "redo".
+
 When a change is generated (whether locally or remotely), it is immediately
 added to the `queue` list of changes. Automerge then iterates through every
 change in `queue`, performing the following steps for each pending change:


### PR DESCRIPTION
This pull request updates the INTERNALS documentation, adding an overview of how the backend actually stores its state. There are a few specific outstanding questions that I still have; I'll call those out inline.