### PR TITLE
Add DocSet.removeDoc

### DIFF
--- a/@types/automerge/index.d.ts
+++ b/@types/automerge/index.d.ts
@@ -116,6 +116,7 @@ declare module 'automerge' {
     constructor()
     applyChanges(docId: string, changes: Change[]): T
     getDoc(docId: string): Doc<T>
+    removeDoc(docId: string): void
     setDoc(docId: string, doc: Doc<T>): void
     docIds: string[]
     registerHandler(handler: DocSetHandler<T>): void

--- a/src/doc_set.js
+++ b/src/doc_set.js
@@ -17,6 +17,10 @@ class DocSet {
     return this.docs.get(docId)
   }
 
+  removeDoc (docId) {
+    this.docs = this.docs.delete(docId)
+  }
+
   setDoc (docId, doc) {
     this.docs = this.docs.set(docId, doc)
     this.handlers.forEach(handler => handler(docId, doc))

--- a/test/docset_test.js
+++ b/test/docset_test.js
@@ -42,4 +42,9 @@ describe('Automerge.DocSet', () => {
     docSet.applyChanges(ID, changes)
     assert.strictEqual(callback.notCalled, true)
   })
+
+  it('should allow removing a document', () => {
+    docSet.removeDoc(ID)
+    assert.strictEqual(docSet.getDoc(ID), undefined)
+  })
 })

--- a/test/typescript_test.ts
+++ b/test/typescript_test.ts
@@ -688,6 +688,11 @@ describe('TypeScript support', () => {
       docSet.applyChanges(ID, changes)
     })
 
+    it('should allow removing a document', () => {
+      docSet.removeDoc(ID)
+      assert.strictEqual(docSet.getDoc(ID), undefined)
+    })
+  
     it('should list the ids of its documents', () => {
       assert.deepEqual(Array.from(docSet.docIds), [ID])
     })


### PR DESCRIPTION
Adds functionality to remove a doc from a `DocSet`. I'm not totally sure how the DocSet handlers work so I wasn't sure if it was appropriate to call the handlers with the deleted document's ID and `undefined`. Should that be added as well?