### PR TITLE
Only spread doc clock to a connection if the remote care the doc.

### DIFF
--- a/src/connection.js
+++ b/src/connection.js
@@ -67,9 +67,8 @@ class Connection {
         this.sendMsg(docId, clock, changes)
         return
       }
+      if (!clock.equals(this._ourClock.get(docId, Map()))) this.sendMsg(docId, clock)
     }
-
-    if (!clock.equals(this._ourClock.get(docId, Map()))) this.sendMsg(docId, clock)
   }
 
   // Callback that is called by the docSet whenever a document is changed


### PR DESCRIPTION
Trying to fix https://github.com/automerge/automerge/issues/303
connection should not cache other doc's clock if the doc is unrelated (not in _theirClock). else removed then re-loaded doc will have conflict new clock with the cached one. which will cause the re-loaded doc not sync, and raise "old state" error.