### PR TITLE
Initial implementation of cursors (perf branch version)

### DIFF
--- a/@types/automerge/index.d.ts
+++ b/@types/automerge/index.d.ts
@@ -42,6 +42,7 @@ declare module 'automerge' {
   function getAllChanges<T>(doc: Doc<T>): Uint8Array[]
   function getChanges<T>(olddoc: Doc<T>, newdoc: Doc<T>): Uint8Array[]
   function getConflicts<T>(doc: Doc<T>, key: keyof T): any
+  function getCursorIndex<T>(doc: Doc<T>, cursor: Cursor, findClosest?: boolean): number
   function getHistory<D, T = Proxy<D>>(doc: Doc<T>): State<T>[]
   function getMissingDeps<T>(doc: Doc<T>): Hash[]
   function getObjectById<T>(doc: Doc<T>, objectId: OpId): any
@@ -74,6 +75,8 @@ declare module 'automerge' {
   class Text extends List<string> {
     constructor(text?: string | string[])
     get(index: number): string
+    getCursorAt(index: number): Cursor
+    getElemId(index: number): string
     toSpans<T>(): (string | T)[]
   }
 
@@ -90,6 +93,11 @@ declare module 'automerge' {
     toString(): string
     valueOf(): number
     value: number
+  }
+
+  interface Cursor {
+    objectId: string
+    elemId: string
   }
 
   // Readonly variants

--- a/backend/index.js
+++ b/backend/index.js
@@ -267,7 +267,17 @@ function getMissingDeps(backend) {
   }
 }
 
+function getListIndex(backend, objectId, elemId) {
+  const opSet = backendState(backend).get('opSet')
+  return OpSet.getListIndex(opSet, objectId, elemId)
+}
+
+function getPrecedingListIndex(backend, objectId, elemId) {
+  const opSet = backendState(backend).get('opSet')
+  return OpSet.getPrecedingListIndex(opSet, objectId, elemId)
+}
+
 module.exports = {
   init, clone, free, applyChanges, applyLocalChange, save, load, loadChanges, getPatch,
-  getHeads, getChanges, getMissingDeps
+  getHeads, getChanges, getMissingDeps, getListIndex, getPrecedingListIndex
 }

--- a/backend/op_set.js
+++ b/backend/op_set.js
@@ -71,8 +71,15 @@ function applyInsert(opSet, op) {
     .setIn(['byObject', objectId, '_insertion', opId], op)
 }
 
-// find the index of the closest preceding list element
-function findClosestListIndex(opSet, objectId, elemId) {
+// Finds the index of the list element with a given ID.
+// Returns -1 if the element does not exist or has been deleted.
+function getListIndex(opSet, objectId, elemId) {
+  return opSet.getIn(['byObject', objectId, '_elemIds']).indexOf(elemId)
+}
+
+// Find the index of the closest visible list element that precedes the given element ID.
+// Returns -1 if there is no such element.
+function getPrecedingListIndex(opSet, objectId, elemId) {
   const elemIds = opSet.getIn(['byObject', objectId, '_elemIds'])
 
   let prevId = elemId, index
@@ -103,10 +110,9 @@ function updateListElement(opSet, objectId, elemId, patch) {
     } else {
       elemIds = elemIds.setValue(elemId, ops.first().get('value'))
     }
-
   } else {
     if (ops.isEmpty()) return opSet // deleting a non-existent element = no-op
-    index = findClosestListIndex(opSet, objectId, elemId) + 1
+    index = getPrecedingListIndex(opSet, objectId, elemId) + 1
     elemIds = elemIds.insertIndex(index, elemId, ops.first().get('value'))
     if (patch) patch.edits.push({action: 'insert', index, elemId})
   }
@@ -636,5 +642,6 @@ function constructObject(opSet, objectId) {
 
 module.exports = {
   init, addChange, addLocalChange, getHeads, getMissingChanges, getMissingDeps,
-  constructObject, getFieldOps, getOperationKey, finalizePatch, findClosestListIndex
+  constructObject, getFieldOps, getOperationKey, finalizePatch,
+  getListIndex, getPrecedingListIndex
 }

--- a/frontend/index.js
+++ b/frontend/index.js
@@ -3,6 +3,7 @@ const { isObject, copyObject } = require('../src/common')
 const uuid = require('../src/uuid')
 const { interpretPatch, cloneRootObject } = require('./apply_patch')
 const { rootObjectProxy } = require('./proxies')
+const { findClosestListIndex } = require('../backend/op_set')
 const { Context } = require('./context')
 const { Text } = require('./text')
 const { Table } = require('./table')
@@ -366,9 +367,33 @@ function getElementIds(list) {
   }
 }
 
+/**
+ * Finds the latest integer index of a cursor object.
+ * If the character was deleted, returns -1.
+ * 
+ * todos:
+ * - consider returning the closest character if deleted
+ * - consider optimizing the linear search
+ */
+function findCursorIndex (cursor, doc, findClosest) {
+  if(cursor.textId === undefined || cursor.elemId === undefined) {
+    throw new TypeError('Invalid cursor object')
+  }
+
+  const backend = getBackendState(doc)
+  const elemIds = backend.getIn(['opSet', 'byObject', cursor.textId, '_elemIds'])
+  let index = elemIds.indexOf(cursor.elemId)
+
+  if (index === -1 && findClosest) {
+    index = findClosestListIndex(backend.getIn(['opSet']), cursor.textId, cursor.elemId)
+  }
+
+  return index
+}
+
 module.exports = {
   init, from, change, emptyChange, applyPatch,
   getObjectId, getObjectById, getActorId, setActorId, getConflicts, getLastLocalChange,
-  getBackendState, getElementIds,
+  getBackendState, getElementIds, findCursorIndex,
   Text, Table, Counter
 }

--- a/frontend/index.js
+++ b/frontend/index.js
@@ -3,7 +3,6 @@ const { isObject, copyObject } = require('../src/common')
 const uuid = require('../src/uuid')
 const { interpretPatch, cloneRootObject } = require('./apply_patch')
 const { rootObjectProxy } = require('./proxies')
-const { findClosestListIndex } = require('../backend/op_set')
 const { Context } = require('./context')
 const { Text } = require('./text')
 const { Table } = require('./table')
@@ -367,33 +366,9 @@ function getElementIds(list) {
   }
 }
 
-/**
- * Finds the latest integer index of a cursor object.
- * If the character was deleted, returns -1.
- * 
- * todos:
- * - consider returning the closest character if deleted
- * - consider optimizing the linear search
- */
-function findCursorIndex (cursor, doc, findClosest) {
-  if(cursor.textId === undefined || cursor.elemId === undefined) {
-    throw new TypeError('Invalid cursor object')
-  }
-
-  const backend = getBackendState(doc)
-  const elemIds = backend.getIn(['opSet', 'byObject', cursor.textId, '_elemIds'])
-  let index = elemIds.indexOf(cursor.elemId)
-
-  if (index === -1 && findClosest) {
-    index = findClosestListIndex(backend.getIn(['opSet']), cursor.textId, cursor.elemId)
-  }
-
-  return index
-}
-
 module.exports = {
   init, from, change, emptyChange, applyPatch,
   getObjectId, getObjectById, getActorId, setActorId, getConflicts, getLastLocalChange,
-  getBackendState, getElementIds, findCursorIndex,
+  getBackendState, getElementIds,
   Text, Table, Counter
 }

--- a/frontend/text.js
+++ b/frontend/text.js
@@ -34,7 +34,7 @@ class Text {
   getCursorAt (index) {
     return {
       // todo: are there any points in the lifecycle where the Text object doesn't have an ID?
-      textId: this[OBJECT_ID], 
+      objectId: this[OBJECT_ID],
       elemId: this.getElemId(index)
     }
   }

--- a/frontend/text.js
+++ b/frontend/text.js
@@ -40,24 +40,6 @@ class Text {
   }
 
   /**
-   * Finds the latest integer index of a cursor object.
-   * If the character was deleted, returns -1.
-   * 
-   * todos:
-   * - consider returning the closest character if deleted
-   * - consider optimizing the linear search
-   */
-  findCursorIndex (cursor) {
-    if(cursor.textId === undefined || cursor.elemId === undefined) {
-      throw new TypeError('Invalid cursor object')
-    }
-    if(cursor.textId !== this[OBJECT_ID]) {
-      throw new TypeError('Cursor was initialized with a different text object')
-    }
-    return this.elems.findIndex(e => e.elemId === cursor.elemId)
-  }
-
-  /**
    * Iterates over the text elements character by character, including any
    * inline objects.
    */

--- a/frontend/text.js
+++ b/frontend/text.js
@@ -28,6 +28,36 @@ class Text {
   }
 
   /**
+   * Returns a cursor that points to a specific point in the text.
+   * For now, represented by a plain object.
+   */
+  getCursorAt (index) {
+    return {
+      // todo: are there any points in the lifecycle where the Text object doesn't have an ID?
+      textId: this[OBJECT_ID], 
+      elemId: this.getElemId(index)
+    }
+  }
+
+  /**
+   * Finds the latest integer index of a cursor object.
+   * If the character was deleted, returns -1.
+   * 
+   * todos:
+   * - consider returning the closest character if deleted
+   * - consider optimizing the linear search
+   */
+  findCursorIndex (cursor) {
+    if(cursor.textId === undefined || cursor.elemId === undefined) {
+      throw new TypeError('Invalid cursor object')
+    }
+    if(cursor.textId !== this[OBJECT_ID]) {
+      throw new TypeError('Cursor was initialized with a different text object')
+    }
+    return this.elems.findIndex(e => e.elemId === cursor.elemId)
+  }
+
+  /**
    * Iterates over the text elements character by character, including any
    * inline objects.
    */

--- a/src/automerge.js
+++ b/src/automerge.js
@@ -123,10 +123,33 @@ function setDefaultBackend(newBackend) {
   backend = newBackend
 }
 
+/**
+ * Finds the latest integer index of a cursor object.
+ * If the character was deleted, returns -1.
+ *
+ * todos:
+ * - consider returning the closest character if deleted
+ * - consider optimizing the linear search
+ */
+function getCursorIndex(doc, cursor, findClosest = false) {
+  if (cursor.objectId === undefined || cursor.elemId === undefined) {
+    throw new TypeError('Invalid cursor object')
+  }
+
+  const state = Frontend.getBackendState(doc)
+  let index = backend.getListIndex(state, cursor.objectId, cursor.elemId)
+
+  if (index === -1 && findClosest) {
+    index = backend.getPrecedingListIndex(state, cursor.objectId, cursor.elemId)
+  }
+  return index
+}
+
+
 module.exports = {
   init, from, change, emptyChange, clone, free,
   load, save, merge, getChanges, getAllChanges, applyChanges, getMissingDeps,
-  encodeChange, decodeChange, equals, getHistory, uuid,
+  encodeChange, decodeChange, equals, getHistory, getCursorIndex, uuid,
   Frontend, setDefaultBackend,
   get Backend() { return backend }
 }

--- a/test/text_test.js
+++ b/test/text_test.js
@@ -373,7 +373,7 @@ describe('Automerge.Text', () => {
     })
 
     it('can retrieve the initial index on the cursor', () => {
-      assert.deepStrictEqual(Automerge.Frontend.findCursorIndex(s1.cursor, s1), 2)
+      assert.deepStrictEqual(Automerge.getCursorIndex(s1, s1.cursor), 2)
     })
 
     it('updates the cursor index when text is updated', () => {
@@ -381,7 +381,7 @@ describe('Automerge.Text', () => {
         doc.text.insertAt(0, 'a', 'b', 'c')
       })
 
-      assert.deepStrictEqual(Automerge.Frontend.findCursorIndex(s1.cursor, s1), 5)
+      assert.deepStrictEqual(Automerge.getCursorIndex(s1, s1.cursor), 5)
     })
 
     it('throws an error if a non-cursor is passed in', () => {
@@ -389,7 +389,7 @@ describe('Automerge.Text', () => {
         doc.value = "random string"
       })
 
-      assert.throws(() => Automerge.Frontend.findCursorIndex(s1.value, s1), /Invalid cursor object/)
+      assert.throws(() => Automerge.getCursorIndex(s1, s1.value), /Invalid cursor object/)
     })
 
     it('returns -1 by default if character was deleted', () => {
@@ -397,7 +397,7 @@ describe('Automerge.Text', () => {
         doc.text.deleteAt(2)
       })
 
-      assert.deepStrictEqual(Automerge.Frontend.findCursorIndex(s1.cursor, s1), -1)
+      assert.deepStrictEqual(Automerge.getCursorIndex(s1, s1.cursor), -1)
     })
 
     it('returns closest index if character was deleted and findClosest is set to true', () => {
@@ -405,7 +405,7 @@ describe('Automerge.Text', () => {
         doc.text.deleteAt(2)
       })
 
-      assert.deepStrictEqual(Automerge.Frontend.findCursorIndex(s1.cursor, s1, true), 1)
+      assert.deepStrictEqual(Automerge.getCursorIndex(s1, s1.cursor, true), 1)
     })
   })
 

--- a/test/text_test.js
+++ b/test/text_test.js
@@ -379,33 +379,33 @@ describe('Automerge.Text', () => {
     it('updates the cursor index when text is updated', () => {
       s1 = Automerge.change(s1, doc => {
         doc.text.insertAt(0, 'a', 'b', 'c')
-      }) 
+      })
 
-      assert.deepStrictEqual(Automerge.Frontend.findCursorIndex(s1.cursor, s1), 5)   
+      assert.deepStrictEqual(Automerge.Frontend.findCursorIndex(s1.cursor, s1), 5)
     })
 
     it('throws an error if a non-cursor is passed in', () => {
       s1 = Automerge.change(s1, doc => {
         doc.value = "random string"
-      }) 
+      })
 
-      assert.throws(() => Automerge.Frontend.findCursorIndex(s1.value, s1), /Invalid cursor object/) 
+      assert.throws(() => Automerge.Frontend.findCursorIndex(s1.value, s1), /Invalid cursor object/)
     })
 
     it('returns -1 by default if character was deleted', () => {
       s1 = Automerge.change(s1, doc => {
         doc.text.deleteAt(2)
-      })  
+      })
 
-      assert.deepStrictEqual(Automerge.Frontend.findCursorIndex(s1.cursor, s1), -1) 
+      assert.deepStrictEqual(Automerge.Frontend.findCursorIndex(s1.cursor, s1), -1)
     })
 
     it('returns closest index if character was deleted and findClosest is set to true', () => {
       s1 = Automerge.change(s1, doc => {
         doc.text.deleteAt(2)
-      })  
+      })
 
-      assert.deepStrictEqual(Automerge.Frontend.findCursorIndex(s1.cursor, s1, true), 1) 
+      assert.deepStrictEqual(Automerge.Frontend.findCursorIndex(s1.cursor, s1, true), 1)
     })
   })
 

--- a/test/text_test.js
+++ b/test/text_test.js
@@ -363,6 +363,52 @@ describe('Automerge.Text', () => {
     })
   })
 
+  describe.only('cursors', () => {
+    let s1
+    beforeEach(() => {
+      s1 = Automerge.change(Automerge.init(), doc => {
+        doc.text = new Automerge.Text('hello world')
+        doc.cursor = doc.text.getCursorAt(2)
+      })
+    })
+
+    it('can retrieve the initial index on the cursor', () => {
+      assert.deepStrictEqual(s1.text.findCursorIndex(s1.cursor), 2)
+    })
+
+    it('updates the cursor index when text is updated', () => {
+      s1 = Automerge.change(s1, doc => {
+        doc.text.insertAt(0, 'a', 'b', 'c')
+      }) 
+
+      assert.deepStrictEqual(s1.text.findCursorIndex(s1.cursor), 5)      
+    })
+
+    it('throws an error if a non-cursor is passed in', () => {
+      s1 = Automerge.change(s1, doc => {
+        doc.value = "random string"
+      }) 
+
+      assert.throws(() => s1.text.findCursorIndex(s1.value), /Invalid cursor object/) 
+    })
+
+    it('throws an error if the cursor was created on a different text object', () => {
+      s1 = Automerge.change(s1, doc => {
+        doc.text = new Automerge.Text('another text object')
+      }) 
+
+      assert.throws(() => s1.text.findCursorIndex(s1.cursor), /Cursor was initialized with a different text object/) 
+    })
+
+    it('handles the case where the cursor character was deleted', () => {
+      s1 = Automerge.change(s1, doc => {
+        doc.text.deleteAt(2)
+      })  
+
+      assert.deepStrictEqual(s1.text.findCursorIndex(s1.cursor), -1) 
+    })
+  })
+
   describe('non-textual control characters', () => {
     let s1
     beforeEach(() => {

--- a/test/text_test.js
+++ b/test/text_test.js
@@ -363,7 +363,7 @@ describe('Automerge.Text', () => {
     })
   })
 
-  describe.only('cursors', () => {
+  describe('cursors', () => {
     let s1
     beforeEach(() => {
       s1 = Automerge.change(Automerge.init(), doc => {
@@ -373,7 +373,7 @@ describe('Automerge.Text', () => {
     })
 
     it('can retrieve the initial index on the cursor', () => {
-      assert.deepStrictEqual(s1.text.findCursorIndex(s1.cursor), 2)
+      assert.deepStrictEqual(Automerge.Frontend.findCursorIndex(s1.cursor, s1), 2)
     })
 
     it('updates the cursor index when text is updated', () => {
@@ -381,7 +381,7 @@ describe('Automerge.Text', () => {
         doc.text.insertAt(0, 'a', 'b', 'c')
       }) 
 
-      assert.deepStrictEqual(s1.text.findCursorIndex(s1.cursor), 5)      
+      assert.deepStrictEqual(Automerge.Frontend.findCursorIndex(s1.cursor, s1), 5)   
     })
 
     it('throws an error if a non-cursor is passed in', () => {
@@ -389,23 +389,23 @@ describe('Automerge.Text', () => {
         doc.value = "random string"
       }) 
 
-      assert.throws(() => s1.text.findCursorIndex(s1.value), /Invalid cursor object/) 
+      assert.throws(() => Automerge.Frontend.findCursorIndex(s1.value, s1), /Invalid cursor object/) 
     })
 
-    it('throws an error if the cursor was created on a different text object', () => {
-      s1 = Automerge.change(s1, doc => {
-        doc.text = new Automerge.Text('another text object')
-      }) 
-
-      assert.throws(() => s1.text.findCursorIndex(s1.cursor), /Cursor was initialized with a different text object/) 
-    })
-
-    it('handles the case where the cursor character was deleted', () => {
+    it('returns -1 by default if character was deleted', () => {
       s1 = Automerge.change(s1, doc => {
         doc.text.deleteAt(2)
       })  
 
-      assert.deepStrictEqual(s1.text.findCursorIndex(s1.cursor), -1) 
+      assert.deepStrictEqual(Automerge.Frontend.findCursorIndex(s1.cursor, s1), -1) 
+    })
+
+    it('returns closest index if character was deleted and findClosest is set to true', () => {
+      s1 = Automerge.change(s1, doc => {
+        doc.text.deleteAt(2)
+      })  
+
+      assert.deepStrictEqual(Automerge.Frontend.findCursorIndex(s1.cursor, s1, true), 1) 
     })
   })
 

--- a/test/typescript_test.ts
+++ b/test/typescript_test.ts
@@ -379,6 +379,19 @@ describe('TypeScript support', () => {
         assert.deepStrictEqual(elemIds, [`2@${Automerge.getActorId(doc)}`, `3@${Automerge.getActorId(doc)}`])
       })
     })
+
+    describe('cursors API', () => {
+      beforeEach(() => {
+        doc = Automerge.change(doc, doc => doc.text.insertAt(0, 'a', 'b'))
+      })
+
+      it('should convert between cursor and index', () => {
+        const cursor = doc.text.getCursorAt(1)
+        assert.strictEqual(cursor.objectId, Automerge.getObjectId(doc.text))
+        assert.strictEqual(cursor.elemId, `3@${Automerge.getActorId(doc)}`)
+        assert.strictEqual(Automerge.getCursorIndex(doc, cursor), 1)
+      })
+    })
   })
 
   describe('Automerge.Table', () => {

--- a/test/typescript_test.ts
+++ b/test/typescript_test.ts
@@ -381,6 +381,14 @@ describe('TypeScript support', () => {
     })
 
     describe('cursors API', () => {
+      interface CursorPerUser {
+        [userName: string]: Automerge.Cursor
+      }
+      interface TextDocWithCursors {
+        text: Automerge.Text
+        cursors: CursorPerUser
+      }
+  
       beforeEach(() => {
         doc = Automerge.change(doc, doc => doc.text.insertAt(0, 'a', 'b'))
       })
@@ -390,6 +398,20 @@ describe('TypeScript support', () => {
         assert.strictEqual(cursor.objectId, Automerge.getObjectId(doc.text))
         assert.strictEqual(cursor.elemId, `3@${Automerge.getActorId(doc)}`)
         assert.strictEqual(Automerge.getCursorIndex(doc, cursor), 1)
+      })
+
+      it('should allow cursors to be stored in a document', () => {
+        let doc = Automerge.from<TextDocWithCursors>({
+          text: new Automerge.Text(),
+          cursors: {}
+        })
+        doc = Automerge.change(doc, doc => {
+          doc.text.insertAt(0, 'a', 'b', 'c')
+          doc.cursors['user1'] = doc.text.getCursorAt(1)
+        })
+        assert.strictEqual(doc.cursors.user1.objectId, Automerge.getObjectId(doc.text))
+        assert.strictEqual(doc.cursors.user1.elemId, `4@${Automerge.getActorId(doc)}`)
+        assert.strictEqual(Automerge.getCursorIndex(doc, doc.cursors.user1, true), 1)
       })
     })
   })


### PR DESCRIPTION
This PR is the same as #306, but based on the performance branch rather than main. It provides a first attempt at an API for cursors.

A cursor is an object of the form `{objectId: 'string', elemId: 'string'}` and it can be stored anywhere: inside an Automerge document or somewhere external. To get the cursor for a particular index of a text object, use:

```js
const cursor = doc.text.getCursorAt(index)
```

The cursor identifies a particular character in the text; the position of that character may change as text is inserted or deleted before it. To get the current index of a previously created cursor, use:

```js
const index = Automerge.getCursorIndex(doc, cursor, true)
```

The third argument controls what to do if the character referenced by the cursor has been deleted. If `false` and the character has been deleted, `getCursorIndex` returns -1. If the argument is `true` and the character has been deleted, `getCursorIndex` returns the index of the closest preceding non-deleted character, or -1 if there is no such preceding character.

I am not super happy with this approach, but putting up the PR nevertheless so that folks can play with it.