### PR TITLE
Tweaks to data formats

### DIFF
--- a/BINARY_FORMAT.md
+++ b/BINARY_FORMAT.md
@@ -86,16 +86,16 @@ An operation is a JSON object with the following properties:
 * `insert`: A boolean that may be present on operations that modify list or text
   objects, and on all operation types except `del` and `inc`. If the `insert`
   property is false or absent, the operation updates the property or list
-  element identified by `key`. If it is true, the operation inserts a new list
-  element or character after the element identified by `key`, and the ID of this
-  operation becomes the list element ID of the new element.
+  element identified by `elemId`. If it is true, the operation inserts a new
+  list element or character after the element identified by `elemId`, and the ID
+  of this operation becomes the list element ID of the new element.
 * `key`: A string that identifies the property of the object `obj` that is being
-  modified, present on all operations. If the object is a map, this is a string
-  containing the property name. If the object is a table, this is a string
-  containing the primary key of the row (a UUID). If the object is a list or
-  text, this is a string of the form `counter@actorId` identifying the list
-  element ID, or the string `'_head'` indicating insertion at the beginning of
-  the list (the value `'_head'` is allowed only if `insert` is true).
+  modified. If the object is a map, this is a string containing the property
+  name. If the object is a table, this is a string containing the primary key of
+  the row (a UUID). If the object is a list or text, `elemId` is used instead.
+* `elemId`: A string of the form `counter@actorId` identifying a list element or
+  text character, or the string `'_head'` indicating the beginning of the list.
+  The value `'_head'` is allowed only if `insert` is true.
 * `value`: On `set` operations only, this property contains the primitive value
   (string, number, boolean, or null) to assign.
 * `datatype`: On `set` operations only, this property can optionally be set to
@@ -127,13 +127,6 @@ Note several differences to the old format:
    assignment overwrites another, or whether they are concurrent. In the new
    format there is a new `pred` property of operations that explicitly captures
    the relationship between operations on the same property.
-
-Open questions:
-
-* Get rid of the all-zeros UUID, and just use a special string `_root` instead?
-* Use different properties for `key` in the cases where it is a string versus
-  being an opId? (At the moment we treat it as opId if it contains an `@` sign,
-  which effectively rules out string properties from containing `@`.)
 
 
 Binary representation of changes

--- a/backend/op_set.js
+++ b/backend/op_set.js
@@ -64,9 +64,10 @@ function applyInsert(opSet, op) {
   const objectId = op.get('obj'), opId = op.get('opId')
   if (!opSet.get('byObject').has(objectId)) throw new Error(`Modification of unknown object ${objectId}`)
   if (opSet.hasIn(['byObject', objectId, '_insertion', opId])) throw new Error(`Duplicate list element ID ${opId}`)
+  if (!op.get('elemId')) throw new RangeError('insert operation has no key')
 
   return opSet
-    .updateIn(['byObject', objectId, '_following', op.get('key')], List(), list => list.push(op))
+    .updateIn(['byObject', objectId, '_following', op.get('elemId')], List(), list => list.push(op))
     .setIn(['byObject', objectId, '_insertion', opId], op)
 }
 
@@ -127,7 +128,11 @@ function getChildId(op) {
  * the key is the element ID; in the case of maps, it is the property name.
  */
 function getOperationKey(op) {
-  return op.get('insert') ? op.get('opId') : op.get('key')
+  const keyStr = op.get('key')
+  if (keyStr) return keyStr
+  const key = op.get('insert') ? op.get('opId') : op.get('elemId')
+  if (!key) throw new RangeError(`operation has no key: ${op}`)
+  return key
 }
 
 /**
@@ -506,7 +511,7 @@ function getParent(opSet, objectId, key) {
   if (key === '_head') return
   const insertion = opSet.getIn(['byObject', objectId, '_insertion', key])
   if (!insertion) throw new TypeError(`Missing index entry for list element ${key}`)
-  return insertion.get('key')
+  return insertion.get('elemId')
 }
 
 function lamportCompare(op1, op2) {

--- a/backend/op_set.js
+++ b/backend/op_set.js
@@ -1,7 +1,7 @@
 const { Map, List, Set, fromJS } = require('immutable')
 const { SkipList } = require('./skip_list')
 const { decodeChange, decodeChangeMeta } = require('./columnar')
-const { ROOT_ID, parseOpId } = require('../src/common')
+const { parseOpId } = require('../src/common')
 
 // Returns true if all changes that causally precede the given change
 // have already been applied in `opSet`.
@@ -19,7 +19,7 @@ function causallyReady(opSet, change) {
  */
 function getPath(opSet, objectId) {
   let path = []
-  while (objectId !== ROOT_ID) {
+  while (objectId !== '_root') {
     const ref = opSet.getIn(['byObject', objectId, '_inbound'], Set()).first()
     if (!ref) throw new RangeError(`No path found to object ${objectId}`)
     path.unshift(ref)
@@ -33,7 +33,7 @@ function getPath(opSet, objectId) {
  * the type of the object with ID `objectId`.
  */
 function getObjectType(opSet, objectId) {
-  if (objectId === ROOT_ID) return 'map'
+  if (objectId === '_root') return 'map'
   const objInit = opSet.getIn(['byObject', objectId, '_init', 'action'])
   const type = {makeMap: 'map', makeTable: 'table', makeList: 'list', makeText: 'text'}[objInit]
   if (!type) throw new RangeError(`Unknown object type ${objInit} for ${objectId}`)
@@ -422,7 +422,7 @@ function init() {
   return Map()
     .set('states',   Map())
     .set('history',  List())
-    .set('byObject', Map().set(ROOT_ID, Map().set('_keys', Map())))
+    .set('byObject', Map().set('_root', Map().set('_keys', Map())))
     .set('hashes',   Map())
     .set('deps',     Set())
     .set('maxOp',     0)
@@ -626,5 +626,5 @@ function constructObject(opSet, objectId) {
 
 module.exports = {
   init, addChange, addLocalChange, getHeads, getMissingChanges, getMissingDeps,
-  constructObject, getFieldOps, getOperationKey, finalizePatch, ROOT_ID
+  constructObject, getFieldOps, getOperationKey, finalizePatch
 }

--- a/frontend/apply_patch.js
+++ b/frontend/apply_patch.js
@@ -1,4 +1,4 @@
-const { ROOT_ID, isObject, copyObject, parseOpId } = require('../src/common')
+const { isObject, copyObject, parseOpId } = require('../src/common')
 const { OPTIONS, OBJECT_ID, CONFLICTS, ELEM_IDS } = require('./constants')
 const { Text, instantiateText } = require('./text')
 const { Table, instantiateTable } = require('./table')
@@ -300,10 +300,10 @@ function interpretPatch(patch, obj, updated) {
  * Creates a writable copy of the immutable document root object `root`.
  */
 function cloneRootObject(root) {
-  if (root[OBJECT_ID] !== ROOT_ID) {
+  if (root[OBJECT_ID] !== '_root') {
     throw new RangeError(`Not the root object: ${root[OBJECT_ID]}`)
   }
-  return cloneMapObject(root, ROOT_ID)
+  return cloneMapObject(root, '_root')
 }
 
 module.exports = {

--- a/frontend/proxies.js
+++ b/frontend/proxies.js
@@ -1,4 +1,3 @@
-const { ROOT_ID } = require('../src/common')
 const { OBJECT_ID, CHANGE, STATE } = require('./constants')
 const { Counter } = require('./counter')
 const { Text } = require('./text')
@@ -225,7 +224,7 @@ function instantiateProxy(path, objectId, readonly) {
 
 function rootObjectProxy(context) {
   context.instantiateObject = instantiateProxy
-  return mapProxy(context, ROOT_ID, [])
+  return mapProxy(context, '_root', [])
 }
 
 module.exports = { rootObjectProxy }

--- a/src/common.js
+++ b/src/common.js
@@ -1,5 +1,3 @@
-const ROOT_ID   = '00000000-0000-0000-0000-000000000000'
-
 function isObject(obj) {
   return typeof obj === 'object' && obj !== null
 }
@@ -44,5 +42,5 @@ function equalBytes(array1, array2) {
 }
 
 module.exports = {
-  ROOT_ID, isObject, copyObject, parseOpId, equalBytes
+  isObject, copyObject, parseOpId, equalBytes
 }

--- a/test/backend_test.js
+++ b/test/backend_test.js
@@ -271,7 +271,7 @@ describe('Automerge.Backend', () => {
         }}
       })
       assert.deepStrictEqual(changes01, [{
-        hash: 'aa6c0ad0182866094a41e348f8b2b1be3b2343a50b1cb8c2b18b40124caa6487',
+        hash: '6fc48e6635e2bab050a340119fff7a559679ed4f26734623c2b4738815f48371',
         actor: '111111', seq: 1, startOp: 1, time: 0, message: '', deps: [], ops: [
           {action: 'set', obj: '_root', key: 'bird', insert: false, value: 'magpie', pred: []}
         ]
@@ -311,19 +311,19 @@ describe('Automerge.Backend', () => {
       const [s3, patch3] = Backend.applyLocalChange(s2, local2)
       const changes23 = Backend.getChanges(s3, [changes01[0].hash, changes12[0].hash]).map(decodeChange)
       assert.deepStrictEqual(changes01, [{
-        hash: 'aa6c0ad0182866094a41e348f8b2b1be3b2343a50b1cb8c2b18b40124caa6487',
+        hash: '6fc48e6635e2bab050a340119fff7a559679ed4f26734623c2b4738815f48371',
         actor: '111111', seq: 1, startOp: 1, time: 0, message: '', deps: [], ops: [
           {action: 'set', obj: '_root', key: 'bird', insert: false, value: 'magpie', pred: []}
         ]
       }])
       assert.deepStrictEqual(changes12, [{
-        hash: 'e5d411e5929aa7bda4cd6744ea29503c62fda001a8b39645a82e7ee09fec1bcd',
+        hash: 'aca4a51a8d538f2b16b6f9b923cf6dd5a4bb5ad550b6e618aa529a036b45ea1f',
         actor: '222222', seq: 1, startOp: 1, time: 0, message: '', deps: [], ops: [
           {action: 'set', obj: '_root', key: 'fish', insert: false, value: 'goldfish', pred: []}
         ]
       }])
       assert.deepStrictEqual(changes23, [{
-        hash: 'f652f5a1cfa140cc2c6101028bcdb798896194b478baa7c11e3077cfd561028f',
+        hash: '1caeeaf4fb120b8bed4c6c92311f679264f070637b5531979e95ec8249499f5a',
         actor: '111111', seq: 2, startOp: 2, time: 0, message: '', deps: [changes01[0].hash], ops: [
           {action: 'set', obj: '_root', key: 'bird', insert: false, value: 'jay', pred: ['1@111111']}
         ]
@@ -357,7 +357,7 @@ describe('Automerge.Backend', () => {
         }}
       })
       assert.deepStrictEqual(changes23, [{
-        hash: '22982372e08747fa4f00255acecc1c57a128faedeea49c6a36be2cc87ff480c9',
+        hash: 'b6f22ff5606622a9b8f4efed87a5202128bc5e35021d09e04529b9076ec98d0e',
         actor: '111111', seq: 2, startOp: 2, time: 0, message: '', deps: [changes01[0].hash], ops: [
           {action: 'set', obj: '_root', key: 'bird', insert: false, value: 'jay', pred: ['1@111111']}
         ]
@@ -391,19 +391,19 @@ describe('Automerge.Backend', () => {
       const [s5, patch5] = Backend.applyLocalChange(s4, local3)
       const changes45 = Backend.getChanges(s5, [hash(remote2), changes34[0].hash]).map(decodeChange)
       assert.deepStrictEqual(changes12, [{
-        hash: 'f6dd1f3238885bf542e56d347bbd8d4a552bfcf427bc64d2105d6332cbc9a5cf',
+        hash: '96db9a3bb6471912a2acbe3948365d202b89145816efa37bd0ccaa3be8ebee14',
         actor: '111111', seq: 1, startOp: 2, time: 0, message: '', deps: [hash(remote1)], ops: [
           {obj: '1@222222', action: 'set', key: '_head', insert: true, value: 'goldfinch', pred: []}
         ]
       }])
       assert.deepStrictEqual(changes34, [{
-        hash: '89908f10ba6ef56200aa44c7ec010f4525a7f583f65ad441487ef797c61a3093',
+        hash: '57e8ec00028e0a0a1ae325ad2c86dd4d8f63ace7c3ccb67a351682f0f6879cfd',
         actor: '111111', seq: 2, startOp: 3, time: 0, message: '', deps: [changes12[0].hash], ops: [
           {obj: '1@222222', action: 'set', key: '2@111111', insert: true, value: 'wagtail', pred: []}
         ]
       }])
       assert.deepStrictEqual(changes45, [{
-        hash: 'f8b8c5b82db29ec768788a70b288de2079c898141abd48de14adb94b94e36db0',
+        hash: 'd999eeeb5f69689f65b0e47b1f4dcc69c29b4b3ccaca69884425e5a6443e8d5d',
         actor: '111111', seq: 3, startOp: 4, time: 0, message: '',
         deps: [hash(remote2), changes34[0].hash].sort(), ops: [
           {obj: '1@222222', action: 'set', key: '2@222222', insert: false, value: 'Magpie',    pred: ['2@222222']},
@@ -438,7 +438,7 @@ describe('Automerge.Backend', () => {
           {obj: '_root', action: 'makeList', key: 'birds', insert: false, pred: []}
         ]
       }, {
-        hash: '6f45ecffd1ae6b00575609d3d47ea3aac06eff94e7ad329a9d810b90ec1534c8',
+        hash: 'd96f0023f949581eb10459c2ad8467148857f1d230abc0f0fd446ab95fdbf7ea',
         actor: '111111', seq: 2, startOp: 2, time: 0, message: '', deps: [changes[0].hash], ops: [
           {obj: '1@111111', action: 'set', key: '_head', insert: true, value: 'magpie', pred: []},
           {obj: '1@111111', action: 'del', key: '2@111111', insert: false, pred: ['2@111111']}

--- a/test/backend_test.js
+++ b/test/backend_test.js
@@ -119,7 +119,7 @@ describe('Automerge.Backend', () => {
       const actor = uuid()
       const change1 = {actor, seq: 1, startOp: 1, time: 0, deps: [], ops: [
         {action: 'makeList', obj: '_root', key: 'birds', pred: []},
-        {action: 'set', obj: `1@${actor}`, key: '_head', insert: true, value: 'chaffinch', pred: []}
+        {action: 'set', obj: `1@${actor}`, elemId: '_head', insert: true, value: 'chaffinch', pred: []}
       ]}
       const s0 = Backend.init()
       const [s1, patch1] = Backend.applyChanges(s0, [encodeChange(change1)])
@@ -137,10 +137,10 @@ describe('Automerge.Backend', () => {
       const actor = uuid()
       const change1 = {actor, seq: 1, startOp: 1, time: 0, deps: [], ops: [
         {action: 'makeList', obj: '_root', key: 'birds', pred: []},
-        {action: 'set', obj: `1@${actor}`, key: '_head', insert: true, value: 'chaffinch', pred: []}
+        {action: 'set', obj: `1@${actor}`, elemId: '_head', insert: true, value: 'chaffinch', pred: []}
       ]}
       const change2 = {actor, seq: 2, startOp: 3, time: 0, deps: [hash(change1)], ops: [
-        {action: 'set', obj: `1@${actor}`, key: `2@${actor}`, value: 'greenfinch', pred: [`2@${actor}`]}
+        {action: 'set', obj: `1@${actor}`, elemId: `2@${actor}`, value: 'greenfinch', pred: [`2@${actor}`]}
       ]}
       const s0 = Backend.init()
       const [s1, patch1] = Backend.applyChanges(s0, [encodeChange(change1)])
@@ -158,10 +158,10 @@ describe('Automerge.Backend', () => {
       const actor = uuid()
       const change1 = {actor, seq: 1, startOp: 1, time: 0, deps: [], ops: [
         {action: 'makeList', obj: '_root', key: 'birds', pred: []},
-        {action: 'set', obj: `1@${actor}`, key: '_head', insert: true, value: 'chaffinch', pred: []}
+        {action: 'set', obj: `1@${actor}`, elemId: '_head', insert: true, value: 'chaffinch', pred: []}
       ]}
       const change2 = {actor, seq: 2, startOp: 3, time: 0, deps: [hash(change1)], ops: [
-        {action: 'del', obj: `1@${actor}`, key: `2@${actor}`, pred: [`2@${actor}`]}
+        {action: 'del', obj: `1@${actor}`, elemId: `2@${actor}`, pred: [`2@${actor}`]}
       ]}
       const s0 = Backend.init()
       const [s1, patch1] = Backend.applyChanges(s0, [encodeChange(change1)])
@@ -181,8 +181,8 @@ describe('Automerge.Backend', () => {
         {action: 'makeList', obj: '_root', key: 'birds', pred: []}
       ]}
       const change2 = {actor, seq: 2, startOp: 2, time: 0, deps: [hash(change1)], ops: [
-        {action: 'set', obj: `1@${actor}`, key: '_head', insert: true, value: 'chaffinch', pred: []},
-        {action: 'del', obj: `1@${actor}`, key: `2@${actor}`, pred: [`2@${actor}`]}
+        {action: 'set', obj: `1@${actor}`, elemId: '_head', insert: true, value: 'chaffinch', pred: []},
+        {action: 'del', obj: `1@${actor}`, elemId: `2@${actor}`, pred: [`2@${actor}`]}
       ]}
       const s0 = Backend.init()
       const [s1, patch1] = Backend.applyChanges(s0, [encodeChange(change1)])
@@ -241,7 +241,7 @@ describe('Automerge.Backend', () => {
       const now = new Date(), actor = uuid()
       const change = {actor, seq: 1, startOp: 1, time: 0, deps: [], ops: [
         {action: 'makeList', obj: '_root', key: 'list', pred: []},
-        {action: 'set', obj: `1@${actor}`, key: '_head', insert: true, value: now.getTime(), datatype: 'timestamp', pred: []}
+        {action: 'set', obj: `1@${actor}`, elemId: '_head', insert: true, value: now.getTime(), datatype: 'timestamp', pred: []}
       ]}
       const s0 = Backend.init()
       const [s1, patch] = Backend.applyChanges(s0, [encodeChange(change)])
@@ -369,17 +369,17 @@ describe('Automerge.Backend', () => {
         {obj: '_root', action: 'makeList', key: 'birds', pred: []}
       ]}
       const remote2 = {actor: '222222', seq: 2, startOp: 2, time: 0, deps: [hash(remote1)], ops: [
-        {obj: '1@222222', action: 'set', key: '_head', insert: true, value: 'magpie', pred: []}
+        {obj: '1@222222', action: 'set', elemId: '_head', insert: true, value: 'magpie', pred: []}
       ]}
       const local1 = {actor: '111111', seq: 1, startOp: 2, time: 0, deps: [hash(remote1)], ops: [
-        {obj: '1@222222', action: 'set', key: '_head', insert: true, value: 'goldfinch', pred: []}
+        {obj: '1@222222', action: 'set', elemId: '_head', insert: true, value: 'goldfinch', pred: []}
       ]}
       const local2 = {actor: '111111', seq: 2, startOp: 3, time: 0, deps: [], ops: [
-        {obj: '1@222222', action: 'set', key: '2@111111', insert: true, value: 'wagtail', pred: []}
+        {obj: '1@222222', action: 'set', elemId: '2@111111', insert: true, value: 'wagtail', pred: []}
       ]}
       const local3 = {actor: '111111', seq: 3, startOp: 4, time: 0, deps: [hash(remote2)], ops: [
-        {obj: '1@222222', action: 'set', key: '2@222222', value: 'Magpie', pred: ['2@222222']},
-        {obj: '1@222222', action: 'set', key: '2@111111', value: 'Goldfinch', pred: ['2@111111']}
+        {obj: '1@222222', action: 'set', elemId: '2@222222', value: 'Magpie', pred: ['2@222222']},
+        {obj: '1@222222', action: 'set', elemId: '2@111111', value: 'Goldfinch', pred: ['2@111111']}
       ]}
       const s0 = Backend.init()
       const [s1, patch1] = Backend.applyChanges(s0, [encodeChange(remote1)])
@@ -393,21 +393,21 @@ describe('Automerge.Backend', () => {
       assert.deepStrictEqual(changes12, [{
         hash: '96db9a3bb6471912a2acbe3948365d202b89145816efa37bd0ccaa3be8ebee14',
         actor: '111111', seq: 1, startOp: 2, time: 0, message: '', deps: [hash(remote1)], ops: [
-          {obj: '1@222222', action: 'set', key: '_head', insert: true, value: 'goldfinch', pred: []}
+          {obj: '1@222222', action: 'set', elemId: '_head', insert: true, value: 'goldfinch', pred: []}
         ]
       }])
       assert.deepStrictEqual(changes34, [{
         hash: '57e8ec00028e0a0a1ae325ad2c86dd4d8f63ace7c3ccb67a351682f0f6879cfd',
         actor: '111111', seq: 2, startOp: 3, time: 0, message: '', deps: [changes12[0].hash], ops: [
-          {obj: '1@222222', action: 'set', key: '2@111111', insert: true, value: 'wagtail', pred: []}
+          {obj: '1@222222', action: 'set', elemId: '2@111111', insert: true, value: 'wagtail', pred: []}
         ]
       }])
       assert.deepStrictEqual(changes45, [{
         hash: 'd999eeeb5f69689f65b0e47b1f4dcc69c29b4b3ccaca69884425e5a6443e8d5d',
         actor: '111111', seq: 3, startOp: 4, time: 0, message: '',
         deps: [hash(remote2), changes34[0].hash].sort(), ops: [
-          {obj: '1@222222', action: 'set', key: '2@222222', insert: false, value: 'Magpie',    pred: ['2@222222']},
-          {obj: '1@222222', action: 'set', key: '2@111111', insert: false, value: 'Goldfinch', pred: ['2@111111']}
+          {obj: '1@222222', action: 'set', elemId: '2@222222', insert: false, value: 'Magpie',    pred: ['2@222222']},
+          {obj: '1@222222', action: 'set', elemId: '2@111111', insert: false, value: 'Goldfinch', pred: ['2@111111']}
         ]
       }])
     })
@@ -417,8 +417,8 @@ describe('Automerge.Backend', () => {
         {obj: '_root', action: 'makeList', key: 'birds', pred: []}
       ]}
       const local2 = {requestType: 'change', actor: '111111', seq: 2, startOp: 2, deps: [], time: 0, ops: [
-        {obj: '1@111111', action: 'set', key: '_head', insert: true, value: 'magpie', pred: []},
-        {obj: '1@111111', action: 'del', key: '2@111111', pred: ['2@111111']}
+        {obj: '1@111111', action: 'set', elemId: '_head', insert: true, value: 'magpie', pred: []},
+        {obj: '1@111111', action: 'del', elemId: '2@111111', pred: ['2@111111']}
       ]}
       const s0 = Backend.init()
       const [s1, patch1] = Backend.applyLocalChange(s0, local1)
@@ -440,8 +440,8 @@ describe('Automerge.Backend', () => {
       }, {
         hash: 'd96f0023f949581eb10459c2ad8467148857f1d230abc0f0fd446ab95fdbf7ea',
         actor: '111111', seq: 2, startOp: 2, time: 0, message: '', deps: [changes[0].hash], ops: [
-          {obj: '1@111111', action: 'set', key: '_head', insert: true, value: 'magpie', pred: []},
-          {obj: '1@111111', action: 'del', key: '2@111111', insert: false, pred: ['2@111111']}
+          {obj: '1@111111', action: 'set', elemId: '_head', insert: true, value: 'magpie', pred: []},
+          {obj: '1@111111', action: 'del', elemId: '2@111111', insert: false, pred: ['2@111111']}
         ]
       }])
     })
@@ -540,7 +540,7 @@ describe('Automerge.Backend', () => {
       const actor = uuid()
       const change1 = {actor, seq: 1, startOp: 1, time: 0, deps: [], ops: [
         {action: 'makeList', obj: '_root', key: 'birds', pred: []},
-        {action: 'set', obj: `1@${actor}`, key: '_head', insert: true, value: 'chaffinch', pred: []}
+        {action: 'set', obj: `1@${actor}`, elemId: '_head', insert: true, value: 'chaffinch', pred: []}
       ]}
       const s1 = Backend.loadChanges(Backend.init(), [encodeChange(change1)])
       assert.deepStrictEqual(Backend.getPatch(s1), {
@@ -557,13 +557,13 @@ describe('Automerge.Backend', () => {
       const actor = uuid()
       const change1 = {actor, seq: 1, startOp: 1, time: 0, deps: [], ops: [
         {action: 'makeList', obj: '_root', key: 'birds', pred: []},
-        {action: 'set', obj: `1@${actor}`, key: '_head',      insert: true, value: 'chaffinch', pred: []},
-        {action: 'set', obj: `1@${actor}`, key: `2@${actor}`, insert: true, value: 'goldfinch', pred: []}
+        {action: 'set', obj: `1@${actor}`, elemId: '_head',      insert: true, value: 'chaffinch', pred: []},
+        {action: 'set', obj: `1@${actor}`, elemId: `2@${actor}`, insert: true, value: 'goldfinch', pred: []}
       ]}
       const change2 = {actor, seq: 2, startOp: 4, time: 0, deps: [hash(change1)], ops: [
-        {action: 'del', obj: `1@${actor}`, key: `2@${actor}`, pred: [`2@${actor}`]},
-        {action: 'set', obj: `1@${actor}`, key: `2@${actor}`, insert: true, value: 'greenfinch', pred: []},
-        {action: 'set', obj: `1@${actor}`, key: `3@${actor}`, value: 'goldfinches!!', pred: [`3@${actor}`]}
+        {action: 'del', obj: `1@${actor}`, elemId: `2@${actor}`, pred: [`2@${actor}`]},
+        {action: 'set', obj: `1@${actor}`, elemId: `2@${actor}`, insert: true, value: 'greenfinch', pred: []},
+        {action: 'set', obj: `1@${actor}`, elemId: `3@${actor}`, value: 'goldfinches!!', pred: [`3@${actor}`]}
       ]}
       const s1 = Backend.loadChanges(Backend.init(), [change1, change2].map(encodeChange))
       assert.deepStrictEqual(Backend.getPatch(s1), {
@@ -580,7 +580,7 @@ describe('Automerge.Backend', () => {
       const actor = uuid()
       const change = {actor, seq: 1, startOp: 1, time: 0, deps: [], ops: [
         {action: 'makeList', obj: '_root', key: 'todos', pred: []},
-        {action: 'makeMap', obj: `1@${actor}`, key: '_head', insert: true, pred: []},
+        {action: 'makeMap', obj: `1@${actor}`, elemId: '_head', insert: true, pred: []},
         {action: 'set', obj: `2@${actor}`, key: 'title', value: 'water plants', pred: []},
         {action: 'set', obj: `2@${actor}`, key: 'done', value: false, pred: []}
       ]}
@@ -618,7 +618,7 @@ describe('Automerge.Backend', () => {
       const now = new Date(), actor = uuid()
       const change = {actor, seq: 1, startOp: 1, time: 0, deps: [], ops: [
         {action: 'makeList', obj: '_root', key: 'list', pred: []},
-        {action: 'set', obj: `1@${actor}`, key: '_head', insert: true, value: now.getTime(), datatype: 'timestamp', pred: []}
+        {action: 'set', obj: `1@${actor}`, elemId: '_head', insert: true, value: now.getTime(), datatype: 'timestamp', pred: []}
       ]}
       const s1 = Backend.loadChanges(Backend.init(), [encodeChange(change)])
       assert.deepStrictEqual(Backend.getPatch(s1), {

--- a/test/backend_test.js
+++ b/test/backend_test.js
@@ -3,7 +3,6 @@ const Automerge = process.env.TEST_DIST === '1' ? require('../dist/automerge') :
 const Backend = Automerge.Backend
 const { encodeChange, decodeChange } = require('../backend/columnar')
 const uuid = require('../src/uuid')
-const ROOT_ID = '00000000-0000-0000-0000-000000000000'
 
 function hash(change) {
   return decodeChange(encodeChange(change)).hash
@@ -14,13 +13,13 @@ describe('Automerge.Backend', () => {
     it('should assign to a key in a map', () => {
       const actor = uuid()
       const change1 = {actor, seq: 1, startOp: 1, time: 0, deps: [], ops: [
-        {action: 'set', obj: ROOT_ID, key: 'bird', value: 'magpie', pred: []}
+        {action: 'set', obj: '_root', key: 'bird', value: 'magpie', pred: []}
       ]}
       const s0 = Backend.init()
       const [s1, patch1] = Backend.applyChanges(s0, [encodeChange(change1)])
       assert.deepStrictEqual(patch1, {
         clock: {[actor]: 1}, deps: [hash(change1)], maxOp: 1,
-        diffs: {objectId: ROOT_ID, type: 'map', props: {
+        diffs: {objectId: '_root', type: 'map', props: {
           bird: {[`1@${actor}`]: {value: 'magpie'}}
         }}
       })
@@ -29,17 +28,17 @@ describe('Automerge.Backend', () => {
     it('should increment a key in a map', () => {
       const actor = uuid()
       const change1 = {actor, seq: 1, startOp: 1, time: 0, deps: [], ops: [
-        {action: 'set', obj: ROOT_ID, key: 'counter', value: 1, datatype: 'counter', pred: []}
+        {action: 'set', obj: '_root', key: 'counter', value: 1, datatype: 'counter', pred: []}
       ]}
       const change2 = {actor, seq: 2, startOp: 2, time: 0, deps: [hash(change1)], ops: [
-        {action: 'inc', obj: ROOT_ID, key: 'counter', value: 2, pred: [`1@${actor}`]}
+        {action: 'inc', obj: '_root', key: 'counter', value: 2, pred: [`1@${actor}`]}
       ]}
       const s0 = Backend.init()
       const [s1, patch1] = Backend.applyChanges(s0, [encodeChange(change1)])
       const [s2, patch2] = Backend.applyChanges(s1, [encodeChange(change2)])
       assert.deepStrictEqual(patch2, {
         clock: {[actor]: 2}, deps: [hash(change2)], maxOp: 2,
-        diffs: {objectId: ROOT_ID, type: 'map', props: {
+        diffs: {objectId: '_root', type: 'map', props: {
           counter: {[`1@${actor}`]: {value: 3, datatype: 'counter'}}
         }}
       })
@@ -47,17 +46,17 @@ describe('Automerge.Backend', () => {
 
     it('should make a conflict on assignment to the same key', () => {
       const change1 = {actor: '111111', seq: 1, startOp: 1, time: 0, deps: [], ops: [
-        {action: 'set', obj: ROOT_ID, key: 'bird', value: 'magpie', pred: []}
+        {action: 'set', obj: '_root', key: 'bird', value: 'magpie', pred: []}
       ]}
       const change2 = {actor: '222222', seq: 1, startOp: 2, time: 0, deps: [hash(change1)], ops: [
-        {action: 'set', obj: ROOT_ID, key: 'bird', value: 'blackbird', pred: []}
+        {action: 'set', obj: '_root', key: 'bird', value: 'blackbird', pred: []}
       ]}
       const s0 = Backend.init()
       const [s1, patch1] = Backend.applyChanges(s0, [encodeChange(change1)])
       const [s2, patch2] = Backend.applyChanges(s1, [encodeChange(change2)])
       assert.deepStrictEqual(patch2, {
         clock: {111111: 1, 222222: 1}, deps: [hash(change2)], maxOp: 2,
-        diffs: {objectId: ROOT_ID, type: 'map', props: {
+        diffs: {objectId: '_root', type: 'map', props: {
           bird: {'1@111111': {value: 'magpie'}, '2@222222': {value: 'blackbird'}}
         }}
       })
@@ -66,31 +65,31 @@ describe('Automerge.Backend', () => {
     it('should delete a key from a map', () => {
       const actor = uuid()
       const change1 = {actor, seq: 1, startOp: 1, time: 0, deps: [], ops: [
-        {action: 'set', obj: ROOT_ID, key: 'bird', value: 'magpie', pred: []}
+        {action: 'set', obj: '_root', key: 'bird', value: 'magpie', pred: []}
       ]}
       const change2 = {actor, seq: 2, startOp: 2, time: 0, deps: [hash(change1)], ops: [
-        {action: 'del', obj: ROOT_ID, key: 'bird', pred: [`1@${actor}`]}
+        {action: 'del', obj: '_root', key: 'bird', pred: [`1@${actor}`]}
       ]}
       const s0 = Backend.init()
       const [s1, patch1] = Backend.applyChanges(s0, [encodeChange(change1)])
       const [s2, patch2] = Backend.applyChanges(s1, [encodeChange(change2)])
       assert.deepStrictEqual(patch2, {
         clock: {[actor]: 2}, deps: [hash(change2)], maxOp: 2,
-        diffs: {objectId: ROOT_ID, type: 'map', props: {bird: {}}}
+        diffs: {objectId: '_root', type: 'map', props: {bird: {}}}
       })
     })
 
     it('should create nested maps', () => {
       const actor = uuid()
       const change1 = {actor, seq: 1, startOp: 1, time: 0, deps: [], ops: [
-        {action: 'makeMap', obj: ROOT_ID, key: 'birds', pred: []},
+        {action: 'makeMap', obj: '_root', key: 'birds', pred: []},
         {action: 'set', obj: `1@${actor}`, key: 'wrens', value: 3, pred: []}
       ]}
       const s0 = Backend.init()
       const [s1, patch1] = Backend.applyChanges(s0, [encodeChange(change1)])
       assert.deepStrictEqual(patch1, {
         clock: {[actor]: 1}, deps: [hash(change1)], maxOp: 2,
-        diffs: {objectId: ROOT_ID, type: 'map', props: {birds: {[`1@${actor}`]: {
+        diffs: {objectId: '_root', type: 'map', props: {birds: {[`1@${actor}`]: {
           objectId: `1@${actor}`, type: 'map', props: {wrens: {[`2@${actor}`]: {value: 3}}}
         }}}}
       })
@@ -99,7 +98,7 @@ describe('Automerge.Backend', () => {
     it('should assign to keys in nested maps', () => {
       const actor = uuid()
       const change1 = {actor, seq: 1, startOp: 1, time: 0, deps: [], ops: [
-        {action: 'makeMap', obj: ROOT_ID, key: 'birds', pred: []},
+        {action: 'makeMap', obj: '_root', key: 'birds', pred: []},
         {action: 'set', obj: `1@${actor}`, key: 'wrens', value: 3, pred: []}
       ]}
       const change2 = {actor, seq: 2, startOp: 3, time: 0, deps: [hash(change1)], ops: [
@@ -110,7 +109,7 @@ describe('Automerge.Backend', () => {
       const [s2, patch2] = Backend.applyChanges(s1, [encodeChange(change2)])
       assert.deepStrictEqual(patch2, {
         clock: {[actor]: 2}, deps: [hash(change2)], maxOp: 3,
-        diffs: {objectId: ROOT_ID, type: 'map', props: {birds: {[`1@${actor}`]: {
+        diffs: {objectId: '_root', type: 'map', props: {birds: {[`1@${actor}`]: {
           objectId: `1@${actor}`, type: 'map', props: {sparrows: {[`3@${actor}`]: {value: 15}}}
         }}}}
       })
@@ -119,14 +118,14 @@ describe('Automerge.Backend', () => {
     it('should create lists', () => {
       const actor = uuid()
       const change1 = {actor, seq: 1, startOp: 1, time: 0, deps: [], ops: [
-        {action: 'makeList', obj: ROOT_ID, key: 'birds', pred: []},
+        {action: 'makeList', obj: '_root', key: 'birds', pred: []},
         {action: 'set', obj: `1@${actor}`, key: '_head', insert: true, value: 'chaffinch', pred: []}
       ]}
       const s0 = Backend.init()
       const [s1, patch1] = Backend.applyChanges(s0, [encodeChange(change1)])
       assert.deepStrictEqual(patch1, {
         clock: {[actor]: 1}, deps: [hash(change1)], maxOp: 2,
-        diffs: {objectId: ROOT_ID, type: 'map', props: {birds: {[`1@${actor}`]: {
+        diffs: {objectId: '_root', type: 'map', props: {birds: {[`1@${actor}`]: {
           objectId: `1@${actor}`, type: 'list',
           edits: [{action: 'insert', index: 0, elemId: `2@${actor}`}],
           props: {0: {[`2@${actor}`]: {value: 'chaffinch'}}}
@@ -137,7 +136,7 @@ describe('Automerge.Backend', () => {
     it('should apply updates inside lists', () => {
       const actor = uuid()
       const change1 = {actor, seq: 1, startOp: 1, time: 0, deps: [], ops: [
-        {action: 'makeList', obj: ROOT_ID, key: 'birds', pred: []},
+        {action: 'makeList', obj: '_root', key: 'birds', pred: []},
         {action: 'set', obj: `1@${actor}`, key: '_head', insert: true, value: 'chaffinch', pred: []}
       ]}
       const change2 = {actor, seq: 2, startOp: 3, time: 0, deps: [hash(change1)], ops: [
@@ -148,7 +147,7 @@ describe('Automerge.Backend', () => {
       const [s2, patch2] = Backend.applyChanges(s1, [encodeChange(change2)])
       assert.deepStrictEqual(patch2, {
         clock: {[actor]: 2}, deps: [hash(change2)], maxOp: 3,
-        diffs: {objectId: ROOT_ID, type: 'map', props: {birds: {[`1@${actor}`]: {
+        diffs: {objectId: '_root', type: 'map', props: {birds: {[`1@${actor}`]: {
           objectId: `1@${actor}`, type: 'list', edits: [],
           props: {0: {[`3@${actor}`]: {value: 'greenfinch'}}}
         }}}}
@@ -158,7 +157,7 @@ describe('Automerge.Backend', () => {
     it('should delete list elements', () => {
       const actor = uuid()
       const change1 = {actor, seq: 1, startOp: 1, time: 0, deps: [], ops: [
-        {action: 'makeList', obj: ROOT_ID, key: 'birds', pred: []},
+        {action: 'makeList', obj: '_root', key: 'birds', pred: []},
         {action: 'set', obj: `1@${actor}`, key: '_head', insert: true, value: 'chaffinch', pred: []}
       ]}
       const change2 = {actor, seq: 2, startOp: 3, time: 0, deps: [hash(change1)], ops: [
@@ -169,7 +168,7 @@ describe('Automerge.Backend', () => {
       const [s2, patch2] = Backend.applyChanges(s1, [encodeChange(change2)])
       assert.deepStrictEqual(patch2, {
         clock: {[actor]: 2}, deps: [hash(change2)], maxOp: 3,
-        diffs: {objectId: ROOT_ID, type: 'map', props: {birds: {[`1@${actor}`]: {
+        diffs: {objectId: '_root', type: 'map', props: {birds: {[`1@${actor}`]: {
           objectId: `1@${actor}`, type: 'list', props: {},
           edits: [{action: 'remove', index: 0}]
         }}}}
@@ -179,7 +178,7 @@ describe('Automerge.Backend', () => {
     it('should handle list element insertion and deletion in the same change', () => {
       const actor = uuid()
       const change1 = {actor, seq: 1, startOp: 1, time: 0, deps: [], ops: [
-        {action: 'makeList', obj: ROOT_ID, key: 'birds', pred: []}
+        {action: 'makeList', obj: '_root', key: 'birds', pred: []}
       ]}
       const change2 = {actor, seq: 2, startOp: 2, time: 0, deps: [hash(change1)], ops: [
         {action: 'set', obj: `1@${actor}`, key: '_head', insert: true, value: 'chaffinch', pred: []},
@@ -190,7 +189,7 @@ describe('Automerge.Backend', () => {
       const [s2, patch2] = Backend.applyChanges(s1, [encodeChange(change2)])
       assert.deepStrictEqual(patch2, {
         clock: {[actor]: 2}, deps: [hash(change2)], maxOp: 3,
-        diffs: {objectId: ROOT_ID, type: 'map', props: {birds: {[`1@${actor}`]: {
+        diffs: {objectId: '_root', type: 'map', props: {birds: {[`1@${actor}`]: {
           objectId: `1@${actor}`, type: 'list', edits: [
             {action: 'insert', index: 0, elemId: `2@${actor}`}, {action: 'remove', index: 0}
           ], props: {}
@@ -201,10 +200,10 @@ describe('Automerge.Backend', () => {
     it('should handle changes within conflicted objects', () => {
       const actor1 = uuid(), actor2 = uuid()
       const change1 = {actor: actor1, seq: 1, startOp: 1, time: 0, deps: [], ops: [
-        {action: 'makeList', obj: ROOT_ID, key: 'conflict', pred: []}
+        {action: 'makeList', obj: '_root', key: 'conflict', pred: []}
       ]}
       const change2 = {actor: actor2, seq: 1, startOp: 1, time: 0, deps: [], ops: [
-        {action: 'makeMap',  obj: ROOT_ID, key: 'conflict', pred: []}
+        {action: 'makeMap',  obj: '_root', key: 'conflict', pred: []}
       ]}
       const change3 = {actor: actor2, seq: 2, startOp: 2, time: 0, deps: [hash(change2)], ops: [
         {action: 'set', obj: `1@${actor2}`, key: 'sparrows', value: 12, pred: []}
@@ -216,7 +215,7 @@ describe('Automerge.Backend', () => {
       assert.deepStrictEqual(patch3, {
         clock: {[actor1]: 1, [actor2]: 2}, maxOp: 2,
         deps: [hash(change1), hash(change3)].sort(), 
-        diffs: {objectId: ROOT_ID, type: 'map', props: {conflict: {
+        diffs: {objectId: '_root', type: 'map', props: {conflict: {
           [`1@${actor1}`]: {objectId: `1@${actor1}`, type: 'list'},
           [`1@${actor2}`]: {objectId: `1@${actor2}`, type: 'map', props: {sparrows: {[`2@${actor2}`]: {value: 12}}}}
         }}}
@@ -226,13 +225,13 @@ describe('Automerge.Backend', () => {
     it('should support Date objects at the root', () => {
       const now = new Date()
       const actor = uuid(), change = {actor, seq: 1, startOp: 1, time: 0, deps: [], ops: [
-        {action: 'set', obj: ROOT_ID, key: 'now', value: now.getTime(), datatype: 'timestamp', pred: []}
+        {action: 'set', obj: '_root', key: 'now', value: now.getTime(), datatype: 'timestamp', pred: []}
       ]}
       const s0 = Backend.init()
       const [s1, patch] = Backend.applyChanges(s0, [encodeChange(change)])
       assert.deepStrictEqual(patch, {
         clock: {[actor]: 1}, deps: [hash(change)], maxOp: 1,
-        diffs: {objectId: ROOT_ID, type: 'map', props: {
+        diffs: {objectId: '_root', type: 'map', props: {
           now: {[`1@${actor}`]: {value: now.getTime(), datatype: 'timestamp'}}
         }}
       })
@@ -241,14 +240,14 @@ describe('Automerge.Backend', () => {
     it('should support Date objects in a list', () => {
       const now = new Date(), actor = uuid()
       const change = {actor, seq: 1, startOp: 1, time: 0, deps: [], ops: [
-        {action: 'makeList', obj: ROOT_ID, key: 'list', pred: []},
+        {action: 'makeList', obj: '_root', key: 'list', pred: []},
         {action: 'set', obj: `1@${actor}`, key: '_head', insert: true, value: now.getTime(), datatype: 'timestamp', pred: []}
       ]}
       const s0 = Backend.init()
       const [s1, patch] = Backend.applyChanges(s0, [encodeChange(change)])
       assert.deepStrictEqual(patch, {
         clock: {[actor]: 1}, deps: [hash(change)], maxOp: 2,
-        diffs: {objectId: ROOT_ID, type: 'map', props: {list: {[`1@${actor}`]: {
+        diffs: {objectId: '_root', type: 'map', props: {list: {[`1@${actor}`]: {
           objectId: `1@${actor}`, type: 'list',
           edits: [{action: 'insert', index: 0, elemId: `2@${actor}`}],
           props: {0: {[`2@${actor}`]: {value: now.getTime(), datatype: 'timestamp'}}}
@@ -260,21 +259,21 @@ describe('Automerge.Backend', () => {
   describe('applyLocalChange()', () => {
     it('should apply change requests', () => {
       const change1 = {actor: '111111', seq: 1, time: 0, startOp: 1, deps: [], ops: [
-        {action: 'set', obj: ROOT_ID, key: 'bird', value: 'magpie', pred: []}
+        {action: 'set', obj: '_root', key: 'bird', value: 'magpie', pred: []}
       ]}
       const s0 = Backend.init()
       const [s1, patch1] = Backend.applyLocalChange(s0, change1)
       const changes01 = Backend.getChanges(s1, []).map(decodeChange)
       assert.deepStrictEqual(patch1, {
         actor: '111111', seq: 1, clock: {'111111': 1}, deps: [], maxOp: 1,
-        diffs: {objectId: ROOT_ID, type: 'map', props: {
+        diffs: {objectId: '_root', type: 'map', props: {
           bird: {['1@111111']: {value: 'magpie'}}
         }}
       })
       assert.deepStrictEqual(changes01, [{
         hash: '442651a167f5f362db4e2b33c5ce276e9d327170633a4f798d6cec353ac0d76c',
         actor: '111111', seq: 1, startOp: 1, time: 0, message: '', deps: [], ops: [
-          {action: 'set', obj: ROOT_ID, key: 'bird', insert: false, value: 'magpie', pred: []}
+          {action: 'set', obj: '_root', key: 'bird', insert: false, value: 'magpie', pred: []}
         ]
       }])
     })
@@ -282,10 +281,10 @@ describe('Automerge.Backend', () => {
     it('should throw an exception on duplicate requests', () => {
       const actor = uuid()
       const change1 = {actor, seq: 1, time: 0, startOp: 1, deps: [], ops: [
-        {action: 'set', obj: ROOT_ID, key: 'bird', value: 'magpie', pred: []}
+        {action: 'set', obj: '_root', key: 'bird', value: 'magpie', pred: []}
       ]}
       const change2 = {actor, seq: 2, time: 0, startOp: 2, deps: [], ops: [
-        {action: 'set', obj: ROOT_ID, key: 'bird', value: 'jay', pred: []}
+        {action: 'set', obj: '_root', key: 'bird', value: 'jay', pred: []}
       ]}
       const s0 = Backend.init()
       const [s1, patch1] = Backend.applyLocalChange(s0, change1)
@@ -296,13 +295,13 @@ describe('Automerge.Backend', () => {
 
     it('should handle frontend and backend changes happening concurrently', () => {
       const local1 = {actor: '111111', seq: 1, time: 0, startOp: 1, deps: [], ops: [
-        {action: 'set', obj: ROOT_ID, key: 'bird', value: 'magpie', pred: []}
+        {action: 'set', obj: '_root', key: 'bird', value: 'magpie', pred: []}
       ]}
       const local2 = {actor: '111111', seq: 2, time: 0, startOp: 2, deps: [], ops: [
-        {action: 'set', obj: ROOT_ID, key: 'bird', value: 'jay', pred: ['1@111111']}
+        {action: 'set', obj: '_root', key: 'bird', value: 'jay', pred: ['1@111111']}
       ]}
       const remote1 = {actor: '222222', seq: 1, startOp: 1, time: 0, deps: [], ops: [
-        {action: 'set', obj: ROOT_ID, key: 'fish', value: 'goldfish', pred: []}
+        {action: 'set', obj: '_root', key: 'fish', value: 'goldfish', pred: []}
       ]}
       const s0 = Backend.init()
       const [s1, patch1] = Backend.applyLocalChange(s0, local1)
@@ -314,34 +313,34 @@ describe('Automerge.Backend', () => {
       assert.deepStrictEqual(changes01, [{
         hash: '442651a167f5f362db4e2b33c5ce276e9d327170633a4f798d6cec353ac0d76c',
         actor: '111111', seq: 1, startOp: 1, time: 0, message: '', deps: [], ops: [
-          {action: 'set', obj: ROOT_ID, key: 'bird', insert: false, value: 'magpie', pred: []}
+          {action: 'set', obj: '_root', key: 'bird', insert: false, value: 'magpie', pred: []}
         ]
       }])
       assert.deepStrictEqual(changes12, [{
         hash: '51fbd2710738fdadf426befb08befea5816196715e457b64bde3d5d621d725d4',
         actor: '222222', seq: 1, startOp: 1, time: 0, message: '', deps: [], ops: [
-          {action: 'set', obj: ROOT_ID, key: 'fish', insert: false, value: 'goldfish', pred: []}
+          {action: 'set', obj: '_root', key: 'fish', insert: false, value: 'goldfish', pred: []}
         ]
       }])
       assert.deepStrictEqual(changes23, [{
         hash: '64b47cbb40ae01dc35e416d028ef30584312746e4658b102b955568b8e69aabb',
         actor: '111111', seq: 2, startOp: 2, time: 0, message: '', deps: [changes01[0].hash], ops: [
-          {action: 'set', obj: ROOT_ID, key: 'bird', insert: false, value: 'jay', pred: ['1@111111']}
+          {action: 'set', obj: '_root', key: 'bird', insert: false, value: 'jay', pred: ['1@111111']}
         ]
       }])
     })
 
     it('should detect conflicts based on the frontend version', () => {
       const local1 = {requestType: 'change', actor: '111111', seq: 1, time: 0, startOp: 1, deps: [], ops: [
-        {action: 'set', obj: ROOT_ID, key: 'bird', value: 'goldfinch', pred: []}
+        {action: 'set', obj: '_root', key: 'bird', value: 'goldfinch', pred: []}
       ]}
       // remote1 depends on local1; the deps field is filled in below when we've computed the hash
       const remote1 = {actor: '222222', seq: 1, startOp: 2, time: 0, deps: [], ops: [
-        {action: 'set', obj: ROOT_ID, key: 'bird', value: 'magpie', pred: ['1@111111']}
+        {action: 'set', obj: '_root', key: 'bird', value: 'magpie', pred: ['1@111111']}
       ]}
       // local2 is concurrent with remote1 (because version < 2)
       const local2 = {requestType: 'change', actor: '111111', seq: 2, time: 0, startOp: 2, deps: [], ops: [
-        {action: 'set', obj: ROOT_ID, key: 'bird', value: 'jay', pred: ['1@111111']}
+        {action: 'set', obj: '_root', key: 'bird', value: 'jay', pred: ['1@111111']}
       ]}
       const s0 = Backend.init()
       const [s1, patch1] = Backend.applyLocalChange(s0, local1)
@@ -353,21 +352,21 @@ describe('Automerge.Backend', () => {
       const changes23 = Backend.getChanges(s3, [changes12[0].hash]).map(decodeChange)
       assert.deepStrictEqual(patch3, {
         actor: '111111', seq: 2, clock: {'111111': 2, '222222': 1}, deps: [hash(remote1)], maxOp: 2,
-        diffs: {objectId: ROOT_ID, type: 'map', props: {
+        diffs: {objectId: '_root', type: 'map', props: {
           bird: {'2@222222': {value: 'magpie'}, '2@111111': {value: 'jay'}}
         }}
       })
       assert.deepStrictEqual(changes23, [{
         hash: '1387476c317fff61163e9ed885f7856688efc24be664f8da69bcd577fc8db732',
         actor: '111111', seq: 2, startOp: 2, time: 0, message: '', deps: [changes01[0].hash], ops: [
-          {action: 'set', obj: ROOT_ID, key: 'bird', insert: false, value: 'jay', pred: ['1@111111']}
+          {action: 'set', obj: '_root', key: 'bird', insert: false, value: 'jay', pred: ['1@111111']}
         ]
       }])
     })
 
     it('should transform list indexes into element IDs', () => {
       const remote1 = {actor: '222222', seq: 1, startOp: 1, time: 0, deps: [], ops: [
-        {obj: ROOT_ID, action: 'makeList', key: 'birds', pred: []}
+        {obj: '_root', action: 'makeList', key: 'birds', pred: []}
       ]}
       const remote2 = {actor: '222222', seq: 2, startOp: 2, time: 0, deps: [hash(remote1)], ops: [
         {obj: '1@222222', action: 'set', key: '_head', insert: true, value: 'magpie', pred: []}
@@ -415,7 +414,7 @@ describe('Automerge.Backend', () => {
 
     it('should handle list element insertion and deletion in the same change', () => {
       const local1 = {requestType: 'change', actor: '111111', seq: 1, startOp: 1, deps: [], time: 0, ops: [
-        {obj: ROOT_ID, action: 'makeList', key: 'birds', pred: []}
+        {obj: '_root', action: 'makeList', key: 'birds', pred: []}
       ]}
       const local2 = {requestType: 'change', actor: '111111', seq: 2, startOp: 2, deps: [], time: 0, ops: [
         {obj: '1@111111', action: 'set', key: '_head', insert: true, value: 'magpie', pred: []},
@@ -427,7 +426,7 @@ describe('Automerge.Backend', () => {
       const changes = Backend.getChanges(s2, []).map(decodeChange)
       assert.deepStrictEqual(patch2, {
         actor: '111111', seq: 2, clock: {'111111': 2}, deps: [], maxOp: 3,
-        diffs: {objectId: ROOT_ID, type: 'map', props: {
+        diffs: {objectId: '_root', type: 'map', props: {
           birds: {['1@111111']: {objectId: '1@111111', type: 'list',
             edits: [{action: 'insert', index: 0, elemId: '2@111111'}, {action: 'remove', index: 0}],
             props: {}
@@ -436,7 +435,7 @@ describe('Automerge.Backend', () => {
       })
       assert.deepStrictEqual(changes, [{
         hash: changes[0].hash, actor: '111111', seq: 1, startOp: 1, time: 0, message: '', deps: [], ops: [
-          {obj: ROOT_ID, action: 'makeList', key: 'birds', insert: false, pred: []}
+          {obj: '_root', action: 'makeList', key: 'birds', insert: false, pred: []}
         ]
       }, {
         hash: 'e4ac64e701a14d92b3096cfa9763178f9b778039b596189e3e7efbdd1b2f0b35',
@@ -452,15 +451,15 @@ describe('Automerge.Backend', () => {
     it('should include the most recent value for a key', () => {
       const actor = uuid()
       const change1 = {actor, seq: 1, startOp: 1, time: 0, deps: [], ops: [
-        {action: 'set', obj: ROOT_ID, key: 'bird', value: 'magpie', pred: []}
+        {action: 'set', obj: '_root', key: 'bird', value: 'magpie', pred: []}
       ]}
       const change2 = {actor, seq: 2, startOp: 2, time: 0, deps: [hash(change1)], ops: [
-        {action: 'set', obj: ROOT_ID, key: 'bird', value: 'blackbird', pred: [`1@${actor}`]}
+        {action: 'set', obj: '_root', key: 'bird', value: 'blackbird', pred: [`1@${actor}`]}
       ]}
       const s1 = Backend.loadChanges(Backend.init(), [change1, change2].map(encodeChange))
       assert.deepStrictEqual(Backend.getPatch(s1), {
         clock: {[actor]: 2}, deps: [hash(change2)], maxOp: 2,
-        diffs: {objectId: ROOT_ID, type: 'map', props: {
+        diffs: {objectId: '_root', type: 'map', props: {
           bird: {[`2@${actor}`]: {value: 'blackbird'}}
         }}
       })
@@ -468,16 +467,16 @@ describe('Automerge.Backend', () => {
 
     it('should include conflicting values for a key', () => {
       const change1 = {actor: '111111', seq: 1, startOp: 1, time: 0, deps: [], ops: [
-        {action: 'set', obj: ROOT_ID, key: 'bird', value: 'magpie', pred: []}
+        {action: 'set', obj: '_root', key: 'bird', value: 'magpie', pred: []}
       ]}
       const change2 = {actor: '222222', seq: 1, startOp: 1, time: 0, deps: [], ops: [
-        {action: 'set', obj: ROOT_ID, key: 'bird', value: 'blackbird', pred: []}
+        {action: 'set', obj: '_root', key: 'bird', value: 'blackbird', pred: []}
       ]}
       const s1 = Backend.loadChanges(Backend.init(), [change1, change2].map(encodeChange))
       assert.deepStrictEqual(Backend.getPatch(s1), {
         clock: {111111: 1, 222222: 1},
         deps: [hash(change1), hash(change2)].sort(), maxOp: 1,
-        diffs: {objectId: ROOT_ID, type: 'map', props: {
+        diffs: {objectId: '_root', type: 'map', props: {
           bird: {'1@111111': {value: 'magpie'}, '1@222222': {value: 'blackbird'}}
         }}
       })
@@ -486,15 +485,15 @@ describe('Automerge.Backend', () => {
     it('should handle counter increments at a key in a map', () => {
       const actor = uuid()
       const change1 = {actor, seq: 1, startOp: 1, time: 0, deps: [], ops: [
-        {action: 'set', obj: ROOT_ID, key: 'counter', value: 1, datatype: 'counter', pred: []}
+        {action: 'set', obj: '_root', key: 'counter', value: 1, datatype: 'counter', pred: []}
       ]}
       const change2 = {actor, seq: 2, startOp: 2, time: 0, deps: [hash(change1)], ops: [
-        {action: 'inc', obj: ROOT_ID, key: 'counter', value: 2, pred: [`1@${actor}`]}
+        {action: 'inc', obj: '_root', key: 'counter', value: 2, pred: [`1@${actor}`]}
       ]}
       const s1 = Backend.loadChanges(Backend.init(), [change1, change2].map(encodeChange))
       assert.deepStrictEqual(Backend.getPatch(s1), {
         clock: {[actor]: 2}, deps: [hash(change2)], maxOp: 2,
-        diffs: {objectId: ROOT_ID, type: 'map', props: {
+        diffs: {objectId: '_root', type: 'map', props: {
           counter: {[`1@${actor}`]: {value: 3, datatype: 'counter'}}
         }}
       })
@@ -503,25 +502,25 @@ describe('Automerge.Backend', () => {
     it('should handle deletion of a counter', () => {
       const actor = uuid()
       const change1 = {actor, seq: 1, startOp: 1, time: 0, deps: [], ops: [
-        {action: 'set', obj: ROOT_ID, key: 'counter', value: 1, datatype: 'counter', pred: []}
+        {action: 'set', obj: '_root', key: 'counter', value: 1, datatype: 'counter', pred: []}
       ]}
       const change2 = {actor, seq: 2, startOp: 2, time: 0, deps: [hash(change1)], ops: [
-        {action: 'inc', obj: ROOT_ID, key: 'counter', value: 2, pred: [`1@${actor}`]}
+        {action: 'inc', obj: '_root', key: 'counter', value: 2, pred: [`1@${actor}`]}
       ]}
       const change3 = {actor, seq: 3, startOp: 3, time: 0, deps: [hash(change2)], ops: [
-        {action: 'del', obj: ROOT_ID, key: 'counter', pred: [`1@${actor}`]}
+        {action: 'del', obj: '_root', key: 'counter', pred: [`1@${actor}`]}
       ]}
       const s1 = Backend.loadChanges(Backend.init(), [change1, change2, change3].map(encodeChange))
       assert.deepStrictEqual(Backend.getPatch(s1), {
         clock: {[actor]: 3}, deps: [hash(change3)], maxOp: 3,
-        diffs: {objectId: ROOT_ID, type: 'map'}
+        diffs: {objectId: '_root', type: 'map'}
       })
     })
 
     it('should create nested maps', () => {
       const actor = uuid()
       const change1 = {actor, seq: 1, startOp: 1, time: 0, deps: [], ops: [
-        {action: 'makeMap', obj: ROOT_ID, key: 'birds', pred: []},
+        {action: 'makeMap', obj: '_root', key: 'birds', pred: []},
         {action: 'set', obj: `1@${actor}`, key: 'wrens', value: 3,     pred: []}
       ]}
       const change2 = {actor, seq: 2, startOp: 3, time: 0, deps: [hash(change1)], ops: [
@@ -531,7 +530,7 @@ describe('Automerge.Backend', () => {
       const s1 = Backend.loadChanges(Backend.init(), [change1, change2].map(encodeChange))
       assert.deepStrictEqual(Backend.getPatch(s1), {
         clock: {[actor]: 2}, deps: [hash(change2)], maxOp: 4,
-        diffs: {objectId: ROOT_ID, type: 'map', props: {birds: {[`1@${actor}`]: {
+        diffs: {objectId: '_root', type: 'map', props: {birds: {[`1@${actor}`]: {
           objectId: `1@${actor}`, type: 'map', props: {sparrows: {[`4@${actor}`]: {value: 15}}}
         }}}}
       })
@@ -540,13 +539,13 @@ describe('Automerge.Backend', () => {
     it('should create lists', () => {
       const actor = uuid()
       const change1 = {actor, seq: 1, startOp: 1, time: 0, deps: [], ops: [
-        {action: 'makeList', obj: ROOT_ID, key: 'birds', pred: []},
+        {action: 'makeList', obj: '_root', key: 'birds', pred: []},
         {action: 'set', obj: `1@${actor}`, key: '_head', insert: true, value: 'chaffinch', pred: []}
       ]}
       const s1 = Backend.loadChanges(Backend.init(), [encodeChange(change1)])
       assert.deepStrictEqual(Backend.getPatch(s1), {
         clock: {[actor]: 1}, deps: [hash(change1)], maxOp: 2,
-        diffs: {objectId: ROOT_ID, type: 'map', props: {birds: {[`1@${actor}`]: {
+        diffs: {objectId: '_root', type: 'map', props: {birds: {[`1@${actor}`]: {
           objectId: `1@${actor}`, type: 'list',
           edits: [{action: 'insert', index: 0, elemId: `2@${actor}`}],
           props: {0: {[`2@${actor}`]: {value: 'chaffinch'}}}
@@ -557,7 +556,7 @@ describe('Automerge.Backend', () => {
     it('should include the latest state of a list', () => {
       const actor = uuid()
       const change1 = {actor, seq: 1, startOp: 1, time: 0, deps: [], ops: [
-        {action: 'makeList', obj: ROOT_ID, key: 'birds', pred: []},
+        {action: 'makeList', obj: '_root', key: 'birds', pred: []},
         {action: 'set', obj: `1@${actor}`, key: '_head',      insert: true, value: 'chaffinch', pred: []},
         {action: 'set', obj: `1@${actor}`, key: `2@${actor}`, insert: true, value: 'goldfinch', pred: []}
       ]}
@@ -569,7 +568,7 @@ describe('Automerge.Backend', () => {
       const s1 = Backend.loadChanges(Backend.init(), [change1, change2].map(encodeChange))
       assert.deepStrictEqual(Backend.getPatch(s1), {
         clock: {[actor]: 2}, deps: [hash(change2)], maxOp: 6,
-        diffs: {objectId: ROOT_ID, type: 'map', props: {birds: {[`1@${actor}`]: {
+        diffs: {objectId: '_root', type: 'map', props: {birds: {[`1@${actor}`]: {
           objectId: `1@${actor}`, type: 'list',
           edits: [{action: 'insert', index: 0, elemId: `5@${actor}`}, {action: 'insert', index: 1, elemId: `3@${actor}`}],
           props: {0: {[`5@${actor}`]: {value: 'greenfinch'}}, 1: {[`6@${actor}`]: {value: 'goldfinches!!'}}}
@@ -580,7 +579,7 @@ describe('Automerge.Backend', () => {
     it('should handle nested maps in lists', () => {
       const actor = uuid()
       const change = {actor, seq: 1, startOp: 1, time: 0, deps: [], ops: [
-        {action: 'makeList', obj: ROOT_ID, key: 'todos', pred: []},
+        {action: 'makeList', obj: '_root', key: 'todos', pred: []},
         {action: 'makeMap', obj: `1@${actor}`, key: '_head', insert: true, pred: []},
         {action: 'set', obj: `2@${actor}`, key: 'title', value: 'water plants', pred: []},
         {action: 'set', obj: `2@${actor}`, key: 'done', value: false, pred: []}
@@ -588,7 +587,7 @@ describe('Automerge.Backend', () => {
       const s1 = Backend.loadChanges(Backend.init(), [encodeChange(change)])
       assert.deepStrictEqual(Backend.getPatch(s1), {
         clock: {[actor]: 1}, deps: [hash(change)], maxOp: 4,
-        diffs: {objectId: ROOT_ID, type: 'map', props: {todos: {[`1@${actor}`]: {
+        diffs: {objectId: '_root', type: 'map', props: {todos: {[`1@${actor}`]: {
           objectId: `1@${actor}`, type: 'list',
           edits: [{action: 'insert', index: 0, elemId: `2@${actor}`}],
           props: {0: {[`2@${actor}`]: {
@@ -604,12 +603,12 @@ describe('Automerge.Backend', () => {
     it('should include Date objects at the root', () => {
       const now = new Date()
       const actor = uuid(), change = {actor, seq: 1, startOp: 1, time: 0, deps: [], ops: [
-        {action: 'set', obj: ROOT_ID, key: 'now', value: now.getTime(), datatype: 'timestamp', pred: []}
+        {action: 'set', obj: '_root', key: 'now', value: now.getTime(), datatype: 'timestamp', pred: []}
       ]}
       const s1 = Backend.loadChanges(Backend.init(), [encodeChange(change)])
       assert.deepStrictEqual(Backend.getPatch(s1), {
         clock: {[actor]: 1}, deps: [hash(change)], maxOp: 1,
-        diffs: {objectId: ROOT_ID, type: 'map', props: {
+        diffs: {objectId: '_root', type: 'map', props: {
           now: {[`1@${actor}`]: {value: now.getTime(), datatype: 'timestamp'}}
         }}
       })
@@ -618,13 +617,13 @@ describe('Automerge.Backend', () => {
     it('should include Date objects in a list', () => {
       const now = new Date(), actor = uuid()
       const change = {actor, seq: 1, startOp: 1, time: 0, deps: [], ops: [
-        {action: 'makeList', obj: ROOT_ID, key: 'list', pred: []},
+        {action: 'makeList', obj: '_root', key: 'list', pred: []},
         {action: 'set', obj: `1@${actor}`, key: '_head', insert: true, value: now.getTime(), datatype: 'timestamp', pred: []}
       ]}
       const s1 = Backend.loadChanges(Backend.init(), [encodeChange(change)])
       assert.deepStrictEqual(Backend.getPatch(s1), {
         clock: {[actor]: 1}, deps: [hash(change)], maxOp: 2,
-        diffs: {objectId: ROOT_ID, type: 'map', props: {list: {[`1@${actor}`]: {
+        diffs: {objectId: '_root', type: 'map', props: {list: {[`1@${actor}`]: {
           objectId: `1@${actor}`, type: 'list',
           edits: [{action: 'insert', index: 0, elemId: `2@${actor}`}],
           props: {0: {[`2@${actor}`]: {value: now.getTime(), datatype: 'timestamp'}}}

--- a/test/backend_test.js
+++ b/test/backend_test.js
@@ -271,7 +271,7 @@ describe('Automerge.Backend', () => {
         }}
       })
       assert.deepStrictEqual(changes01, [{
-        hash: '442651a167f5f362db4e2b33c5ce276e9d327170633a4f798d6cec353ac0d76c',
+        hash: 'aa6c0ad0182866094a41e348f8b2b1be3b2343a50b1cb8c2b18b40124caa6487',
         actor: '111111', seq: 1, startOp: 1, time: 0, message: '', deps: [], ops: [
           {action: 'set', obj: '_root', key: 'bird', insert: false, value: 'magpie', pred: []}
         ]
@@ -311,19 +311,19 @@ describe('Automerge.Backend', () => {
       const [s3, patch3] = Backend.applyLocalChange(s2, local2)
       const changes23 = Backend.getChanges(s3, [changes01[0].hash, changes12[0].hash]).map(decodeChange)
       assert.deepStrictEqual(changes01, [{
-        hash: '442651a167f5f362db4e2b33c5ce276e9d327170633a4f798d6cec353ac0d76c',
+        hash: 'aa6c0ad0182866094a41e348f8b2b1be3b2343a50b1cb8c2b18b40124caa6487',
         actor: '111111', seq: 1, startOp: 1, time: 0, message: '', deps: [], ops: [
           {action: 'set', obj: '_root', key: 'bird', insert: false, value: 'magpie', pred: []}
         ]
       }])
       assert.deepStrictEqual(changes12, [{
-        hash: '51fbd2710738fdadf426befb08befea5816196715e457b64bde3d5d621d725d4',
+        hash: 'e5d411e5929aa7bda4cd6744ea29503c62fda001a8b39645a82e7ee09fec1bcd',
         actor: '222222', seq: 1, startOp: 1, time: 0, message: '', deps: [], ops: [
           {action: 'set', obj: '_root', key: 'fish', insert: false, value: 'goldfish', pred: []}
         ]
       }])
       assert.deepStrictEqual(changes23, [{
-        hash: '64b47cbb40ae01dc35e416d028ef30584312746e4658b102b955568b8e69aabb',
+        hash: 'f652f5a1cfa140cc2c6101028bcdb798896194b478baa7c11e3077cfd561028f',
         actor: '111111', seq: 2, startOp: 2, time: 0, message: '', deps: [changes01[0].hash], ops: [
           {action: 'set', obj: '_root', key: 'bird', insert: false, value: 'jay', pred: ['1@111111']}
         ]
@@ -357,7 +357,7 @@ describe('Automerge.Backend', () => {
         }}
       })
       assert.deepStrictEqual(changes23, [{
-        hash: '1387476c317fff61163e9ed885f7856688efc24be664f8da69bcd577fc8db732',
+        hash: '22982372e08747fa4f00255acecc1c57a128faedeea49c6a36be2cc87ff480c9',
         actor: '111111', seq: 2, startOp: 2, time: 0, message: '', deps: [changes01[0].hash], ops: [
           {action: 'set', obj: '_root', key: 'bird', insert: false, value: 'jay', pred: ['1@111111']}
         ]
@@ -391,19 +391,19 @@ describe('Automerge.Backend', () => {
       const [s5, patch5] = Backend.applyLocalChange(s4, local3)
       const changes45 = Backend.getChanges(s5, [hash(remote2), changes34[0].hash]).map(decodeChange)
       assert.deepStrictEqual(changes12, [{
-        hash: '9e4bfa0cfa532c4b0c0d4a98edb2b833753d23978122f632da42d4cad81062ea',
+        hash: 'f6dd1f3238885bf542e56d347bbd8d4a552bfcf427bc64d2105d6332cbc9a5cf',
         actor: '111111', seq: 1, startOp: 2, time: 0, message: '', deps: [hash(remote1)], ops: [
           {obj: '1@222222', action: 'set', key: '_head', insert: true, value: 'goldfinch', pred: []}
         ]
       }])
       assert.deepStrictEqual(changes34, [{
-        hash: '989560a58e050781303f27751fca5db6b68e3435eaeb628468d87bb18368384f',
+        hash: '89908f10ba6ef56200aa44c7ec010f4525a7f583f65ad441487ef797c61a3093',
         actor: '111111', seq: 2, startOp: 3, time: 0, message: '', deps: [changes12[0].hash], ops: [
           {obj: '1@222222', action: 'set', key: '2@111111', insert: true, value: 'wagtail', pred: []}
         ]
       }])
       assert.deepStrictEqual(changes45, [{
-        hash: 'dd37ad188ecda7986467e8ff382667d3417cf5962bbbba9ddc7eb6fc049f718c',
+        hash: 'f8b8c5b82db29ec768788a70b288de2079c898141abd48de14adb94b94e36db0',
         actor: '111111', seq: 3, startOp: 4, time: 0, message: '',
         deps: [hash(remote2), changes34[0].hash].sort(), ops: [
           {obj: '1@222222', action: 'set', key: '2@222222', insert: false, value: 'Magpie',    pred: ['2@222222']},
@@ -438,7 +438,7 @@ describe('Automerge.Backend', () => {
           {obj: '_root', action: 'makeList', key: 'birds', insert: false, pred: []}
         ]
       }, {
-        hash: 'e4ac64e701a14d92b3096cfa9763178f9b778039b596189e3e7efbdd1b2f0b35',
+        hash: '6f45ecffd1ae6b00575609d3d47ea3aac06eff94e7ad329a9d810b90ec1534c8',
         actor: '111111', seq: 2, startOp: 2, time: 0, message: '', deps: [changes[0].hash], ops: [
           {obj: '1@111111', action: 'set', key: '_head', insert: true, value: 'magpie', pred: []},
           {obj: '1@111111', action: 'del', key: '2@111111', insert: false, pred: ['2@111111']}

--- a/test/columnar_test.js
+++ b/test/columnar_test.js
@@ -1,7 +1,6 @@
 const assert = require('assert')
 const { checkEncoded } = require('./helpers')
 const { DOC_OPS_COLUMNS, encodeChange, decodeChange, BackendDoc } = require('../backend/columnar')
-const { ROOT_ID } = require('../src/common')
 const uuid = require('../src/uuid')
 
 function checkColumns(actualCols, expectedCols) {
@@ -20,7 +19,7 @@ function hash(change) {
 describe('change encoding', () => {
   it('should encode text edits', () => {
     const change1 = {actor: 'aaaa', seq: 1, startOp: 1, time: 9, message: '', deps: [], ops: [
-      {action: 'makeText', obj: ROOT_ID, key: 'text', insert: false, pred: []},
+      {action: 'makeText', obj: '_root', key: 'text', insert: false, pred: []},
       {action: 'set', obj: '1@aaaa', key: '_head', insert: true, value: 'h', pred: []},
       {action: 'del', obj: '1@aaaa', key: '2@aaaa', insert: false, pred: ['2@aaaa']},
       {action: 'set', obj: '1@aaaa', key: '_head', insert: true, value: 'H', pred: []},
@@ -53,23 +52,23 @@ describe('BackendDoc applying changes', () => {
   it('should overwrite root object properties (1)', () => {
     const actor = uuid()
     const change1 = {actor, seq: 1, startOp: 1, time: 0, deps: [], ops: [
-      {action: 'set', obj: ROOT_ID, key: 'x', value: 3, pred: []},
-      {action: 'set', obj: ROOT_ID, key: 'y', value: 4, pred: []}
+      {action: 'set', obj: '_root', key: 'x', value: 3, pred: []},
+      {action: 'set', obj: '_root', key: 'y', value: 4, pred: []}
     ]}
     const change2 = {actor, seq: 2, startOp: 3, time: 0, deps: [hash(change1)], ops: [
-      {action: 'set', obj: ROOT_ID, key: 'x', value: 5, pred: [`1@${actor}`]}
+      {action: 'set', obj: '_root', key: 'x', value: 5, pred: [`1@${actor}`]}
     ]}
     const backend = new BackendDoc()
     assert.deepStrictEqual(backend.applyChanges([encodeChange(change1)]), {
       maxOp: 2, clock: {[actor]: 1}, deps: [hash(change1)],
-      diffs: {objectId: ROOT_ID, type: 'map', props: {
+      diffs: {objectId: '_root', type: 'map', props: {
         x: {[`1@${actor}`]: {value: 3}},
         y: {[`2@${actor}`]: {value: 4}}
       }}
     })
     assert.deepStrictEqual(backend.applyChanges([encodeChange(change2)]), {
       maxOp: 3, clock: {[actor]: 2}, deps: [hash(change2)],
-      diffs: {objectId: ROOT_ID, type: 'map', props: {
+      diffs: {objectId: '_root', type: 'map', props: {
         x: {[`3@${actor}`]: {value: 5}}
       }}
     })
@@ -94,24 +93,24 @@ describe('BackendDoc applying changes', () => {
   it('should overwrite root object properties (2)', () => {
     const actor = uuid()
     const change1 = {actor, seq: 1, startOp: 1, time: 0, deps: [], ops: [
-      {action: 'set', obj: ROOT_ID, key: 'x', value: 3, pred: []},
-      {action: 'set', obj: ROOT_ID, key: 'y', value: 4, pred: []}
+      {action: 'set', obj: '_root', key: 'x', value: 3, pred: []},
+      {action: 'set', obj: '_root', key: 'y', value: 4, pred: []}
     ]}
     const change2 = {actor, seq: 2, startOp: 3, time: 0, deps: [hash(change1)], ops: [
-      {action: 'set', obj: ROOT_ID, key: 'y', value: 5, pred: [`2@${actor}`]},
-      {action: 'set', obj: ROOT_ID, key: 'z', value: 6, pred: []}
+      {action: 'set', obj: '_root', key: 'y', value: 5, pred: [`2@${actor}`]},
+      {action: 'set', obj: '_root', key: 'z', value: 6, pred: []}
     ]}
     const backend = new BackendDoc()
     assert.deepStrictEqual(backend.applyChanges([encodeChange(change1)]), {
       maxOp: 2, clock: {[actor]: 1}, deps: [hash(change1)],
-      diffs: {objectId: ROOT_ID, type: 'map', props: {
+      diffs: {objectId: '_root', type: 'map', props: {
         x: {[`1@${actor}`]: {value: 3}},
         y: {[`2@${actor}`]: {value: 4}}
       }}
     })
     assert.deepStrictEqual(backend.applyChanges([encodeChange(change2)]), {
       maxOp: 4, clock: {[actor]: 2}, deps: [hash(change2)],
-      diffs: {objectId: ROOT_ID, type: 'map', props: {
+      diffs: {objectId: '_root', type: 'map', props: {
         y: {[`3@${actor}`]: {value: 5}},
         z: {[`4@${actor}`]: {value: 6}}
       }}
@@ -137,52 +136,52 @@ describe('BackendDoc applying changes', () => {
   it('should allow concurrent overwrites of the same value', () => {
     const actor1 = '01234567', actor2 = '89abcdef', actor3 = 'fedcba98'
     const change1 = {actor: actor1, seq: 1, startOp: 1, time: 0, deps: [], ops: [
-      {action: 'set', obj: ROOT_ID, key: 'x', value: 1, pred: []}
+      {action: 'set', obj: '_root', key: 'x', value: 1, pred: []}
     ]}
     const change2 = {actor: actor1, seq: 2, startOp: 2, time: 0, deps: [hash(change1)], ops: [
-      {action: 'set', obj: ROOT_ID, key: 'x', value: 2, pred: [`1@${actor1}`]}
+      {action: 'set', obj: '_root', key: 'x', value: 2, pred: [`1@${actor1}`]}
     ]}
     const change3 = {actor: actor2, seq: 1, startOp: 2, time: 0, deps: [hash(change1)], ops: [
-      {action: 'set', obj: ROOT_ID, key: 'x', value: 3, pred: [`1@${actor1}`]}
+      {action: 'set', obj: '_root', key: 'x', value: 3, pred: [`1@${actor1}`]}
     ]}
     const change4 = {actor: actor3, seq: 1, startOp: 2, time: 0, deps: [hash(change1)], ops: [
-      {action: 'set', obj: ROOT_ID, key: 'x', value: 4, pred: [`1@${actor1}`]}
+      {action: 'set', obj: '_root', key: 'x', value: 4, pred: [`1@${actor1}`]}
     ]}
     const backend1 = new BackendDoc(), backend2 = new BackendDoc()
     backend1.applyChanges([encodeChange(change1)])
     assert.deepStrictEqual(backend1.applyChanges([encodeChange(change2)]), {
       maxOp: 2, clock: {[actor1]: 2}, deps: [hash(change2)],
-      diffs: {objectId: ROOT_ID, type: 'map', props: {x: {[`2@${actor1}`]: {value: 2}}}}
+      diffs: {objectId: '_root', type: 'map', props: {x: {[`2@${actor1}`]: {value: 2}}}}
     })
     assert.deepStrictEqual(backend1.applyChanges([encodeChange(change3)]), {
       maxOp: 2, clock: {[actor1]: 2, [actor2]: 1}, deps: [hash(change2), hash(change3)].sort(),
-      diffs: {objectId: ROOT_ID, type: 'map', props: {
+      diffs: {objectId: '_root', type: 'map', props: {
         x: {[`2@${actor1}`]: {value: 2}, [`2@${actor2}`]: {value: 3}}
       }}
     })
     assert.deepStrictEqual(backend1.applyChanges([encodeChange(change4)]), {
       maxOp: 2, clock: {[actor1]: 2, [actor2]: 1, [actor3]: 1},
       deps: [hash(change2), hash(change3), hash(change4)].sort(),
-      diffs: {objectId: ROOT_ID, type: 'map', props: {
+      diffs: {objectId: '_root', type: 'map', props: {
         x: {[`2@${actor1}`]: {value: 2}, [`2@${actor2}`]: {value: 3}, [`2@${actor3}`]: {value: 4}}
       }}
     })
     backend2.applyChanges([encodeChange(change1)])
     assert.deepStrictEqual(backend2.applyChanges([encodeChange(change4)]), {
       maxOp: 2, clock: {[actor1]: 1, [actor3]: 1}, deps: [hash(change4)],
-      diffs: {objectId: ROOT_ID, type: 'map', props: {x: {[`2@${actor3}`]: {value: 4}}}}
+      diffs: {objectId: '_root', type: 'map', props: {x: {[`2@${actor3}`]: {value: 4}}}}
     })
     assert.deepStrictEqual(backend2.applyChanges([encodeChange(change3)]), {
       maxOp: 2, clock: {[actor1]: 1, [actor2]: 1, [actor3]: 1},
       deps: [hash(change3), hash(change4)].sort(),
-      diffs: {objectId: ROOT_ID, type: 'map', props: {
+      diffs: {objectId: '_root', type: 'map', props: {
         x: {[`2@${actor2}`]: {value: 3}, [`2@${actor3}`]: {value: 4}}
       }}
     })
     assert.deepStrictEqual(backend2.applyChanges([encodeChange(change2)]), {
       maxOp: 2, clock: {[actor1]: 2, [actor2]: 1, [actor3]: 1},
       deps: [hash(change2), hash(change3), hash(change4)].sort(),
-      diffs: {objectId: ROOT_ID, type: 'map', props: {
+      diffs: {objectId: '_root', type: 'map', props: {
         x: {[`2@${actor1}`]: {value: 2}, [`2@${actor2}`]: {value: 3}, [`2@${actor3}`]: {value: 4}}
       }}
     })
@@ -224,28 +223,28 @@ describe('BackendDoc applying changes', () => {
   it('should allow a conflict to be resolved', () => {
     const actor1 = '01234567', actor2 = '89abcdef'
     const change1 = {actor: actor1, seq: 1, startOp: 1, time: 0, deps: [], ops: [
-      {action: 'set', obj: ROOT_ID, key: 'x', value: 1, pred: []}
+      {action: 'set', obj: '_root', key: 'x', value: 1, pred: []}
     ]}
     const change2 = {actor: actor2, seq: 1, startOp: 1, time: 0, deps: [], ops: [
-      {action: 'set', obj: ROOT_ID, key: 'x', value: 2, pred: []}
+      {action: 'set', obj: '_root', key: 'x', value: 2, pred: []}
     ]}
     const change3 = {actor: actor1, seq: 2, startOp: 2, time: 0, deps: [hash(change1), hash(change2)], ops: [
-      {action: 'set', obj: ROOT_ID, key: 'x', value: 3, pred: [`1@${actor1}`, `1@${actor2}`]}
+      {action: 'set', obj: '_root', key: 'x', value: 3, pred: [`1@${actor1}`, `1@${actor2}`]}
     ]}
     const backend = new BackendDoc()
     assert.deepStrictEqual(backend.applyChanges([encodeChange(change1)]), {
       maxOp: 1, clock: {[actor1]: 1}, deps: [hash(change1)],
-      diffs: {objectId: ROOT_ID, type: 'map', props: {x: {[`1@${actor1}`]: {value: 1}}}}
+      diffs: {objectId: '_root', type: 'map', props: {x: {[`1@${actor1}`]: {value: 1}}}}
     })
     assert.deepStrictEqual(backend.applyChanges([encodeChange(change2)]), {
       maxOp: 1, clock: {[actor1]: 1, [actor2]: 1}, deps: [hash(change1), hash(change2)].sort(),
-      diffs: {objectId: ROOT_ID, type: 'map', props: {
+      diffs: {objectId: '_root', type: 'map', props: {
         x: {[`1@${actor1}`]: {value: 1}, [`1@${actor2}`]: {value: 2}}
       }}
     })
     assert.deepStrictEqual(backend.applyChanges([encodeChange(change3)]), {
       maxOp: 2, clock: {[actor1]: 2, [actor2]: 1}, deps: [hash(change3)],
-      diffs: {objectId: ROOT_ID, type: 'map', props: {x: {[`2@${actor1}`]: {value: 3}}}}
+      diffs: {objectId: '_root', type: 'map', props: {x: {[`2@${actor1}`]: {value: 3}}}}
     })
     checkColumns(backend.docColumns, {
       objActor: [],
@@ -268,11 +267,11 @@ describe('BackendDoc applying changes', () => {
   it('should throw an error if the predecessor operation does not exist (1)', () => {
     const actor = uuid()
     const change1 = {actor, seq: 1, startOp: 1, time: 0, deps: [], ops: [
-      {action: 'set', obj: ROOT_ID, key: 'x', value: 1, pred: []},
-      {action: 'set', obj: ROOT_ID, key: 'y', value: 2, pred: []}
+      {action: 'set', obj: '_root', key: 'x', value: 1, pred: []},
+      {action: 'set', obj: '_root', key: 'y', value: 2, pred: []}
     ]}
     const change2 = {actor, seq: 2, startOp: 3, time: 0, deps: [hash(change1)], ops: [
-      {action: 'set', obj: ROOT_ID, key: 'x', value: 3, pred: [`2@${actor}`]}
+      {action: 'set', obj: '_root', key: 'x', value: 3, pred: [`2@${actor}`]}
     ]}
     const backend = new BackendDoc()
     backend.applyChanges([encodeChange(change1)])
@@ -282,14 +281,14 @@ describe('BackendDoc applying changes', () => {
   it('should throw an error if the predecessor operation does not exist (2)', () => {
     const actor1 = '01234567', actor2 = '89abcdef'
     const change1 = {actor: actor1, seq: 1, startOp: 1, time: 0, deps: [], ops: [
-      {action: 'set', obj: ROOT_ID, key: 'x', value: 1, pred: []}
+      {action: 'set', obj: '_root', key: 'x', value: 1, pred: []}
     ]}
     const change2 = {actor: actor2, seq: 1, startOp: 1, time: 0, deps: [], ops: [
-      {action: 'set', obj: ROOT_ID, key: 'w', value: 2, pred: []},
-      {action: 'set', obj: ROOT_ID, key: 'x', value: 2, pred: []}
+      {action: 'set', obj: '_root', key: 'w', value: 2, pred: []},
+      {action: 'set', obj: '_root', key: 'x', value: 2, pred: []}
     ]}
     const change3 = {actor: actor1, seq: 2, startOp: 2, time: 0, deps: [hash(change1), hash(change2)], ops: [
-      {action: 'set', obj: ROOT_ID, key: 'x', value: 3, pred: [`1@${actor2}`]}
+      {action: 'set', obj: '_root', key: 'x', value: 3, pred: [`1@${actor2}`]}
     ]}
     const backend = new BackendDoc()
     backend.applyChanges([encodeChange(change1)])
@@ -300,7 +299,7 @@ describe('BackendDoc applying changes', () => {
   it('should create and update nested maps', () => {
     const actor = uuid()
     const change1 = {actor, seq: 1, startOp: 1, time: 0, deps: [], ops: [
-      {action: 'makeMap', obj: ROOT_ID,      key: 'map',             pred: []},
+      {action: 'makeMap', obj: '_root',      key: 'map',             pred: []},
       {action: 'set',     obj: `1@${actor}`, key: 'x',   value: 'a', pred: []},
       {action: 'set',     obj: `1@${actor}`, key: 'y',   value: 'b', pred: []},
       {action: 'set',     obj: `1@${actor}`, key: 'z',   value: 'c', pred: []}
@@ -311,7 +310,7 @@ describe('BackendDoc applying changes', () => {
     const backend = new BackendDoc()
     assert.deepStrictEqual(backend.applyChanges([encodeChange(change1)]), {
       maxOp: 4, clock: {[actor]: 1}, deps: [hash(change1)],
-      diffs: {objectId: ROOT_ID, type: 'map', props: {map: {[`1@${actor}`]: {
+      diffs: {objectId: '_root', type: 'map', props: {map: {[`1@${actor}`]: {
         objectId: `1@${actor}`, type: 'map', props: {
           x: {[`2@${actor}`]: {value: 'a'}},
           y: {[`3@${actor}`]: {value: 'b'}},
@@ -321,7 +320,7 @@ describe('BackendDoc applying changes', () => {
     })
     assert.deepStrictEqual(backend.applyChanges([encodeChange(change2)]), {
       maxOp: 5, clock: {[actor]: 2}, deps: [hash(change2)],
-      diffs: {objectId: ROOT_ID, type: 'map', props: {map: {[`1@${actor}`]: {
+      diffs: {objectId: '_root', type: 'map', props: {map: {[`1@${actor}`]: {
         objectId: `1@${actor}`, type: 'map', props: {y: {[`5@${actor}`]: {value: 'B'}}}
       }}}}
     })
@@ -346,7 +345,7 @@ describe('BackendDoc applying changes', () => {
   it('should create nested maps several levels deep', () => {
     const actor = uuid()
     const change1 = {actor, seq: 1, startOp: 1, time: 0, deps: [], ops: [
-      {action: 'makeMap', obj: ROOT_ID,      key: 'a',           pred: []},
+      {action: 'makeMap', obj: '_root',      key: 'a',           pred: []},
       {action: 'makeMap', obj: `1@${actor}`, key: 'b',           pred: []},
       {action: 'makeMap', obj: `2@${actor}`, key: 'c',           pred: []},
       {action: 'set',     obj: `3@${actor}`, key: 'd', value: 1, pred: []}
@@ -357,7 +356,7 @@ describe('BackendDoc applying changes', () => {
     const backend = new BackendDoc()
     assert.deepStrictEqual(backend.applyChanges([encodeChange(change1)]), {
       maxOp: 4, clock: {[actor]: 1}, deps: [hash(change1)],
-      diffs: {objectId: ROOT_ID, type: 'map', props: {a: {[`1@${actor}`]: {
+      diffs: {objectId: '_root', type: 'map', props: {a: {[`1@${actor}`]: {
         objectId: `1@${actor}`, type: 'map', props: {b: {[`2@${actor}`]: {
           objectId: `2@${actor}`, type: 'map', props: {c: {[`3@${actor}`]: {
             objectId: `3@${actor}`, type: 'map', props: {d: {[`4@${actor}`]: {value: 1}}}
@@ -367,7 +366,7 @@ describe('BackendDoc applying changes', () => {
     })
     assert.deepStrictEqual(backend.applyChanges([encodeChange(change2)]), {
       maxOp: 5, clock: {[actor]: 2}, deps: [hash(change2)],
-      diffs: {objectId: ROOT_ID, type: 'map', props: {a: {[`1@${actor}`]: {
+      diffs: {objectId: '_root', type: 'map', props: {a: {[`1@${actor}`]: {
         objectId: `1@${actor}`, type: 'map', props: {b: {[`2@${actor}`]: {
           objectId: `2@${actor}`, type: 'map', props: {c: {[`3@${actor}`]: {
             objectId: `3@${actor}`, type: 'map', props: {d: {[`5@${actor}`]: {value: 2}}}
@@ -396,13 +395,13 @@ describe('BackendDoc applying changes', () => {
   it('should create a text object', () => {
     const actor = uuid()
     const change1 = {actor, seq: 1, startOp: 1, time: 0, deps: [], ops: [
-      {action: 'makeText', obj: ROOT_ID,      key: 'text',  insert: false,             pred: []},
+      {action: 'makeText', obj: '_root',      key: 'text',  insert: false,             pred: []},
       {action: 'set',      obj: `1@${actor}`, key: '_head', insert: true,  value: 'a', pred: []}
     ]}
     const backend = new BackendDoc()
     assert.deepStrictEqual(backend.applyChanges([encodeChange(change1)]), {
       maxOp: 2, clock: {[actor]: 1}, deps: [hash(change1)],
-      diffs: {objectId: ROOT_ID, type: 'map', props: {text: {[`1@${actor}`]: {
+      diffs: {objectId: '_root', type: 'map', props: {text: {[`1@${actor}`]: {
         objectId: `1@${actor}`, type: 'text',
         edits: [{action: 'insert', index: 0, elemId: `2@${actor}`}],
         props: {0: {[`2@${actor}`]: {value: 'a'}}}
@@ -427,7 +426,7 @@ describe('BackendDoc applying changes', () => {
   it('should insert text characters', () => {
     const actor = uuid()
     const change1 = {actor, seq: 1, startOp: 1, time: 0, deps: [], ops: [
-      {action: 'makeText', obj: ROOT_ID,      key: 'text',       insert: false,             pred: []},
+      {action: 'makeText', obj: '_root',      key: 'text',       insert: false,             pred: []},
       {action: 'set',      obj: `1@${actor}`, key: '_head',      insert: true,  value: 'a', pred: []},
       {action: 'set',      obj: `1@${actor}`, key: `2@${actor}`, insert: true,  value: 'b', pred: []}
     ]}
@@ -438,7 +437,7 @@ describe('BackendDoc applying changes', () => {
     const backend = new BackendDoc()
     assert.deepStrictEqual(backend.applyChanges([encodeChange(change1)]), {
       maxOp: 3, clock: {[actor]: 1}, deps: [hash(change1)],
-      diffs: {objectId: ROOT_ID, type: 'map', props: {text: {[`1@${actor}`]: {
+      diffs: {objectId: '_root', type: 'map', props: {text: {[`1@${actor}`]: {
         objectId: `1@${actor}`, type: 'text', edits: [
           {action: 'insert', index: 0, elemId: `2@${actor}`},
           {action: 'insert', index: 1, elemId: `3@${actor}`}
@@ -448,7 +447,7 @@ describe('BackendDoc applying changes', () => {
     })
     assert.deepStrictEqual(backend.applyChanges([encodeChange(change2)]), {
       maxOp: 5, clock: {[actor]: 2}, deps: [hash(change2)],
-      diffs: {objectId: ROOT_ID, type: 'map', props: {text: {[`1@${actor}`]: {
+      diffs: {objectId: '_root', type: 'map', props: {text: {[`1@${actor}`]: {
         objectId: `1@${actor}`, type: 'text', edits: [
           {action: 'insert', index: 2, elemId: `4@${actor}`},
           {action: 'insert', index: 3, elemId: `5@${actor}`}
@@ -475,10 +474,10 @@ describe('BackendDoc applying changes', () => {
   it('should throw an error if the reference element of an insertion does not exist', () => {
     const actor = uuid()
     const change1 = {actor, seq: 1, startOp: 1, time: 0, deps: [], ops: [
-      {action: 'makeText', obj: ROOT_ID,      key: 'text',       insert: false,             pred: []},
+      {action: 'makeText', obj: '_root',      key: 'text',       insert: false,             pred: []},
       {action: 'set',      obj: `1@${actor}`, key: '_head',      insert: true,  value: 'a', pred: []},
       {action: 'set',      obj: `1@${actor}`, key: `2@${actor}`, insert: true,  value: 'b', pred: []},
-      {action: 'makeMap',  obj: ROOT_ID,      key: 'map',        insert: false,             pred: []},
+      {action: 'makeMap',  obj: '_root',      key: 'map',        insert: false,             pred: []},
       {action: 'set',      obj: `4@${actor}`, key: 'foo',        insert: false, value: 'c', pred: []}
     ]}
     const change2 = {actor, seq: 2, startOp: 6, time: 0, deps: [], ops: [
@@ -487,7 +486,7 @@ describe('BackendDoc applying changes', () => {
     const backend = new BackendDoc()
     assert.deepStrictEqual(backend.applyChanges([encodeChange(change1)]), {
       maxOp: 5, clock: {[actor]: 1}, deps: [hash(change1)],
-      diffs: {objectId: ROOT_ID, type: 'map', props: {
+      diffs: {objectId: '_root', type: 'map', props: {
         text: {[`1@${actor}`]: {
           objectId: `1@${actor}`, type: 'text', edits: [
             {action: 'insert', index: 0, elemId: `2@${actor}`},
@@ -506,7 +505,7 @@ describe('BackendDoc applying changes', () => {
   it('should handle non-consecutive insertions', () => {
     const actor = uuid()
     const change1 = {actor, seq: 1, startOp: 1, time: 0, deps: [], ops: [
-      {action: 'makeText', obj: ROOT_ID,      key: 'text',       insert: false,             pred: []},
+      {action: 'makeText', obj: '_root',      key: 'text',       insert: false,             pred: []},
       {action: 'set',      obj: `1@${actor}`, key: '_head',      insert: true,  value: 'a', pred: []},
       {action: 'set',      obj: `1@${actor}`, key: `2@${actor}`, insert: true,  value: 'c', pred: []}
     ]}
@@ -517,7 +516,7 @@ describe('BackendDoc applying changes', () => {
     const backend = new BackendDoc()
     assert.deepStrictEqual(backend.applyChanges([encodeChange(change1)]), {
       maxOp: 3, clock: {[actor]: 1}, deps: [hash(change1)],
-      diffs: {objectId: ROOT_ID, type: 'map', props: {text: {[`1@${actor}`]: {
+      diffs: {objectId: '_root', type: 'map', props: {text: {[`1@${actor}`]: {
         objectId: `1@${actor}`, type: 'text', edits: [
           {action: 'insert', index: 0, elemId: `2@${actor}`},
           {action: 'insert', index: 1, elemId: `3@${actor}`}
@@ -527,7 +526,7 @@ describe('BackendDoc applying changes', () => {
     })
     assert.deepStrictEqual(backend.applyChanges([encodeChange(change2)]), {
       maxOp: 5, clock: {[actor]: 2}, deps: [hash(change2)],
-      diffs: {objectId: ROOT_ID, type: 'map', props: {text: {[`1@${actor}`]: {
+      diffs: {objectId: '_root', type: 'map', props: {text: {[`1@${actor}`]: {
         objectId: `1@${actor}`, type: 'text', edits: [
           {action: 'insert', index: 1, elemId: `4@${actor}`},
           {action: 'insert', index: 3, elemId: `5@${actor}`}
@@ -554,7 +553,7 @@ describe('BackendDoc applying changes', () => {
   it('should throw an error if insertions are not in ascending order', () => {
     const actor = uuid()
     const change1 = {actor, seq: 1, startOp: 1, time: 0, deps: [], ops: [
-      {action: 'makeText', obj: ROOT_ID,      key: 'text',       insert: false,             pred: []},
+      {action: 'makeText', obj: '_root',      key: 'text',       insert: false,             pred: []},
       {action: 'set',      obj: `1@${actor}`, key: '_head',      insert: true,  value: 'A', pred: []},
       {action: 'set',      obj: `1@${actor}`, key: `2@${actor}`, insert: true,  value: 'C', pred: []}
     ]}
@@ -570,7 +569,7 @@ describe('BackendDoc applying changes', () => {
   it('should delete the first character', () => {
     const actor = uuid()
     const change1 = {actor, seq: 1, startOp: 1, time: 0, deps: [], ops: [
-      {action: 'makeText', obj: ROOT_ID,      key: 'text',  insert: false,             pred: []},
+      {action: 'makeText', obj: '_root',      key: 'text',  insert: false,             pred: []},
       {action: 'set',      obj: `1@${actor}`, key: '_head', insert: true,  value: 'a', pred: []}
     ]}
     const change2 = {actor, seq: 2, startOp: 3, time: 0, deps: [hash(change1)], ops: [
@@ -579,7 +578,7 @@ describe('BackendDoc applying changes', () => {
     const backend = new BackendDoc()
     assert.deepStrictEqual(backend.applyChanges([encodeChange(change1)]), {
       maxOp: 2, clock: {[actor]: 1}, deps: [hash(change1)],
-      diffs: {objectId: ROOT_ID, type: 'map', props: {text: {[`1@${actor}`]: {
+      diffs: {objectId: '_root', type: 'map', props: {text: {[`1@${actor}`]: {
         objectId: `1@${actor}`, type: 'text',
         edits: [{action: 'insert', index: 0, elemId: `2@${actor}`}],
         props: {0: {[`2@${actor}`]: {value: 'a'}}}
@@ -587,7 +586,7 @@ describe('BackendDoc applying changes', () => {
     })
     assert.deepStrictEqual(backend.applyChanges([encodeChange(change2)]), {
       maxOp: 3, clock: {[actor]: 2}, deps: [hash(change2)],
-      diffs: {objectId: ROOT_ID, type: 'map', props: {text: {[`1@${actor}`]: {
+      diffs: {objectId: '_root', type: 'map', props: {text: {[`1@${actor}`]: {
         objectId: `1@${actor}`, type: 'text', edits: [{action: 'remove', index: 0}], props: {}
       }}}}
     })
@@ -612,7 +611,7 @@ describe('BackendDoc applying changes', () => {
   it('should delete a character in the middle', () => {
     const actor = uuid()
     const change1 = {actor, seq: 1, startOp: 1, time: 0, deps: [], ops: [
-      {action: 'makeText', obj: ROOT_ID,      key: 'text',       insert: false,             pred: []},
+      {action: 'makeText', obj: '_root',      key: 'text',       insert: false,             pred: []},
       {action: 'set',      obj: `1@${actor}`, key: '_head',      insert: true,  value: 'a', pred: []},
       {action: 'set',      obj: `1@${actor}`, key: `2@${actor}`, insert: true,  value: 'b', pred: []},
       {action: 'set',      obj: `1@${actor}`, key: `3@${actor}`, insert: true,  value: 'c', pred: []}
@@ -623,7 +622,7 @@ describe('BackendDoc applying changes', () => {
     const backend = new BackendDoc()
     assert.deepStrictEqual(backend.applyChanges([encodeChange(change1)]), {
       maxOp: 4, clock: {[actor]: 1}, deps: [hash(change1)],
-      diffs: {objectId: ROOT_ID, type: 'map', props: {text: {[`1@${actor}`]: {
+      diffs: {objectId: '_root', type: 'map', props: {text: {[`1@${actor}`]: {
         objectId: `1@${actor}`, type: 'text', edits: [
           {action: 'insert', index: 0, elemId: `2@${actor}`},
           {action: 'insert', index: 1, elemId: `3@${actor}`},
@@ -638,7 +637,7 @@ describe('BackendDoc applying changes', () => {
     })
     assert.deepStrictEqual(backend.applyChanges([encodeChange(change2)]), {
       maxOp: 5, clock: {[actor]: 2}, deps: [hash(change2)],
-      diffs: {objectId: ROOT_ID, type: 'map', props: {text: {[`1@${actor}`]: {
+      diffs: {objectId: '_root', type: 'map', props: {text: {[`1@${actor}`]: {
         objectId: `1@${actor}`, type: 'text', edits: [{action: 'remove', index: 1}], props: {}
       }}}}
     })
@@ -663,7 +662,7 @@ describe('BackendDoc applying changes', () => {
   it('should throw an error if a deleted element does not exist', () => {
     const actor = uuid()
     const change1 = {actor, seq: 1, startOp: 1, time: 0, deps: [], ops: [
-      {action: 'makeText', obj: ROOT_ID,      key: 'text',       insert: false,             pred: []},
+      {action: 'makeText', obj: '_root',      key: 'text',       insert: false,             pred: []},
       {action: 'set',      obj: `1@${actor}`, key: '_head',      insert: true,  value: 'a', pred: []},
       {action: 'set',      obj: `1@${actor}`, key: `2@${actor}`, insert: true,  value: 'b', pred: []}
     ]}
@@ -678,7 +677,7 @@ describe('BackendDoc applying changes', () => {
   it('should apply concurrent insertions at the same position', () => {
     const actor1 = '01234567', actor2 = '89abcdef'
     const change1 = {actor: actor1, seq: 1, startOp: 1, time: 0, deps: [], ops: [
-      {action: 'makeText', obj: ROOT_ID,       key: 'text',        insert: false,             pred: []},
+      {action: 'makeText', obj: '_root',       key: 'text',        insert: false,             pred: []},
       {action: 'set',      obj: `1@${actor1}`, key: '_head',       insert: true,  value: 'a', pred: []}
     ]}
     const change2 = {actor: actor1, seq: 2, startOp: 3, time: 0, deps: [hash(change1)], ops: [
@@ -690,7 +689,7 @@ describe('BackendDoc applying changes', () => {
     const backend1 = new BackendDoc(), backend2 = new BackendDoc()
     assert.deepStrictEqual(backend1.applyChanges([encodeChange(change1)]), {
       maxOp: 2, clock: {[actor1]: 1}, deps: [hash(change1)],
-      diffs: {objectId: ROOT_ID, type: 'map', props: {text: {[`1@${actor1}`]: {
+      diffs: {objectId: '_root', type: 'map', props: {text: {[`1@${actor1}`]: {
         objectId: `1@${actor1}`, type: 'text',
         edits: [{action: 'insert', index: 0, elemId: `2@${actor1}`}],
         props: {0: {[`2@${actor1}`]: {value: 'a'}}}
@@ -698,7 +697,7 @@ describe('BackendDoc applying changes', () => {
     })
     assert.deepStrictEqual(backend1.applyChanges([encodeChange(change2)]), {
       maxOp: 3, clock: {[actor1]: 2}, deps: [hash(change2)],
-      diffs: {objectId: ROOT_ID, type: 'map', props: {text: {[`1@${actor1}`]: {
+      diffs: {objectId: '_root', type: 'map', props: {text: {[`1@${actor1}`]: {
         objectId: `1@${actor1}`, type: 'text',
         edits: [{action: 'insert', index: 1, elemId: `3@${actor1}`}],
         props: {1: {[`3@${actor1}`]: {value: 'c'}}}
@@ -706,7 +705,7 @@ describe('BackendDoc applying changes', () => {
     })
     assert.deepStrictEqual(backend1.applyChanges([encodeChange(change3)]), {
       maxOp: 3, clock: {[actor1]: 2, [actor2]: 1}, deps: [hash(change2), hash(change3)].sort(),
-      diffs: {objectId: ROOT_ID, type: 'map', props: {text: {[`1@${actor1}`]: {
+      diffs: {objectId: '_root', type: 'map', props: {text: {[`1@${actor1}`]: {
         objectId: `1@${actor1}`, type: 'text',
         edits: [{action: 'insert', index: 1, elemId: `3@${actor2}`}],
         props: {1: {[`3@${actor2}`]: {value: 'b'}}}
@@ -714,7 +713,7 @@ describe('BackendDoc applying changes', () => {
     })
     assert.deepStrictEqual(backend2.applyChanges([encodeChange(change1)]), {
       maxOp: 2, clock: {[actor1]: 1}, deps: [hash(change1)],
-      diffs: {objectId: ROOT_ID, type: 'map', props: {text: {[`1@${actor1}`]: {
+      diffs: {objectId: '_root', type: 'map', props: {text: {[`1@${actor1}`]: {
         objectId: `1@${actor1}`, type: 'text',
         edits: [{action: 'insert', index: 0, elemId: `2@${actor1}`}],
         props: {0: {[`2@${actor1}`]: {value: 'a'}}}
@@ -722,7 +721,7 @@ describe('BackendDoc applying changes', () => {
     })
     assert.deepStrictEqual(backend2.applyChanges([encodeChange(change3)]), {
       maxOp: 3, clock: {[actor1]: 1, [actor2]: 1}, deps: [hash(change3)],
-      diffs: {objectId: ROOT_ID, type: 'map', props: {text: {[`1@${actor1}`]: {
+      diffs: {objectId: '_root', type: 'map', props: {text: {[`1@${actor1}`]: {
         objectId: `1@${actor1}`, type: 'text',
         edits: [{action: 'insert', index: 1, elemId: `3@${actor2}`}],
         props: {1: {[`3@${actor2}`]: {value: 'b'}}}
@@ -730,7 +729,7 @@ describe('BackendDoc applying changes', () => {
     })
     assert.deepStrictEqual(backend2.applyChanges([encodeChange(change2)]), {
       maxOp: 3, clock: {[actor1]: 2, [actor2]: 1}, deps: [hash(change2), hash(change3)].sort(),
-      diffs: {objectId: ROOT_ID, type: 'map', props: {text: {[`1@${actor1}`]: {
+      diffs: {objectId: '_root', type: 'map', props: {text: {[`1@${actor1}`]: {
         objectId: `1@${actor1}`, type: 'text',
         edits: [{action: 'insert', index: 2, elemId: `3@${actor1}`}],
         props: {2: {[`3@${actor1}`]: {value: 'c'}}}
@@ -757,7 +756,7 @@ describe('BackendDoc applying changes', () => {
   it('should apply concurrent insertions at the head', () => {
     const actor1 = '01234567', actor2 = '89abcdef'
     const change1 = {actor: actor1, seq: 1, startOp: 1, time: 0, deps: [], ops: [
-      {action: 'makeText', obj: ROOT_ID,       key: 'text',        insert: false,             pred: []},
+      {action: 'makeText', obj: '_root',       key: 'text',        insert: false,             pred: []},
       {action: 'set',      obj: `1@${actor1}`, key: '_head',       insert: true,  value: 'd', pred: []}
     ]}
     const change2 = {actor: actor1, seq: 2, startOp: 3, time: 0, deps: [hash(change1)], ops: [
@@ -770,7 +769,7 @@ describe('BackendDoc applying changes', () => {
     const backend1 = new BackendDoc(), backend2 = new BackendDoc()
     assert.deepStrictEqual(backend1.applyChanges([encodeChange(change1)]), {
       maxOp: 2, clock: {[actor1]: 1}, deps: [hash(change1)],
-      diffs: {objectId: ROOT_ID, type: 'map', props: {text: {[`1@${actor1}`]: {
+      diffs: {objectId: '_root', type: 'map', props: {text: {[`1@${actor1}`]: {
         objectId: `1@${actor1}`, type: 'text',
         edits: [{action: 'insert', index: 0, elemId: `2@${actor1}`}],
         props: {0: {[`2@${actor1}`]: {value: 'd'}}}
@@ -778,7 +777,7 @@ describe('BackendDoc applying changes', () => {
     })
     assert.deepStrictEqual(backend1.applyChanges([encodeChange(change2)]), {
       maxOp: 3, clock: {[actor1]: 2}, deps: [hash(change2)],
-      diffs: {objectId: ROOT_ID, type: 'map', props: {text: {[`1@${actor1}`]: {
+      diffs: {objectId: '_root', type: 'map', props: {text: {[`1@${actor1}`]: {
         objectId: `1@${actor1}`, type: 'text',
         edits: [{action: 'insert', index: 0, elemId: `3@${actor1}`}],
         props: {0: {[`3@${actor1}`]: {value: 'c'}}}
@@ -786,7 +785,7 @@ describe('BackendDoc applying changes', () => {
     })
     assert.deepStrictEqual(backend1.applyChanges([encodeChange(change3)]), {
       maxOp: 4, clock: {[actor1]: 2, [actor2]: 1}, deps: [hash(change2), hash(change3)].sort(),
-      diffs: {objectId: ROOT_ID, type: 'map', props: {text: {[`1@${actor1}`]: {
+      diffs: {objectId: '_root', type: 'map', props: {text: {[`1@${actor1}`]: {
         objectId: `1@${actor1}`, type: 'text', edits: [
           {action: 'insert', index: 0, elemId: `3@${actor2}`},
           {action: 'insert', index: 1, elemId: `4@${actor2}`}
@@ -796,7 +795,7 @@ describe('BackendDoc applying changes', () => {
     })
     assert.deepStrictEqual(backend2.applyChanges([encodeChange(change1)]), {
       maxOp: 2, clock: {[actor1]: 1}, deps: [hash(change1)],
-      diffs: {objectId: ROOT_ID, type: 'map', props: {text: {[`1@${actor1}`]: {
+      diffs: {objectId: '_root', type: 'map', props: {text: {[`1@${actor1}`]: {
         objectId: `1@${actor1}`, type: 'text',
         edits: [{action: 'insert', index: 0, elemId: `2@${actor1}`}],
         props: {0: {[`2@${actor1}`]: {value: 'd'}}}
@@ -804,7 +803,7 @@ describe('BackendDoc applying changes', () => {
     })
     assert.deepStrictEqual(backend2.applyChanges([encodeChange(change3)]), {
       maxOp: 4, clock: {[actor1]: 1, [actor2]: 1}, deps: [hash(change3)],
-      diffs: {objectId: ROOT_ID, type: 'map', props: {text: {[`1@${actor1}`]: {
+      diffs: {objectId: '_root', type: 'map', props: {text: {[`1@${actor1}`]: {
         objectId: `1@${actor1}`, type: 'text', edits: [
           {action: 'insert', index: 0, elemId: `3@${actor2}`},
           {action: 'insert', index: 1, elemId: `4@${actor2}`}
@@ -814,7 +813,7 @@ describe('BackendDoc applying changes', () => {
     })
     assert.deepStrictEqual(backend2.applyChanges([encodeChange(change2)]), {
       maxOp: 4, clock: {[actor1]: 2, [actor2]: 1}, deps: [hash(change2), hash(change3)].sort(),
-      diffs: {objectId: ROOT_ID, type: 'map', props: {text: {[`1@${actor1}`]: {
+      diffs: {objectId: '_root', type: 'map', props: {text: {[`1@${actor1}`]: {
         objectId: `1@${actor1}`, type: 'text',
         edits: [{action: 'insert', index: 2, elemId: `3@${actor1}`}],
         props: {2: {[`3@${actor1}`]: {value: 'c'}}}
@@ -841,7 +840,7 @@ describe('BackendDoc applying changes', () => {
   it('should perform multiple list element updates', () => {
     const actor = uuid()
     const change1 = {actor, seq: 1, startOp: 1, time: 0, deps: [], ops: [
-      {action: 'makeText', obj: ROOT_ID,      key: 'text',       insert: false,             pred: []},
+      {action: 'makeText', obj: '_root',      key: 'text',       insert: false,             pred: []},
       {action: 'set',      obj: `1@${actor}`, key: '_head',      insert: true,  value: 'a', pred: []},
       {action: 'set',      obj: `1@${actor}`, key: `2@${actor}`, insert: true,  value: 'b', pred: []},
       {action: 'set',      obj: `1@${actor}`, key: `3@${actor}`, insert: true,  value: 'c', pred: []}
@@ -853,7 +852,7 @@ describe('BackendDoc applying changes', () => {
     const backend = new BackendDoc()
     assert.deepStrictEqual(backend.applyChanges([encodeChange(change1)]), {
       maxOp: 4, clock: {[actor]: 1}, deps: [hash(change1)],
-      diffs: {objectId: ROOT_ID, type: 'map', props: {text: {[`1@${actor}`]: {
+      diffs: {objectId: '_root', type: 'map', props: {text: {[`1@${actor}`]: {
         objectId: `1@${actor}`, type: 'text', edits: [
           {action: 'insert', index: 0, elemId: `2@${actor}`},
           {action: 'insert', index: 1, elemId: `3@${actor}`},
@@ -864,7 +863,7 @@ describe('BackendDoc applying changes', () => {
     })
     assert.deepStrictEqual(backend.applyChanges([encodeChange(change2)]), {
       maxOp: 6, clock: {[actor]: 2}, deps: [hash(change2)],
-      diffs: {objectId: ROOT_ID, type: 'map', props: {text: {[`1@${actor}`]: {
+      diffs: {objectId: '_root', type: 'map', props: {text: {[`1@${actor}`]: {
         objectId: `1@${actor}`, type: 'text', edits: [],
         props: {0: {[`5@${actor}`]: {value: 'A'}}, 2: {[`6@${actor}`]: {value: 'C'}}}
       }}}}
@@ -890,7 +889,7 @@ describe('BackendDoc applying changes', () => {
   it('should require list element updates to be in ascending order', () => {
     const actor = uuid()
     const change1 = {actor, seq: 1, startOp: 1, time: 0, deps: [], ops: [
-      {action: 'makeText', obj: ROOT_ID,      key: 'text',       insert: false,             pred: []},
+      {action: 'makeText', obj: '_root',      key: 'text',       insert: false,             pred: []},
       {action: 'set',      obj: `1@${actor}`, key: '_head',      insert: true,  value: 'a', pred: []},
       {action: 'set',      obj: `1@${actor}`, key: `2@${actor}`, insert: true,  value: 'b', pred: []},
       {action: 'set',      obj: `1@${actor}`, key: `3@${actor}`, insert: true,  value: 'c', pred: []}
@@ -907,7 +906,7 @@ describe('BackendDoc applying changes', () => {
   it('should handle nested objects inside list elements', () => {
     const actor = uuid()
     const change1 = {actor, seq: 1, startOp: 1, time: 0, deps: [], ops: [
-      {action: 'makeList', obj: ROOT_ID,      key: 'list',       insert: false,           pred: []},
+      {action: 'makeList', obj: '_root',      key: 'list',       insert: false,           pred: []},
       {action: 'set',      obj: `1@${actor}`, key: '_head',      insert: true,  value: 1, pred: []},
       {action: 'makeMap',  obj: `1@${actor}`, key: `2@${actor}`, insert: true,            pred: []}
     ]}
@@ -917,7 +916,7 @@ describe('BackendDoc applying changes', () => {
     const backend = new BackendDoc()
     assert.deepStrictEqual(backend.applyChanges([encodeChange(change1)]), {
       maxOp: 3, clock: {[actor]: 1}, deps: [hash(change1)],
-      diffs: {objectId: ROOT_ID, type: 'map', props: {list: {[`1@${actor}`]: {
+      diffs: {objectId: '_root', type: 'map', props: {list: {[`1@${actor}`]: {
         objectId: `1@${actor}`, type: 'list', edits: [
           {action: 'insert', index: 0, elemId: `2@${actor}`},
           {action: 'insert', index: 1, elemId: `3@${actor}`}
@@ -929,7 +928,7 @@ describe('BackendDoc applying changes', () => {
     })
     assert.deepStrictEqual(backend.applyChanges([encodeChange(change2)]), {
       maxOp: 4, clock: {[actor]: 2}, deps: [hash(change2)],
-      diffs: {objectId: ROOT_ID, type: 'map', props: {list: {[`1@${actor}`]: {
+      diffs: {objectId: '_root', type: 'map', props: {list: {[`1@${actor}`]: {
         objectId: `1@${actor}`, type: 'list', props: {1: {[`3@${actor}`]: {
           objectId: `3@${actor}`, type: 'map', props: {x: {[`4@${actor}`]: {value: 2}}}
         }}}
@@ -956,30 +955,30 @@ describe('BackendDoc applying changes', () => {
   it('should handle a counter inside a map', () => {
     const actor = uuid()
     const change1 = {actor, seq: 1, startOp: 1, time: 0, deps: [], ops: [
-      {action: 'set', obj: ROOT_ID, key: 'counter', value: 1, datatype: 'counter', pred: []}
+      {action: 'set', obj: '_root', key: 'counter', value: 1, datatype: 'counter', pred: []}
     ]}
     const change2 = {actor, seq: 2, startOp: 2, time: 0, deps: [hash(change1)], ops: [
-      {action: 'inc', obj: ROOT_ID, key: 'counter', value: 2, pred: [`1@${actor}`]}
+      {action: 'inc', obj: '_root', key: 'counter', value: 2, pred: [`1@${actor}`]}
     ]}
     const change3 = {actor, seq: 3, startOp: 3, time: 0, deps: [hash(change2)], ops: [
-      {action: 'inc', obj: ROOT_ID, key: 'counter', value: 3, pred: [`1@${actor}`]}
+      {action: 'inc', obj: '_root', key: 'counter', value: 3, pred: [`1@${actor}`]}
     ]}
     const backend = new BackendDoc()
     assert.deepStrictEqual(backend.applyChanges([encodeChange(change1)]), {
       maxOp: 1, clock: {[actor]: 1}, deps: [hash(change1)],
-      diffs: {objectId: ROOT_ID, type: 'map', props: {
+      diffs: {objectId: '_root', type: 'map', props: {
         counter: {[`1@${actor}`]: {value: 1, datatype: 'counter'}}
       }}
     })
     assert.deepStrictEqual(backend.applyChanges([encodeChange(change2)]), {
       maxOp: 2, clock: {[actor]: 2}, deps: [hash(change2)],
-      diffs: {objectId: ROOT_ID, type: 'map', props: {
+      diffs: {objectId: '_root', type: 'map', props: {
         counter: {[`1@${actor}`]: {value: 3, datatype: 'counter'}}
       }}
     })
     assert.deepStrictEqual(backend.applyChanges([encodeChange(change3)]), {
       maxOp: 3, clock: {[actor]: 3}, deps: [hash(change3)],
-      diffs: {objectId: ROOT_ID, type: 'map', props: {
+      diffs: {objectId: '_root', type: 'map', props: {
         counter: {[`1@${actor}`]: {value: 6, datatype: 'counter'}}
       }}
     })
@@ -1004,7 +1003,7 @@ describe('BackendDoc applying changes', () => {
   it('should handle a counter inside a list element', () => {
     const actor = uuid()
     const change1 = {actor, seq: 1, startOp: 1, time: 0, deps: [], ops: [
-      {action: 'makeList', obj: ROOT_ID,      key: 'list',       insert: false, pred: []},
+      {action: 'makeList', obj: '_root',      key: 'list',       insert: false, pred: []},
       {action: 'set',      obj: `1@${actor}`, key: '_head',      insert: true,  pred: [], value: 1, datatype: 'counter'}
     ]}
     const change2 = {actor, seq: 2, startOp: 3, time: 0, deps: [hash(change1)], ops: [
@@ -1013,7 +1012,7 @@ describe('BackendDoc applying changes', () => {
     const backend = new BackendDoc()
     assert.deepStrictEqual(backend.applyChanges([encodeChange(change1)]), {
       maxOp: 2, clock: {[actor]: 1}, deps: [hash(change1)],
-      diffs: {objectId: ROOT_ID, type: 'map', props: {list: {[`1@${actor}`]: {
+      diffs: {objectId: '_root', type: 'map', props: {list: {[`1@${actor}`]: {
         objectId: `1@${actor}`, type: 'list',
         edits: [{action: 'insert', index: 0, elemId: `2@${actor}`}],
         props: {0: {[`2@${actor}`]: {value: 1, datatype: 'counter'}}}
@@ -1021,7 +1020,7 @@ describe('BackendDoc applying changes', () => {
     })
     assert.deepStrictEqual(backend.applyChanges([encodeChange(change2)]), {
       maxOp: 3, clock: {[actor]: 2}, deps: [hash(change2)],
-      diffs: {objectId: ROOT_ID, type: 'map', props: {list: {[`1@${actor}`]: {
+      diffs: {objectId: '_root', type: 'map', props: {list: {[`1@${actor}`]: {
         objectId: `1@${actor}`, type: 'list', edits: [],
         props: {0: {[`2@${actor}`]: {value: 3, datatype: 'counter'}}}
       }}}}
@@ -1047,32 +1046,32 @@ describe('BackendDoc applying changes', () => {
   it('should delete a counter from a map', () => {
     const actor = uuid()
     const change1 = {actor, seq: 1, startOp: 1, time: 0, deps: [], ops: [
-      {action: 'set', obj: ROOT_ID, key: 'counter', value: 1, datatype: 'counter', pred: []}
+      {action: 'set', obj: '_root', key: 'counter', value: 1, datatype: 'counter', pred: []}
     ]}
     const change2 = {actor, seq: 2, startOp: 2, time: 0, deps: [hash(change1)], ops: [
-      {action: 'inc', obj: ROOT_ID, key: 'counter', value: 2, pred: [`1@${actor}`]}
+      {action: 'inc', obj: '_root', key: 'counter', value: 2, pred: [`1@${actor}`]}
     ]}
     const change3 = {actor, seq: 3, startOp: 3, time: 0, deps: [hash(change2)], ops: [
-      {action: 'del', obj: ROOT_ID, key: 'counter', pred: [`1@${actor}`]}
+      {action: 'del', obj: '_root', key: 'counter', pred: [`1@${actor}`]}
     ]}
     const backend = new BackendDoc()
     backend.applyChanges([encodeChange(change1)])
     assert.deepStrictEqual(backend.applyChanges([encodeChange(change2)]), {
       maxOp: 2, clock: {[actor]: 2}, deps: [hash(change2)],
-      diffs: {objectId: ROOT_ID, type: 'map', props: {
+      diffs: {objectId: '_root', type: 'map', props: {
         counter: {[`1@${actor}`]: {value: 3, datatype: 'counter'}}
       }}
     })
     assert.deepStrictEqual(backend.applyChanges([encodeChange(change3)]), {
       maxOp: 3, clock: {[actor]: 3}, deps: [hash(change3)],
-      diffs: {objectId: ROOT_ID, type: 'map', props: {counter: {}}}
+      diffs: {objectId: '_root', type: 'map', props: {counter: {}}}
     })
   })
 
   it('should handle conflicts inside list elements', () => {
     const actor1 = '01234567', actor2 = '89abcdef'
     const change1 = {actor: actor1, seq: 1, startOp: 1, time: 0, deps: [], ops: [
-      {action: 'makeList', obj: ROOT_ID,       key: 'list',        insert: false,           pred: []},
+      {action: 'makeList', obj: '_root',       key: 'list',        insert: false,           pred: []},
       {action: 'set',      obj: `1@${actor1}`, key: '_head',       insert: true,  value: 1, pred: []}
     ]}
     const change2 = {actor: actor1, seq: 2, startOp: 3, time: 0, deps: [hash(change1)], ops: [
@@ -1084,7 +1083,7 @@ describe('BackendDoc applying changes', () => {
     const backend1 = new BackendDoc(), backend2 = new BackendDoc()
     assert.deepStrictEqual(backend1.applyChanges([encodeChange(change1)]), {
       maxOp: 2, clock: {[actor1]: 1}, deps: [hash(change1)],
-      diffs: {objectId: ROOT_ID, type: 'map', props: {list: {[`1@${actor1}`]: {
+      diffs: {objectId: '_root', type: 'map', props: {list: {[`1@${actor1}`]: {
         objectId: `1@${actor1}`, type: 'list',
         edits: [{action: 'insert', index: 0, elemId: `2@${actor1}`}],
         props: {0: {[`2@${actor1}`]: {value: 1}}}
@@ -1092,14 +1091,14 @@ describe('BackendDoc applying changes', () => {
     })
     assert.deepStrictEqual(backend1.applyChanges([encodeChange(change2)]), {
       maxOp: 3, clock: {[actor1]: 2}, deps: [hash(change2)],
-      diffs: {objectId: ROOT_ID, type: 'map', props: {list: {[`1@${actor1}`]: {
+      diffs: {objectId: '_root', type: 'map', props: {list: {[`1@${actor1}`]: {
         objectId: `1@${actor1}`, type: 'list', edits: [],
         props: {0: {[`3@${actor1}`]: {value: 2}}}
       }}}}
     })
     assert.deepStrictEqual(backend1.applyChanges([encodeChange(change3)]), {
       maxOp: 3, clock: {[actor1]: 2, [actor2]: 1}, deps: [hash(change2), hash(change3)].sort(),
-      diffs: {objectId: ROOT_ID, type: 'map', props: {list: {[`1@${actor1}`]: {
+      diffs: {objectId: '_root', type: 'map', props: {list: {[`1@${actor1}`]: {
         objectId: `1@${actor1}`, type: 'list', edits: [],
         props: {0: {[`3@${actor1}`]: {value: 2}, [`3@${actor2}`]: {value: 3}}}
       }}}}
@@ -1107,14 +1106,14 @@ describe('BackendDoc applying changes', () => {
     backend2.applyChanges([encodeChange(change1)])
     assert.deepStrictEqual(backend2.applyChanges([encodeChange(change3)]), {
       maxOp: 3, clock: {[actor1]: 1, [actor2]: 1}, deps: [hash(change3)],
-      diffs: {objectId: ROOT_ID, type: 'map', props: {list: {[`1@${actor1}`]: {
+      diffs: {objectId: '_root', type: 'map', props: {list: {[`1@${actor1}`]: {
         objectId: `1@${actor1}`, type: 'list', edits: [],
         props: {0: {[`3@${actor2}`]: {value: 3}}}
       }}}}
     })
     assert.deepStrictEqual(backend2.applyChanges([encodeChange(change2)]), {
       maxOp: 3, clock: {[actor1]: 2, [actor2]: 1}, deps: [hash(change2), hash(change3)].sort(),
-      diffs: {objectId: ROOT_ID, type: 'map', props: {list: {[`1@${actor1}`]: {
+      diffs: {objectId: '_root', type: 'map', props: {list: {[`1@${actor1}`]: {
         objectId: `1@${actor1}`, type: 'list', edits: [],
         props: {0: {[`3@${actor1}`]: {value: 2}, [`3@${actor2}`]: {value: 3}}}
       }}}}
@@ -1142,7 +1141,7 @@ describe('BackendDoc applying changes', () => {
   it('should allow conflicts to be introduced by a single change', () => {
     const actor = uuid()
     const change1 = {actor, seq: 1, startOp: 1, time: 0, deps: [], ops: [
-      {action: 'makeText', obj: ROOT_ID,      key: 'text',       insert: false,             pred: []},
+      {action: 'makeText', obj: '_root',      key: 'text',       insert: false,             pred: []},
       {action: 'set',      obj: `1@${actor}`, key: '_head',      insert: true,  value: 'a', pred: []},
       {action: 'set',      obj: `1@${actor}`, key: `2@${actor}`, insert: true,  value: 'b', pred: []}
     ]}
@@ -1153,7 +1152,7 @@ describe('BackendDoc applying changes', () => {
     const backend = new BackendDoc()
     assert.deepStrictEqual(backend.applyChanges([encodeChange(change1)]), {
       maxOp: 3, clock: {[actor]: 1}, deps: [hash(change1)],
-      diffs: {objectId: ROOT_ID, type: 'map', props: {text: {[`1@${actor}`]: {
+      diffs: {objectId: '_root', type: 'map', props: {text: {[`1@${actor}`]: {
         objectId: `1@${actor}`, type: 'text', edits: [
           {action: 'insert', index: 0, elemId: `2@${actor}`},
           {action: 'insert', index: 1, elemId: `3@${actor}`}
@@ -1163,7 +1162,7 @@ describe('BackendDoc applying changes', () => {
     })
     assert.deepStrictEqual(backend.applyChanges([encodeChange(change2)]), {
       maxOp: 5, clock: {[actor]: 2}, deps: [hash(change2)],
-      diffs: {objectId: ROOT_ID, type: 'map', props: {text: {[`1@${actor}`]: {
+      diffs: {objectId: '_root', type: 'map', props: {text: {[`1@${actor}`]: {
         objectId: `1@${actor}`, type: 'text', edits: [],
         props: {0: {[`4@${actor}`]: {value: 'x'}, [`5@${actor}`]: {value: 'y'}}}
       }}}}
@@ -1189,11 +1188,11 @@ describe('BackendDoc applying changes', () => {
   it('should handle updates inside conflicted properties', () => {
     const actor1 = '01234567', actor2 = '89abcdef'
     const change1 = {actor: actor1, seq: 1, startOp: 1, time: 0, deps: [], ops: [
-      {action: 'makeMap', obj: ROOT_ID,       key: 'map',         pred: []},
+      {action: 'makeMap', obj: '_root',       key: 'map',         pred: []},
       {action: 'set',     obj: `1@${actor1}`, key: 'x', value: 1, pred: []}
     ]}
     const change2 = {actor: actor2, seq: 1, startOp: 1, time: 0, deps: [], ops: [
-      {action: 'makeMap', obj: ROOT_ID,       key: 'map',         pred: []},
+      {action: 'makeMap', obj: '_root',       key: 'map',         pred: []},
       {action: 'set',     obj: `1@${actor2}`, key: 'y', value: 2, pred: []}
     ]}
     const change3 = {actor: actor1, seq: 2, startOp: 3, time: 0, deps: [hash(change1), hash(change2)], ops: [
@@ -1202,20 +1201,20 @@ describe('BackendDoc applying changes', () => {
     const backend = new BackendDoc()
     assert.deepStrictEqual(backend.applyChanges([encodeChange(change1)]), {
       maxOp: 2, clock: {[actor1]: 1}, deps: [hash(change1)],
-      diffs: {objectId: ROOT_ID, type: 'map', props: {map: {
+      diffs: {objectId: '_root', type: 'map', props: {map: {
         [`1@${actor1}`]: {objectId: `1@${actor1}`, type: 'map', props: {x: {[`2@${actor1}`]: {value: 1}}}}
       }}}
     })
     assert.deepStrictEqual(backend.applyChanges([encodeChange(change2)]), {
       maxOp: 2, clock: {[actor1]: 1, [actor2]: 1}, deps: [hash(change1), hash(change2)].sort(),
-      diffs: {objectId: ROOT_ID, type: 'map', props: {map: {
+      diffs: {objectId: '_root', type: 'map', props: {map: {
         [`1@${actor1}`]: {objectId: `1@${actor1}`, type: 'map', props: {}},
         [`1@${actor2}`]: {objectId: `1@${actor2}`, type: 'map', props: {y: {[`2@${actor2}`]: {value: 2}}}}
       }}}
     })
     assert.deepStrictEqual(backend.applyChanges([encodeChange(change3)]), {
       maxOp: 3, clock: {[actor1]: 2, [actor2]: 1}, deps: [hash(change3)],
-      diffs: {objectId: ROOT_ID, type: 'map', props: {map: {
+      diffs: {objectId: '_root', type: 'map', props: {map: {
         [`1@${actor1}`]: {objectId: `1@${actor1}`, type: 'map', props: {x: {[`3@${actor1}`]: {value: 3}}}},
         [`1@${actor2}`]: {objectId: `1@${actor2}`, type: 'map', props: {}}
       }}}
@@ -1241,11 +1240,11 @@ describe('BackendDoc applying changes', () => {
   it('should allow a conflict consisting of a nested object and a value', () => {
     const actor1 = '01234567', actor2 = '89abcdef'
     const change1 = {actor: actor1, seq: 1, startOp: 1, time: 0, deps: [], ops: [
-      {action: 'makeMap', obj: ROOT_ID,       key: 'x',           pred: []},
+      {action: 'makeMap', obj: '_root',       key: 'x',           pred: []},
       {action: 'set',     obj: `1@${actor1}`, key: 'y', value: 2, pred: []}
     ]}
     const change2 = {actor: actor2, seq: 1, startOp: 1, time: 0, deps: [], ops: [
-      {action: 'set',     obj: ROOT_ID,       key: 'x', value: 1, pred: []}
+      {action: 'set',     obj: '_root',       key: 'x', value: 1, pred: []}
     ]}
     const change3 = {actor: actor1, seq: 2, startOp: 3, time: 0, deps: [hash(change1), hash(change2)], ops: [
       {action: 'set',     obj: `1@${actor1}`, key: 'y', value: 3, pred: [`2@${actor1}`]}
@@ -1253,20 +1252,20 @@ describe('BackendDoc applying changes', () => {
     const backend = new BackendDoc()
     assert.deepStrictEqual(backend.applyChanges([encodeChange(change1)]), {
       maxOp: 2, clock: {[actor1]: 1}, deps: [hash(change1)],
-      diffs: {objectId: ROOT_ID, type: 'map', props: {x: {
+      diffs: {objectId: '_root', type: 'map', props: {x: {
         [`1@${actor1}`]: {objectId: `1@${actor1}`, type: 'map', props: {y: {[`2@${actor1}`]: {value: 2}}}}
       }}}
     })
     assert.deepStrictEqual(backend.applyChanges([encodeChange(change2)]), {
       maxOp: 2, clock: {[actor1]: 1, [actor2]: 1}, deps: [hash(change1), hash(change2)].sort(),
-      diffs: {objectId: ROOT_ID, type: 'map', props: {x: {
+      diffs: {objectId: '_root', type: 'map', props: {x: {
         [`1@${actor1}`]: {objectId: `1@${actor1}`, type: 'map', props: {}},
         [`1@${actor2}`]: {value: 1}
       }}}
     })
     assert.deepStrictEqual(backend.applyChanges([encodeChange(change3)]), {
       maxOp: 3, clock: {[actor1]: 2, [actor2]: 1}, deps: [hash(change3)],
-      diffs: {objectId: ROOT_ID, type: 'map', props: {x: {
+      diffs: {objectId: '_root', type: 'map', props: {x: {
         [`1@${actor1}`]: {objectId: `1@${actor1}`, type: 'map', props: {y: {[`3@${actor1}`]: {value: 3}}}},
         [`1@${actor2}`]: {value: 1}
       }}}

--- a/test/columnar_test.js
+++ b/test/columnar_test.js
@@ -27,9 +27,9 @@ describe('change encoding', () => {
     ]}
     checkEncoded(encodeChange(change1), [
       0x85, 0x6f, 0x4a, 0x83, // magic bytes
-      0x4f, 0x5f, 0x3a, 0xa5, // checksum
-      1, 93, 2, 0xaa, 0xaa, // chunkType: change, length, actor 'aaaa'
-      1, 1, 9, 0, 0, 0, // seq, startOp, time, message, actor list, deps
+      0xa9, 0xfe, 0x24, 0x30, // checksum
+      1, 93, 0, 2, 0xaa, 0xaa, // chunkType: change, length, deps, actor 'aaaa'
+      1, 1, 9, 0, 0, // seq, startOp, time, message, actor list
       1, 4, 0, 1, 4, 0, // objActor column: null, 0, 0, 0, 0
       2, 4, 0, 1, 4, 1, // objCtr column: null, 1, 1, 1, 1
       9, 8, 0, 2, 0x7f, 0, 0, 1, 0x7f, 0, // keyActor column: null, null, 0, null, 0

--- a/test/columnar_test.js
+++ b/test/columnar_test.js
@@ -27,21 +27,26 @@ describe('change encoding', () => {
     ]}
     checkEncoded(encodeChange(change1), [
       0x85, 0x6f, 0x4a, 0x83, // magic bytes
-      0xa9, 0xfe, 0x24, 0x30, // checksum
-      1, 93, 0, 2, 0xaa, 0xaa, // chunkType: change, length, deps, actor 'aaaa'
+      0xcf, 0xc7, 0x77, 0xe2, // checksum
+      1, 94, 0, 2, 0xaa, 0xaa, // chunkType: change, length, deps, actor 'aaaa'
       1, 1, 9, 0, 0, // seq, startOp, time, message, actor list
-      1, 4, 0, 1, 4, 0, // objActor column: null, 0, 0, 0, 0
-      2, 4, 0, 1, 4, 1, // objCtr column: null, 1, 1, 1, 1
-      9, 8, 0, 2, 0x7f, 0, 0, 1, 0x7f, 0, // keyActor column: null, null, 0, null, 0
-      11, 7, 0, 1, 0x7c, 0, 2, 0x7e, 4, // keyCtr column: null, 0, 2, 0, 4
-      13, 8, 0x7f, 4, 0x74, 0x65, 0x78, 0x74, 0, 4, // keyStr column: 'text', null, null, null, null
-      28, 4, 1, 1, 1, 2, // insert column: false, true, false, true, true
-      34, 6, 0x7d, 4, 1, 3, 2, 1, // action column: makeText, set, del, set, set
-      46, 6, 0x7d, 0, 0x16, 0, 2, 0x16, // valLen column: 0, 0x16, 0, 0x16, 0x16
-      47, 3, 0x68, 0x48, 0x69, // valRaw column: 'h', 'H', 'i'
-      56, 6, 2, 0, 0x7f, 1, 2, 0, // predNum column: 0, 0, 1, 0, 0
-      57, 2, 0x7f, 0, // predActor column: 0
-      59, 2, 0x7f, 2 // predCtr column: 2
+      12, 1, 4, 2, 4, // column count, objActor, objCtr
+      9, 8, 11, 7, 13, 8, // keyActor, keyCtr, keyStr
+      28, 4, 34, 6, // insert, action
+      46, 6, 47, 3, // valLen, valRaw
+      56, 6, 57, 2, 59, 2, // predNum, predActor, predCtr
+      0, 1, 4, 0, // objActor column: null, 0, 0, 0, 0
+      0, 1, 4, 1, // objCtr column: null, 1, 1, 1, 1
+      0, 2, 0x7f, 0, 0, 1, 0x7f, 0, // keyActor column: null, null, 0, null, 0
+      0, 1, 0x7c, 0, 2, 0x7e, 4, // keyCtr column: null, 0, 2, 0, 4
+      0x7f, 4, 0x74, 0x65, 0x78, 0x74, 0, 4, // keyStr column: 'text', null, null, null, null
+      1, 1, 1, 2, // insert column: false, true, false, true, true
+      0x7d, 4, 1, 3, 2, 1, // action column: makeText, set, del, set, set
+      0x7d, 0, 0x16, 0, 2, 0x16, // valLen column: 0, 0x16, 0, 0x16, 0x16
+      0x68, 0x48, 0x69, // valRaw column: 'h', 'H', 'i'
+      2, 0, 0x7f, 1, 2, 0, // predNum column: 0, 0, 1, 0, 0
+      0x7f, 0, // predActor column: 0
+      0x7f, 2 // predCtr column: 2
     ])
     const decoded = decodeChange(encodeChange(change1))
     assert.deepStrictEqual(decoded, Object.assign({hash: decoded.hash}, change1))

--- a/test/context_test.js
+++ b/test/context_test.js
@@ -132,8 +132,8 @@ describe('Proxying context', () => {
       }})
       assert.deepStrictEqual(context.ops, [
         {obj: '_root', action: 'makeList', key: 'birds', insert: false, pred: []},
-        {obj: objectId, action: 'set', key: '_head', insert: true, value: 'sparrow', pred: []},
-        {obj: objectId, action: 'set', key: `2@${context.actorId}`, insert: true, value: 'goldfinch', pred: []}
+        {obj: objectId, action: 'set', elemId: '_head', insert: true, value: 'sparrow', pred: []},
+        {obj: objectId, action: 'set', elemId: `2@${context.actorId}`, insert: true, value: 'goldfinch', pred: []}
       ])
     })
 
@@ -152,8 +152,8 @@ describe('Proxying context', () => {
       }})
       assert.deepStrictEqual(context.ops, [
         {obj: '_root', action: 'makeText', key: 'text', insert: false, pred: []},
-        {obj: objectId, action: 'set', key: '_head', insert: true, value: 'h', pred: []},
-        {obj: objectId, action: 'set', key: `2@${context.actorId}`, insert: true, value: 'i', pred: []}
+        {obj: objectId, action: 'set', elemId: '_head', insert: true, value: 'h', pred: []},
+        {obj: objectId, action: 'set', elemId: `2@${context.actorId}`, insert: true, value: 'i', pred: []}
       ])
     })
 
@@ -250,7 +250,7 @@ describe('Proxying context', () => {
         }}}
       }})
       assert.deepStrictEqual(context.ops, [
-        {obj: listId, action: 'set', key: '1@xxx', insert: false, value: 'starling', pred: ['1@xxx']}
+        {obj: listId, action: 'set', elemId: '1@xxx', insert: false, value: 'starling', pred: ['1@xxx']}
       ])
     })
 
@@ -267,7 +267,7 @@ describe('Proxying context', () => {
         }}}
       }})
       assert.deepStrictEqual(context.ops, [
-        {obj: listId, action: 'makeMap', key: '2@xxx', insert: false, pred: ['2@xxx']},
+        {obj: listId, action: 'makeMap', elemId: '2@xxx', insert: false, pred: ['2@xxx']},
         {obj: nestedId, action: 'set', key: 'english', insert: false, value: 'goldfinch', pred: []},
         {obj: nestedId, action: 'set', key: 'latin', insert: false, value: 'carduelis', pred: []}
       ])
@@ -288,7 +288,7 @@ describe('Proxying context', () => {
         }}}
       }})
       assert.deepStrictEqual(context.ops, [
-        {obj: listId, action: 'makeMap', key: '2@xxx', insert: true, pred: []},
+        {obj: listId, action: 'makeMap', elemId: '2@xxx', insert: true, pred: []},
         {obj: nestedId, action: 'set', key: 'english', insert: false, value: 'goldfinch', pred: []},
         {obj: nestedId, action: 'set', key: 'latin', insert: false, value: 'carduelis', pred: []}
       ])
@@ -303,8 +303,8 @@ describe('Proxying context', () => {
         ]}}
       }})
       assert.deepStrictEqual(context.ops, [
-        {obj: listId, action: 'del', key: '1@xxx', insert: false, pred: ['1@xxx']},
-        {obj: listId, action: 'del', key: '2@xxx', insert: false, pred: ['2@xxx']}
+        {obj: listId, action: 'del', elemId: '1@xxx', insert: false, pred: ['1@xxx']},
+        {obj: listId, action: 'del', elemId: '2@xxx', insert: false, pred: ['2@xxx']}
       ])
     })
 
@@ -322,9 +322,9 @@ describe('Proxying context', () => {
         }}}
       }})
       assert.deepStrictEqual(context.ops, [
-        {obj: listId, action: 'del', key: '1@xxx', insert: false, pred: ['1@xxx']},
-        {obj: listId, action: 'set', key: '_head', insert: true, value: 'starling', pred: []},
-        {obj: listId, action: 'set', key: `2@${context.actorId}`, insert: true, value: 'goldfinch', pred: []}
+        {obj: listId, action: 'del', elemId: '1@xxx', insert: false, pred: ['1@xxx']},
+        {obj: listId, action: 'set', elemId: '_head', insert: true, value: 'starling', pred: []},
+        {obj: listId, action: 'set', elemId: `2@${context.actorId}`, insert: true, value: 'goldfinch', pred: []}
       ])
     })
   })

--- a/test/frontend_test.js
+++ b/test/frontend_test.js
@@ -103,7 +103,7 @@ describe('Automerge.Frontend', () => {
       assert.deepStrictEqual(change, {
         actor, seq: 1, time: change.time, message: '', startOp: 1, deps: [], ops: [
           {obj: '_root', action: 'makeList', key: 'birds', insert: false, pred: []},
-          {obj: `1@${actor}`, action: 'set', key: '_head', insert: true, value: 'chaffinch', pred: []}
+          {obj: `1@${actor}`, action: 'set', elemId: '_head', insert: true, value: 'chaffinch', pred: []}
         ]
       })
     })
@@ -116,7 +116,7 @@ describe('Automerge.Frontend', () => {
       assert.deepStrictEqual(doc2, {birds: ['greenfinch']})
       assert.deepStrictEqual(change2, {
         actor, seq: 2, time: change2.time, message: '', startOp: 3, deps: [], ops: [
-          {obj: birds, action: 'set', key: `2@${actor}`, insert: false, value: 'greenfinch', pred: [ `2@${actor}` ]}
+          {obj: birds, action: 'set', elemId: `2@${actor}`, insert: false, value: 'greenfinch', pred: [ `2@${actor}` ]}
         ]
       })
     })
@@ -129,7 +129,7 @@ describe('Automerge.Frontend', () => {
       assert.deepStrictEqual(doc2, {birds: ['goldfinch']})
       assert.deepStrictEqual(change2, {
         actor, seq: 2, time: change2.time, message: '', startOp: 4, deps: [], ops: [
-          {obj: birds, action: 'del', key: `2@${actor}`, insert: false, pred: [`2@${actor}`]}
+          {obj: birds, action: 'del', elemId: `2@${actor}`, insert: false, pred: [`2@${actor}`]}
         ]
       })
     })
@@ -187,12 +187,12 @@ describe('Automerge.Frontend', () => {
         assert.deepStrictEqual(change1, {
           actor, deps: [], seq: 1, time: change1.time, message: '', startOp: 1, ops: [
             {obj: '_root', action: 'makeList', key: 'counts', insert: false, pred: []},
-            {obj: counts, action: 'set', key: '_head', insert: true, value: 1, datatype: 'counter', pred: []}
+            {obj: counts, action: 'set', elemId: '_head', insert: true, value: 1, datatype: 'counter', pred: []}
           ]
         })
         assert.deepStrictEqual(change2, {
           actor, deps: [], seq: 2, time: change2.time, message: '', startOp: 3, ops: [
-            {obj: counts, action: 'inc', key: `2@${actor}`, insert: false, value: 2, pred: [`2@${actor}`]}
+            {obj: counts, action: 'inc', elemId: `2@${actor}`, insert: false, value: 2, pred: [`2@${actor}`]}
           ]
         })
       })

--- a/test/frontend_test.js
+++ b/test/frontend_test.js
@@ -2,7 +2,6 @@ const assert = require('assert')
 const Frontend = require('../frontend')
 const { encodeChange, decodeChange } = require('../backend/columnar')
 const { Backend } = require('../src/automerge')
-const ROOT_ID = '00000000-0000-0000-0000-000000000000'
 const uuid = require('../src/uuid')
 const { STATE } = require('../frontend/constants')
 const UUID_PATTERN = /^[0-9a-f]{32}$/
@@ -54,7 +53,7 @@ describe('Automerge.Frontend', () => {
       assert.deepStrictEqual(doc, {bird: 'magpie'})
       assert.deepStrictEqual(change, {
         actor, seq: 1, time: change.time, message: '', startOp: 1, deps: [], ops: [
-          {obj: ROOT_ID, action: 'set', key: 'bird', insert: false, value: 'magpie', pred: []}
+          {obj: '_root', action: 'set', key: 'bird', insert: false, value: 'magpie', pred: []}
         ]
       })
     })
@@ -65,7 +64,7 @@ describe('Automerge.Frontend', () => {
       assert.deepStrictEqual(doc, {birds: {wrens: 3}})
       assert.deepStrictEqual(change, {
         actor, seq: 1, time: change.time, message: '', startOp: 1, deps: [], ops: [
-          {obj: ROOT_ID, action: 'makeMap', key: 'birds', insert: false, pred: []},
+          {obj: '_root', action: 'makeMap', key: 'birds', insert: false, pred: []},
           {obj: birds,   action: 'set',     key: 'wrens', insert: false, value: 3, pred: []}
         ]
       })
@@ -92,7 +91,7 @@ describe('Automerge.Frontend', () => {
       assert.deepStrictEqual(doc2, {sparrows: 15})
       assert.deepStrictEqual(change2, {
         actor, seq: 2, time: change2.time, message: '', startOp: 3, deps: [], ops: [
-          {obj: ROOT_ID, action: 'del', key: 'magpies', insert: false, pred: [ `1@${actor}`]}
+          {obj: '_root', action: 'del', key: 'magpies', insert: false, pred: [ `1@${actor}`]}
         ]
       })
     })
@@ -103,7 +102,7 @@ describe('Automerge.Frontend', () => {
       assert.deepStrictEqual(doc, {birds: ['chaffinch']})
       assert.deepStrictEqual(change, {
         actor, seq: 1, time: change.time, message: '', startOp: 1, deps: [], ops: [
-          {obj: ROOT_ID, action: 'makeList', key: 'birds', insert: false, pred: []},
+          {obj: '_root', action: 'makeList', key: 'birds', insert: false, pred: []},
           {obj: `1@${actor}`, action: 'set', key: '_head', insert: true, value: 'chaffinch', pred: []}
         ]
       })
@@ -143,7 +142,7 @@ describe('Automerge.Frontend', () => {
       assert.strictEqual(doc.now.getTime(), now.getTime())
       assert.deepStrictEqual(change, {
         actor, seq: 1, time: change.time, message: '', startOp: 1, deps: [], ops: [
-          {obj: ROOT_ID, action: 'set', key: 'now', insert: false, value: now.getTime(), datatype: 'timestamp', pred: []}
+          {obj: '_root', action: 'set', key: 'now', insert: false, value: now.getTime(), datatype: 'timestamp', pred: []}
         ]
       })
     })
@@ -163,12 +162,12 @@ describe('Automerge.Frontend', () => {
         assert.deepStrictEqual(doc2, {wrens: new Frontend.Counter(1)})
         assert.deepStrictEqual(change1, {
           actor, seq: 1, time: change1.time, message: '', startOp: 1, deps: [], ops: [
-            {obj: ROOT_ID, action: 'set', key: 'wrens', insert: false, value: 0, datatype: 'counter', pred: []}
+            {obj: '_root', action: 'set', key: 'wrens', insert: false, value: 0, datatype: 'counter', pred: []}
           ]
         })
         assert.deepStrictEqual(change2, {
           actor, seq: 2, time: change2.time, message: '', startOp: 2, deps: [], ops: [
-            {obj: ROOT_ID, action: 'inc', key: 'wrens', insert: false, value: 1, pred: [`1@${actor}`]}
+            {obj: '_root', action: 'inc', key: 'wrens', insert: false, value: 1, pred: [`1@${actor}`]}
           ]
         })
       })
@@ -187,7 +186,7 @@ describe('Automerge.Frontend', () => {
         assert.deepStrictEqual(doc2, {counts: [new Frontend.Counter(3)]})
         assert.deepStrictEqual(change1, {
           actor, deps: [], seq: 1, time: change1.time, message: '', startOp: 1, ops: [
-            {obj: ROOT_ID, action: 'makeList', key: 'counts', insert: false, pred: []},
+            {obj: '_root', action: 'makeList', key: 'counts', insert: false, pred: []},
             {obj: counts, action: 'set', key: '_head', insert: true, value: 1, datatype: 'counter', pred: []}
           ]
         })
@@ -235,13 +234,13 @@ describe('Automerge.Frontend', () => {
       const local = uuid(), remote1 = uuid(), remote2 = uuid()
       const patch1 = {
         clock: {[local]: 4, [remote1]: 11, [remote2]: 41}, maxOp: 4, deps: [],
-        diffs: {objectId: ROOT_ID, type: 'map', props: {blackbirds: {[local]: {value: 24}}}}
+        diffs: {objectId: '_root', type: 'map', props: {blackbirds: {[local]: {value: 24}}}}
       }
       let doc1 = Frontend.applyPatch(Frontend.init(local), patch1)
       let [doc2, change] = Frontend.change(doc1, doc => doc.partridges = 1)
       assert.deepStrictEqual(change, {
         actor: local, seq: 5, deps: [], startOp: 5, time: change.time, message: '', ops: [
-          {obj: ROOT_ID, action: 'set', key: 'partridges', insert: false, value: 1, pred: []}
+          {obj: '_root', action: 'set', key: 'partridges', insert: false, value: 1, pred: []}
         ]
       })
       assert.deepStrictEqual(getRequests(doc2), [{actor: local, seq: 5}])
@@ -253,19 +252,19 @@ describe('Automerge.Frontend', () => {
       let [doc2, change2] = Frontend.change(doc1, doc => doc.partridges = 1)
       assert.deepStrictEqual(change1, {
         actor, seq: 1, deps: [], startOp: 1, time: change1.time, message: '', ops: [
-          {obj: ROOT_ID, action: 'set', key: 'blackbirds', insert: false, value: 24, pred: []}
+          {obj: '_root', action: 'set', key: 'blackbirds', insert: false, value: 24, pred: []}
         ]
       })
       assert.deepStrictEqual(change2, {
         actor, seq: 2, deps: [], startOp: 2, time: change2.time, message: '', ops: [
-          {obj: ROOT_ID, action: 'set', key: 'partridges', insert: false, value: 1, pred: []}
+          {obj: '_root', action: 'set', key: 'partridges', insert: false, value: 1, pred: []}
         ]
       })
       assert.deepStrictEqual(getRequests(doc2), [{actor, seq: 1}, {actor, seq: 2}])
 
       doc2 = Frontend.applyPatch(doc2, {
         actor, seq: 1, clock: {[actor]: 1}, diffs: {
-          objectId: ROOT_ID, type: 'map', props: {blackbirds: {[actor]: {value: 24}}}
+          objectId: '_root', type: 'map', props: {blackbirds: {[actor]: {value: 24}}}
         }
       })
       assert.deepStrictEqual(getRequests(doc2), [{actor, seq: 2}])
@@ -273,7 +272,7 @@ describe('Automerge.Frontend', () => {
 
       doc2 = Frontend.applyPatch(doc2, {
         actor, seq: 2, clock: {[actor]: 2}, diffs: {
-          objectId: ROOT_ID, type: 'map', props: {partridges: {[actor]: {value: 1}}}
+          objectId: '_root', type: 'map', props: {partridges: {[actor]: {value: 1}}}
         }
       })
       assert.deepStrictEqual(doc2, {blackbirds: 24, partridges: 1})
@@ -285,14 +284,14 @@ describe('Automerge.Frontend', () => {
       let [doc, req] = Frontend.change(Frontend.init(actor), doc => doc.blackbirds = 24)
       assert.deepStrictEqual(req, {
         actor, seq: 1, deps: [], startOp: 1, time: req.time, message: '', ops: [
-          {obj: ROOT_ID, action: 'set', key: 'blackbirds', insert: false, value: 24, pred: []}
+          {obj: '_root', action: 'set', key: 'blackbirds', insert: false, value: 24, pred: []}
         ]
       })
       assert.deepStrictEqual(getRequests(doc), [{actor, seq: 1}])
 
       doc = Frontend.applyPatch(doc, {
         clock: {[other]: 1}, diffs: {
-          objectId: ROOT_ID, type: 'map', props: {pheasants: {[other]: {value: 2}}}
+          objectId: '_root', type: 'map', props: {pheasants: {[other]: {value: 2}}}
         }
       })
       assert.deepStrictEqual(doc, {blackbirds: 24})
@@ -300,7 +299,7 @@ describe('Automerge.Frontend', () => {
 
       doc = Frontend.applyPatch(doc, {
         actor, seq: 1, clock: {[actor]: 1, [other]: 1}, diffs: {
-          objectId: ROOT_ID, type: 'map', props: {blackbirds: {[actor]: {value: 24}}}
+          objectId: '_root', type: 'map', props: {blackbirds: {[actor]: {value: 24}}}
         }
       })
       assert.deepStrictEqual(doc, {blackbirds: 24, pheasants: 2})
@@ -311,7 +310,7 @@ describe('Automerge.Frontend', () => {
       const [doc1, req1] = Frontend.change(Frontend.init(), doc => doc.blackbirds = 24)
       const [doc2, req2] = Frontend.change(doc1, doc => doc.partridges = 1)
       const actor = Frontend.getActorId(doc2)
-      const diffs = {objectId: ROOT_ID, type: 'map', props: {partridges: {[actor]: {value: 1}}}}
+      const diffs = {objectId: '_root', type: 'map', props: {partridges: {[actor]: {value: 1}}}}
       assert.throws(() => {
         Frontend.applyPatch(doc2, {actor, seq: 2, clock: {[actor]: 2}, diffs})
       }, /Mismatched sequence number/)
@@ -322,7 +321,7 @@ describe('Automerge.Frontend', () => {
       const birds = Frontend.getObjectId(doc1.birds), actor = Frontend.getActorId(doc1)
       doc1 = Frontend.applyPatch(doc1, {
         actor, seq: 1, clock: {[actor]: 1},
-        diffs: {objectId: ROOT_ID, type: 'map', props: {
+        diffs: {objectId: '_root', type: 'map', props: {
           birds: {[actor]: {objectId: birds, type: 'list',
             edits: [{action: 'insert', index: 0}],
             props: {0: {[actor]: {value: 'goldfinch'}}}
@@ -341,7 +340,7 @@ describe('Automerge.Frontend', () => {
       const remoteActor = uuid()
       const doc3 = Frontend.applyPatch(doc2, {
         clock: {[actor]: 1, [remoteActor]: 1},
-        diffs: {objectId: ROOT_ID, type: 'map', props: {
+        diffs: {objectId: '_root', type: 'map', props: {
           birds: {[actor]: {objectId: birds, type: 'list',
             edits: [{action: 'insert', index: 1}],
             props: {1: {[remoteActor]: {value: 'bullfinch'}}}
@@ -354,7 +353,7 @@ describe('Automerge.Frontend', () => {
 
       const doc4 = Frontend.applyPatch(doc3, {
         actor, seq: 2, clock: {[actor]: 2, [remoteActor]: 1},
-        diffs: {objectId: ROOT_ID, type: 'map', props: {
+        diffs: {objectId: '_root', type: 'map', props: {
           birds: {[actor]: {objectId: birds, type: 'list',
             edits: [{action: 'insert', index: 0}, {action: 'insert', index: 2}],
             props: {0: {[actor]: {value: 'chaffinch'}}, 2: {[actor]: {value: 'greenfinch'}}}
@@ -371,12 +370,12 @@ describe('Automerge.Frontend', () => {
       const [doc2, change2] = Frontend.change(doc1, doc => doc.number = 2)
       assert.deepStrictEqual(change1, {
         actor, deps: [], startOp: 1, seq: 1, time: change1.time, message: '', ops: [
-          {obj: ROOT_ID, action: 'set', key: 'number', insert: false, value: 1, pred: []}
+          {obj: '_root', action: 'set', key: 'number', insert: false, value: 1, pred: []}
         ]
       })
       assert.deepStrictEqual(change2, {
         actor, deps: [], startOp: 2, seq: 2, time: change2.time, message: '', ops: [
-          {obj: ROOT_ID, action: 'set', key: 'number', insert: false, value: 2, pred: [`1@${actor}`]}
+          {obj: '_root', action: 'set', key: 'number', insert: false, value: 2, pred: [`1@${actor}`]}
         ]
       })
       const state0 = Backend.init()
@@ -385,7 +384,7 @@ describe('Automerge.Frontend', () => {
       const [doc3, change3] = Frontend.change(doc2a, doc => doc.number = 3)
       assert.deepStrictEqual(change3, {
         actor, seq: 3, startOp: 3, time: change3.time, message: '', deps: [], ops: [
-          {obj: ROOT_ID, action: 'set', key: 'number', insert: false, value: 3, pred: [`2@${actor}`]}
+          {obj: '_root', action: 'set', key: 'number', insert: false, value: 3, pred: [`2@${actor}`]}
         ]
       })
     })
@@ -401,12 +400,12 @@ describe('Automerge.Frontend', () => {
       const [doc3, change3] = Frontend.change(doc2, doc => doc.number = 3)
       assert.deepStrictEqual(change2, {
         actor: actor2, seq: 1, startOp: 2, deps: [decodeChange(binChange1).hash], time: change2.time, message: '', ops: [
-          {obj: ROOT_ID, action: 'set', key: 'number', insert: false, value: 2, pred: [`1@${actor1}`]}
+          {obj: '_root', action: 'set', key: 'number', insert: false, value: 2, pred: [`1@${actor1}`]}
         ]
       })
       assert.deepStrictEqual(change3, {
         actor: actor2, seq: 2, startOp: 3, deps: [], time: change3.time, message: '', ops: [
-          {obj: ROOT_ID, action: 'set', key: 'number', insert: false, value: 3, pred: [`2@${actor2}`]}
+          {obj: '_root', action: 'set', key: 'number', insert: false, value: 3, pred: [`2@${actor2}`]}
         ]
       })
 
@@ -422,7 +421,7 @@ describe('Automerge.Frontend', () => {
       const [doc4, change4] = Frontend.change(doc3a, doc => doc.number = 4)
       assert.deepStrictEqual(change4, {
         actor: actor2, seq: 3, startOp: 4, time: change4.time, message: '', deps: [], ops: [
-          {obj: ROOT_ID, action: 'set', key: 'number', insert: false, value: 4, pred: [`3@${actor2}`]}
+          {obj: '_root', action: 'set', key: 'number', insert: false, value: 4, pred: [`3@${actor2}`]}
         ]
       })
       const [state4, patch4, binChange4] = Backend.applyLocalChange(state3, change4)
@@ -435,7 +434,7 @@ describe('Automerge.Frontend', () => {
       const actor = uuid()
       const patch = {
         clock: {[actor]: 1},
-        diffs: {objectId: ROOT_ID, type: 'map', props: {bird: {[actor]: {value: 'magpie'}}}}
+        diffs: {objectId: '_root', type: 'map', props: {bird: {[actor]: {value: 'magpie'}}}}
       }
       const doc = Frontend.applyPatch(Frontend.init(), patch)
       assert.deepStrictEqual(doc, {bird: 'magpie'})
@@ -444,7 +443,7 @@ describe('Automerge.Frontend', () => {
     it('should reveal conflicts on root object properties', () => {
       const patch = {
         clock: {actor1: 1, actor2: 1},
-        diffs: {objectId: ROOT_ID, type: 'map', props: {
+        diffs: {objectId: '_root', type: 'map', props: {
           favoriteBird: {actor1: {value: 'robin'}, actor2: {value: 'wagtail'}}
         }}
       }
@@ -457,7 +456,7 @@ describe('Automerge.Frontend', () => {
       const birds = uuid(), actor = uuid()
       const patch = {
         clock: {[actor]: 1},
-        diffs: {objectId: ROOT_ID, type: 'map', props: {birds: {[actor]: {
+        diffs: {objectId: '_root', type: 'map', props: {birds: {[actor]: {
           objectId: birds, type: 'map', props: {wrens: {[actor]: {value: 3}}}
         }}}}
       }
@@ -469,13 +468,13 @@ describe('Automerge.Frontend', () => {
       const birds = uuid(), actor = uuid()
       const patch1 = {
         clock: {[actor]: 1},
-        diffs: {objectId: ROOT_ID, type: 'map', props: {birds: {[actor]: {
+        diffs: {objectId: '_root', type: 'map', props: {birds: {[actor]: {
           objectId: birds, type: 'map', props: {wrens: {[actor]: {value: 3}}}
         }}}}
       }
       const patch2 = {
         clock: {[actor]: 2},
-        diffs: {objectId: ROOT_ID, type: 'map', props: {birds: {[actor]: {
+        diffs: {objectId: '_root', type: 'map', props: {birds: {[actor]: {
           objectId: birds, type: 'map', props: {sparrows: {[actor]: {value: 15}}}
         }}}}
       }
@@ -489,14 +488,14 @@ describe('Automerge.Frontend', () => {
       const birds1 = uuid(), birds2 = uuid()
       const patch1 = {
         clock: {[birds1]: 1, [birds2]: 1},
-        diffs: {objectId: ROOT_ID, type: 'map', props: {favoriteBirds: {
+        diffs: {objectId: '_root', type: 'map', props: {favoriteBirds: {
           actor1: {objectId: birds1, type: 'map', props: {blackbirds: {actor1: {value: 1}}}},
           actor2: {objectId: birds2, type: 'map', props: {wrens:      {actor2: {value: 3}}}}
         }}}
       }
       const patch2 = {
         clock: {[birds1]: 2, [birds2]: 1},
-        diffs: {objectId: ROOT_ID, type: 'map', props: {favoriteBirds: {
+        diffs: {objectId: '_root', type: 'map', props: {favoriteBirds: {
           actor1: {objectId: birds1, type: 'map', props: {blackbirds: {actor1: {value: 2}}}},
           actor2: {objectId: birds2, type: 'map'}
         }}}
@@ -513,14 +512,14 @@ describe('Automerge.Frontend', () => {
       const birds = uuid(), mammals = uuid(), actor = uuid()
       const patch1 = {
         clock: {[actor]: 1},
-        diffs: {objectId: ROOT_ID, type: 'map', props: {
+        diffs: {objectId: '_root', type: 'map', props: {
           birds:   {[actor]: {objectId: birds,     type: 'map', props: {wrens:   {[actor]: {value: 3}}}}},
           mammals: {[actor]: {objectId: mammals,   type: 'map', props: {badgers: {[actor]: {value: 1}}}}}
         }}
       }
       const patch2 = {
         clock: {[actor]: 2},
-        diffs: {objectId: ROOT_ID, type: 'map', props: {
+        diffs: {objectId: '_root', type: 'map', props: {
           birds:   {[actor]: {objectId: birds,     type: 'map', props: {sparrows: {[actor]: {value: 15}}}}}
         }}
       }
@@ -535,13 +534,13 @@ describe('Automerge.Frontend', () => {
       const actor = uuid()
       const patch1 = {
         clock: {[actor]: 1},
-        diffs: {objectId: ROOT_ID, type: 'map', props: {
+        diffs: {objectId: '_root', type: 'map', props: {
           magpies: {[actor]: {value: 2}}, sparrows: {[actor]: {value: 15}}
         }}
       }
       const patch2 = {
         clock: {[actor]: 2},
-        diffs: {objectId: ROOT_ID, type: 'map', props: {
+        diffs: {objectId: '_root', type: 'map', props: {
           magpies: {}
         }}
       }
@@ -555,7 +554,7 @@ describe('Automerge.Frontend', () => {
       const birds = uuid(), actor = uuid()
       const patch = {
         clock: {[actor]: 1},
-        diffs: {objectId: ROOT_ID, type: 'map', props: {birds: {[actor]: {
+        diffs: {objectId: '_root', type: 'map', props: {birds: {[actor]: {
           objectId: birds, type: 'list',
           edits: [{action: 'insert', index: 0}],
           props: {0: {[actor]: {value: 'chaffinch'}}}
@@ -569,7 +568,7 @@ describe('Automerge.Frontend', () => {
       const birds = uuid(), actor = uuid()
       const patch1 = {
         clock: {[actor]: 1},
-        diffs: {objectId: ROOT_ID, type: 'map', props: {birds: {[actor]: {
+        diffs: {objectId: '_root', type: 'map', props: {birds: {[actor]: {
           objectId: birds, type: 'list',
           edits: [{action: 'insert', index: 0}],
           props: {0: {[actor]: {value: 'chaffinch'}}}
@@ -577,7 +576,7 @@ describe('Automerge.Frontend', () => {
       }
       const patch2 = {
         clock: {[actor]: 2},
-        diffs: {objectId: ROOT_ID, type: 'map', props: {birds: {[actor]: {
+        diffs: {objectId: '_root', type: 'map', props: {birds: {[actor]: {
           objectId: birds, type: 'list', edits: [],
           props: {0: {[actor]: {value: 'greenfinch'}}}
         }}}}
@@ -592,7 +591,7 @@ describe('Automerge.Frontend', () => {
       const birds = uuid(), item1 = uuid(), item2 = uuid(), actor = uuid()
       const patch1 = {
         clock: {[actor]: 1},
-        diffs: {objectId: ROOT_ID, type: 'map', props: {birds: {[actor]: {
+        diffs: {objectId: '_root', type: 'map', props: {birds: {[actor]: {
           objectId: birds, type: 'list',
           edits: [{action: 'insert', index: 0}],
           props: {0: {
@@ -603,7 +602,7 @@ describe('Automerge.Frontend', () => {
       }
       const patch2 = {
         clock: {[actor]: 2},
-        diffs: {objectId: ROOT_ID, type: 'map', props: {birds: {[actor]: {
+        diffs: {objectId: '_root', type: 'map', props: {birds: {[actor]: {
           objectId: birds, type: 'list', edits: [],
           props: {0: {
             actor1: {objectId: item1, type: 'map', props: {numSeen: {actor1: {value: 2}}}},
@@ -630,7 +629,7 @@ describe('Automerge.Frontend', () => {
       const birds = uuid(), actor = uuid()
       const patch1 = {
         clock: {[actor]: 1},
-        diffs: {objectId: ROOT_ID, type: 'map', props: {birds: {[actor]: {
+        diffs: {objectId: '_root', type: 'map', props: {birds: {[actor]: {
           objectId: birds, type: 'list',
           edits: [{action: 'insert', index: 0}, {action: 'insert', index: 1}],
           props: {
@@ -641,7 +640,7 @@ describe('Automerge.Frontend', () => {
       }
       const patch2 = {
         clock: {[actor]: 2},
-        diffs: {objectId: ROOT_ID, type: 'map', props: {birds: {[actor]: {
+        diffs: {objectId: '_root', type: 'map', props: {birds: {[actor]: {
           objectId: birds, type: 'list', props: {},
           edits: [{action: 'remove', index: 0}]
         }}}}
@@ -656,7 +655,7 @@ describe('Automerge.Frontend', () => {
       const counts = uuid(), details = uuid(), detail1 = uuid(), actor = uuid()
       const patch1 = {
         clock: {[actor]: 1},
-        diffs: {objectId: ROOT_ID, type: 'map', props: {
+        diffs: {objectId: '_root', type: 'map', props: {
           counts: {[actor]: {objectId: counts, type: 'map', props: {
             magpies: {[actor]: {value: 2}}
           }}},
@@ -671,7 +670,7 @@ describe('Automerge.Frontend', () => {
       }
       const patch2 = {
         clock: {[actor]: 2},
-        diffs: {objectId: ROOT_ID, type: 'map', props: {
+        diffs: {objectId: '_root', type: 'map', props: {
           counts: {[actor]: {objectId: counts, type: 'map', props: {
             magpies: {[actor]: {value: 3}}
           }}},

--- a/test/fuzz_test.js
+++ b/test/fuzz_test.js
@@ -1,5 +1,3 @@
-const { ROOT_ID } = require('../src/common')
-
 /**
  * Miniature implementation of a subset of Automerge, which is used below as definition of the
  * expected behaviour during fuzz testing. Supports the following:
@@ -14,12 +12,12 @@ const { ROOT_ID } = require('../src/common')
 class Micromerge {
   constructor() {
     this.byActor = {} // map from actorId to array of changes
-    this.byObjId = {[ROOT_ID]: {}} // objects, keyed by the ID of the operation that created the object
-    this.metadata = {[ROOT_ID]: {}} // map from objID to object with CRDT metadata for each object field
+    this.byObjId = {_root: {}} // objects, keyed by the ID of the operation that created the object
+    this.metadata = {_root: {}} // map from objID to object with CRDT metadata for each object field
   }
 
   get root() {
-    return this.byObjId[ROOT_ID]
+    return this.byObjId._root
   }
 
   /**
@@ -144,19 +142,19 @@ class Micromerge {
 const assert = require('assert')
 
 const change1 = {actor: '1234', seq: 1, deps: {}, startOp: 1, ops: [
-  {action: 'set',      obj: ROOT_ID,  key: 'title',  insert: false, value: 'Hello'},
-  {action: 'makeList', obj: ROOT_ID,  key: 'tags',   insert: false},
+  {action: 'set',      obj: '_root',  key: 'title',  insert: false, value: 'Hello'},
+  {action: 'makeList', obj: '_root',  key: 'tags',   insert: false},
   {action: 'set',      obj: '2@1234', key: '_head',  insert: true,  value: 'foo'}
 ]}
 
 const change2 = {actor: '1234', seq: 2, deps: {}, startOp: 4, ops: [
-  {action: 'set',      obj: ROOT_ID,  key: 'title',  insert: false, value: 'Hello 1'},
+  {action: 'set',      obj: '_root',  key: 'title',  insert: false, value: 'Hello 1'},
   {action: 'set',      obj: '2@1234', key: '3@1234', insert: true,  value: 'bar'},
   {action: 'del',      obj: '2@1234', key: '3@1234', insert: false}
 ]}
 
 const change3 = {actor: 'abcd', seq: 1, deps: {'1234': 1}, startOp: 4, ops: [
-  {action: 'set',      obj: ROOT_ID,  key: 'title',  insert: false, value: 'Hello 2'},
+  {action: 'set',      obj: '_root',  key: 'title',  insert: false, value: 'Hello 2'},
   {action: 'set',      obj: '2@1234', key: '3@1234', insert: true,  value: 'baz'}
 ]}
 
@@ -167,7 +165,7 @@ assert.deepStrictEqual(doc1.root, {title: 'Hello 2', tags: ['baz', 'bar']})
 assert.deepStrictEqual(doc2.root, {title: 'Hello 2', tags: ['baz', 'bar']})
 
 const change4 = {actor: '2345', seq: 1, deps: {}, startOp: 1, ops: [
-  {action: 'makeList', obj: ROOT_ID,  key: 'todos',  insert: false},
+  {action: 'makeList', obj: '_root',  key: 'todos',  insert: false},
   {action: 'set',      obj: '1@2345', key: '_head',  insert: true,  value: 'Task 1'},
   {action: 'set',      obj: '1@2345', key: '2@2345', insert: true,  value: 'Task 2'}
 ]}

--- a/test/proxies_test.js
+++ b/test/proxies_test.js
@@ -1,21 +1,20 @@
 const assert = require('assert')
 const Automerge = process.env.TEST_DIST === '1' ? require('../dist/automerge') : require('../src/automerge')
 const { assertEqualsOneOf } = require('./helpers')
-const ROOT_ID = '00000000-0000-0000-0000-000000000000'
 const UUID_PATTERN = /^[0-9a-f]{32}$/
 
 describe('Automerge proxy API', () => {
   describe('root object', () => {
     it('should have a fixed object ID', () => {
       Automerge.change(Automerge.init(), doc => {
-        assert.strictEqual(Automerge.getObjectId(doc), ROOT_ID)
+        assert.strictEqual(Automerge.getObjectId(doc), '_root')
       })
     })
 
     it('should know its actor ID', () => {
       Automerge.change(Automerge.init(), doc => {
         assert(UUID_PATTERN.test(Automerge.getActorId(doc).toString()))
-        assert.notEqual(Automerge.getActorId(doc), ROOT_ID)
+        assert.notEqual(Automerge.getActorId(doc), '_root')
         assert.strictEqual(Automerge.getActorId(Automerge.init('01234567')), '01234567')
       })
     })

--- a/test/table_test.js
+++ b/test/table_test.js
@@ -1,7 +1,6 @@
 const assert = require('assert')
 const Automerge = process.env.TEST_DIST === '1' ? require('../dist/automerge') : require('../src/automerge')
 const Frontend = Automerge.Frontend
-const ROOT_ID = '00000000-0000-0000-0000-000000000000'
 const uuid = require('../src/uuid')
 const { assertEqualsOneOf } = require('./helpers')
 
@@ -27,7 +26,7 @@ describe('Automerge.Table', () => {
       const books = Frontend.getObjectId(doc.books)
       assert.deepStrictEqual(change, {
         actor, seq: 1, time: change.time, message: '', startOp: 1, deps: [], ops: [
-          {obj: ROOT_ID, action: 'makeTable', key: 'books', insert: false, pred: []}
+          {obj: '_root', action: 'makeTable', key: 'books', insert: false, pred: []}
         ]
       })
     })

--- a/test/test.js
+++ b/test/test.js
@@ -1027,7 +1027,7 @@ describe('Automerge', () => {
       assert.deepStrictEqual(s2, {todos: [{title: 'water plants', done: false}]})
     })
 
-    it.skip('should save and load maps with @ symbols in the keys', () => {
+    it('should save and load maps with @ symbols in the keys', () => {
       let s1 = Automerge.change(Automerge.init(), doc => doc["123@4567"] = "hello")
       let s2 = Automerge.load(Automerge.save(s1))
       assert.deepStrictEqual(s2, { ["123@4567"]: "hello" })
@@ -1053,7 +1053,7 @@ describe('Automerge', () => {
         hash: changes12[0].hash, actor: '01234567', seq: 1, startOp: 1,
         time: changes12[0].time, message: '', deps: [], ops: [
           {obj: '_root', action: 'makeList', key: 'list', insert: false, pred: []},
-          {obj: listId,  action: 'set', key: '_head', insert: true, value: 'a', pred: []}
+          {obj: listId,  action: 'set', elemId: '_head', insert: true, value: 'a', pred: []}
         ]
       }])
       const s3 = Automerge.change(s2, doc => doc.list.deleteAt(0))
@@ -1064,7 +1064,7 @@ describe('Automerge', () => {
       assert.deepStrictEqual(changes45[2], {
         hash: changes45[2].hash, actor: '01234567', seq: 3, startOp: 4,
         time: changes45[2].time, message: '', deps: [changes45[1].hash], ops: [
-          {obj: listId, action: 'set', key: '_head', insert: true, value: 'b', pred: []}
+          {obj: listId, action: 'set', elemId: '_head', insert: true, value: 'b', pred: []}
         ]
       })
     })

--- a/test/test.js
+++ b/test/test.js
@@ -2,7 +2,6 @@ const assert = require('assert')
 const Automerge = process.env.TEST_DIST === '1' ? require('../dist/automerge') : require('../src/automerge')
 const { assertEqualsOneOf } = require('./helpers')
 const { decodeChange } = require('../backend/columnar')
-const ROOT_ID = '00000000-0000-0000-0000-000000000000'
 const UUID_PATTERN = /^[0-9a-f]{32}$/
 const OPID_PATTERN = /^[0-9]+@[0-9a-f]{32}$/
 
@@ -81,7 +80,7 @@ describe('Automerge', () => {
       assert.deepStrictEqual(change, {
         actor: change.actor, deps: [], seq: 1, startOp: 1,
         hash: change.hash, message: '', time: change.time,
-        ops: [{obj: ROOT_ID, key: 'foo', action: 'set', insert: false, value: 'bar', pred: []}]
+        ops: [{obj: '_root', key: 'foo', action: 'set', insert: false, value: 'bar', pred: []}]
       })
     })
 
@@ -369,7 +368,7 @@ describe('Automerge', () => {
       it('should assign an objectId to nested maps', () => {
         s1 = Automerge.change(s1, doc => { doc.nested = {} })
         assert.strictEqual(OPID_PATTERN.test(Automerge.getObjectId(s1.nested)), true)
-        assert.notEqual(Automerge.getObjectId(s1.nested), ROOT_ID)
+        assert.notEqual(Automerge.getObjectId(s1.nested), '_root')
       })
 
       it('should handle assignment of a nested property', () => {
@@ -1053,7 +1052,7 @@ describe('Automerge', () => {
       assert.deepStrictEqual(changes12, [{
         hash: changes12[0].hash, actor: '01234567', seq: 1, startOp: 1,
         time: changes12[0].time, message: '', deps: [], ops: [
-          {obj: ROOT_ID, action: 'makeList', key: 'list', insert: false, pred: []},
+          {obj: '_root', action: 'makeList', key: 'list', insert: false, pred: []},
           {obj: listId,  action: 'set', key: '_head', insert: true, value: 'a', pred: []}
         ]
       }])

--- a/test/typescript_test.ts
+++ b/test/typescript_test.ts
@@ -3,7 +3,6 @@ import * as Automerge from 'automerge'
 import { Backend, Frontend, Counter, Doc } from 'automerge'
 
 const UUID_PATTERN = /^[0-9a-f]{32}$/
-const ROOT_ID = '00000000-0000-0000-0000-000000000000'
 
 interface BirdList {
   birds: Automerge.List<string>
@@ -229,7 +228,7 @@ describe('TypeScript support', () => {
       assert.strictEqual(s2.number, 1)
       assert.strictEqual(patch1.actor, Automerge.getActorId(s0))
       assert.strictEqual(patch1.seq, 1)
-      assert.strictEqual(patch1.diffs.objectId, ROOT_ID)
+      assert.strictEqual(patch1.diffs.objectId, '_root')
       assert.strictEqual(patch1.diffs.type, 'map')
       assert.deepStrictEqual(Object.keys(patch1.diffs.props), ['number'])
       const value = patch1.diffs.props.number[`1@${Automerge.getActorId(s0)}`]
@@ -258,7 +257,7 @@ describe('TypeScript support', () => {
       const change = Automerge.decodeChange(changes[0])
       assert.strictEqual(change.ops.length, 1)
       assert.strictEqual(change.ops[0].action, 'set')
-      assert.strictEqual(change.ops[0].obj, ROOT_ID)
+      assert.strictEqual(change.ops[0].obj, '_root')
       assert.strictEqual(change.ops[0].key, 'number')
       assert.strictEqual(change.ops[0].value, 3)
     })

--- a/test/wasm.js
+++ b/test/wasm.js
@@ -100,7 +100,7 @@ function interopTests(sourceBackend, destBackend) {
     const [source1, p1, change1] = sourceBackend.applyLocalChange(source, {
       actor, seq: 1, startOp: 1, time: 0, deps: [], ops: [
         {action: 'makeList', obj: '_root', key: 'birds', pred: []},
-        {action: 'set', obj: `1@${actor}`, key: '_head', insert: true, value: 'chaffinch', pred: []}
+        {action: 'set', obj: `1@${actor}`, elemId: '_head', insert: true, value: 'chaffinch', pred: []}
       ]
     })
     const [dest1, patch1] = destBackend.applyChanges(dest, [change1])
@@ -119,12 +119,12 @@ function interopTests(sourceBackend, destBackend) {
     const [source1, p1, change1] = sourceBackend.applyLocalChange(source, {
       actor, seq: 1, startOp: 1, time: 0, deps: [], ops: [
         {action: 'makeList', obj: '_root', key: 'birds', pred: []},
-        {action: 'set', obj: `1@${actor}`, key: '_head', insert: true, value: 'chaffinch', pred: []}
+        {action: 'set', obj: `1@${actor}`, elemId: '_head', insert: true, value: 'chaffinch', pred: []}
       ]
     })
     const [source2, p2, change2] = sourceBackend.applyLocalChange(source1, {
       actor, seq: 2, startOp: 3, time: 0, deps: [], ops: [
-        {action: 'del', obj: `1@${actor}`, key: `2@${actor}`, pred: [`2@${actor}`]}
+        {action: 'del', obj: `1@${actor}`, elemId: `2@${actor}`, pred: [`2@${actor}`]}
       ]
     })
     const [dest1, patch1] = destBackend.applyChanges(dest, [change1])
@@ -143,9 +143,9 @@ function interopTests(sourceBackend, destBackend) {
     const [source1, p1, change1] = sourceBackend.applyLocalChange(source, {
       actor, seq: 1, startOp: 1, time: 0, deps: [], ops: [
         {action: 'makeText', obj: '_root', key: 'text', pred: []},
-        {action: 'set', obj: `1@${actor}`, key: '_head',      insert: true, value: 'a', pred: []},
-        {action: 'set', obj: `1@${actor}`, key: `2@${actor}`, insert: true, value: 'b', pred: []},
-        {action: 'set', obj: `1@${actor}`, key: `3@${actor}`, insert: true, value: 'c', pred: []}
+        {action: 'set', obj: `1@${actor}`, elemId: '_head',      insert: true, value: 'a', pred: []},
+        {action: 'set', obj: `1@${actor}`, elemId: `2@${actor}`, insert: true, value: 'b', pred: []},
+        {action: 'set', obj: `1@${actor}`, elemId: `3@${actor}`, insert: true, value: 'c', pred: []}
       ]
     })
     const [dest1, patch1] = destBackend.applyChanges(dest, [change1])

--- a/test/wasm.js
+++ b/test/wasm.js
@@ -16,7 +16,6 @@ const assert = require('assert')
 const Automerge = process.env.TEST_DIST === '1' ? require('../dist/automerge') : require('../src/automerge')
 const jsBackend = require('../backend')
 const { decodeChange } = require('../backend/columnar')
-const { ROOT_ID } = require('../src/common')
 const uuid = require('../src/uuid')
 
 const path = require('path')
@@ -47,13 +46,13 @@ function interopTests(sourceBackend, destBackend) {
     const actor = uuid()
     const [source1, p1, change1] = sourceBackend.applyLocalChange(source, {
       actor, seq: 1, time: 0, startOp: 1, deps: [], ops: [
-        {action: 'set', obj: ROOT_ID, key: 'bird', value: 'magpie', pred: []}
+        {action: 'set', obj: '_root', key: 'bird', value: 'magpie', pred: []}
       ]
     })
     const [dest1, patch] = destBackend.applyChanges(dest, [change1])
     assert.deepStrictEqual(patch, {
       clock: {[actor]: 1}, deps: [decodeChange(change1).hash], maxOp: 1,
-      diffs: {objectId: ROOT_ID, type: 'map', props: {
+      diffs: {objectId: '_root', type: 'map', props: {
         bird: {[`1@${actor}`]: {value: 'magpie'}}
       }}
     })
@@ -63,19 +62,19 @@ function interopTests(sourceBackend, destBackend) {
     const actor = uuid()
     const [source1, p1, change1] = sourceBackend.applyLocalChange(source, {
       actor, seq: 1, startOp: 1, time: 0, deps: [], ops: [
-        {action: 'set', obj: ROOT_ID, key: 'bird', value: 'magpie', pred: []}
+        {action: 'set', obj: '_root', key: 'bird', value: 'magpie', pred: []}
       ]
     })
     const [source2, p2, change2] = sourceBackend.applyLocalChange(source1, {
       actor, seq: 2, startOp: 2, time: 0, deps: [], ops: [
-        {action: 'del', obj: ROOT_ID, key: 'bird', pred: [`1@${actor}`]}
+        {action: 'del', obj: '_root', key: 'bird', pred: [`1@${actor}`]}
       ]
     })
     const [dest1, patch1] = destBackend.applyChanges(dest, [change1])
     const [dest2, patch2] = destBackend.applyChanges(dest1, [change2])
     assert.deepStrictEqual(patch2, {
       clock: {[actor]: 2}, deps: [decodeChange(change2).hash], maxOp: 2,
-      diffs: {objectId: ROOT_ID, type: 'map', props: {bird: {}}}
+      diffs: {objectId: '_root', type: 'map', props: {bird: {}}}
     })
   })
 
@@ -83,14 +82,14 @@ function interopTests(sourceBackend, destBackend) {
     const actor = uuid()
     const [source1, p1, change1] = sourceBackend.applyLocalChange(source, {
       actor, seq: 1, startOp: 1, time: 0, deps: [], ops: [
-        {action: 'makeMap', obj: ROOT_ID, key: 'birds', pred: []},
+        {action: 'makeMap', obj: '_root', key: 'birds', pred: []},
         {action: 'set', obj: `1@${actor}`, key: 'wrens', value: 3, pred: []}
       ]
     })
     const [dest1, patch1] = destBackend.applyChanges(dest, [change1])
     assert.deepStrictEqual(patch1, {
       clock: {[actor]: 1}, deps: [decodeChange(change1).hash], maxOp: 2,
-      diffs: {objectId: ROOT_ID, type: 'map', props: {birds: {[`1@${actor}`]: {
+      diffs: {objectId: '_root', type: 'map', props: {birds: {[`1@${actor}`]: {
         objectId: `1@${actor}`, type: 'map', props: {wrens: {[`2@${actor}`]: {value: 3}}}
       }}}}
     })
@@ -100,14 +99,14 @@ function interopTests(sourceBackend, destBackend) {
     const actor = uuid()
     const [source1, p1, change1] = sourceBackend.applyLocalChange(source, {
       actor, seq: 1, startOp: 1, time: 0, deps: [], ops: [
-        {action: 'makeList', obj: ROOT_ID, key: 'birds', pred: []},
+        {action: 'makeList', obj: '_root', key: 'birds', pred: []},
         {action: 'set', obj: `1@${actor}`, key: '_head', insert: true, value: 'chaffinch', pred: []}
       ]
     })
     const [dest1, patch1] = destBackend.applyChanges(dest, [change1])
     assert.deepStrictEqual(patch1, {
       clock: {[actor]: 1}, deps: [decodeChange(change1).hash], maxOp: 2,
-      diffs: {objectId: ROOT_ID, type: 'map', props: {birds: {[`1@${actor}`]: {
+      diffs: {objectId: '_root', type: 'map', props: {birds: {[`1@${actor}`]: {
         objectId: `1@${actor}`, type: 'list',
         edits: [{action: 'insert', index: 0, elemId: `2@${actor}`}],
         props: {0: {[`2@${actor}`]: {value: 'chaffinch'}}}
@@ -119,7 +118,7 @@ function interopTests(sourceBackend, destBackend) {
     const actor = uuid()
     const [source1, p1, change1] = sourceBackend.applyLocalChange(source, {
       actor, seq: 1, startOp: 1, time: 0, deps: [], ops: [
-        {action: 'makeList', obj: ROOT_ID, key: 'birds', pred: []},
+        {action: 'makeList', obj: '_root', key: 'birds', pred: []},
         {action: 'set', obj: `1@${actor}`, key: '_head', insert: true, value: 'chaffinch', pred: []}
       ]
     })
@@ -132,7 +131,7 @@ function interopTests(sourceBackend, destBackend) {
     const [dest2, patch2] = destBackend.applyChanges(dest1, [change2])
     assert.deepStrictEqual(patch2, {
       clock: {[actor]: 2}, deps: [decodeChange(change2).hash], maxOp: 3,
-      diffs: {objectId: ROOT_ID, type: 'map', props: {birds: {[`1@${actor}`]: {
+      diffs: {objectId: '_root', type: 'map', props: {birds: {[`1@${actor}`]: {
         objectId: `1@${actor}`, type: 'list', props: {},
         edits: [{action: 'remove', index: 0}]
       }}}}
@@ -143,7 +142,7 @@ function interopTests(sourceBackend, destBackend) {
     const actor = uuid()
     const [source1, p1, change1] = sourceBackend.applyLocalChange(source, {
       actor, seq: 1, startOp: 1, time: 0, deps: [], ops: [
-        {action: 'makeText', obj: ROOT_ID, key: 'text', pred: []},
+        {action: 'makeText', obj: '_root', key: 'text', pred: []},
         {action: 'set', obj: `1@${actor}`, key: '_head',      insert: true, value: 'a', pred: []},
         {action: 'set', obj: `1@${actor}`, key: `2@${actor}`, insert: true, value: 'b', pred: []},
         {action: 'set', obj: `1@${actor}`, key: `3@${actor}`, insert: true, value: 'c', pred: []}
@@ -152,7 +151,7 @@ function interopTests(sourceBackend, destBackend) {
     const [dest1, patch1] = destBackend.applyChanges(dest, [change1])
     assert.deepStrictEqual(patch1, {
       clock: {[actor]: 1}, deps: [decodeChange(change1).hash], maxOp: 4,
-      diffs: {objectId: ROOT_ID, type: 'map', props: {text: {[`1@${actor}`]: {
+      diffs: {objectId: '_root', type: 'map', props: {text: {[`1@${actor}`]: {
         objectId: `1@${actor}`, type: 'text', edits: [
           {action: 'insert', index: 0, elemId: `2@${actor}`},
           {action: 'insert', index: 1, elemId: `3@${actor}`},
@@ -171,7 +170,7 @@ function interopTests(sourceBackend, destBackend) {
     const actor = uuid(), rowId = uuid()
     const [source1, p1, change1] = sourceBackend.applyLocalChange(source, {
       actor, seq: 1, startOp: 1, time: 0, deps: [], ops: [
-        {action: 'makeTable', obj: ROOT_ID,      key: 'birds',   insert: false, pred: []},
+        {action: 'makeTable', obj: '_root',      key: 'birds',   insert: false, pred: []},
         {action: 'makeMap',   obj: `1@${actor}`, key: rowId,     insert: false, pred: []},
         {action: 'set',       obj: `2@${actor}`, key: 'species', insert: false, value: 'Chaffinch', pred: []},
         {action: 'set',       obj: `2@${actor}`, key: 'colour',  insert: false, value: 'brown',     pred: []}
@@ -180,7 +179,7 @@ function interopTests(sourceBackend, destBackend) {
     const [dest1, patch1] = destBackend.applyChanges(dest, [change1])
     assert.deepStrictEqual(patch1, {
       clock: {[actor]: 1}, deps: [decodeChange(change1).hash], maxOp: 4,
-      diffs: {objectId: ROOT_ID, type: 'map', props: {birds: {[`1@${actor}`]: {
+      diffs: {objectId: '_root', type: 'map', props: {birds: {[`1@${actor}`]: {
         objectId: `1@${actor}`, type: 'table', props: {[rowId]: {[`2@${actor}`]: {
           objectId: `2@${actor}`, type: 'map', props: {
             species: {[`3@${actor}`]: {value: 'Chaffinch'}},
@@ -195,19 +194,19 @@ function interopTests(sourceBackend, destBackend) {
     const actor = uuid()
     const [source1, p1, change1] = sourceBackend.applyLocalChange(source, {
       actor, seq: 1, startOp: 1, time: 0, deps: [], ops: [
-        {action: 'set', obj: ROOT_ID, key: 'counter', value: 1, datatype: 'counter', pred: []}
+        {action: 'set', obj: '_root', key: 'counter', value: 1, datatype: 'counter', pred: []}
       ]
     })
     const [source2, p2, change2] = sourceBackend.applyLocalChange(source1, {
       actor, seq: 2, startOp: 2, time: 0, deps: [], ops: [
-        {action: 'inc', obj: ROOT_ID, key: 'counter', value: 2, pred: [`1@${actor}`]}
+        {action: 'inc', obj: '_root', key: 'counter', value: 2, pred: [`1@${actor}`]}
       ]
     })
     const [dest1, patch1] = destBackend.applyChanges(dest, [change1])
     const [dest2, patch2] = destBackend.applyChanges(dest1, [change2])
     assert.deepStrictEqual(patch2, {
       clock: {[actor]: 2}, deps: [decodeChange(change2).hash], maxOp: 2,
-      diffs: {objectId: ROOT_ID, type: 'map', props: {
+      diffs: {objectId: '_root', type: 'map', props: {
         counter: {[`1@${actor}`]: {value: 3, datatype: 'counter'}}
       }}
     })
@@ -217,13 +216,13 @@ function interopTests(sourceBackend, destBackend) {
     const actor = uuid(), now = new Date()
     const [source1, p1, change1] = sourceBackend.applyLocalChange(source, {
       actor, seq: 1, startOp: 1, time: 0, deps: [], ops: [
-        {action: 'set', obj: ROOT_ID, key: 'now', value: now.getTime(), datatype: 'timestamp', pred: []}
+        {action: 'set', obj: '_root', key: 'now', value: now.getTime(), datatype: 'timestamp', pred: []}
       ]
     })
     const [dest1, patch1] = destBackend.applyChanges(dest, [change1])
     assert.deepStrictEqual(patch1, {
       clock: {[actor]: 1}, deps: [decodeChange(change1).hash], maxOp: 1,
-      diffs: {objectId: ROOT_ID, type: 'map', props: {
+      diffs: {objectId: '_root', type: 'map', props: {
         now: {[`1@${actor}`]: {value: now.getTime(), datatype: 'timestamp'}}
       }}
     })


### PR DESCRIPTION
This PR makes a bunch of small, but breaking changes to the data formats (both binary and JSON representation). The intention is to clean up a bunch of minor annoyances, and to get our breaking changes out of the way now before we make commitments to the data formats we will support long-term.

Brief summary of the changes made (see the commit messages for details):

* Use the string `'_root'` instead of the all-zeros UUID in changes and patches (10ec271cbd66955390cd5c0b3ab22def76302f44)
* On operations that change a list or text object, use the property `elemId` instead of the property `key` to identify the list element being updated (6fa8b5a5b9bbfb178750c629fc6107b30b9c35a3)
* Reorder some of the fields in the binary encoding to make it easier and faster to parse (7d9adb4807441448c5d61f3884ca93f670f62292, d7f97c5387e2388d3fbc850f53513ebe7b808f8d)
* Allow a change to include arbitrary uninterpreted binary data, giving us a mechanism for future extensions to the data format without breaking compatibility (7f2e9f4897a420ca6ebd36421e935dc09484d1d4)

I have also tried to make the corresponding changes in the Rust implementation, for which I have put up a separate PR: automerge/automerge-rs#37. I also added some tests to check interoperability between the JS implementation and the Wasm backend compiled from Rust (3fef7e2a6945cfaff8687ed3e339dba17c911efc).

With these changes out of the way, I have no further changes to the binary format planned before 1.0. For the frontend/backend protocol I still have a few more changes in mind (e.g. compress runs of consecutive insertions or deletions in text, to improve the efficiency of inserting and deleting large chunks of text) but we can do that on a separate PR.

@orionz can you take a look please?