### PR TITLE
Update table class type to reflect property getter

### DIFF
--- a/@types/automerge/index.d.ts
+++ b/@types/automerge/index.d.ts
@@ -66,7 +66,7 @@ declare module 'automerge' {
     count: number
     ids: UUID[]
     remove(id: UUID): void
-    rows(): (T & TableRow)[]
+    rows: (T & TableRow)[]
   }
 
   class List<T> extends Array<T> {


### PR DESCRIPTION
The `rows` here is a property getter and not a function that can be called from what I can see [here](https://github.com/automerge/automerge/blob/14409f01adae1778c76ca13e7432f395fea4db54/frontend/table.js#L60-L66). As it is right now I can't use it since TypeScript think it's a function and calling gives an error.