### PR TITLE
Add run on Repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "nodejs"
+run = "yarn test && yarn build"

--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ and merging**:
 
 ## Setup
 
+[![Run on Repl.it](https://repl.it/badge/github/automerge/automerge)](https://repl.it/github/automerge/automerge)
+
 If you're using npm, `npm install automerge`. If you're using yarn, `yarn add automerge`. Then you
 can import it with `require('automerge')` as in [the example below](#usage) (or
 `import * as Automerge from 'automerge'` if using ES2015 or TypeScript).


### PR DESCRIPTION
This pull request adds a `.replit` file and a badge to the `README`. If you aren't familiar with Repl.it, it's a free cloud IDE that's a really valuable tool for a lot of programmers. This will enable anyone to quickly start editing Automerge code without setting up a local dev environment or installing anything.

Feel free to test it out here!  
[![Run on Repl.it](https://repl.it/badge/github/automerge/automerge)](https://repl.it/github/automerge/automerge)