### PR TITLE
add Automerge.getClock and Automerge.getMissingChanges

### DIFF
--- a/@types/automerge/index.d.ts
+++ b/@types/automerge/index.d.ts
@@ -38,11 +38,11 @@ declare module 'automerge' {
   function getActorId<T>(doc: Doc<T>): string
   function getAllChanges<T>(doc: Doc<T>): Change[]
   function getChanges<T>(olddoc: Doc<T>, newdoc: Doc<T>): Change[]
+  function getClock<T>(doc: Doc<T>): Clock
   function getConflicts<T>(doc: Doc<T>, key: keyof T): any
   function getHistory<D, T = Proxy<D>>(doc: Doc<T>): State<T>[]
-  function getClock<T>(doc: Doc<T>): Clock
   function getMissingDeps<T>(doc: Doc<T>): Clock
-  function getMissingChanges<T>(oldClock: Clock, newDoc: Doc<T>): Change[]
+  function getMissingChanges<T>(newDoc: Doc<T>, oldClock: Clock): Change[]
   function getObjectById<T>(doc: Doc<T>, objectId: UUID): any
   function getObjectId(object: any): UUID
 
@@ -154,6 +154,7 @@ declare module 'automerge' {
     function from<T>(initialState: T | Doc<T>, options?: InitOptions): [Doc<T>, Change]
     function getActorId<T>(doc: Doc<T>): string
     function getBackendState<T>(doc: Doc<T>): BackendState
+    function getClock<T>(doc: Doc<T>): Clock
     function getConflicts<T>(doc: Doc<T>, key: keyof T): any
     function getElementIds(list: any): string[]
     function getObjectById<T>(doc: Doc<T>, objectId: UUID): Doc<T>
@@ -169,6 +170,7 @@ declare module 'automerge' {
     function applyLocalChange(state: BackendState, change: Change): [BackendState, Patch]
     function getChanges(oldState: BackendState, newState: BackendState): Change[]
     function getChangesForActor(state: BackendState, actorId: string): Change[]
+    function getClock<T>(doc: Doc<T>): Clock
     function getMissingChanges(state: BackendState, clock: Clock): Change[]
     function getMissingDeps(state: BackendState): Clock
     function getPatch(state: BackendState): Patch

--- a/@types/automerge/index.d.ts
+++ b/@types/automerge/index.d.ts
@@ -40,7 +40,9 @@ declare module 'automerge' {
   function getChanges<T>(olddoc: Doc<T>, newdoc: Doc<T>): Change[]
   function getConflicts<T>(doc: Doc<T>, key: keyof T): any
   function getHistory<D, T = Proxy<D>>(doc: Doc<T>): State<T>[]
+  function getClock<T>(doc: Doc<T>): Clock
   function getMissingDeps<T>(doc: Doc<T>): Clock
+  function getMissingChanges<T>(oldClock: Clock, newDoc: Doc<T>): Change[]
   function getObjectById<T>(doc: Doc<T>, objectId: UUID): any
   function getObjectId(object: any): UUID
 

--- a/README.md
+++ b/README.md
@@ -407,6 +407,8 @@ options, with more under development:
   an implementation of a protocol that syncs up two nodes by determining missing changes and sending
   them to each other. The [automerge-net](https://github.com/automerge/automerge-net) repository
   contains an example that runs the Connection protocol over a simple TCP connection.
+- [Cevitxe](https://github.com/DevResults/cevitxe) extends Automerge with a WebSocket server for
+  synchronisation, database storage adapters, and integration with React and Redux.
 - [automerge-client-server](https://gitlab.com/codewitchbella/automerge-client-server)
   ([usage example](https://github.com/automerge/automerge/issues/117)) runs the `Automerge.Connection`
   protocol over [WebSocket](https://developer.mozilla.org/en-US/docs/Web/API/WebSockets_API).

--- a/backend/index.js
+++ b/backend/index.js
@@ -169,7 +169,7 @@ function applyChanges(state, changes) {
 
 /**
  * Takes a single change request `change` made by the local user, and applies
- * it to the node state `state`. The difference to `applyChange()` is that this
+ * it to the node state `state`. The difference to `applyChanges()` is that this
  * function adds the change to the undo history, so it can be undone (whereas
  * remote changes are not normally added to the undo history). Returns a
  * two-element array `[state, patch]` where `state` is the updated node state,
@@ -212,6 +212,14 @@ function getPatch(state) {
   return makePatch(state, diffs)
 }
 
+/**
+ * Returns an object in which the keys are actor IDs, and the values are the number of changes we
+ * have applied from that actor ID. Used in conjunction with `getMissingChanges`.
+ */
+function getClock(state) {
+  return state.getIn(['opSet', 'clock']).toJS()
+}
+
 function getChanges(oldState, newState) {
   const oldClock = oldState.getIn(['opSet', 'clock'])
   const newClock = newState.getIn(['opSet', 'clock'])
@@ -227,8 +235,14 @@ function getChangesForActor(state, actorId) {
   return OpSet.getChangesForActor(state.get('opSet'), actorId).toJS()
 }
 
+/**
+ * Returns an array of changes that have been applied to the backend `state`, but which are not
+ * included in the vector clock `clock`. The clock is an object where keys are actor IDs and the
+ * values are sequence numbers, and for each actor we return any changes with a greater sequence
+ * number than that in the clock.
+ */
 function getMissingChanges(state, clock) {
-  return OpSet.getMissingChanges(state.get('opSet'), clock).toJS()
+  return OpSet.getMissingChanges(state.get('opSet'), fromJS(clock)).toJS()
 }
 
 function getMissingDeps(state) {
@@ -316,6 +330,6 @@ function redo(state, request) {
 }
 
 module.exports = {
-  init, applyChanges, applyLocalChange, getPatch,
+  init, applyChanges, applyLocalChange, getPatch, getClock,
   getChanges, getChangesForActor, getMissingChanges, getMissingDeps, merge
 }

--- a/frontend/index.js
+++ b/frontend/index.js
@@ -488,6 +488,14 @@ function getBackendState(doc) {
   return doc[STATE].backendState
 }
 
+/**
+ * Returns a vector clock representing the current change in doc.
+ * Use with Automerge.getMissingChanges.
+ */
+function getClock(doc) {
+  return getBackendState(doc).getIn(['opSet', 'clock']).toJS()
+}
+
 function getElementIds(list) {
   return list[ELEM_IDS]
 }
@@ -496,6 +504,6 @@ module.exports = {
   init, from, change, emptyChange, applyPatch,
   canUndo, undo, canRedo, redo,
   getObjectId, getObjectById, getActorId, setActorId, getConflicts,
-  getBackendState, getElementIds,
+  getBackendState, getElementIds, getClock,
   Text, Table, Counter
 }

--- a/frontend/index.js
+++ b/frontend/index.js
@@ -141,6 +141,7 @@ function applyPatchToDoc(doc, patch, state, fromBackend) {
   if (fromBackend) {
     const seq = patch.clock ? patch.clock[actor] : undefined
     if (seq && seq > state.seq) state.seq = seq
+    state.clock = patch.clock
     state.deps = patch.deps
     state.canUndo = patch.canUndo
     state.canRedo = patch.canRedo
@@ -227,7 +228,7 @@ function init(options) {
   }
 
   const root = {}, cache = {[ROOT_ID]: root}
-  const state = {seq: 0, requests: [], deps: {}, canUndo: false, canRedo: false}
+  const state = {seq: 0, requests: [], clock: {}, deps: {}, canUndo: false, canRedo: false}
   if (options.backend) {
     state.backendState = options.backend.init()
   }
@@ -489,11 +490,11 @@ function getBackendState(doc) {
 }
 
 /**
- * Returns a vector clock representing the current change in doc.
+ * Returns a vector clock representing the set of changes applied to the document.
  * Use with Automerge.getMissingChanges.
  */
 function getClock(doc) {
-  return getBackendState(doc).getIn(['opSet', 'clock']).toJS()
+  return doc[STATE].clock
 }
 
 function getElementIds(list) {

--- a/src/automerge.js
+++ b/src/automerge.js
@@ -1,4 +1,3 @@
-const { fromJS } = require('immutable')
 const transit = require('transit-immutable-js')
 const uuid = require('./uuid')
 const Frontend = require('../frontend')
@@ -110,8 +109,8 @@ function getMissingDeps(doc) {
 /**
  * Returns an array of changes in newDoc since oldClock.
  */
-function getMissingChanges(oldClock, newDoc) {
-  return Backend.getMissingChanges(Frontend.getBackendState(newDoc), fromJS(oldClock))
+function getMissingChanges(newDoc, oldClock) {
+  return Backend.getMissingChanges(Frontend.getBackendState(newDoc), oldClock)
 }
 
 function equals(val1, val2) {

--- a/src/automerge.js
+++ b/src/automerge.js
@@ -1,3 +1,4 @@
+const { fromJS } = require('immutable')
 const transit = require('transit-immutable-js')
 const uuid = require('./uuid')
 const Frontend = require('../frontend')
@@ -106,6 +107,13 @@ function getMissingDeps(doc) {
   return Backend.getMissingDeps(Frontend.getBackendState(doc))
 }
 
+/**
+ * Returns an array of changes in newDoc since oldClock.
+ */
+function getMissingChanges(oldClock, newDoc) {
+  return Backend.getMissingChanges(Frontend.getBackendState(newDoc), fromJS(oldClock))
+}
+
 function equals(val1, val2) {
   if (!isObject(val1) || !isObject(val2)) return val1 === val2
   const keys1 = Object.keys(val1).sort(), keys2 = Object.keys(val2).sort()
@@ -136,7 +144,7 @@ function getHistory(doc) {
 module.exports = {
   init, from, change, emptyChange, undo, redo,
   load, save, merge, diff, getChanges, getAllChanges, applyChanges, getMissingDeps,
-  equals, getHistory, uuid,
+  getMissingChanges, equals, getHistory, uuid,
   Frontend, Backend,
   DocSet: require('./doc_set'),
   WatchableDoc: require('./watchable_doc'),
@@ -144,6 +152,6 @@ module.exports = {
 }
 
 for (let name of ['canUndo', 'canRedo', 'getObjectId', 'getObjectById', 'getActorId',
-     'setActorId', 'getConflicts', 'Text', 'Table', 'Counter']) {
+     'setActorId', 'getConflicts', 'getClock', 'Text', 'Table', 'Counter']) {
   module.exports[name] = Frontend[name]
 }

--- a/src/connection.js
+++ b/src/connection.js
@@ -58,7 +58,7 @@ class Connection {
   maybeSendChanges (docId) {
     const doc = this._docSet.getDoc(docId)
     const state = Frontend.getBackendState(doc)
-    const clock = state.getIn(['opSet', 'clock'])
+    const clock = fromJS(Frontend.getClock(doc))
 
     if (this._theirClock.has(docId)) {
       const changes = Backend.getMissingChanges(state, this._theirClock.get(docId))
@@ -74,8 +74,7 @@ class Connection {
 
   // Callback that is called by the docSet whenever a document is changed
   docChanged (docId, doc) {
-    const state = Frontend.getBackendState(doc)
-    const clock = state.getIn(['opSet', 'clock'])
+    const clock = fromJS(Frontend.getClock(doc))
     if (!clock) {
       throw new TypeError('This object cannot be used for network sync. ' +
                           'Are you trying to sync a snapshot from the history?')

--- a/test/test.js
+++ b/test/test.js
@@ -1532,5 +1532,15 @@ describe('Automerge', () => {
       let s6 = Automerge.applyChanges(s5, changes1to2)
       assert.deepEqual(Automerge.getMissingDeps(s6), {[Automerge.getActorId(s0)]: 2})
     })
+
+    it('should allow getting changes by vector clock', () => {
+      let s1 = Automerge.change(Automerge.init('actor1'), 'first', doc => doc.number = 1)
+      assert.deepStrictEqual(Automerge.getClock(s1), {actor1: 1})
+      let s2 = Automerge.change(Automerge.merge(Automerge.init('actor2'), s1), 'second', doc => doc.number = 2)
+      assert.deepStrictEqual(Automerge.getClock(s2), {actor1: 1, actor2: 1})
+      assert.deepStrictEqual(Automerge.getMissingChanges(s2, {}).map(c => c.message), ['first', 'second'])
+      assert.deepStrictEqual(Automerge.getMissingChanges(s2, {actor1: 1}).map(c => c.message), ['second'])
+      assert.deepStrictEqual(Automerge.getMissingChanges(s2, {actor1: 1, actor2: 1}).map(c => c.message), [])
+    })
   })
 })

--- a/test/typescript_test.ts
+++ b/test/typescript_test.ts
@@ -244,16 +244,24 @@ describe('TypeScript support', () => {
       let s1 = Automerge.init<BirdList>()
       s1 = Automerge.change(s1, doc => (doc.birds = ['goldfinch']))
       let s2 = Automerge.change(s1, 'add chaffinch', doc => doc.birds.push('chaffinch'))
-      // Document-based API.
       const changes = Automerge.getChanges(s1, s2)
       assert.strictEqual(changes.length, 1)
       assert.strictEqual(changes[0].message, 'add chaffinch')
       assert.strictEqual(changes[0].actor, Automerge.getActorId(s2))
       assert.strictEqual(changes[0].seq, 2)
-      // Clock-based API.
-      let clock = Automerge.getClock(s1)
-      const changes2 = Automerge.getMissingChanges(clock, s2)
-      assert.deepEqual(changes, changes2)
+    })
+
+    it('should support a vector clock API', () => {
+      let s1 = Automerge.change(Automerge.init<BirdList>(), doc => (doc.birds = ['goldfinch']))
+      let clock1 = {[Automerge.getActorId(s1)]: 1}
+      assert.deepStrictEqual(Automerge.getClock(s1), clock1)
+      let s2 = Automerge.merge(Automerge.init<BirdList>(), s1)
+      let s3 = Automerge.change(s2, doc => doc.birds.push('chaffinch'))
+      let clock2 = {[Automerge.getActorId(s1)]: 1, [Automerge.getActorId(s2)]: 1}
+      assert.deepStrictEqual(Automerge.getClock(s3), clock2)
+      assert.strictEqual(Automerge.getMissingChanges(s3, {}).length, 2)
+      assert.strictEqual(Automerge.getMissingChanges(s3, clock1).length, 1)
+      assert.strictEqual(Automerge.getMissingChanges(s3, clock2).length, 0)
     })
 
     it('should include operations in changes', () => {

--- a/test/typescript_test.ts
+++ b/test/typescript_test.ts
@@ -244,11 +244,16 @@ describe('TypeScript support', () => {
       let s1 = Automerge.init<BirdList>()
       s1 = Automerge.change(s1, doc => (doc.birds = ['goldfinch']))
       let s2 = Automerge.change(s1, 'add chaffinch', doc => doc.birds.push('chaffinch'))
+      // Document-based API.
       const changes = Automerge.getChanges(s1, s2)
       assert.strictEqual(changes.length, 1)
       assert.strictEqual(changes[0].message, 'add chaffinch')
       assert.strictEqual(changes[0].actor, Automerge.getActorId(s2))
       assert.strictEqual(changes[0].seq, 2)
+      // Clock-based API.
+      let clock = Automerge.getClock(s1)
+      const changes2 = Automerge.getMissingChanges(clock, s2)
+      assert.deepEqual(changes, changes2)
     })
 
     it('should include operations in changes', () => {


### PR DESCRIPTION
This is a new clock-based API for recording the current state of a document and then calculating changes since
that state. The advantage of this API is that vector clocks are far more concise than an entire document, which makes them more suitable for persistence and network transfer.

Please review skeptically. My javascript and typescript skills are not strong.

Writing the docs made me wonder whether `getMissingChanges` is the right function name. It's hard to remember the difference between `getChanges` and `getMissingChanges` based on their name. Perhaps `changesSince` or `getChangesSince` might be better? Your decision; I'll implement whatever you pick.
