### PR TITLE
Add Perge to list of Send/Receive libraries in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -357,6 +357,8 @@ options, with more under development:
 - [Hypermerge](https://github.com/automerge/hypermerge) is a peer-to-peer networking layer that
   combines Automerge with [Hypercore](https://github.com/mafintosh/hypercore), part of the
   [Dat project](https://datproject.org/).
+- [Perge](https://github.com/sammccord/perge) is a minimal library that runs the `Automerge.Connection` protocol over
+  [PeerJS](https://github.com/peers/peerjs).
 
 The `getChanges()/applyChanges()` API works as follows:
 


### PR DESCRIPTION
I've been messing around with Automerge for a while now and I'm big fan, so I took a stab at writing a library to integrate PeerJS. Since MPL was a little more than I needed, and PeerJS makes working with WebRTC DataChannels dead simple, I figured this combo would be super pleasant.

Check out the project and feel free to reach out with any feedback!