### PR TITLE
Allow non-string children in Text objects

### DIFF
--- a/@types/automerge/index.d.ts
+++ b/@types/automerge/index.d.ts
@@ -76,7 +76,7 @@ declare module 'automerge' {
     constructor(objectId?: UUID, elems?: string[], maxElem?: number)
     get(index: number): string
     getElemId(index: number): string
-    toSpans(): (string | any)[]
+    toSpans<T>(): (string | T)[]
   }
 
   // Note that until https://github.com/Microsoft/TypeScript/issues/2361 is addressed, we

--- a/@types/automerge/index.d.ts
+++ b/@types/automerge/index.d.ts
@@ -76,6 +76,7 @@ declare module 'automerge' {
     constructor(objectId?: UUID, elems?: string[], maxElem?: number)
     get(index: number): string
     getElemId(index: number): string
+    toSpans(): (string | any)[]
   }
 
   // Note that until https://github.com/Microsoft/TypeScript/issues/2361 is addressed, we

--- a/frontend/apply_patch.js
+++ b/frontend/apply_patch.js
@@ -341,7 +341,8 @@ function updateTextObject(diffs, startIndex, endIndex, cache, updated) {
         insertions = []
       }
       maxElem = Math.max(maxElem, parseElemId(diff.elemId).counter)
-      insertions.push({elemId: diff.elemId, value: diff.value, conflicts: diff.conflicts})
+      const value = getValue(diff, cache, updated)
+      insertions.push({elemId: diff.elemId, value, conflicts: diff.conflicts})
 
       if (startIndex === endIndex || diffs[startIndex + 1].action !== 'insert' ||
           diffs[startIndex + 1].index !== diff.index + 1) {
@@ -352,7 +353,7 @@ function updateTextObject(diffs, startIndex, endIndex, cache, updated) {
     } else if (diff.action === 'set') {
       elems[diff.index] = {
         elemId: elems[diff.index].elemId,
-        value: diff.value,
+        value: getValue(diff, cache, updated),
         conflicts: diff.conflicts
       }
 

--- a/frontend/text.js
+++ b/frontend/text.js
@@ -56,6 +56,26 @@ class Text {
     return chars.join('')
   }
 
+  toSpans() {
+    let spans = []
+    let chars = []
+    for (let elem of this.elems) {
+      if (typeof elem.value === 'string') {
+        chars.push(elem.value)
+      } else {
+        if (chars.length > 0) {
+          spans.push(chars.join(''))
+          chars = []
+        }
+        spans.push(elem.value)
+      }
+    }
+    if (chars.length > 0) { 
+      spans.push(chars.join(''))
+    }
+    return spans
+  } 
+
   /**
    * Returns the content of the Text object as a simple string, so that the
    * JSON serialization of an Automerge document represents text nicely.

--- a/frontend/text.js
+++ b/frontend/text.js
@@ -46,35 +46,46 @@ class Text {
   }
 
   /**
-   * Returns the content of the Text object as a simple string.
+   * Returns the content of the Text object as a simple string, ignoring any
+   * non-character elements.
    */
   toString() {
-    let chars = []
-    for (let elem of this.elems) {
-      if (typeof elem.value === 'string') chars.push(elem.value)
+    // Concatting to a string is faster than creating an array and then
+    // .join()ing for small (<100KB) arrays.
+    // https://jsperf.com/join-vs-loop-w-type-test
+    let str = ''
+    for (const elem of this.elems) {
+      if (typeof elem.value === 'string') str += elem.value
     }
-    return chars.join('')
+    return str
   }
 
+  /**
+   * Returns the content of the Text object as a sequence of strings,
+   * interleaved with non-character elements.
+   *
+   * For example, the value ['a', 'b', {x: 3}, 'c', 'd'] has spans:
+   * => ['ab', {x: 3}, 'cd']
+   */
   toSpans() {
     let spans = []
-    let chars = []
-    for (let elem of this.elems) {
+    let chars = ''
+    for (const elem of this.elems) {
       if (typeof elem.value === 'string') {
-        chars.push(elem.value)
+        chars += elem.value
       } else {
         if (chars.length > 0) {
-          spans.push(chars.join(''))
-          chars = []
+          spans.push(chars)
+          chars = ''
         }
         spans.push(elem.value)
       }
     }
-    if (chars.length > 0) { 
-      spans.push(chars.join(''))
+    if (chars.length > 0) {
+      spans.push(chars)
     }
     return spans
-  } 
+  }
 
   /**
    * Returns the content of the Text object as a simple string, so that the

--- a/frontend/text.js
+++ b/frontend/text.js
@@ -27,6 +27,10 @@ class Text {
     return this.elems[index].elemId
   }
 
+  /**
+   * Iterates over the text elements character by character, including any
+   * inline objects.
+   */
   [Symbol.iterator] () {
     let elems = this.elems, index = -1
     return {
@@ -45,14 +49,19 @@ class Text {
    * Returns the content of the Text object as a simple string.
    */
   toString() {
-    return this.join('')
+    let chars = []
+    for (let elem of this.elems) {
+      if (typeof elem.value === 'string') chars.push(elem.value)
+    }
+    return chars.join('')
   }
+
   /**
    * Returns the content of the Text object as a simple string, so that the
    * JSON serialization of an Automerge document represents text nicely.
    */
   toJSON() {
-    return this.join('')
+    return this.toString()
   }
 
   /**

--- a/test/text_test.js
+++ b/test/text_test.js
@@ -183,5 +183,54 @@ describe('Automerge.Text', () => {
     it('should exclude control characters from toString()', () => {
       assert.strictEqual(s1.text.toString(), 'a')
     })
+
+    describe('spans interface to Text', () => {
+      it('should return a simple string as a single span', () =>{
+        let s1 = Automerge.change(Automerge.init(), doc => {
+          doc.text = new Automerge.Text('hello world')
+        })
+        assert.deepEqual(s1.text.toSpans(), ['hello world'])
+      })
+      it('should return an empty string as an empty array', () =>{
+        let s1 = Automerge.change(Automerge.init(), doc => {
+          doc.text = new Automerge.Text()
+        })
+        assert.deepEqual(s1.text.toSpans(), [])
+      })
+      it('should split a span at a control character', () => {
+        let s1 = Automerge.change(Automerge.init(), doc => {
+          doc.text = new Automerge.Text('hello world')
+          doc.text.insertAt(5, {attribute: 'bold'})
+        })
+        assert.deepEqual(s1.text.toSpans(), 
+          ['hello', {attribute: 'bold'}, ' world'])
+      })
+      it('should allow consecutive control characters', () => {
+        let s1 = Automerge.change(Automerge.init(), doc => {
+          doc.text = new Automerge.Text('hello world')
+          doc.text.insertAt(5, {attribute: 'bold'})
+          doc.text.insertAt(6, {attribute: 'italic'})
+        })
+        assert.deepEqual(s1.text.toSpans(), 
+          ['hello', 
+           { attribute: 'bold' }, 
+           { attribute: 'italic' },
+           ' world'
+          ])
+      })
+      it('should allow non-consecutive control characters', () => {
+        let s1 = Automerge.change(Automerge.init(), doc => {
+          doc.text = new Automerge.Text('hello world')
+          doc.text.insertAt(5, {attribute: 'bold'})
+          doc.text.insertAt(12, {attribute: 'italic'})
+        })
+        assert.deepEqual(s1.text.toSpans(), 
+          ['hello', 
+           { attribute: 'bold' }, 
+           ' world',
+           { attribute: 'italic' },
+          ])
+      })
+    })
   })
 })

--- a/test/text_test.js
+++ b/test/text_test.js
@@ -159,5 +159,18 @@ describe('Automerge.Text', () => {
       assert.strictEqual(s1.text.join(''), 'Init')
       assert.strictEqual(s1.text.toString(), 'Init')
     })
+
+    it('should allow non-textual characters', () => {
+      let s1 = Automerge.change(Automerge.init(), doc => {
+        doc.text = new Automerge.Text()
+        doc.text.insertAt(0, 'a')
+        doc.text.insertAt(1, { attribute: 'bold' })
+      })
+
+      assert.strictEqual(s1.text.length, 2)
+      assert.strictEqual(s1.text.get(0), 'a')
+      assert.deepEqual(s1.text.get(1), { attribute: 'bold' })
+      assert.strictEqual(s1.text.toString(), 'a')
+    })
   })
 })

--- a/test/text_test.js
+++ b/test/text_test.js
@@ -159,17 +159,26 @@ describe('Automerge.Text', () => {
       assert.strictEqual(s1.text.join(''), 'Init')
       assert.strictEqual(s1.text.toString(), 'Init')
     })
-
-    it('should allow non-textual characters', () => {
-      let s1 = Automerge.change(Automerge.init(), doc => {
-        doc.text = new Automerge.Text()
-        doc.text.insertAt(0, 'a')
-        doc.text.insertAt(1, { attribute: 'bold' })
+  })
+  describe('non-textual control characters', () => {
+    let s1
+    beforeEach(() => {
+      s1 = Automerge.change(Automerge.init(), doc => {
+      doc.text = new Automerge.Text()
+      doc.text.insertAt(0, 'a')
+      doc.text.insertAt(1, { attribute: 'bold' })
       })
+    })
+    it('should allow fetching non-textual characters', () => {
+      assert.deepEqual(s1.text.get(1), { attribute: 'bold' })
+    })
 
+    it('should include control characters in string length', () => {
       assert.strictEqual(s1.text.length, 2)
       assert.strictEqual(s1.text.get(0), 'a')
-      assert.deepEqual(s1.text.get(1), { attribute: 'bold' })
+    })
+
+    it('should exclude control characters from toString()', () => {
       assert.strictEqual(s1.text.toString(), 'a')
     })
   })

--- a/test/text_test.js
+++ b/test/text_test.js
@@ -13,21 +13,25 @@ function attributeStateToAttributes(accumulatedAttributes) {
 }
 
 function isEquivalent(a, b) {
-  var aProps = Object.getOwnPropertyNames(a);
-  var bProps = Object.getOwnPropertyNames(b);
+  var aProps = Object.getOwnPropertyNames(a)
+  var bProps = Object.getOwnPropertyNames(b)
 
   if (aProps.length != bProps.length) {
-      return false;
+      return false
   }
 
   for (var i = 0; i < aProps.length; i++) {
-      var propName = aProps[i];
+      var propName = aProps[i]
       if (a[propName] !== b[propName]) {
-          return false;
+          return false
       }
   }
 
-  return true;
+  return true
+}
+
+function isControlMarker(pseudoCharacter) {
+  return typeof pseudoCharacter === 'object' && pseudoCharacter.attributes
 }
 
 function opFrom(text, attributes) {
@@ -58,7 +62,7 @@ function automergeTextToDeltaDoc(text) {
   let currentString = ""
   let attributes = {}
   text.toSpans().forEach((span) => {
-    if (typeof span === 'object' && span.attributes ) {
+    if (isControlMarker(span)) {
       controlState = accumulateAttributes(span.attributes, controlState)
     } else {
       let next = attributeStateToAttributes(controlState)
@@ -109,12 +113,12 @@ function inverseAttributes(attributes) {
 function applyDeleteOp(text, offset, op) {
   let length = op.delete
   while (length > 0) {
-    if (typeof text.get(offset) === 'string') {
-      // we need to not delete control characters
+    if (isControlMarker(text.get(offset))) {
+      offset += 1
+    } else {
+      // we need to not delete control characters, but we do delete embed characters
       text.deleteAt(offset, 1)
       length -= 1
-    } else {
-      offset += 1
     }
   }
   return [text, offset]
@@ -124,7 +128,7 @@ function applyRetainOp(text, offset, op) {
   let slice = text.slice(offset, offset + op.retain)
   slice.forEach((i) => {
     // don't count control characters towards length
-    if (typeof i !== 'string') {
+    if (isControlMarker(i)) {
       offset += 1
     }
   })

--- a/test/text_test.js
+++ b/test/text_test.js
@@ -160,15 +160,17 @@ describe('Automerge.Text', () => {
       assert.strictEqual(s1.text.toString(), 'Init')
     })
   })
+
   describe('non-textual control characters', () => {
     let s1
     beforeEach(() => {
       s1 = Automerge.change(Automerge.init(), doc => {
-      doc.text = new Automerge.Text()
-      doc.text.insertAt(0, 'a')
-      doc.text.insertAt(1, { attribute: 'bold' })
+        doc.text = new Automerge.Text()
+        doc.text.insertAt(0, 'a')
+        doc.text.insertAt(1, { attribute: 'bold' })
       })
     })
+
     it('should allow fetching non-textual characters', () => {
       assert.deepEqual(s1.text.get(1), { attribute: 'bold' })
     })


### PR DESCRIPTION
This builds on work from @pvh and @ept to allow non-string objects to be present in `Automerge.Text`. While the experiments with representing rich-text formatting by "format markers" proved unsuccessful, I think this is still useful for representing "embedded objects" within text.

Closes #194