### PR TITLE
Support freezing of opaque string types

### DIFF
--- a/@types/automerge/index.d.ts
+++ b/@types/automerge/index.d.ts
@@ -288,13 +288,14 @@ declare module 'automerge' {
   // It's like TypeScript's `readonly`, but goes all the way down a tree.
 
   // prettier-ignore
-  type Freeze<T> = 
+  type Freeze<T> =
     T extends Function ? T
     : T extends Text ? ReadonlyText
     : T extends Table<infer T, infer KeyOrder> ? FreezeTable<T, KeyOrder>
     : T extends List<infer T> ? FreezeList<T>
     : T extends Array<infer T> ? FreezeArray<T>
     : T extends Map<infer K, infer V> ? FreezeMap<K, V>
+    : T extends string & infer O ? string & O
     : FreezeObject<T>
 
   interface FreezeTable<T, KeyOrder> extends ReadonlyTable<Freeze<T>, Array<keyof Freeze<T>>> {}


### PR DESCRIPTION
We often use `type FooUrl = string & { __fooUrl: void }` to give types to different kinds of strings.
The current `Freeze<T>` type breaks these. This PR is a small fix that we've been using for awhile that has `Freeze<T>` treat these types like normal strings.