### PR TITLE
Remove set() method from Automerge.Table API

### DIFF
--- a/@types/automerge/index.d.ts
+++ b/@types/automerge/index.d.ts
@@ -67,7 +67,6 @@ declare module 'automerge' {
     ids: UUID[]
     remove(id: UUID): void
     rows(): (T & TableRow)[]
-    set(id: UUID, value: T): void
   }
 
   class List<T> extends Array<T> {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
   the `columns` property of `Automerge.Table` is also removed ([@ept])
 - **Changed** [#242]: Rows of `Automerge.Table` now automatically get an `id` property containing
   the primary key of that row ([@ept])
+- **Removed** [#243]: `Automerge.Table` objects no longer have a `set()` method. Use `add()` or
+  `remove()` instead ([@ept])
 - **Removed** support for Node 8, which is no longer being maintained
 - **Added** [#194], [#238]: `Automerge.Text` objects may now contain objects as well as strings;
   new method `Text.toSpans()` that concatenates characters while leaving objects unchanged
@@ -258,6 +260,7 @@ is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 [0.4.0]: https://github.com/automerge/automerge/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/automerge/automerge/compare/v0.2.0...v0.3.0
 
+[#243]: https://github.com/automerge/automerge/pull/243
 [#242]: https://github.com/automerge/automerge/pull/242
 [#241]: https://github.com/automerge/automerge/pull/241
 [#238]: https://github.com/automerge/automerge/pull/238

--- a/frontend/apply_patch.js
+++ b/frontend/apply_patch.js
@@ -167,10 +167,10 @@ function updateTableObject(diff, cache, updated, inbound) {
     const previous = object.byId(diff.key)
     if (isObject(previous)) refsBefore[previous[OBJECT_ID]] = true
     if (diff.link) {
-      object.set(diff.key, updated[diff.value] || cache[diff.value])
+      object._set(diff.key, updated[diff.value] || cache[diff.value])
       refsAfter[diff.value] = true
     } else {
-      object.set(diff.key, diff.value)
+      object._set(diff.key, diff.value)
     }
   } else if (diff.action === 'remove') {
     const previous = object.byId(diff.key)
@@ -197,7 +197,7 @@ function parentTableObject(objectId, cache, updated) {
   for (let key of Object.keys(table.entries)) {
     let value = table.byId(key)
     if (isObject(value) && updated[value[OBJECT_ID]]) {
-      table.set(key, updated[value[OBJECT_ID]])
+      table._set(key, updated[value[OBJECT_ID]])
     }
   }
 }

--- a/frontend/table.js
+++ b/frontend/table.js
@@ -144,9 +144,10 @@ class Table {
   }
 
   /**
-   * Sets the entry with key `id` to `value`.
+   * Sets the entry with key `id` to `value`. This method is for internal use
+   * only; it is not part of the public API of Automerge.Table.
    */
-  set(id, value) {
+  _set(id, value) {
     if (Object.isFrozen(this.entries)) {
       throw new Error('A table can only be modified in a change function')
     }

--- a/test/table_test.js
+++ b/test/table_test.js
@@ -90,8 +90,7 @@ describe('Automerge.Table', () => {
 
     it('should be immutable', () => {
       assert.strictEqual(s1.books.add, undefined)
-      assert.throws(() => s1.books.set('publisher', {}), /can only be modified in a change function/)
-      assert.throws(() => s1.books.remove('publisher'),  /can only be modified in a change function/)
+      assert.throws(() => s1.books.remove(rowId), /can only be modified in a change function/)
     })
 
     it('should save and reload', () => {


### PR DESCRIPTION
The `set()` method is not needed, since `add()` and `remove()` handle changes to the set of rows, and properties of row objects can be updated directly without requiring any `set()` operation at the table level. The method may lead to confusion, as in #228.

Looking at the code, I now realise that `set()` was not intended to be part of the public API at all: it is called while applying a patch, and if a user calls it, it does not generate any operations in the change
context. Hence I renamed it to start with an underscore (like `_clone()` and `_freeze()`), and added a warning to the comment.