### PR TITLE
frontend: splice's deleteCount can overflow

### DIFF
--- a/frontend/proxies.js
+++ b/frontend/proxies.js
@@ -75,7 +75,7 @@ function listMethods(context, listId) {
     splice(start, deleteCount, ...values) {
       let list = context.getObject(listId)
       start = parseListIndex(start)
-      if (deleteCount === undefined) {
+      if (deleteCount === undefined || deleteCount > list.length - start) {
         deleteCount = list.length - start
       }
       const deleted = []

--- a/test/proxies_test.js
+++ b/test/proxies_test.js
@@ -446,6 +446,8 @@ describe('Automerge proxy API', () => {
         assert.deepEqual(root.list, ['a', 'b', 'c', 1])
         root = Automerge.change(root, doc => assert.deepEqual(doc.list.splice(1, 2, '-->'), ['b', 'c']))
         assert.deepEqual(root.list, ['a', '-->', 1])
+        root = Automerge.change(root, doc => assert.deepEqual(doc.list.splice(2, 200, '2'), ['1']))
+        assert.deepEqual(root.list, ['a', '-->', 2])
       })
 
       it('unshift()', () => {


### PR DESCRIPTION
Before to this patch, calling `splice` on an Automerge list with a
deleteCount that overflows the list results in a RangeError.

However, according to Mozilla's documentation (and tested on Node
v14.15.4), splice's `deleteCount` argument can be equal or greater than
the list. In that case, all the elements from start to the end of the
array should be deleted.

With this patch, deleteCount can overflow the list's length and the
behaviour is like no deleteCount was passed.

[1]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/splice
