### PR TITLE
List methods such as .filter() should use proxy objects

### DIFF
--- a/frontend/proxies.js
+++ b/frontend/proxies.js
@@ -88,6 +88,7 @@ function listMethods(context, listId) {
                       'slice', 'some', 'toLocaleString', 'toString']) {
     methods[method] = (...args) => {
       const list = context.getObject(listId)
+        .map((item, index) => context.getObjectField(listId, index))
       return list[method].call(list, ...args)
     }
   }

--- a/test/proxies_test.js
+++ b/test/proxies_test.js
@@ -364,6 +364,26 @@ describe('Automerge proxy API', () => {
           assert.deepEqual([...doc.list.values()], [1, 2, 3])
         })
       })
+
+      it('should allow mutation of objects returned from built in list iteration', () => {
+        root = Automerge.change(Automerge.init({freeze: true}), doc => {
+          doc.objects = [{id: 1, value: 'one'}, {id: 2, value: 'two'}]
+        })
+        root = Automerge.change(root, doc => {
+          for (let obj of doc.objects) if (obj.id === 1) obj.value = 'ONE!'
+        })
+        assert.deepEqual(root, {objects: [{id: 1, value: 'ONE!'}, {id: 2, value: 'two'}]})
+      })
+
+      it('should allow mutation of objects returned from readonly list methods', () => {
+        root = Automerge.change(Automerge.init({freeze: true}), doc => {
+          doc.objects = [{id: 1, value: 'one'}, {id: 2, value: 'two'}]
+        })
+        root = Automerge.change(root, doc => {
+          doc.objects.find(obj => obj.id === 1).value = 'ONE!'
+        })
+        assert.deepEqual(root, {objects: [{id: 1, value: 'ONE!'}, {id: 2, value: 'two'}]})
+      })
     })
 
     describe('should support standard mutation methods', () => {


### PR DESCRIPTION
Currently the read-only list methods such as `.map()`, `.filter()`, `.find()` and so on operate on and return plain read-only objects, as highlighted in #174. This PR changes them to operate on proxy objects instead, so that mutations of those objects are reflected on the Automerge state as expected.