### PR TITLE
canUndo should return false after Automerge.from()

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -186,7 +186,8 @@ function applyLocalChange(state, change) {
 
   let patch
   if (change.requestType === 'change') {
-    ;[state, patch] = apply(state, [change], true)
+    const undoable = (change.undoable === false) ? false : true
+    ;[state, patch] = apply(state, [change], undoable)
   } else if (change.requestType === 'undo') {
     ;[state, patch] = undo(state, change)
   } else if (change.requestType === 'redo') {

--- a/frontend/index.js
+++ b/frontend/index.js
@@ -100,6 +100,9 @@ function makeChange(doc, requestType, context, options) {
   if (options && options.message !== undefined) {
     request.message = options.message
   }
+  if (options && options.undoable === false) {
+    request.undoable = false
+  }
   if (context) {
     request.ops = ensureSingleAssignment(context.ops)
   }

--- a/src/automerge.js
+++ b/src/automerge.js
@@ -35,23 +35,23 @@ function from(initialState, options) {
   return change(init(options), 'Initialization', doc => Object.assign(doc, initialState))
 }
 
-function change(doc, message, callback) {
-  const [newDoc, change] = Frontend.change(doc, message, callback)
+function change(doc, options, callback) {
+  const [newDoc, change] = Frontend.change(doc, options, callback)
   return newDoc
 }
 
-function emptyChange(doc, message) {
-  const [newDoc, change] = Frontend.emptyChange(doc, message)
+function emptyChange(doc, options) {
+  const [newDoc, change] = Frontend.emptyChange(doc, options)
   return newDoc
 }
 
-function undo(doc, message) {
-  const [newDoc, change] = Frontend.undo(doc, message)
+function undo(doc, options) {
+  const [newDoc, change] = Frontend.undo(doc, options)
   return newDoc
 }
 
-function redo(doc, message) {
-  const [newDoc, change] = Frontend.redo(doc, message)
+function redo(doc, options) {
+  const [newDoc, change] = Frontend.redo(doc, options)
   return newDoc
 }
 

--- a/src/automerge.js
+++ b/src/automerge.js
@@ -32,7 +32,8 @@ function init(options) {
  * Returns a new document object initialized with the given state.
  */
 function from(initialState, options) {
-  return change(init(options), 'Initialization', doc => Object.assign(doc, initialState))
+  const changeOpts = {message: 'Initialization', undoable: false}
+  return change(init(options), changeOpts, doc => Object.assign(doc, initialState))
 }
 
 function change(doc, options, callback) {

--- a/test/test.js
+++ b/test/test.js
@@ -52,6 +52,11 @@ describe('Automerge', () => {
         let doc2 = Automerge.merge(Automerge.init(), doc1)
         assert.deepEqual(doc2, {cards: []})
       })
+
+      it('should not enable undo after Automerge.from', () => {
+        let doc = Automerge.from({cards: []})
+        assert.deepEqual(Automerge.canUndo(doc), false)
+      })
     })
 
     describe('changes', () => {

--- a/test/test.js
+++ b/test/test.js
@@ -176,12 +176,6 @@ describe('Automerge', () => {
         }, /Calls to Automerge.change cannot be nested/)
       })
 
-      it('should not allow objects as change message', () => {
-        assert.throws(() => {
-          Automerge.change(s1, {key: 'value'}, doc => doc.foo = 'bar')
-        }, /Change message must be a string/)
-      })
-
       it('should not interfere with each other when forking', () => {
         s1 = Automerge.change(s1, doc1 => {
           s2 = Automerge.change(s1, doc2 => doc2.two = 2)


### PR DESCRIPTION
After initializing a document with `Automerge.from()`, this patch changes the behaviour such that the initialization cannot be undone, as suggested in #219.