### PR TITLE
WIP: initial implementation of cursors

### DIFF
--- a/@types/automerge/index.d.ts
+++ b/@types/automerge/index.d.ts
@@ -39,6 +39,7 @@ declare module 'automerge' {
   function getAllChanges<T>(doc: Doc<T>): Change[]
   function getChanges<T>(olddoc: Doc<T>, newdoc: Doc<T>): Change[]
   function getConflicts<T>(doc: Doc<T>, key: keyof T): any
+  function getCursorIndex<T>(doc: Doc<T>, cursor: Cursor, findClosest?: boolean): number
   function getHistory<D, T = Proxy<D>>(doc: Doc<T>): State<T>[]
   function getMissingDeps<T>(doc: Doc<T>): Clock
   function getObjectById<T>(doc: Doc<T>, objectId: UUID): any
@@ -77,6 +78,7 @@ declare module 'automerge' {
   class Text extends List<string> {
     constructor(objectId?: UUID, elems?: string[], maxElem?: number)
     get(index: number): string
+    getCursorAt(index: number): Cursor
     getElemId(index: number): string
     toSpans<T>(): (string | T)[]
   }
@@ -94,6 +96,11 @@ declare module 'automerge' {
     toString(): string
     valueOf(): number
     value: number
+  }
+
+  interface Cursor {
+    objectId: string
+    elemId: string
   }
 
   // Readonly variants

--- a/backend/index.js
+++ b/backend/index.js
@@ -248,6 +248,14 @@ function merge(local, remote) {
   return applyChanges(local, changes)
 }
 
+function getListIndex(state, objectId, elemId) {
+  return OpSet.getListIndex(state.get('opSet'), objectId, elemId)
+}
+
+function getPrecedingListIndex(state, objectId, elemId) {
+  return OpSet.getPrecedingListIndex(state.get('opSet'), objectId, elemId)
+}
+
 /**
  * Undoes the last change by the local user in the node state `state`. The
  * `request` object contains all parts of the change except the operations;
@@ -317,5 +325,6 @@ function redo(state, request) {
 
 module.exports = {
   init, applyChanges, applyLocalChange, getPatch,
-  getChanges, getChangesForActor, getMissingChanges, getMissingDeps, merge
+  getChanges, getChangesForActor, getMissingChanges, getMissingDeps, merge,
+  getListIndex, getPrecedingListIndex
 }

--- a/backend/op_set.js
+++ b/backend/op_set.js
@@ -145,7 +145,7 @@ function patchList(opSet, objectId, index, elemId, action, ops) {
 function findClosestListIndex(opSet, objectId, elemId) {
   const elemIds = opSet.getIn(['byObject', objectId, '_elemIds'])
 
-  let prevId = elemId
+  let prevId = elemId, index
   while (true) {
     index = -1
     prevId = getPrevious(opSet, objectId, prevId)

--- a/backend/op_set.js
+++ b/backend/op_set.js
@@ -141,6 +141,22 @@ function patchList(opSet, objectId, index, elemId, action, ops) {
   return [opSet, [edit]]
 }
 
+// find the index of the closest preceding list element
+function findClosestListIndex(opSet, objectId, elemId) {
+  const elemIds = opSet.getIn(['byObject', objectId, '_elemIds'])
+
+  let prevId = elemId
+  while (true) {
+    index = -1
+    prevId = getPrevious(opSet, objectId, prevId)
+    if (!prevId) break
+    index = elemIds.indexOf(prevId)
+    if (index >= 0) break
+  }
+
+  return index
+}
+
 function updateListElement(opSet, objectId, elemId) {
   const ops = getFieldOps(opSet, objectId, elemId)
   const elemIds = opSet.getIn(['byObject', objectId, '_elemIds'])
@@ -155,17 +171,7 @@ function updateListElement(opSet, objectId, elemId) {
 
   } else {
     if (ops.isEmpty()) return [opSet, []] // deleting a non-existent element = no-op
-
-    // find the index of the closest preceding list element
-    let prevId = elemId
-    while (true) {
-      index = -1
-      prevId = getPrevious(opSet, objectId, prevId)
-      if (!prevId) break
-      index = elemIds.indexOf(prevId)
-      if (index >= 0) break
-    }
-
+    index = findClosestListIndex(opSet, objectId, elemId)
     return patchList(opSet, objectId, index + 1, elemId, 'insert', ops)
   }
 }
@@ -569,5 +575,5 @@ function listIterator(opSet, listId, context) {
 module.exports = {
   init, addChange, getMissingChanges, getChangesForActor, getMissingDeps,
   getObjectFields, getObjectField, getObjectConflicts, getFieldOps,
-  listElemByIndex, listLength, listIterator, ROOT_ID
+  listElemByIndex, listLength, listIterator, findClosestListIndex, ROOT_ID
 }

--- a/frontend/index.js
+++ b/frontend/index.js
@@ -3,7 +3,6 @@ const { ROOT_ID, isObject, copyObject } = require('../src/common')
 const uuid = require('../src/uuid')
 const { applyDiffs, updateParentObjects, cloneRootObject } = require('./apply_patch')
 const { rootObjectProxy } = require('./proxies')
-const { findClosestListIndex } = require('../backend/op_set')
 const { Context } = require('./context')
 const { Text } = require('./text')
 const { Table } = require('./table')
@@ -493,34 +492,10 @@ function getElementIds(list) {
   return list[ELEM_IDS]
 }
 
-/**
- * Finds the latest integer index of a cursor object.
- * If the character was deleted, returns -1.
- * 
- * todos:
- * - consider returning the closest character if deleted
- * - consider optimizing the linear search
- */
-function findCursorIndex (cursor, doc, findClosest) {
-  if(cursor.textId === undefined || cursor.elemId === undefined) {
-    throw new TypeError('Invalid cursor object')
-  }
-
-  const backend = getBackendState(doc)
-  const elemIds = backend.getIn(['opSet', 'byObject', cursor.textId, '_elemIds'])
-  let index = elemIds.indexOf(cursor.elemId)
-
-  if (index === -1 && findClosest) {
-    index = findClosestListIndex(backend.getIn(['opSet']), cursor.textId, cursor.elemId)
-  }
-
-  return index
-}
-
 module.exports = {
   init, from, change, emptyChange, applyPatch,
   canUndo, undo, canRedo, redo,
   getObjectId, getObjectById, getActorId, setActorId, getConflicts,
-  getBackendState, getElementIds, findCursorIndex,
-  Text, Table, Counter,
+  getBackendState, getElementIds,
+  Text, Table, Counter
 }

--- a/frontend/text.js
+++ b/frontend/text.js
@@ -34,7 +34,7 @@ class Text {
   getCursorAt (index) {
     return {
       // todo: are there any points in the lifecycle where the Text object doesn't have an ID?
-      textId: this[OBJECT_ID], 
+      objectId: this[OBJECT_ID],
       elemId: this.getElemId(index)
     }
   }

--- a/frontend/text.js
+++ b/frontend/text.js
@@ -40,24 +40,6 @@ class Text {
   }
 
   /**
-   * Finds the latest integer index of a cursor object.
-   * If the character was deleted, returns -1.
-   * 
-   * todos:
-   * - consider returning the closest character if deleted
-   * - consider optimizing the linear search
-   */
-  findCursorIndex (cursor) {
-    if(cursor.textId === undefined || cursor.elemId === undefined) {
-      throw new TypeError('Invalid cursor object')
-    }
-    if(cursor.textId !== this[OBJECT_ID]) {
-      throw new TypeError('Cursor was initialized with a different text object')
-    }
-    return this.elems.findIndex(e => e.elemId === cursor.elemId)
-  }
-
-  /**
    * Iterates over the text elements character by character, including any
    * inline objects.
    */

--- a/frontend/text.js
+++ b/frontend/text.js
@@ -28,6 +28,36 @@ class Text {
   }
 
   /**
+   * Returns a cursor that points to a specific point in the text.
+   * For now, represented by a plain object.
+   */
+  getCursorAt (index) {
+    return {
+      // todo: are there any points in the lifecycle where the Text object doesn't have an ID?
+      textId: this[OBJECT_ID], 
+      elemId: this.getElemId(index)
+    }
+  }
+
+  /**
+   * Finds the latest integer index of a cursor object.
+   * If the character was deleted, returns -1.
+   * 
+   * todos:
+   * - consider returning the closest character if deleted
+   * - consider optimizing the linear search
+   */
+  findCursorIndex (cursor) {
+    if(cursor.textId === undefined || cursor.elemId === undefined) {
+      throw new TypeError('Invalid cursor object')
+    }
+    if(cursor.textId !== this[OBJECT_ID]) {
+      throw new TypeError('Cursor was initialized with a different text object')
+    }
+    return this.elems.findIndex(e => e.elemId === cursor.elemId)
+  }
+
+  /**
    * Iterates over the text elements character by character, including any
    * inline objects.
    */

--- a/src/automerge.js
+++ b/src/automerge.js
@@ -134,12 +134,11 @@ function getHistory(doc) {
 }
 
 /**
- * Finds the latest integer index of a cursor object.
- * If the character was deleted, returns -1.
+ * Returns the updated integer index of a cursor pointing into a text object.
  *
- * todos:
- * - consider returning the closest character if deleted
- * - consider optimizing the linear search
+ * If the character has been deleted:
+ * - By default, returns -1
+ * - If findClosest parameter is true, returns closest preceding index.
  */
 function getCursorIndex(doc, cursor, findClosest = false) {
   if (cursor.objectId === undefined || cursor.elemId === undefined) {

--- a/src/automerge.js
+++ b/src/automerge.js
@@ -133,10 +133,33 @@ function getHistory(doc) {
   }).toArray()
 }
 
+/**
+ * Finds the latest integer index of a cursor object.
+ * If the character was deleted, returns -1.
+ *
+ * todos:
+ * - consider returning the closest character if deleted
+ * - consider optimizing the linear search
+ */
+function getCursorIndex(doc, cursor, findClosest = false) {
+  if (cursor.objectId === undefined || cursor.elemId === undefined) {
+    throw new TypeError('Invalid cursor object')
+  }
+
+  const backend = Frontend.getBackendState(doc)
+  let index = Backend.getListIndex(backend, cursor.objectId, cursor.elemId)
+
+  if (index === -1 && findClosest) {
+    index = Backend.getPrecedingListIndex(backend, cursor.objectId, cursor.elemId)
+  }
+  return index
+}
+
+
 module.exports = {
   init, from, change, emptyChange, undo, redo,
   load, save, merge, diff, getChanges, getAllChanges, applyChanges, getMissingDeps,
-  equals, getHistory, uuid,
+  equals, getHistory, getCursorIndex, uuid,
   Frontend, Backend,
   DocSet: require('./doc_set'),
   WatchableDoc: require('./watchable_doc'),

--- a/test/text_test.js
+++ b/test/text_test.js
@@ -365,6 +365,52 @@ describe('Automerge.Text', () => {
     })
   })
 
+  describe.only('cursors', () => {
+    let s1
+    beforeEach(() => {
+      s1 = Automerge.change(Automerge.init(), doc => {
+        doc.text = new Automerge.Text('hello world')
+        doc.cursor = doc.text.getCursorAt(2)
+      })
+    })
+
+    it('can retrieve the initial index on the cursor', () => {
+      assert.deepStrictEqual(s1.text.findCursorIndex(s1.cursor), 2)
+    })
+
+    it('updates the cursor index when text is updated', () => {
+      s1 = Automerge.change(s1, doc => {
+        doc.text.insertAt(0, 'a', 'b', 'c')
+      }) 
+
+      assert.deepStrictEqual(s1.text.findCursorIndex(s1.cursor), 5)      
+    })
+
+    it('throws an error if a non-cursor is passed in', () => {
+      s1 = Automerge.change(s1, doc => {
+        doc.value = "random string"
+      }) 
+
+      assert.throws(() => s1.text.findCursorIndex(s1.value), /Invalid cursor object/) 
+    })
+
+    it('throws an error if the cursor was created on a different text object', () => {
+      s1 = Automerge.change(s1, doc => {
+        doc.text = new Automerge.Text('another text object')
+      }) 
+
+      assert.throws(() => s1.text.findCursorIndex(s1.cursor), /Cursor was initialized with a different text object/) 
+    })
+
+    it('handles the case where the cursor character was deleted', () => {
+      s1 = Automerge.change(s1, doc => {
+        doc.text.deleteAt(2)
+      })  
+
+      assert.deepStrictEqual(s1.text.findCursorIndex(s1.cursor), -1) 
+    })
+  })
+
   describe('non-textual control characters', () => {
     let s1
     beforeEach(() => {

--- a/test/text_test.js
+++ b/test/text_test.js
@@ -375,7 +375,7 @@ describe('Automerge.Text', () => {
     })
 
     it('can retrieve the initial index on the cursor', () => {
-      assert.deepStrictEqual(Automerge.Frontend.findCursorIndex(s1.cursor, s1), 2)
+      assert.deepStrictEqual(Automerge.getCursorIndex(s1, s1.cursor), 2)
     })
 
     it('updates the cursor index when text is updated', () => {
@@ -383,7 +383,7 @@ describe('Automerge.Text', () => {
         doc.text.insertAt(0, 'a', 'b', 'c')
       })
 
-      assert.deepStrictEqual(Automerge.Frontend.findCursorIndex(s1.cursor, s1), 5)
+      assert.deepStrictEqual(Automerge.getCursorIndex(s1, s1.cursor), 5)
     })
 
     it('throws an error if a non-cursor is passed in', () => {
@@ -391,7 +391,7 @@ describe('Automerge.Text', () => {
         doc.value = "random string"
       })
 
-      assert.throws(() => Automerge.Frontend.findCursorIndex(s1.value, s1), /Invalid cursor object/)
+      assert.throws(() => Automerge.getCursorIndex(s1, s1.value), /Invalid cursor object/)
     })
 
     it('returns -1 by default if character was deleted', () => {
@@ -399,7 +399,7 @@ describe('Automerge.Text', () => {
         doc.text.deleteAt(2)
       })
 
-      assert.deepStrictEqual(Automerge.Frontend.findCursorIndex(s1.cursor, s1), -1)
+      assert.deepStrictEqual(Automerge.getCursorIndex(s1, s1.cursor), -1)
     })
 
     it('returns closest index if character was deleted and findClosest is set to true', () => {
@@ -407,7 +407,7 @@ describe('Automerge.Text', () => {
         doc.text.deleteAt(2)
       })
 
-      assert.deepStrictEqual(Automerge.Frontend.findCursorIndex(s1.cursor, s1, true), 1)
+      assert.deepStrictEqual(Automerge.getCursorIndex(s1, s1.cursor, true), 1)
     })
   })
 

--- a/test/text_test.js
+++ b/test/text_test.js
@@ -365,7 +365,7 @@ describe('Automerge.Text', () => {
     })
   })
 
-  describe.only('cursors', () => {
+  describe('cursors', () => {
     let s1
     beforeEach(() => {
       s1 = Automerge.change(Automerge.init(), doc => {
@@ -375,7 +375,7 @@ describe('Automerge.Text', () => {
     })
 
     it('can retrieve the initial index on the cursor', () => {
-      assert.deepStrictEqual(s1.text.findCursorIndex(s1.cursor), 2)
+      assert.deepStrictEqual(Automerge.Frontend.findCursorIndex(s1.cursor, s1), 2)
     })
 
     it('updates the cursor index when text is updated', () => {
@@ -383,7 +383,7 @@ describe('Automerge.Text', () => {
         doc.text.insertAt(0, 'a', 'b', 'c')
       }) 
 
-      assert.deepStrictEqual(s1.text.findCursorIndex(s1.cursor), 5)      
+      assert.deepStrictEqual(Automerge.Frontend.findCursorIndex(s1.cursor, s1), 5)   
     })
 
     it('throws an error if a non-cursor is passed in', () => {
@@ -391,23 +391,23 @@ describe('Automerge.Text', () => {
         doc.value = "random string"
       }) 
 
-      assert.throws(() => s1.text.findCursorIndex(s1.value), /Invalid cursor object/) 
+      assert.throws(() => Automerge.Frontend.findCursorIndex(s1.value, s1), /Invalid cursor object/) 
     })
 
-    it('throws an error if the cursor was created on a different text object', () => {
-      s1 = Automerge.change(s1, doc => {
-        doc.text = new Automerge.Text('another text object')
-      }) 
-
-      assert.throws(() => s1.text.findCursorIndex(s1.cursor), /Cursor was initialized with a different text object/) 
-    })
-
-    it('handles the case where the cursor character was deleted', () => {
+    it('returns -1 by default if character was deleted', () => {
       s1 = Automerge.change(s1, doc => {
         doc.text.deleteAt(2)
       })  
 
-      assert.deepStrictEqual(s1.text.findCursorIndex(s1.cursor), -1) 
+      assert.deepStrictEqual(Automerge.Frontend.findCursorIndex(s1.cursor, s1), -1) 
+    })
+
+    it('returns closest index if character was deleted and findClosest is set to true', () => {
+      s1 = Automerge.change(s1, doc => {
+        doc.text.deleteAt(2)
+      })  
+
+      assert.deepStrictEqual(Automerge.Frontend.findCursorIndex(s1.cursor, s1, true), 1) 
     })
   })
 

--- a/test/text_test.js
+++ b/test/text_test.js
@@ -381,33 +381,33 @@ describe('Automerge.Text', () => {
     it('updates the cursor index when text is updated', () => {
       s1 = Automerge.change(s1, doc => {
         doc.text.insertAt(0, 'a', 'b', 'c')
-      }) 
+      })
 
-      assert.deepStrictEqual(Automerge.Frontend.findCursorIndex(s1.cursor, s1), 5)   
+      assert.deepStrictEqual(Automerge.Frontend.findCursorIndex(s1.cursor, s1), 5)
     })
 
     it('throws an error if a non-cursor is passed in', () => {
       s1 = Automerge.change(s1, doc => {
         doc.value = "random string"
-      }) 
+      })
 
-      assert.throws(() => Automerge.Frontend.findCursorIndex(s1.value, s1), /Invalid cursor object/) 
+      assert.throws(() => Automerge.Frontend.findCursorIndex(s1.value, s1), /Invalid cursor object/)
     })
 
     it('returns -1 by default if character was deleted', () => {
       s1 = Automerge.change(s1, doc => {
         doc.text.deleteAt(2)
-      })  
+      })
 
-      assert.deepStrictEqual(Automerge.Frontend.findCursorIndex(s1.cursor, s1), -1) 
+      assert.deepStrictEqual(Automerge.Frontend.findCursorIndex(s1.cursor, s1), -1)
     })
 
     it('returns closest index if character was deleted and findClosest is set to true', () => {
       s1 = Automerge.change(s1, doc => {
         doc.text.deleteAt(2)
-      })  
+      })
 
-      assert.deepStrictEqual(Automerge.Frontend.findCursorIndex(s1.cursor, s1, true), 1) 
+      assert.deepStrictEqual(Automerge.Frontend.findCursorIndex(s1.cursor, s1, true), 1)
     })
   })
 

--- a/test/typescript_test.ts
+++ b/test/typescript_test.ts
@@ -431,6 +431,19 @@ describe('TypeScript support', () => {
       it('supports `concat`', () => assert.strictEqual(doc.text.concat(['j']).length, 10))
       it('supports `includes`', () => assert.strictEqual(doc.text.includes('q'), false))
     })
+
+    describe('cursors API', () => {
+      beforeEach(() => {
+        doc = Automerge.change(doc, doc => doc.text.insertAt(0, 'a', 'b'))
+      })
+
+      it('should convert between cursor and index', () => {
+        const cursor = doc.text.getCursorAt(1)
+        assert.strictEqual(cursor.objectId, Automerge.getObjectId(doc.text))
+        assert.strictEqual(cursor.elemId, `${Automerge.getActorId(doc)}:2`)
+        assert.strictEqual(Automerge.getCursorIndex(doc, cursor), 1)
+      })
+    })
   })
 
   describe('Automerge.Table', () => {


### PR DESCRIPTION
An attempt at a simple initial implementation of cursors, as discussed in #239. 

- For now I just used a plain object to store the Cursor, and added a function `Automerge.Frontend.findCursorIndex` which operates on that object, because that was easiest to implement. Probably would provide a nicer API to switch it to a custom datatype?
- I first tried a pure frontend implementation (preserved in commit a80bfe1) but I believe this is limited in how it can handle deleted characters, as mentioned in #198. So I then switched to using the backend state to find the closest index in case of deleted characters, based on [your suggestion here](https://github.com/automerge/automerge/issues/198#issuecomment-519244431). This at least avoids any changes to the frontend-backend protocol, but I wonder if there are still other issues caused by involving the backend. In particular, I'm not sure how this change affects frontend perf yet.
- It seems like the best handling of deleted characters might depend on context of how the cursor is being used. In this PR I provided an option for how to handle the case where the character has been deleted (either return index -1, or try to find the closest one), but not yet sure if this is the best API.
- I wonder if it would make sense to provide this functionality for both lists and text?