### PR TITLE
Make table row's primary key available as `id` property

### DIFF
--- a/@types/automerge/index.d.ts
+++ b/@types/automerge/index.d.ts
@@ -55,14 +55,18 @@ declare module 'automerge' {
 
   // custom CRDT types
 
+  class TableRow {
+    readonly id: UUID
+  }
+
   class Table<T> {
     constructor()
     add(item: T): UUID
-    byId(id: UUID): T
+    byId(id: UUID): T & TableRow
     count: number
     ids: UUID[]
     remove(id: UUID): void
-    rows(): T[]
+    rows(): (T & TableRow)[]
     set(id: UUID, value: T): void
   }
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 - **Removed** [#236]: Undocumented `Automerge.Table` API that allowed rows to be added by
   providing an array of values. Now rows must be given as an object ([@HerbCaudill])
+- **Removed** [#241]: Constructor of `Automerge.Table` no longer takes an array of columns, and
+  the `columns` property of `Automerge.Table` is also removed ([@ept])
+- **Changed** [#242]: Rows of `Automerge.Table` now automatically get an `id` property containing
+  the primary key of that row ([@ept])
 - **Removed** support for Node 8, which is no longer being maintained
 - **Added** [#194], [#238]: `Automerge.Text` objects may now contain objects as well as strings;
   new method `Text.toSpans()` that concatenates characters while leaving objects unchanged
@@ -254,6 +258,8 @@ is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 [0.4.0]: https://github.com/automerge/automerge/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/automerge/automerge/compare/v0.2.0...v0.3.0
 
+[#242]: https://github.com/automerge/automerge/pull/242
+[#241]: https://github.com/automerge/automerge/pull/241
 [#238]: https://github.com/automerge/automerge/pull/238
 [#236]: https://github.com/automerge/automerge/pull/236
 [#232]: https://github.com/automerge/automerge/pull/232

--- a/README.md
+++ b/README.md
@@ -605,7 +605,6 @@ You can create new tables and insert rows like this:
 
 ```js
 let database = Automerge.change(Automerge.init(), doc => {
-  // When creating a table, provide a list of column names
   doc.authors = new Automerge.Table()
   doc.publications = new Automerge.Table()
 
@@ -619,7 +618,7 @@ let database = Automerge.change(Automerge.init(), doc => {
     authors: [martinID],
     title: 'Designing Data-Intensive Applications',
     publisher: "O'Reilly Media",
-    year: 2017,
+    year: 2017
   })
 })
 ```

--- a/frontend/context.js
+++ b/frontend/context.js
@@ -277,11 +277,14 @@ class Context {
    * Returns the objectId of the new row.
    */
   addTableRow(objectId, row) {
-    if (!isObject(row)) {
+    if (!isObject(row) || Array.isArray(row)) {
       throw new TypeError('A table row must be an object')
     }
     if (row[OBJECT_ID]) {
       throw new TypeError('Cannot reuse an existing object as table row')
+    }
+    if (row.id) {
+      throw new TypeError('A table row must not have an "id" property; it is generated automatically')
     }
 
     const rowId = this.createNestedObjects(row)

--- a/test/table_test.js
+++ b/test/table_test.js
@@ -52,18 +52,19 @@ describe('Automerge.Table', () => {
   })
 
   describe('with one row', () => {
-    let s1, rowId
+    let s1, rowId, rowWithId
 
     beforeEach(() => {
       s1 = Automerge.change(Automerge.init({freeze: true}), doc => {
         doc.books = new Automerge.Table()
         rowId = doc.books.add(DDIA)
       })
+      rowWithId = Object.assign({id: rowId}, DDIA)
     })
 
     it('should look up a row by ID', () => {
       const row = s1.books.byId(rowId)
-      assert.deepEqual(row, DDIA)
+      assert.deepEqual(row, rowWithId)
       assert.strictEqual(Frontend.getObjectId(row), rowId)
     })
 
@@ -76,26 +77,26 @@ describe('Automerge.Table', () => {
     })
 
     it('should allow iterating over rows', () => {
-      assert.deepEqual([...s1.books], [DDIA])
+      assert.deepEqual([...s1.books], [rowWithId])
     })
 
     it('should support standard array methods', () => {
-      assert.deepEqual(s1.books.filter(book => book.isbn === '1449373321'), [DDIA])
+      assert.deepEqual(s1.books.filter(book => book.isbn === '1449373321'), [rowWithId])
       assert.deepEqual(s1.books.filter(book => book.isbn === '9781449373320'), [])
-      assert.deepEqual(s1.books.find(book => book.isbn === '1449373321'), DDIA)
+      assert.deepEqual(s1.books.find(book => book.isbn === '1449373321'), rowWithId)
       assert.strictEqual(s1.books.find(book => book.isbn === '9781449373320'), undefined)
       assert.deepEqual(s1.books.map(book => book.title), ['Designing Data-Intensive Applications'])
     })
 
     it('should be immutable', () => {
       assert.strictEqual(s1.books.add, undefined)
-      assert.throws(() => s1.books.set('id', {}), /can only be modified in a change function/)
-      assert.throws(() => s1.books.remove('id'),  /can only be modified in a change function/)
+      assert.throws(() => s1.books.set('publisher', {}), /can only be modified in a change function/)
+      assert.throws(() => s1.books.remove('publisher'),  /can only be modified in a change function/)
     })
 
     it('should save and reload', () => {
       const s2 = Automerge.load(Automerge.save(s1))
-      assert.deepEqual(s2.books.byId(rowId), DDIA)
+      assert.deepEqual(s2.books.byId(rowId), rowWithId)
     })
 
     it('should allow a row to be updated', () => {
@@ -103,6 +104,7 @@ describe('Automerge.Table', () => {
         doc.books.byId(rowId).isbn = '9781449373320'
       })
       assert.deepEqual(s2.books.byId(rowId), {
+        id: rowId,
         authors: ['Kleppmann, Martin'],
         title: 'Designing Data-Intensive Applications',
         isbn: '9781449373320'
@@ -116,6 +118,22 @@ describe('Automerge.Table', () => {
       assert.strictEqual(s2.books.count, 0)
       assert.deepEqual([...s2.books], [])
     })
+
+    it('should not allow a row ID to be specified', () => {
+      assert.throws(() => {
+        Automerge.change(s1, doc => {
+          doc.books.add(Object.assign({id: 'beafbfde-8e44-4a5f-b679-786e2ebba03f'}, RSDP))
+        })
+      }, /A table row must not have an "id" property/)
+    })
+
+    it('should not allow a row ID to be modified', () => {
+      assert.throws(() => {
+        Automerge.change(s1, doc => {
+          doc.books.byId(rowId).id = 'beafbfde-8e44-4a5f-b679-786e2ebba03f'
+        })
+      }, /Object property "id" cannot be modified/)
+    })
   })
 
   it('should allow concurrent row insertion', () => {
@@ -128,23 +146,26 @@ describe('Automerge.Table', () => {
     const a1 = Automerge.change(a0, doc => { ddia = doc.books.add(DDIA) })
     const b1 = Automerge.change(b0, doc => { rsdp = doc.books.add(RSDP) })
     const a2 = Automerge.merge(a1, b1)
-    assert.deepEqual(a2.books.byId(ddia), DDIA)
-    assert.deepEqual(a2.books.byId(rsdp), RSDP)
+    assert.deepEqual(a2.books.byId(ddia), Object.assign({id: ddia}, DDIA))
+    assert.deepEqual(a2.books.byId(rsdp), Object.assign({id: rsdp}, RSDP))
     assert.strictEqual(a2.books.count, 2)
     assertEqualsOneOf(a2.books.ids, [ddia, rsdp], [rsdp, ddia])
   })
 
   it('should allow rows to be sorted in various ways', () => {
+    let ddia, rsdp
     const s = Automerge.change(Automerge.init(), doc => {
       doc.books = new Automerge.Table()
-      doc.books.add(DDIA)
-      doc.books.add(RSDP)
+      ddia = doc.books.add(DDIA)
+      rsdp = doc.books.add(RSDP)
     })
-    assert.deepEqual(s.books.sort('title'), [DDIA, RSDP])
-    assert.deepEqual(s.books.sort(['authors', 'title']), [RSDP, DDIA])
+    const ddiaWithId = Object.assign({id: ddia}, DDIA)
+    const rsdpWithId = Object.assign({id: rsdp}, RSDP)
+    assert.deepEqual(s.books.sort('title'), [ddiaWithId, rsdpWithId])
+    assert.deepEqual(s.books.sort(['authors', 'title']), [rsdpWithId, ddiaWithId])
     assert.deepEqual(s.books.sort((row1, row2) => {
       return (row1.isbn === '1449373321') ? -1 : +1
-    }), [DDIA, RSDP])
+    }), [ddiaWithId, rsdpWithId])
   })
 
   it('should allow serialization to JSON', () => {
@@ -153,6 +174,7 @@ describe('Automerge.Table', () => {
       doc.books = new Automerge.Table()
       ddia = doc.books.add(DDIA)
     })
-    assert.deepEqual(JSON.parse(JSON.stringify(s)), {books: {[ddia]: DDIA}})
+    const ddiaWithId = Object.assign({id: ddia}, DDIA)
+    assert.deepEqual(JSON.parse(JSON.stringify(s)), {books: {[ddia]: ddiaWithId}})
   })
 })

--- a/test/typescript_test.ts
+++ b/test/typescript_test.ts
@@ -457,19 +457,21 @@ describe('TypeScript support', () => {
     }
 
     let s1: Doc<BookDb>
-    let id: string
+    let id: Automerge.UUID
+    let ddiaWithId: Book & Automerge.TableRow
 
     beforeEach(() => {
       s1 = Automerge.change(Automerge.init<BookDb>(), doc => {
         doc.books = new Automerge.Table()
         id = doc.books.add(DDIA)
       })
+      ddiaWithId = Object.assign({id}, DDIA)
     })
 
-    it('supports `byId`', () => assert.deepEqual(s1.books.byId(id), DDIA))
+    it('supports `byId`', () => assert.deepEqual(s1.books.byId(id), ddiaWithId))
     it('supports `count`', () => assert.strictEqual(s1.books.count, 1))
     it('supports `ids`', () => assert.deepEqual(s1.books.ids, [id]))
-    it('supports iteration', () => assert.deepEqual([...s1.books], [DDIA]))
+    it('supports iteration', () => assert.deepEqual([...s1.books], [ddiaWithId]))
 
     it('allows adding row properties', () => {
       // Note that if we add columns and want to actually use them, we need to recast the table to a
@@ -507,15 +509,16 @@ describe('TypeScript support', () => {
       it('accepts value passed as object', () => {
         let bookId: string
         const s2 = Automerge.change(s1, doc => (bookId = doc.books.add(RSDP)))
-        assert.deepEqual(s2.books.byId(bookId), RSDP)
+        assert.deepEqual(s2.books.byId(bookId), Object.assign({id: bookId}, RSDP))
+        assert.strictEqual(s2.books.byId(bookId).id, bookId)
       })
     })
 
     describe('standard array operations on rows', () => {
       it('supports `filter`', () =>
-        assert.deepEqual(s1.books.filter(book => book.authors.length === 1), [DDIA]))
+        assert.deepEqual(s1.books.filter(book => book.authors.length === 1), [ddiaWithId]))
       it('supports `find`', () =>
-        assert.deepEqual(s1.books.find(book => book.isbn === '1449373321'), DDIA))
+        assert.deepEqual(s1.books.find(book => book.isbn === '1449373321'), ddiaWithId))
       it('supports `map`', () =>
         assert.deepEqual(s1.books.map<string>(book => book.title), [DDIA.title]))
     })


### PR DESCRIPTION
While we're making API changes to `Automerge.Table` anyway (#236, #241), here's another change I'd like to make.

Currently, if you have a row object from an Automerge.Table, you can get its primary key with `Automerge.getObjectId(row)`. This API is not very discoverable; users who don't know about this API might be tempted to generate their own IDs for table rows, which would miss the entire point of Automerge.Table.

This patch makes the primary key more visible by making it available as `row.id` instead. When a new row is added, we check that the row object doesn't already have an `id` property. We also ensure that the `id` property cannot be modified.

For example:

```js
let bookId
let database = Automerge.change(Automerge.init(), doc => {
  doc.books = new Automerge.Table()
  // the add() method returns the primary key of the new row
  bookId = doc.books.add({
    author: 'Martin Kleppmann',
    title: 'Designing Data-Intensive Applications',
    year: 2017
  })
})

database.books.byId(bookId)
// Returns {
//   id: bookId,  <--- new property!
//   author: 'Martin Kleppmann',
//   title: 'Designing Data-Intensive Applications',
//   year: 2017
// }
```

(Besides API usability, there is also a deeper reason for making this change: on the `performance` branch, objectIds are backend-generated Lamport timestamps rather than UUIDs to enable better compression; since `Table.add` should synchronously return the primary key of the new row, it must use a different ID from the objectId. Putting the row's primary key in a separate property reinforces that distinction.)