### PR TITLE
Add initialization tests for array, primitives

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -6,58 +6,57 @@ const UUID_PATTERN = /^[0-9a-f]{8}(-[0-9a-f]{4}){3}-[0-9a-f]{12}$/
 
 describe('Automerge', () => {
 
-    describe('initialization ', () => {
-      it('should initially be an empty map', () => {
-        const doc = Automerge.init()
-        assert.deepEqual(doc, {})
-      })
-
-      it('should allow instantiating from an existing object', () => {
-        const initialState = { birds: { wrens: 3, magpies: 4 } }
-        const doc = Automerge.from(initialState)
-        assert.deepEqual(doc, initialState)
-      })
-
-      it('should allow merging of an object initialized with `from`', () => {
-        let doc1 = Automerge.from({ cards: [] })
-        let doc2 = Automerge.merge(Automerge.init(), doc1)
-        assert.deepEqual(doc2, { cards: [] })
-      })
-
-      it('should allow passing an actorId when instantiating from an existing object', () => {
-        const actorId = '123'
-        let doc = Automerge.from({ foo: 1 }, actorId)
-        assert.strictEqual(Automerge.getActorId(doc), '123')
-      })
-
-      it('accepts an empty object as initial state', () => {
-        const doc = Automerge.from({})
-        assert.deepEqual(doc, {})
-      })
-
-      it('accepts an array as initial state, but converts it to an object', () => {
-        const doc = Automerge.from(['a', 'b', 'c'])
-        assert.deepEqual(doc, { '0': 'a', '1': 'b', '2': 'c' })
-      })
-
-      it('accepts strings as initial values, but treats them as an array of characters', () => {
-        const doc = Automerge.from('abc')
-        assert.deepEqual(doc, { '0': 'a', '1': 'b', '2': 'c' })
-      })
-
-      it('ignores numbers provided as initial values', () => {
-        const doc = Automerge.from(123)
-        assert.deepEqual(doc, {})
-      })
-
-      it('ignores booleans provided as initial values', () => {
-        const doc1 = Automerge.from(false)
-        assert.deepEqual(doc1, {})
-        const doc2 = Automerge.from(true)
-        assert.deepEqual(doc2, {})
-      })
+  describe('initialization ', () => {
+    it('should initially be an empty map', () => {
+      const doc = Automerge.init()
+      assert.deepEqual(doc, {})
     })
 
+    it('should allow instantiating from an existing object', () => {
+      const initialState = { birds: { wrens: 3, magpies: 4 } }
+      const doc = Automerge.from(initialState)
+      assert.deepEqual(doc, initialState)
+    })
+
+    it('should allow merging of an object initialized with `from`', () => {
+      let doc1 = Automerge.from({ cards: [] })
+      let doc2 = Automerge.merge(Automerge.init(), doc1)
+      assert.deepEqual(doc2, { cards: [] })
+    })
+
+    it('should allow passing an actorId when instantiating from an existing object', () => {
+      const actorId = '123'
+      let doc = Automerge.from({ foo: 1 }, actorId)
+      assert.strictEqual(Automerge.getActorId(doc), '123')
+    })
+
+    it('accepts an empty object as initial state', () => {
+      const doc = Automerge.from({})
+      assert.deepEqual(doc, {})
+    })
+
+    it('accepts an array as initial state, but converts it to an object', () => {
+      const doc = Automerge.from(['a', 'b', 'c'])
+      assert.deepEqual(doc, { '0': 'a', '1': 'b', '2': 'c' })
+    })
+
+    it('accepts strings as initial values, but treats them as an array of characters', () => {
+      const doc = Automerge.from('abc')
+      assert.deepEqual(doc, { '0': 'a', '1': 'b', '2': 'c' })
+    })
+
+    it('ignores numbers provided as initial values', () => {
+      const doc = Automerge.from(123)
+      assert.deepEqual(doc, {})
+    })
+
+    it('ignores booleans provided as initial values', () => {
+      const doc1 = Automerge.from(false)
+      assert.deepEqual(doc1, {})
+      const doc2 = Automerge.from(true)
+      assert.deepEqual(doc2, {})
+    })
+  })
 
   describe('sequential use', () => {
     let s1, s2

--- a/test/test.js
+++ b/test/test.js
@@ -5,6 +5,60 @@ const ROOT_ID = '00000000-0000-0000-0000-000000000000'
 const UUID_PATTERN = /^[0-9a-f]{8}(-[0-9a-f]{4}){3}-[0-9a-f]{12}$/
 
 describe('Automerge', () => {
+
+    describe('initialization ', () => {
+      it('should initially be an empty map', () => {
+        const doc = Automerge.init()
+        assert.deepEqual(doc, {})
+      })
+
+      it('should allow instantiating from an existing object', () => {
+        const initialState = { birds: { wrens: 3, magpies: 4 } }
+        const doc = Automerge.from(initialState)
+        assert.deepEqual(doc, initialState)
+      })
+
+      it('should allow merging of an object initialized with `from`', () => {
+        let doc1 = Automerge.from({ cards: [] })
+        let doc2 = Automerge.merge(Automerge.init(), doc1)
+        assert.deepEqual(doc2, { cards: [] })
+      })
+
+      it('should allow passing an actorId when instantiating from an existing object', () => {
+        const actorId = '123'
+        let doc = Automerge.from({ foo: 1 }, actorId)
+        assert.strictEqual(Automerge.getActorId(doc), '123')
+      })
+
+      it('should accept an empty object as initial state', () => {
+        const doc = Automerge.from({})
+        assert.deepEqual(doc, {})
+      })
+
+      it('accpets an array as initial state, but converts it to an object', () => {
+        const doc = Automerge.from(['a', 'b', 'c'])
+        assert.deepEqual(doc, { '0': 'a', '1': 'b', '2': 'c' })
+      })
+
+      it('accepts strings as initial values, but treats them as an array of characters', () => {
+        const doc = Automerge.from('abc')
+        assert.deepEqual(doc, { '0': 'a', '1': 'b', '2': 'c' })
+      })
+
+      it('ignores numbers provided as initial values', () => {
+        const doc = Automerge.from(123)
+        assert.deepEqual(doc, {})
+      })
+
+      it('ignores booleans provided as initial values', () => {
+        const doc1 = Automerge.from(false)
+        assert.deepEqual(doc1, {})
+        const doc2 = Automerge.from(true)
+        assert.deepEqual(doc2, {})
+      })
+    })
+
+
   describe('sequential use:', () => {
     let s1, s2
     beforeEach(() => {
@@ -23,35 +77,6 @@ describe('Automerge', () => {
       assert.strictEqual(Automerge.getConflicts(s1, 'foo'), undefined)
       s1 = Automerge.change(s1, 'change', doc => doc.foo = 'two')
       assert.strictEqual(Automerge.getConflicts(s1, 'foo'), undefined)
-    })
-
-    describe('initialization ', () => {
-      it('should initially be an empty map', () => {
-        assert.deepEqual(s1, {})
-      })
-
-      it('should allow instantiating from an existing object', () => {
-        const initialState = { birds: { wrens: 3, magpies: 4 }}
-        const doc = Automerge.from(initialState)
-        assert.deepEqual(doc, initialState)
-      })
-
-      it('should allow passing an actorId when instantiating from an existing object', () => {
-        const actorId = '123'
-        let doc = Automerge.from({ foo: 1 }, actorId)
-        assert.strictEqual(Automerge.getActorId(doc), '123')
-      })
-
-      it('should accept an empty object as initial state', () => {
-        const doc = Automerge.from({})
-        assert.deepEqual(doc, {})
-      })
-
-      it('should allow merging of an object initialized with `from`', () => {
-        let doc1 = Automerge.from({cards: []})
-        let doc2 = Automerge.merge(Automerge.init(), doc1)
-        assert.deepEqual(doc2, {cards: []})
-      })
     })
 
     describe('changes', () => {

--- a/test/test.js
+++ b/test/test.js
@@ -30,12 +30,12 @@ describe('Automerge', () => {
         assert.strictEqual(Automerge.getActorId(doc), '123')
       })
 
-      it('should accept an empty object as initial state', () => {
+      it('accepts an empty object as initial state', () => {
         const doc = Automerge.from({})
         assert.deepEqual(doc, {})
       })
 
-      it('accpets an array as initial state, but converts it to an object', () => {
+      it('accepts an array as initial state, but converts it to an object', () => {
         const doc = Automerge.from(['a', 'b', 'c'])
         assert.deepEqual(doc, { '0': 'a', '1': 'b', '2': 'c' })
       })
@@ -59,7 +59,7 @@ describe('Automerge', () => {
     })
 
 
-  describe('sequential use:', () => {
+  describe('sequential use', () => {
     let s1, s2
     beforeEach(() => {
       s1 = Automerge.init()
@@ -950,7 +950,7 @@ describe('Automerge', () => {
     })
   })
 
-  describe('Automerge.undo()', () => {
+  describe('.undo()', () => {
     function getUndoStack(doc) {
       return Automerge.Frontend.getBackendState(doc).getIn(['opSet', 'undoStack'])
     }
@@ -1099,7 +1099,7 @@ describe('Automerge', () => {
     })
   })
 
-  describe('Automerge.redo()', () => {
+  describe('.redo()', () => {
     function getRedoStack(doc) {
       return Automerge.Frontend.getBackendState(doc).getIn(['opSet', 'redoStack'])
     }


### PR DESCRIPTION
1. Moves all initialization tests to an 'initialization' `describe` block directly under 'Automerge' 
2. Adds tests for passing different types of values to `Automerge.from`: an array, a string, a number, and a boolean. 