### PR TITLE
support calling indexOf with an object

### DIFF
--- a/frontend/proxies.js
+++ b/frontend/proxies.js
@@ -29,6 +29,21 @@ function listMethods(context, listId) {
       return this
     },
 
+    indexOf(o, start = 0) {
+      const id = o[OBJECT_ID]
+      if (id) {
+        const list = context.getObject(listId)
+        for (let index = start; index < list.length; index++) {
+          if (list[index][OBJECT_ID] === id) {
+            return index
+          }
+        }
+        return -1  
+      } else {
+        return context.getObject(listId).indexOf(o, start)
+      }
+    },
+
     insertAt(index, ...values) {
       context.splice(listId, parseListIndex(index), 0, values)
       return this
@@ -84,7 +99,7 @@ function listMethods(context, listId) {
 
   // Read-only methods that can delegate to the JavaScript built-in implementations
   for (let method of ['concat', 'every', 'filter', 'find', 'findIndex', 'forEach', 'includes',
-                      'indexOf', 'join', 'lastIndexOf', 'map', 'reduce', 'reduceRight',
+                      'join', 'lastIndexOf', 'map', 'reduce', 'reduceRight',
                       'slice', 'some', 'toLocaleString', 'toString']) {
     methods[method] = (...args) => {
       const list = context.getObject(listId)

--- a/test/proxies_test.js
+++ b/test/proxies_test.js
@@ -110,7 +110,7 @@ describe('Automerge proxy API', () => {
   describe('list object', () => {
     let root
     beforeEach(() => {
-      root = Automerge.change(Automerge.init(), doc => { doc.list = [1, 2, 3]; doc.empty = [] })
+      root = Automerge.change(Automerge.init(), doc => { doc.list = [1, 2, 3]; doc.empty = [], doc.listObjects = [ {id: "first"}, {id: "second"} ] })
     })
 
     it('should look like a JavaScript array', () => {
@@ -170,7 +170,7 @@ describe('Automerge proxy API', () => {
     it('should support JSON.stringify()', () => {
       Automerge.change(root, doc => {
         assert.deepEqual(JSON.parse(JSON.stringify(doc)), {
-          list: [1, 2, 3], empty: []
+          list: [1, 2, 3], empty: [], listObjects: [ {id: "first"}, {id: "second"} ]
         })
         assert.deepEqual(JSON.stringify(doc.list), '[1,2,3]')
       })
@@ -268,6 +268,18 @@ describe('Automerge proxy API', () => {
           assert.strictEqual(doc.list.indexOf(1, 1), -1)
           assert.strictEqual(doc.list.indexOf(2, -2), 1)
           assert.strictEqual(doc.list.indexOf(0), -1)
+        })
+      })
+
+      it('indexOf() with objects', () => {
+        Automerge.change(root, doc => {
+          assert.strictEqual(doc.listObjects.indexOf(doc.listObjects[0]), 0)
+          assert.strictEqual(doc.listObjects.indexOf(doc.listObjects[1]), 1)
+
+          assert.strictEqual(doc.listObjects.indexOf(doc.listObjects[0], 0), 0)
+          assert.strictEqual(doc.listObjects.indexOf(doc.listObjects[0], 1), -1)
+          assert.strictEqual(doc.listObjects.indexOf(doc.listObjects[1], 0), 1)
+          assert.strictEqual(doc.listObjects.indexOf(doc.listObjects[1], 1), 1)
         })
       })
 


### PR DESCRIPTION
The parameter to `[].indexOf(...)` may be a Proxy object. In that case, the correct index should be returned. Currently it always returns `-1`.