### PR TITLE
Remove the list of columns from Automerge.Table

### DIFF
--- a/@types/automerge/index.d.ts
+++ b/@types/automerge/index.d.ts
@@ -56,16 +56,14 @@ declare module 'automerge' {
   // custom CRDT types
 
   class Table<T> {
-    constructor(columns: (keyof T)[])
+    constructor()
     add(item: T): UUID
     byId(id: UUID): T
-    columns: string[]
     count: number
     ids: UUID[]
     remove(id: UUID): void
     rows(): T[]
     set(id: UUID, value: T): void
-    set(id: 'columns', value: string[]): void
   }
 
   class List<T> extends Array<T> {

--- a/README.md
+++ b/README.md
@@ -606,15 +606,8 @@ You can create new tables and insert rows like this:
 ```js
 let database = Automerge.change(Automerge.init(), doc => {
   // When creating a table, provide a list of column names
-  doc.authors = new Automerge.Table(['surname', 'forename'])
-  doc.publications = new Automerge.Table([
-    'type',
-    'authors',
-    'title',
-    'publisher',
-    'edition',
-    'year',
-  ])
+  doc.authors = new Automerge.Table()
+  doc.publications = new Automerge.Table()
 
   // Automerge.Table.add() inserts a new row into the database
   // and returns the primary key (unique ID) of the new row
@@ -653,10 +646,10 @@ database.publications.filter(pub => pub.title.startsWith('Designing'))
 database.publications.map(pub => pub.publisher)
 ```
 
-Note that currently the `Automerge.Table` type does not enforce a schema; the list of columns is
-given because it is useful metadata, but it doesn't actually change how rows are stored. It's
-possible to have row objects that don't have values for all columns (e.g. in the example above, the
-"edition" property is not set).
+Note that currently the `Automerge.Table` type does not enforce a schema. By convention, the row
+objects that you add to a table should have the same properties (like columns in a table), but
+Automerge does not enforce this. This is because different users may be running different versions
+of your app, which might be using different properties.
 
 ## Caveats
 

--- a/frontend/context.js
+++ b/frontend/context.js
@@ -99,7 +99,6 @@ class Context {
       }
       this.apply({action: 'create', type: 'table', obj: objectId})
       this.addOp({action: 'makeTable', obj: objectId})
-      this.setMapKey(objectId, 'table', 'columns', value.columns)
 
     } else if (Array.isArray(value)) {
       // Create a new list object

--- a/frontend/table.js
+++ b/frontend/table.js
@@ -18,21 +18,16 @@ function compareRows(properties, row1, row2) {
 
 
 /**
- * A relational-style collection of records. A table has an ordered list of
- * columns, and an unordered set of rows. Each row is an object that maps
- * column names to values. The set of rows is represented by a map from
- * object ID to row object.
+ * A relational-style unordered collection of records (rows). Each row is an
+ * object that maps column names to values. The set of rows is represented by
+ * a map from object ID to row object.
  */
 class Table {
   /**
    * This constructor is used by application code when creating a new Table
    * object within a change callback.
    */
-  constructor(columns) {
-    if (!Array.isArray(columns)) {
-      throw new TypeError('When creating a table you must supply a list of columns')
-    }
-    this.columns = columns
+  constructor() {
     this.entries = Object.freeze({})
     Object.freeze(this)
   }
@@ -156,7 +151,6 @@ class Table {
       throw new Error('A table can only be modified in a change function')
     }
     this.entries[id] = value
-    if (id === 'columns') this.columns = value
   }
 
   /**
@@ -195,14 +189,13 @@ class Table {
   }
 
   /**
-   * Returns an object containing both the table entries (indexed by objectID)
-   * and the columns (under the key `columns`). This provides a nice format
-   * when serializing an Automerge document to JSON.
+   * Returns an object containing the table entries, indexed by objectID,
+   * for serializing an Automerge document to JSON.
    */
   toJSON() {
     const rows = {}
     for (let id of this.ids) rows[id] = this.byId(id)
-    return {columns: this.columns, rows}
+    return rows
   }
 }
 
@@ -211,15 +204,6 @@ class Table {
  * callback.
  */
 class WriteableTable extends Table {
-  /**
-   * Returns a proxied version of the columns list. This list can be modified
-   * within a change callback.
-   */
-  get columns() {
-    const columnsId = this.entries.columns[OBJECT_ID]
-    return this.context.instantiateObject(columnsId)
-  }
-
   /**
    * Returns a proxied version of the row with ID `id`. This row object can be
    * modified within a change callback.
@@ -236,7 +220,7 @@ class WriteableTable extends Table {
    */
   add(row) {
     if (typeof row !== 'object' || Array.isArray(row)) {
-      throw new RangeError('Table row must be an object')
+      throw new TypeError('Table row must be an object')
     }
     return this.context.addTableRow(this[OBJECT_ID], row)
   }

--- a/test/table_test.js
+++ b/test/table_test.js
@@ -23,19 +23,11 @@ describe('Automerge.Table', () => {
     it('should generate ops to create a table', () => {
       const actor = uuid()
       const [doc, req] = Frontend.change(Frontend.init(actor), doc => {
-        // isbn is deliberately not listed, to test use of undeclared columns
-        doc.books = new Automerge.Table(['authors', 'title'])
+        doc.books = new Automerge.Table()
       })
       const books = Frontend.getObjectId(doc.books)
-      const cols = Frontend.getObjectId(doc.books.columns)
       assert.deepEqual(req, {requestType: 'change', actor, seq: 1, deps: {}, ops: [
         {obj: books, action: 'makeTable'},
-        {obj: cols, action: 'makeList'},
-        {obj: cols, action: 'ins', elem: 1, key: '_head'},
-        {obj: cols, action: 'set', key: `${actor}:1`, value: 'authors'},
-        {obj: cols, action: 'ins', elem: 2, key: `${actor}:1`},
-        {obj: cols, action: 'set', key: `${actor}:2`, value: 'title'},
-        {obj: books, action: 'link', key: 'columns', value: cols},
         {obj: ROOT_ID, action: 'link', key: 'books', value: books}
       ]})
     })
@@ -43,7 +35,7 @@ describe('Automerge.Table', () => {
     it('should generate ops to insert a row', () => {
       const actor = uuid()
       const [doc1, req1] = Frontend.change(Frontend.init(actor), doc => {
-        doc.books = new Automerge.Table(['authors', 'title'])
+        doc.books = new Automerge.Table()
       })
       let rowId
       const [doc2, req2] = Frontend.change(doc1, doc => {
@@ -64,7 +56,7 @@ describe('Automerge.Table', () => {
 
     beforeEach(() => {
       s1 = Automerge.change(Automerge.init({freeze: true}), doc => {
-        doc.books = new Automerge.Table(['authors', 'title', 'isbn'])
+        doc.books = new Automerge.Table()
         rowId = doc.books.add(DDIA)
       })
     })
@@ -103,7 +95,6 @@ describe('Automerge.Table', () => {
 
     it('should save and reload', () => {
       const s2 = Automerge.load(Automerge.save(s1))
-      assert.deepEqual(s2.books.columns, ['authors', 'title', 'isbn'])
       assert.deepEqual(s2.books.byId(rowId), DDIA)
     })
 
@@ -125,19 +116,11 @@ describe('Automerge.Table', () => {
       assert.strictEqual(s2.books.count, 0)
       assert.deepEqual([...s2.books], [])
     })
-
-    it('should allow the column list to be changed', () => {
-      const s2 = Automerge.change(s1, doc => {
-        doc.books.columns.push('publisher')
-      })
-      assert.deepEqual(s2.books.columns, ['authors', 'title', 'isbn', 'publisher'])
-      assert.deepEqual(s2.books.byId(rowId), DDIA)
-    })
   })
 
   it('should allow concurrent row insertion', () => {
     const a0 = Automerge.change(Automerge.init(), doc => {
-      doc.books = new Automerge.Table(['authors', 'title', 'isbn'])
+      doc.books = new Automerge.Table()
     })
     const b0 = Automerge.merge(Automerge.init(), a0)
 
@@ -153,7 +136,7 @@ describe('Automerge.Table', () => {
 
   it('should allow rows to be sorted in various ways', () => {
     const s = Automerge.change(Automerge.init(), doc => {
-      doc.books = new Automerge.Table(['authors', 'title', 'isbn'])
+      doc.books = new Automerge.Table()
       doc.books.add(DDIA)
       doc.books.add(RSDP)
     })
@@ -167,12 +150,9 @@ describe('Automerge.Table', () => {
   it('should allow serialization to JSON', () => {
     let ddia
     const s = Automerge.change(Automerge.init(), doc => {
-      doc.books = new Automerge.Table(['authors', 'title', 'isbn'])
+      doc.books = new Automerge.Table()
       ddia = doc.books.add(DDIA)
     })
-    assert.deepEqual(JSON.parse(JSON.stringify(s)), {books: {
-      columns: ['authors', 'title', 'isbn'],
-      rows: {[ddia]: DDIA}
-    }})
+    assert.deepEqual(JSON.parse(JSON.stringify(s)), {books: {[ddia]: DDIA}})
   })
 })

--- a/test/typescript_test.ts
+++ b/test/typescript_test.ts
@@ -461,7 +461,7 @@ describe('TypeScript support', () => {
 
     beforeEach(() => {
       s1 = Automerge.change(Automerge.init<BookDb>(), doc => {
-        doc.books = new Automerge.Table(['authors', 'title', 'isbn'])
+        doc.books = new Automerge.Table()
         id = doc.books.add(DDIA)
       })
     })
@@ -470,18 +470,13 @@ describe('TypeScript support', () => {
     it('supports `count`', () => assert.strictEqual(s1.books.count, 1))
     it('supports `ids`', () => assert.deepEqual(s1.books.ids, [id]))
     it('supports iteration', () => assert.deepEqual([...s1.books], [DDIA]))
-    it('supports `columns`', () => assert.deepEqual(s1.books.columns, ['authors', 'title', 'isbn']))
 
-    it('allows modifying the columns array', () => {
-      const s2 = Automerge.change(s1, doc => doc.books.columns.push('publisher'))
-      assert.deepEqual(s2.books.columns, ['authors', 'title', 'isbn', 'publisher'])
-      assert.deepEqual(s2.books.byId(id), DDIA)
-
+    it('allows adding row properties', () => {
       // Note that if we add columns and want to actually use them, we need to recast the table to a
       // new type e.g. without the `ts-ignore` flag, this would throw a type error:
 
       // @ts-ignore - Property 'publisher' does not exist on type book
-      const p2 = s2.books.byId(id).publisher 
+      const p2 = s1.books.byId(id).publisher 
 
       // So we need to create new types
       interface BookDeluxe extends Book {
@@ -492,9 +487,9 @@ describe('TypeScript support', () => {
         books: Automerge.Table<BookDeluxe>
       }
 
-      const s2a = s2 as Doc<BookDeluxeDb> // Cast existing table to new type
+      const s2 = s1 as Doc<BookDeluxeDb> // Cast existing table to new type
       const s3 = Automerge.change(
-        s2a,
+        s2,
         doc => (doc.books.byId(id).publisher = "O'Reilly")
       )
 


### PR DESCRIPTION
Since #236 the Automerge.Table type no longer allows rows to be added as an array of values, which are then mapped to column names. Now that this feature is removed, nothing in Automerge is actually using the list of columns that is currently required by the Automerge.Table constructor. The columns are still saved, but since they do not enforce any schema, they are purely advisory.

Hopefully one day we can have proper schema support in Automerge, but the current half-hearted implementation is not really helping us get there. Therefore I think it is best to just remove this list of columns feature.

Any thoughts?