### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ and merging**:
 
 ## Features and design principles
 
+Automerge is spawn from the [academic essay "Local-first software"](https://www.inkandswitch.com/local-first.html) that compares various approaches to automatic conflict-resolution and details the reasoning behind how automerge came to be.
+
 - **Network-agnostic**. Automerge is a pure data structure library that does not care about what
   kind of network you use: client/server, peer-to-peer, Bluetooth, USB drive in the mail, whatever,
   anything goes. Bindings to particular networking technologies are handled by separate libraries;

--- a/README.md
+++ b/README.md
@@ -43,8 +43,6 @@ and merging**:
 
 ## Features and design principles
 
-Automerge is spawn from the [academic essay "Local-first software"](https://www.inkandswitch.com/local-first.html) that compares various approaches to automatic conflict-resolution and details the reasoning behind how automerge came to be.
-
 - **Network-agnostic**. Automerge is a pure data structure library that does not care about what
   kind of network you use: client/server, peer-to-peer, Bluetooth, USB drive in the mail, whatever,
   anything goes. Bindings to particular networking technologies are handled by separate libraries;
@@ -64,6 +62,17 @@ Automerge is spawn from the [academic essay "Local-first software"](https://www.
   For TypeScript users, Automerge comes with
   [type definitions](https://github.com/automerge/automerge/blob/main/@types/automerge/index.d.ts)
   that allow you to use Automerge in a type-safe way.
+
+Automerge is designed for creating [local-first software](https://www.inkandswitch.com/local-first.html),
+i.e. software that treats a user's local copy of their data (on their own device) as primary, rather
+than centralising data in a cloud service. The local-first approach enables offline working while
+still allowing several users to collaborate in real-time and sync their data across multiple
+devices. By reducing the dependency on cloud services (which may disappear if someone stops paying
+for the servers), local-first software can have greater longevity, stronger privacy, and better
+performance, and it gives users more control over their data.
+The [essay on local-first software](https://www.inkandswitch.com/local-first.html) goes into more
+detail on the philosophy behind Automerge, and the pros and cons of this approach.
+
 
 ## Setup
 


### PR DESCRIPTION
Clarity: Added the authors' original academic essay "Local-first software" in the readme to make it easier to understand how automerge emerged.