### PR TITLE
Include link to Github repository

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,14 @@
     "prepublishOnly": "npm run-script build"
   },
   "author": "",
+  "repository": {
+    "type": "git",
+    "url": "git+ssh://git@github.com/automerge/automerge.git"
+  },
+  "bugs": {
+    "url": "https://github.com/automerge/automerge/issues"
+  },
+  "homepage": "https://github.com/automerge/automerge",
   "license": "MIT",
   "dependencies": {
     "immutable": "^3.8.2",


### PR DESCRIPTION
Currently, the published package on [npm](https://npm.im/automerge) does not link to the repository.

By including those fields not only there will be a direct link, but visitors from there will also see the number of open issues and pull requests.