### PR TITLE
New `Automerge.getAllChanges()` API

### DIFF
--- a/@types/automerge/index.d.ts
+++ b/@types/automerge/index.d.ts
@@ -36,6 +36,7 @@ declare module 'automerge' {
   function equals<T>(val1: T, val2: T): boolean
 
   function getActorId<T>(doc: Doc<T>): string
+  function getAllChanges<T>(doc: Doc<T>): Change[]
   function getChanges<T>(olddoc: Doc<T>, newdoc: Doc<T>): Change[]
   function getConflicts<T>(doc: Doc<T>, key: keyof T): any
   function getHistory<D, T = Proxy<D>>(doc: Doc<T>): State<T>[]

--- a/README.md
+++ b/README.md
@@ -378,8 +378,7 @@ newDoc = Automerge.applyChanges(currentDoc, changes)
 
 Note that `Automerge.getChanges(oldDoc, newDoc)` takes two documents as arguments: an old state and
 a new state. It then returns a list of all the changes that were made in `newDoc` since `oldDoc`. If
-you want a list of all the changes ever made in `newDoc`, you can call
-`Automerge.getChanges(Automerge.init(), newDoc)`.
+you want a list of all the changes ever made in `doc`, you can call `Automerge.getAllChanges(doc)`.
 
 The counterpart, `Automerge.applyChanges(oldDoc, changes)` applies the list of `changes` to the
 given document, and returns a new document with those changes applied. Automerge guarantees that

--- a/src/automerge.js
+++ b/src/automerge.js
@@ -90,6 +90,10 @@ function getChanges(oldDoc, newDoc) {
   return Backend.getChanges(oldState, newState)
 }
 
+function getAllChanges(doc) {
+  return getChanges(init(), doc)
+}
+
 function applyChanges(doc, changes) {
   const oldState = Frontend.getBackendState(doc)
   const [newState, patch] = Backend.applyChanges(oldState, changes)
@@ -130,7 +134,7 @@ function getHistory(doc) {
 
 module.exports = {
   init, from, change, emptyChange, undo, redo,
-  load, save, merge, diff, getChanges, applyChanges, getMissingDeps,
+  load, save, merge, diff, getChanges, getAllChanges, applyChanges, getMissingDeps,
   equals, getHistory, uuid,
   Frontend, Backend,
   DocSet: require('./doc_set'),

--- a/test/test.js
+++ b/test/test.js
@@ -204,7 +204,7 @@ describe('Automerge', () => {
       it('should support Date objects in maps', () => {
         const now = new Date()
         s1 = Automerge.change(s1, doc => doc.now = now)
-        let changes = Automerge.getChanges(Automerge.init(), s1)
+        let changes = Automerge.getAllChanges(s1)
         changes = JSON.parse(JSON.stringify(changes))
         s2 = Automerge.applyChanges(Automerge.init(), changes)
         assert.strictEqual(s2.now instanceof Date, true)
@@ -214,7 +214,7 @@ describe('Automerge', () => {
       it('should support Date objects in lists', () => {
         const now = new Date()
         s1 = Automerge.change(s1, doc => doc.list = [now])
-        let changes = Automerge.getChanges(Automerge.init(), s1)
+        let changes = Automerge.getAllChanges(s1)
         changes = JSON.parse(JSON.stringify(changes))
         s2 = Automerge.applyChanges(Automerge.init(), changes)
         assert.strictEqual(s2.list[0] instanceof Date, true)
@@ -1419,7 +1419,7 @@ describe('Automerge', () => {
 
   describe('changes API', () => {
     it('should return an empty list on an empty document', () => {
-      let changes = Automerge.getChanges(Automerge.init(), Automerge.init())
+      let changes = Automerge.getAllChanges(Automerge.init())
       assert.deepEqual(changes, [])
     })
 
@@ -1443,7 +1443,7 @@ describe('Automerge', () => {
     it('should allow a document copy to be reconstructed from scratch', () => {
       let s1 = Automerge.change(Automerge.init(), 'Add Chaffinch', doc => doc.birds = ['Chaffinch'])
       let s2 = Automerge.change(s1, 'Add Bullfinch', doc => doc.birds.push('Bullfinch'))
-      let changes = Automerge.getChanges(Automerge.init(), s2)
+      let changes = Automerge.getAllChanges(s2)
       let s3 = Automerge.applyChanges(Automerge.init(), changes)
       assert.deepEqual(s3.birds, ['Chaffinch', 'Bullfinch'])
     })
@@ -1451,7 +1451,7 @@ describe('Automerge', () => {
     it('should return changes since the last given version', () => {
       let s1 = Automerge.change(Automerge.init(), 'Add Chaffinch', doc => doc.birds = ['Chaffinch'])
       let s2 = Automerge.change(s1, 'Add Bullfinch', doc => doc.birds.push('Bullfinch'))
-      let changes1 = Automerge.getChanges(Automerge.init(), s1)
+      let changes1 = Automerge.getAllChanges(s1)
       let changes2 = Automerge.getChanges(s1, s2)
       assert.deepEqual(changes1.map(c => c.message), ['Add Chaffinch'])
       assert.deepEqual(changes2.map(c => c.message), ['Add Bullfinch'])
@@ -1460,7 +1460,7 @@ describe('Automerge', () => {
     it('should incrementally apply changes since the last given version', () => {
       let s1 = Automerge.change(Automerge.init(), 'Add Chaffinch', doc => doc.birds = ['Chaffinch'])
       let s2 = Automerge.change(s1, 'Add Bullfinch', doc => doc.birds.push('Bullfinch'))
-      let changes1 = Automerge.getChanges(Automerge.init(), s1)
+      let changes1 = Automerge.getAllChanges(s1)
       let changes2 = Automerge.getChanges(s1, s2)
       let s3 = Automerge.applyChanges(Automerge.init(), changes1)
       let s4 = Automerge.applyChanges(s3, changes2)
@@ -1472,7 +1472,7 @@ describe('Automerge', () => {
       let s1 = Automerge.change(Automerge.init(), doc => doc.birds = ['Chaffinch'])
       let s2 = Automerge.merge(Automerge.init(), s1)
       s2 = Automerge.change(s2, doc => doc.birds.push('Bullfinch'))
-      let changes = Automerge.getChanges(Automerge.init(), s2)
+      let changes = Automerge.getAllChanges(s2)
       let s3 = Automerge.applyChanges(Automerge.init(), [changes[1]])
       assert.deepEqual(s3, {})
       assert.deepEqual(Automerge.getMissingDeps(s3), {[Automerge.getActorId(s1)]: 1})

--- a/test/text_test.js
+++ b/test/text_test.js
@@ -121,7 +121,7 @@ describe('Automerge.Text', () => {
 
     it('should encode the initial value as a change', () => {
       const s1 = Automerge.from({text: new Automerge.Text('init')})
-      const changes = Automerge.getChanges(Automerge.init(), s1)
+      const changes = Automerge.getAllChanges(s1)
       assert.strictEqual(changes.length, 1)
       const s2 = Automerge.applyChanges(Automerge.init(), changes)
       assert.strictEqual(s2.text instanceof Automerge.Text, true)

--- a/test/typescript_test.ts
+++ b/test/typescript_test.ts
@@ -254,7 +254,7 @@ describe('TypeScript support', () => {
     it('should include operations in changes', () => {
       let s1 = Automerge.init<NumberBox>()
       s1 = Automerge.change(s1, doc => (doc.number = 3))
-      const changes = Automerge.getChanges(Automerge.init(), s1)
+      const changes = Automerge.getAllChanges(s1)
       assert.strictEqual(changes.length, 1)
       assert.strictEqual(changes[0].ops.length, 1)
       assert.strictEqual(changes[0].ops[0].action, 'set')
@@ -267,7 +267,7 @@ describe('TypeScript support', () => {
       let s1 = Automerge.init<BirdList>()
       s1 = Automerge.change(s1, doc => (doc.birds = []))
       let s2 = Automerge.change(s1, doc => doc.birds.push('goldfinch'))
-      const changes = Automerge.getChanges(Automerge.init<BirdList>(), s2)
+      const changes = Automerge.getAllChanges(s2)
       let s3 = Automerge.applyChanges(Automerge.init<BirdList>(), changes)
       assert.deepEqual(s3.birds, ['goldfinch'])
     })


### PR DESCRIPTION
Minor API usability enhancement. If you want to get a list of all changes ever made to a document, this PR introduces a new function `Automerge.getAllChanges(doc)`. It does exactly the same as `Automerge.getChanges(Automerge.init(), doc)` but is shorter, and saves having to remember the order of arguments.