### PR TITLE
Simpler `Table` type

### DIFF
--- a/@types/automerge/index.d.ts
+++ b/@types/automerge/index.d.ts
@@ -55,9 +55,9 @@ declare module 'automerge' {
 
   // custom CRDT types
 
-  class Table<T, KeyOrder extends Array<keyof T>> extends Array<T> {
-    constructor(columns: KeyArray<T, KeyOrder>)
-    add(item: T | TupleFromInterface<T, KeyOrder>): UUID
+  class Table<T> {
+    constructor(columns: (keyof T)[])
+    add(item: T): UUID
     byId(id: UUID): T
     columns: string[]
     count: number
@@ -96,7 +96,7 @@ declare module 'automerge' {
 
   // Readonly variants
 
-  type ReadonlyTable<T, KeyOrder extends Array<keyof T>> = ReadonlyArray<T> & Table<T, KeyOrder>
+  type ReadonlyTable<T> = ReadonlyArray<T> & Table<T>
   type ReadonlyList<T> = ReadonlyArray<T> & List<T>
   type ReadonlyText = ReadonlyList<string> & Text
 
@@ -292,46 +292,18 @@ declare module 'automerge' {
   type Freeze<T> =
     T extends Function ? T
     : T extends Text ? ReadonlyText
-    : T extends Table<infer T, infer KeyOrder> ? FreezeTable<T, KeyOrder>
+    : T extends Table<infer T> ? FreezeTable<T>
     : T extends List<infer T> ? FreezeList<T>
     : T extends Array<infer T> ? FreezeArray<T>
     : T extends Map<infer K, infer V> ? FreezeMap<K, V>
     : T extends string & infer O ? string & O
     : FreezeObject<T>
 
-  interface FreezeTable<T, KeyOrder> extends ReadonlyTable<Freeze<T>, Array<keyof Freeze<T>>> {}
+  interface FreezeTable<T> extends ReadonlyTable<Freeze<T>> {}
   interface FreezeList<T> extends ReadonlyList<Freeze<T>> {}
   interface FreezeArray<T> extends ReadonlyArray<Freeze<T>> {}
   interface FreezeMap<K, V> extends ReadonlyMap<Freeze<K>, Freeze<V>> {}
   type FreezeObject<T> = { readonly [P in keyof T]: Freeze<T[P]> }
-
-  // Type utility function: KeyArray
-  // Enforces that the array provided for key order only contains keys of T
-  type KeyArray<T, KeyOrder extends Array<keyof T>> = keyof T extends KeyOrder[number]
-    ? KeyOrder
-    : Exclude<keyof T, KeyOrder[number]>[]
-
-  // Type utility function: TupleFromInterface
-  // Generates a tuple containing the types of each property of T, in the order provided by KeyOrder. For example:
-  // ```
-  // interface Book {
-  //   authors: string[]
-  //   title: string
-  //   date: Date
-  // }
-  // type BookTuple = TupleFromInterface<Book, ['authors', 'title', 'date']> // [ string[], string, Date ]
-  //
-  // function add(b: Book | BookTuple): void
-  // ```
-  // Now the argument for `Table.add` can either be a `Book` object, or an array of values for each
-  // of the properties of `Book`, in the order given.
-  // ```
-  // add({authors, title, date}) // valid
-  // add([authors, title, date]) // also valid
-  // ```
-  type TupleFromInterface<T, KeyOrder extends Array<keyof T>> = {
-    [I in keyof KeyOrder]: Lookup<T, KeyOrder[I]>
-  }
 
   type Lookup<T, K> = K extends keyof T ? T[K] : never
 }

--- a/frontend/table.js
+++ b/frontend/table.js
@@ -235,6 +235,9 @@ class WriteableTable extends Table {
    * column name to value. Returns the objectId of the new row.
    */
   add(row) {
+    if (typeof row !== 'object' || Array.isArray(row)) {
+      throw new RangeError('Table row must be an object')
+    }
     return this.context.addTableRow(this[OBJECT_ID], row)
   }
 

--- a/frontend/table.js
+++ b/frontend/table.js
@@ -231,19 +231,10 @@ class WriteableTable extends Table {
   }
 
   /**
-   * Adds a new row to the table. The row can be given either as a map from
-   * column name to value, or as a list of values. If given as a list of
-   * values, it is translated into a map using the table's column list.
-   * Returns the objectId of the new row.
+   * Adds a new row to the table. The row is given as a map from
+   * column name to value. Returns the objectId of the new row.
    */
   add(row) {
-    if (Array.isArray(row)) {
-      const columns = this.columns, rowObj = {}
-      for (let i = 0; i < columns.length; i++) {
-        rowObj[columns[i]] = row[i]
-      }
-      row = rowObj
-    }
     return this.context.addTableRow(this[OBJECT_ID], row)
   }
 

--- a/test/table_test.js
+++ b/test/table_test.js
@@ -133,28 +133,6 @@ describe('Automerge.Table', () => {
       assert.deepEqual(s2.books.columns, ['authors', 'title', 'isbn', 'publisher'])
       assert.deepEqual(s2.books.byId(rowId), DDIA)
     })
-
-    it('should translate an array row into a map', () => {
-      let rsdp, lovelace
-      const s2 = Automerge.change(s1, doc => {
-        rsdp = doc.books.add([
-          ['Cachin, Christian', 'Guerraoui, Rachid', 'Rodrigues, Luís'],
-          'Introduction to Reliable and Secure Distributed Programming',
-          '3-642-15259-7'
-        ])
-        lovelace = doc.books.add([
-          ['Padua, Sydney'],
-          'The Thrilling Adventures of Lovelace and Babbage',
-          '9780141981536'
-        ])
-      })
-      assert.deepEqual(s2.books.byId(rsdp), RSDP)
-      assert.deepEqual(s2.books.byId(lovelace), {
-        authors: ['Padua, Sydney'],
-        title: 'The Thrilling Adventures of Lovelace and Babbage',
-        isbn: '9780141981536'
-      })
-    })
   })
 
   it('should allow concurrent row insertion', () => {

--- a/test/typescript_test.ts
+++ b/test/typescript_test.ts
@@ -479,21 +479,25 @@ describe('TypeScript support', () => {
 
       // Note that if we add columns and want to actually use them, we need to recast the table to a
       // new type e.g. without the `ts-ignore` flag, this would throw a type error:
-      // @ts-ignore
-      const p2 = s2.books.byId(id).publisher // Property 'publisher' does not exist on type book
 
-      // So we need to create new types:
+      // @ts-ignore - Property 'publisher' does not exist on type book
+      const p2 = s2.books.byId(id).publisher 
+
+      // So we need to create new types
       interface BookDeluxe extends Book {
+        // ... existing properties, plus:
         publisher?: string
       }
       interface BookDeluxeDb {
         books: Automerge.Table<BookDeluxe>
       }
 
+      const s2a = s2 as Doc<BookDeluxeDb> // Cast existing table to new type
       const s3 = Automerge.change(
-        s2 as BookDeluxeDb, // Cast existing table to new type
+        s2a,
         doc => (doc.books.byId(id).publisher = "O'Reilly")
       )
+
       // Now we're off to the races
       const p3 = s3.books.byId(id).publisher
       assert.deepEqual(p3, "O'Reilly")

--- a/test/typescript_test.ts
+++ b/test/typescript_test.ts
@@ -497,16 +497,6 @@ describe('TypeScript support', () => {
       // Now we're off to the races
       const p3 = s3.books.byId(id).publisher
       assert.deepEqual(p3, "O'Reilly")
-
-      // and we can even do this:
-      Automerge.change(s3, doc => {
-        doc.books.add([
-          ['Cachin, Christian', 'Guerraoui, Rachid', 'Rodrigues, Luís'],
-          'Introduction to Reliable and Secure Distributed Programming',
-          '3-642-15259-7',
-          'Springer',
-        ])
-      })
     })
 
     it('supports `remove`', () => {
@@ -515,18 +505,6 @@ describe('TypeScript support', () => {
     })
 
     describe('supports `add`', () => {
-      it('accepts value passed as correctly-ordered array', () => {
-        let bookId: string
-        const s2 = Automerge.change(s1, doc => {
-          bookId = doc.books.add([
-            ['Cachin, Christian', 'Guerraoui, Rachid', 'Rodrigues, Luís'],
-            'Introduction to Reliable and Secure Distributed Programming',
-            '3-642-15259-7',
-          ])
-        })
-        assert.deepEqual(s2.books.byId(bookId), RSDP)
-      })
-
       it('accepts value passed as object', () => {
         let bookId: string
         const s2 = Automerge.change(s1, doc => (bookId = doc.books.add(RSDP)))

--- a/test/typescript_test.ts
+++ b/test/typescript_test.ts
@@ -441,7 +441,7 @@ describe('TypeScript support', () => {
     }
 
     interface BookDb {
-      books: Automerge.Table<Book, ['authors', 'title', 'isbn']>
+      books: Automerge.Table<Book>
     }
 
     // Example data
@@ -487,7 +487,7 @@ describe('TypeScript support', () => {
         publisher?: string
       }
       interface BookDeluxeDb {
-        books: Automerge.Table<BookDeluxe, ['authors', 'title', 'isbn', 'publisher']>
+        books: Automerge.Table<BookDeluxe>
       }
 
       const s3 = Automerge.change(


### PR DESCRIPTION
### Summary

This PR removes an undocumented API for adding rows to a `Table` by passing an array of values, and simplifies the type definitions for tables accordingly. 

### Problem

Using the Table CRDT, you can add a row by passing an object:

```js
  const ddia = doc.publications.add({
    type: 'book',
    authors: [martinID],
    title: 'Designing Data-Intensive Applications',
    publisher: "O'Reilly Media",
    year: 2017,
  })
```

Or, you can pass an array of values:

```js
const ddia = doc.publications.add([
    'book', 
    [martinID],  
    'Designing Data-Intensive Applications', 
    "O'Reilly Media", 
    2017
])
```


Here Automerge automagically figures out which value goes in which column, based on the order of the columns provided when initializing the table. 

This array-of-values API is undocumented and, I'm guessing, unused. Supporting it in Typescript makes the type definition for a table fairly awkward, because in addition to defining a type for rows, you have to redundantly list the fields in order:

```ts
interface Book {
    authors: string | string[]
    title: string
    isbn?: string
}

interface BookDb {
    books: Automerge.Table<Book, ['authors', 'title', 'isbn']> // <-- 
    // Q: Why do I have to list these fields again? 
    // A: So that Typescript can enforce column types if you ever decide 
    // to use the undocumented API to add a row as an array of values. 🙄
}

let s1 = Automerge.init<BookDb>()
s1 = Automerge.change(s1, doc => {
    doc.books = new Automerge.Table(['authors', 'title', 'isbn'])
    id = doc.books.add(DDIA)
})
```

This has been [confusing](https://automerge.slack.com/archives/C61RJCM9S/p1580753919087700?thread_ts=1580644956.082000&cid=C61RJCM9S) for developers trying to use Automerge with TypeScript. 

### Proposed solution

- Remove the alternative API, so that table rows have to be added in object form. 
- Change the way tables are defined in TypeScript, so you only need to pass the underlying type and not the type *and* an ordered array of column names.

### Questions

This is a breaking change, in two ways:

- If anyone was actually using the array API, they will now (silently) get unexpected results. Should we throw an error instead if an array is passed to `Table.add()`?

- Anyone who defined has previously implemented a `Table` in TypeScript will now get a compilation error:

  ```ts
  // ❌ Array of column names used to be required, now won't compile
  books: Automerge.Table<Book, ['authors', 'title', 'isbn']> 
  // 👍
  books: Automerge.Table<Book> 
  ```

  Should we continue to support the old syntax instead, and just mark it as deprecated in the `Table` type definition?