### PR TITLE
Allow hooking into patch application

### DIFF
--- a/frontend/index.js
+++ b/frontend/index.js
@@ -109,6 +109,7 @@ function makeChange(doc, requestType, context, options) {
 
   if (doc[OPTIONS].backend) {
     const [backendState, patch] = doc[OPTIONS].backend.applyLocalChange(state.backendState, request)
+    if (options && options.patchCallback) options.patchCallback(patch)
     state.backendState = backendState
     state.requests = []
     return [applyPatchToDoc(doc, patch, state, true), request]

--- a/src/automerge.js
+++ b/src/automerge.js
@@ -95,9 +95,10 @@ function getAllChanges(doc) {
   return getChanges(init(), doc)
 }
 
-function applyChanges(doc, changes) {
+function applyChanges(doc, changes, options = {}) {
   const oldState = Frontend.getBackendState(doc)
   const [newState, patch] = Backend.applyChanges(oldState, changes)
+  if (options.patchCallback) options.patchCallback(Object.assign({}, patch))
   patch.state = newState
   return Frontend.applyPatch(doc, patch)
 }

--- a/src/automerge.js
+++ b/src/automerge.js
@@ -11,6 +11,7 @@ function docFromChanges(options, changes) {
   const doc = init(options)
   const [state, _] = Backend.applyChanges(Backend.init(), changes)
   const patch = Backend.getPatch(state)
+  if (options && options.patchCallback) options.patchCallback(Object.assign({}, patch))
   patch.state = state
   return Frontend.applyPatch(doc, patch)
 }


### PR DESCRIPTION
Here is a simple but potentially very important feature: allowing applications to hook into Automerge's process for applying patches to a document.

The use case is when you have some data outside of Automerge that you want to keep consistent with the state of an Automerge document. This could be a user interface (especially a complicated widget like a text editor), or a cache, a search index, or suchlike. Such an application needs a mechanism to get notified when an Automerge document changes, so that it can apply the appropriate update to the external state.

At the moment, Automerge only really supports the React-style approach where you pass the entire document to the render function, and the renderer works out which bits of the document have actually changed, and updates those, while leaving the unchanged parts untouched. But in other circumstances, it would be really useful to have a description of the change that occurred, not just the before-and-after document. Moreover, this process should be the same, regardless of whether a change is generated by the local user or was received over the network from a remote user.

Automerge's existing concept of a patch is probably the best form we have for describing what change occurred. It's easier for applications to consume than the raw change format because it includes more context, and e.g. for list updates it includes the index of the list position being changed, not just the list element ID. This patch format is currently used for updates sent from the backend to the frontend, and used by the frontend to update the document.

This PR adds the ability for applications to get a callback for every patch that is applied to a document. When making a local change, you can add a callback like this:

```js
newState = Automerge.change(oldState, {patchCallback: (patch) => {...}}, doc => {
  // mutate doc as usual
})
```

And when applying a remote change, you can add a callback like this:

```js
newState = Automerge.applyChanges(oldState, changes, {patchCallback: (patch) => {...}})
```

The patch format is the same in both cases. The patch format used by the currently released version of Automerge is documented in [`INTERNALS.md`](https://github.com/automerge/automerge/blob/0678f39eccb9043c5b0ec2189ead49115d88449c/INTERNALS.md#patch-format) (in the "Frontend-backend protocol" section). This format has changed considerably on the `performance` branch, and the new format is documented in [`BINARY_FORMAT.md` on that branch](https://github.com/automerge/automerge/blob/4d605e526f5da74a226e3fdf641b6ff5d0705213/BINARY_FORMAT.md#patch-format). The new format is intended to be easier to consume.

Note that this API is not intended to allow applications to modify the patches before they get applied. The patch callback should treat the patch as read-only.

An alternative API would be to pass in a callback function once when initialising the document, and automatically calling it on all subsequent updates. But I thought that had a bit of a "spooky action at a distance" feel, while the callback on every `change`/`applyChanges` call was more explicit. Though it could also be annoying for app developers to have to add the option to every single `Automerge.change` call, which might be scattered around an application. Any thoughts on this?

This feature is especially for @cklokmose, but I welcome feedback from others as well. @HerbCaudill what do you think?