### PR TITLE
Experimental observable API

### DIFF
--- a/@types/automerge/index.d.ts
+++ b/@types/automerge/index.d.ts
@@ -30,8 +30,8 @@ declare module 'automerge' {
       observable?: Observable
     }
 
-  type PatchCallback<T> = (patch: Patch, before: T, after: T, local: boolean) => void
-  type ObserverCallback<T> = (diff: ObjectDiff, before: T, after: T, local: boolean) => void
+  type PatchCallback<T> = (patch: Patch, before: T, after: T, local: boolean, changes: Uint8Array[]) => void
+  type ObserverCallback<T> = (diff: ObjectDiff, before: T, after: T, local: boolean, changes: Uint8Array[]) => void
 
   class Observable {
     observe<T>(object: T, callback: ObserverCallback<T>): void

--- a/@types/automerge/index.d.ts
+++ b/@types/automerge/index.d.ts
@@ -15,18 +15,27 @@ declare module 'automerge' {
 
   // Automerge.* functions
 
-  function init<T>(options?: InitOptions): Doc<T>
-  function from<T>(initialState: T | Doc<T>, options?: InitOptions): Doc<T>
+  function init<T>(options?: InitOptions<T>): Doc<T>
+  function from<T>(initialState: T | Doc<T>, options?: InitOptions<T>): Doc<T>
   function clone<T>(doc: Doc<T>): Doc<T>
   function free<T>(doc: Doc<T>): void
 
-  type InitOptions =
+  type InitOptions<T> =
     | string // = actorId
     | { 
       actorId?: string
       deferActorId?: boolean
-      freeze?: boolean 
+      freeze?: boolean
+      patchCallback?: PatchCallback<T>
+      observable?: Observable
     }
+
+  type PatchCallback<T> = (patch: Patch, before: T, after: T, local: boolean) => void
+  type ObserverCallback<T> = (diff: ObjectDiff, before: T, after: T, local: boolean) => void
+
+  class Observable {
+    observe<T>(object: T, callback: ObserverCallback<T>): void
+  }
 
   function merge<T>(localdoc: Doc<T>, remotedoc: Doc<T>): Doc<T>
 
@@ -105,7 +114,7 @@ declare module 'automerge' {
     function change<D, T = Proxy<D>>(doc: D, message: string | undefined, callback: ChangeFn<T>): [D, Change]
     function change<D, T = Proxy<D>>(doc: D, callback: ChangeFn<T>): [D, Change]
     function emptyChange<T>(doc: Doc<T>, message?: string): [Doc<T>, Change]
-    function from<T>(initialState: T | Doc<T>, options?: InitOptions): [Doc<T>, Change]
+    function from<T>(initialState: T | Doc<T>, options?: InitOptions<T>): [Doc<T>, Change]
     function getActorId<T>(doc: Doc<T>): string
     function getBackendState<T>(doc: Doc<T>): BackendState
     function getConflicts<T>(doc: Doc<T>, key: keyof T): any
@@ -113,7 +122,7 @@ declare module 'automerge' {
     function getLastLocalChange<T>(doc: Doc<T>): Uint8Array
     function getObjectById<T>(doc: Doc<T>, objectId: OpId): Doc<T>
     function getObjectId<T>(doc: Doc<T>): OpId
-    function init<T>(options?: InitOptions): Doc<T>
+    function init<T>(options?: InitOptions<T>): Doc<T>
     function setActorId<T>(doc: Doc<T>, actorId: string): Doc<T>
   }
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Changelog
 
 Automerge adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html) for assigning
-version numbers.
+version numbers. However, any feature that is not documented or labelled as "experimental" may
+change without warning in a minor release.
 
 All notable changes to Automerge will be documented in this file, which
 is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
@@ -50,6 +51,8 @@ is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - **Removed**: `Automerge.Connection`, `Automerge.DocSet`, and `Automerge.WatchableDoc` have been
   moved to a separate [automerge-connection](https://github.com/automerge/automerge-connection)
   repository.
+- **Added** [#308]: Experimental `Automerge.Observable` API allows an application to receive
+a callback whenever a document (or some object within a document) changes ([@ept])
 
 ## [Unreleased]
 
@@ -308,6 +311,7 @@ is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 [0.4.0]: https://github.com/automerge/automerge/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/automerge/automerge/compare/v0.2.0...v0.3.0
 
+[#308]: https://github.com/automerge/automerge/pull/308
 [#243]: https://github.com/automerge/automerge/pull/243
 [#242]: https://github.com/automerge/automerge/pull/242
 [#241]: https://github.com/automerge/automerge/pull/241

--- a/frontend/apply_patch.js
+++ b/frontend/apply_patch.js
@@ -264,8 +264,11 @@ function updateTextObject(patch, obj, updated) {
     const opId = pred.sort(lamportCompare).reverse()[0]
     if (!opId) throw new RangeError(`No default value at index ${key}`)
 
-    elems[key].value = getValue(patch.props[key][opId], elems[key].value, updated)
-    elems[key].pred = pred
+    elems[key] = {
+      elemId: elems[key].elemId,
+      pred,
+      value: getValue(patch.props[key][opId], elems[key].value, updated)
+    }
   }
 
   updated[objectId] = instantiateText(objectId, elems)

--- a/frontend/context.js
+++ b/frontend/context.js
@@ -76,13 +76,13 @@ class Context {
     if (object instanceof Table) {
       // Table objects don't have conflicts, since rows are identified by their unique objectId
       const value = object.byId(key)
-      if (value) {
-        return {[key]: this.getValueDescription(value)}
-      } else {
-        return {}
-      }
+      return value ? {[key]: this.getValueDescription(value)} : {}
+    } else if (object instanceof Text) {
+      // Text objects don't support conflicts
+      const value = object.get(key)
+      return value ? {[key]: this.getValueDescription(value)} : {}
     } else {
-      // Map, list, or text objects
+      // Map or list objects
       const conflicts = object[CONFLICTS][key], values = {}
       if (!conflicts) {
         throw new RangeError(`No children at key ${key} of path ${JSON.stringify(path)}`)
@@ -101,6 +101,8 @@ class Context {
   getPropertyValue(object, key, opId) {
     if (object instanceof Table) {
       return object.byId(key)
+    } else if (object instanceof Text) {
+      return object.get(key)
     } else {
       return object[CONFLICTS][key][opId]
     }

--- a/frontend/index.js
+++ b/frontend/index.js
@@ -93,6 +93,7 @@ function makeChange(doc, context, options) {
 
   if (doc[OPTIONS].backend) {
     const [backendState, patch, binaryChange] = doc[OPTIONS].backend.applyLocalChange(state.backendState, change)
+    if (options && options.patchCallback) options.patchCallback(patch)
     state.backendState = backendState
     state.lastLocalChange = binaryChange
     // NOTE: When performing a local change, the patch is effectively applied twice -- once by the

--- a/frontend/index.js
+++ b/frontend/index.js
@@ -103,7 +103,7 @@ function makeChange(doc, context, options) {
     // Should we change this?
     const newDoc = applyPatchToDoc(doc, patch, state, true)
     const patchCallback = options && options.patchCallback || doc[OPTIONS].patchCallback
-    if (patchCallback) patchCallback(patch, doc, newDoc, true)
+    if (patchCallback) patchCallback(patch, doc, newDoc, true, [binaryChange])
     return [newDoc, change]
 
   } else {
@@ -167,9 +167,9 @@ function init(options) {
 
   if (options.observable) {
     const patchCallback = options.patchCallback, observable = options.observable
-    options.patchCallback = (patch, before, after, local) => {
-      if (patchCallback) patchCallback(patch, before, after, local)
-      observable.patchCallback(patch, before, after, local)
+    options.patchCallback = (patch, before, after, local, changes) => {
+      if (patchCallback) patchCallback(patch, before, after, local, changes)
+      observable.patchCallback(patch, before, after, local, changes)
     }
   }
 

--- a/frontend/index.js
+++ b/frontend/index.js
@@ -93,7 +93,6 @@ function makeChange(doc, context, options) {
 
   if (doc[OPTIONS].backend) {
     const [backendState, patch, binaryChange] = doc[OPTIONS].backend.applyLocalChange(state.backendState, change)
-    if (options && options.patchCallback) options.patchCallback(patch)
     state.backendState = backendState
     state.lastLocalChange = binaryChange
     // NOTE: When performing a local change, the patch is effectively applied twice -- once by the
@@ -101,7 +100,10 @@ function makeChange(doc, context, options) {
     // (after a round-trip through the backend). This is perhaps more robust, as changes only take
     // effect in the form processed by the backend, but the downside is a performance cost.
     // Should we change this?
-    return [applyPatchToDoc(doc, patch, state, true), change]
+    const newDoc = applyPatchToDoc(doc, patch, state, true)
+    const patchCallback = options && options.patchCallback || doc[OPTIONS].patchCallback
+    if (patchCallback) patchCallback(patch, doc, newDoc, true)
+    return [newDoc, change]
 
   } else {
     const queuedRequest = {actor, seq: change.seq, before: doc}

--- a/frontend/index.js
+++ b/frontend/index.js
@@ -7,6 +7,7 @@ const { Context } = require('./context')
 const { Text } = require('./text')
 const { Table } = require('./table')
 const { Counter } = require('./counter')
+const { Observable } = require('./observable')
 
 /**
  * Actor IDs must consist only of hexadecimal digits so that they can be encoded
@@ -162,6 +163,14 @@ function init(options) {
       options.actorId = uuid()
     }
     checkActorId(options.actorId)
+  }
+
+  if (options.observable) {
+    const patchCallback = options.patchCallback, observable = options.observable
+    options.patchCallback = (patch, before, after, local) => {
+      if (patchCallback) patchCallback(patch, before, after, local)
+      observable.patchCallback(patch, before, after, local)
+    }
   }
 
   const root = {}, cache = {_root: root}
@@ -373,5 +382,5 @@ module.exports = {
   init, from, change, emptyChange, applyPatch,
   getObjectId, getObjectById, getActorId, setActorId, getConflicts, getLastLocalChange,
   getBackendState, getElementIds,
-  Text, Table, Counter
+  Text, Table, Counter, Observable
 }

--- a/frontend/observable.js
+++ b/frontend/observable.js
@@ -1,0 +1,89 @@
+const { OBJECT_ID, CONFLICTS } = require('./constants')
+const { isObject } = require('../src/common')
+
+/**
+ * Allows an application to register a callback when a particular object in
+ * a document changes.
+ */
+class Observable {
+  constructor() {
+    this.observers = {} // map from objectId to array of observers for that object
+  }
+
+  /**
+   * Called by an Automerge document when `patch` is applied. `before` is the
+   * state of the document before the patch, and `after` is the state after
+   * applying it. `local` is true if the update is a result of locally calling
+   * `Automerge.change()`, and false otherwise.
+   */
+  patchCallback(patch, before, after, local) {
+    this._objectUpdate(patch.diffs, before, after, local)
+  }
+
+  /**
+   * Recursively walks a patch and calls the callbacks for all objects that
+   * appear in the patch.
+   */
+  _objectUpdate(diff, before, after, local) {
+    if (!diff.objectId) return
+    if (this.observers[diff.objectId]) {
+      for (let callback of this.observers[diff.objectId]) {
+        callback(diff, before, after, local)
+      }
+    }
+
+    if (!diff.props) return
+    for (let propName of Object.keys(diff.props)) {
+      for (let opId of Object.keys(diff.props[propName])) {
+        let childDiff = diff.props[propName][opId], childBefore, childAfter
+
+        if (diff.type === 'map') {
+          childBefore = before && before[CONFLICTS] && before[CONFLICTS][propName] &&
+            before[CONFLICTS][propName][opId]
+          childAfter = after && after[CONFLICTS] && after[CONFLICTS][propName] &&
+            after[CONFLICTS][propName][opId]
+
+        } else if (diff.type === 'table') {
+          childBefore = before && before.byId(propName)
+          childAfter = after && after.byId(propName)
+
+        } else if (diff.type === 'list') {
+          const index = parseInt(propName)
+          // Don't try to get the child object before if the indexes might have changed
+          if (!diff.edits || diff.edits.length === 0) {
+            childBefore = before && before[CONFLICTS] && before[CONFLICTS][index] &&
+              before[CONFLICTS][index][opId]
+          }
+          childAfter = after && after[CONFLICTS] && after[CONFLICTS][index] &&
+            after[CONFLICTS][index][opId]
+
+        } else if (diff.type === 'text') {
+          const index = parseInt(propName)
+          // Don't try to get the child object before if the indexes might have changed
+          if (!diff.edits || diff.edits.length === 0) {
+            childBefore = before && before.get(index)
+          }
+          childAfter = after && after.get(index)
+        }
+
+        this._objectUpdate(childDiff, childBefore, childAfter, local)
+      }
+    }
+  }
+
+  /**
+   * Call this to register a callback that will get called whenever a particular
+   * object in a document changes. The callback is passed four arguments: the
+   * part of the patch describing the update to that object, the old state of
+   * the object, the new state of the object, and a boolean that is true if the
+   * change is the result of calling `Automerge.change()` locally.
+   */
+  observe(object, callback) {
+    const objectId = object[OBJECT_ID]
+    if (!objectId) throw new TypeError('The observed object must be part of an Automerge document')
+    if (!this.observers[objectId]) this.observers[objectId] = []
+    this.observers[objectId].push(callback)
+  }
+}
+
+module.exports = { Observable }

--- a/frontend/observable.js
+++ b/frontend/observable.js
@@ -14,21 +14,22 @@ class Observable {
    * Called by an Automerge document when `patch` is applied. `before` is the
    * state of the document before the patch, and `after` is the state after
    * applying it. `local` is true if the update is a result of locally calling
-   * `Automerge.change()`, and false otherwise.
+   * `Automerge.change()`, and false otherwise. `changes` is an array of
+   * changes that were applied to the document (as Uint8Arrays).
    */
-  patchCallback(patch, before, after, local) {
-    this._objectUpdate(patch.diffs, before, after, local)
+  patchCallback(patch, before, after, local, changes) {
+    this._objectUpdate(patch.diffs, before, after, local, changes)
   }
 
   /**
    * Recursively walks a patch and calls the callbacks for all objects that
    * appear in the patch.
    */
-  _objectUpdate(diff, before, after, local) {
+  _objectUpdate(diff, before, after, local, changes) {
     if (!diff.objectId) return
     if (this.observers[diff.objectId]) {
       for (let callback of this.observers[diff.objectId]) {
-        callback(diff, before, after, local)
+        callback(diff, before, after, local, changes)
       }
     }
 
@@ -66,7 +67,7 @@ class Observable {
           childAfter = after && after.get(index)
         }
 
-        this._objectUpdate(childDiff, childBefore, childAfter, local)
+        this._objectUpdate(childDiff, childBefore, childAfter, local, changes)
       }
     }
   }

--- a/frontend/observable.js
+++ b/frontend/observable.js
@@ -74,10 +74,11 @@ class Observable {
 
   /**
    * Call this to register a callback that will get called whenever a particular
-   * object in a document changes. The callback is passed four arguments: the
+   * object in a document changes. The callback is passed five arguments: the
    * part of the patch describing the update to that object, the old state of
-   * the object, the new state of the object, and a boolean that is true if the
-   * change is the result of calling `Automerge.change()` locally.
+   * the object, the new state of the object, a boolean that is true if the
+   * change is the result of calling `Automerge.change()` locally, and the array
+   * of binary changes applied to the document.
    */
   observe(object, callback) {
     const objectId = object[OBJECT_ID]

--- a/frontend/observable.js
+++ b/frontend/observable.js
@@ -4,6 +4,8 @@ const { isObject } = require('../src/common')
 /**
  * Allows an application to register a callback when a particular object in
  * a document changes.
+ *
+ * NOTE: This API is experimental and may change without warning in minor releases.
  */
 class Observable {
   constructor() {

--- a/frontend/text.js
+++ b/frontend/text.js
@@ -1,4 +1,5 @@
 const { OBJECT_ID } = require('./constants')
+const { isObject } = require('../src/common')
 
 class Text {
   constructor (text) {
@@ -20,7 +21,14 @@ class Text {
   }
 
   get (index) {
-    return this.elems[index].value
+    const value = this.elems[index].value
+    if (this.context && isObject(value)) {
+      const objectId = value[OBJECT_ID]
+      const path = this.path.concat([{key: index, objectId}])
+      return this.context.instantiateObject(path, objectId)
+    } else {
+      return value
+    }
   }
 
   getElemId (index) {

--- a/src/automerge.js
+++ b/src/automerge.js
@@ -146,6 +146,7 @@ module.exports = {
 }
 
 for (let name of ['getObjectId', 'getObjectById', 'getActorId',
-     'setActorId', 'getConflicts', 'getLastLocalChange', 'Text', 'Table', 'Counter']) {
+     'setActorId', 'getConflicts', 'getLastLocalChange',
+     'Text', 'Table', 'Counter', 'Observable']) {
   module.exports[name] = Frontend[name]
 }

--- a/src/automerge.js
+++ b/src/automerge.js
@@ -49,6 +49,7 @@ function free(doc) {
 function load(data, options) {
   const state = backend.load(data)
   const patch = backend.getPatch(state)
+  if (options && options.patchCallback) options.patchCallback(Object.assign({}, patch))
   patch.state = state
   return Frontend.applyPatch(init(options), patch)
 }
@@ -75,9 +76,10 @@ function getAllChanges(doc) {
   return backend.getChanges(Frontend.getBackendState(doc), [])
 }
 
-function applyChanges(doc, changes) {
+function applyChanges(doc, changes, options = {}) {
   const oldState = Frontend.getBackendState(doc)
   const [newState, patch] = backend.applyChanges(oldState, changes)
+  if (options.patchCallback) options.patchCallback(Object.assign({}, patch))
   patch.state = newState
   return Frontend.applyPatch(doc, patch)
 }

--- a/src/automerge.js
+++ b/src/automerge.js
@@ -55,7 +55,7 @@ function load(data, options) {
 
   if (doc[OPTIONS].patchCallback) {
     delete patch.state
-    doc[OPTIONS].patchCallback(patch, {}, doc, false)
+    doc[OPTIONS].patchCallback(patch, {}, doc, false, [data])
   }
   return doc
 }
@@ -91,7 +91,7 @@ function applyChanges(doc, changes, options = {}) {
   const patchCallback = options.patchCallback || doc[OPTIONS].patchCallback
   if (patchCallback) {
     delete patch.state
-    patchCallback(patch, doc, newDoc, false)
+    patchCallback(patch, doc, newDoc, false, changes)
   }
   return newDoc
 }

--- a/test/observable_test.js
+++ b/test/observable_test.js
@@ -1,0 +1,67 @@
+const assert = require('assert')
+const Automerge = process.env.TEST_DIST === '1' ? require('../dist/automerge') : require('../src/automerge')
+
+describe('Automerge.Observable', () => {
+  it('allows registering a callback on the root object', () => {
+    let observable = new Automerge.Observable(), callbackCalled = false
+    let doc = Automerge.init({observable}), actor = Automerge.getActorId(doc)
+    observable.observe(doc, (diff, before, after, local) => {
+      callbackCalled = true
+      assert.deepStrictEqual(diff, {
+        objectId: '_root', type: 'map', props: {bird: {[`1@${actor}`]: {value: 'Goldfinch'}}}
+      })
+      assert.deepStrictEqual(before, {})
+      assert.deepStrictEqual(after, {bird: 'Goldfinch'})
+      assert.deepStrictEqual(local, true)
+    })
+    doc = Automerge.change(doc, doc => doc.bird = 'Goldfinch')
+    assert.strictEqual(callbackCalled, true)
+  })
+
+  it('allows registering a callback on a text object', () => {
+    let observable = new Automerge.Observable(), callbackCalled = false
+    let doc = Automerge.from({text: new Automerge.Text()}, {observable})
+    let actor = Automerge.getActorId(doc)
+    observable.observe(doc.text, (diff, before, after, local) => {
+      callbackCalled = true
+      assert.deepStrictEqual(diff, {
+        objectId: `1@${actor}`, type: 'text', edits: [
+          {action: 'insert', index: 0, elemId: `2@${actor}`},
+          {action: 'insert', index: 1, elemId: `3@${actor}`},
+          {action: 'insert', index: 2, elemId: `4@${actor}`}
+        ], props: {
+          0: {[`2@${actor}`]: {value: 'a'}},
+          1: {[`3@${actor}`]: {value: 'b'}},
+          2: {[`4@${actor}`]: {value: 'c'}}
+        }
+      })
+      assert.deepStrictEqual(before.toString(), '')
+      assert.deepStrictEqual(after.toString(), 'abc')
+      assert.deepStrictEqual(local, true)
+    })
+    doc = Automerge.change(doc, doc => doc.text.insertAt(0, 'a', 'b', 'c'))
+    assert.strictEqual(callbackCalled, true)
+  })
+
+  it('should call the callback when applying remote changes', () => {
+    let observable = new Automerge.Observable(), callbackCalled = false
+    let local = Automerge.from({text: new Automerge.Text()}, {observable})
+    let remote = Automerge.init()
+    const localId = Automerge.getActorId(local), remoteId = Automerge.getActorId(remote)
+    observable.observe(local.text, (diff, before, after, local) => {
+      callbackCalled = true
+      assert.deepStrictEqual(diff, {
+        objectId: `1@${localId}`, type: 'text',
+        edits: [{action: 'insert', index: 0, elemId: `2@${remoteId}`}],
+        props: {0: {[`2@${remoteId}`]: {value: 'a'}}}
+      })
+      assert.deepStrictEqual(before.toString(), '')
+      assert.deepStrictEqual(after.toString(), 'a')
+      assert.deepStrictEqual(local, false)
+    })
+    remote = Automerge.applyChanges(remote, Automerge.getAllChanges(local))
+    remote = Automerge.change(remote, doc => doc.text.insertAt(0, 'a'))
+    local = Automerge.applyChanges(local, Automerge.getAllChanges(remote))
+    assert.strictEqual(callbackCalled, true)
+  })
+})

--- a/test/text_test.js
+++ b/test/text_test.js
@@ -387,6 +387,14 @@ describe('Automerge.Text', () => {
       assert.strictEqual(s1.text.toString(), 'a')
     })
 
+    it('should allow control characters to be updated', () => {
+      const s2 = Automerge.change(s1, doc => doc.text.get(1).attribute = 'italic')
+      const s3 = Automerge.load(Automerge.save(s2))
+      assert.strictEqual(s1.text.get(1).attribute, 'bold')
+      assert.strictEqual(s2.text.get(1).attribute, 'italic')
+      assert.strictEqual(s3.text.get(1).attribute, 'italic')
+    })
+
     describe('spans interface to Text', () => {
       it('should return a simple string as a single span', () =>{
         let s1 = Automerge.change(Automerge.init(), doc => {

--- a/test/typescript_test.ts
+++ b/test/typescript_test.ts
@@ -559,17 +559,39 @@ describe('TypeScript support', () => {
       text: Automerge.Text
     }
 
-    it('should call a callback when a document changes', () => {
+    it('should call a patchCallback when a document changes', () => {
+      let callbackCalled = false, actor = ''
+      let doc = Automerge.init<TextDoc>({patchCallback: (patch, before, after, local, changes) => {
+        callbackCalled = true
+        assert.deepStrictEqual(patch.diffs.props.text[`1@${actor}`], {
+          objectId: `1@${actor}`, type: 'text',
+          edits: [{action: 'insert', index: 0, elemId: `2@${actor}`}],
+          props: {0: {[`2@${actor}`]: {value: 'a'}}}
+        })
+        assert.deepStrictEqual(before, {})
+        assert.strictEqual(after.text.toString(), 'a')
+        assert.strictEqual(local, true)
+        assert.strictEqual(changes.length, 1)
+        assert.ok(changes[0] instanceof Uint8Array)
+      }})
+      actor = Automerge.getActorId(doc)
+      doc = Automerge.change(doc, doc => doc.text = new Automerge.Text('a'))
+      assert.strictEqual(callbackCalled, true)
+    })
+
+    it('should call an observer when a document changes', () => {
       let observable = new Automerge.Observable(), callbackCalled = false
       let doc = Automerge.from({text: new Automerge.Text()}, {observable})
       let actor = Automerge.getActorId(doc)
-      observable.observe(doc.text, (diff, before, after, local) => {
+      observable.observe(doc.text, (diff, before, after, local, changes) => {
         callbackCalled = true
         assert.deepStrictEqual(diff.edits, [{action: 'insert', index: 0, elemId: `2@${actor}`}])
         assert.deepStrictEqual(diff.props, {0: {[`2@${actor}`]: {value: 'a'}}})
-        assert.deepStrictEqual(before.toString(), '')
-        assert.deepStrictEqual(after.toString(), 'a')
-        assert.deepStrictEqual(local, true)
+        assert.strictEqual(before.toString(), '')
+        assert.strictEqual(after.toString(), 'a')
+        assert.strictEqual(local, true)
+        assert.strictEqual(changes.length, 1)
+        assert.ok(changes[0] instanceof Uint8Array)
       })
       doc = Automerge.change(doc, doc => doc.text.insertAt(0, 'a'))
       assert.strictEqual(callbackCalled, true)

--- a/test/typescript_test.ts
+++ b/test/typescript_test.ts
@@ -553,4 +553,26 @@ describe('TypeScript support', () => {
       })
     })
   })
+
+  describe('Automerge.Observable', () => {
+    interface TextDoc {
+      text: Automerge.Text
+    }
+
+    it('should call a callback when a document changes', () => {
+      let observable = new Automerge.Observable(), callbackCalled = false
+      let doc = Automerge.from({text: new Automerge.Text()}, {observable})
+      let actor = Automerge.getActorId(doc)
+      observable.observe(doc.text, (diff, before, after, local) => {
+        callbackCalled = true
+        assert.deepStrictEqual(diff.edits, [{action: 'insert', index: 0, elemId: `2@${actor}`}])
+        assert.deepStrictEqual(diff.props, {0: {[`2@${actor}`]: {value: 'a'}}})
+        assert.deepStrictEqual(before.toString(), '')
+        assert.deepStrictEqual(after.toString(), 'a')
+        assert.deepStrictEqual(local, true)
+      })
+      doc = Automerge.change(doc, doc => doc.text.insertAt(0, 'a'))
+      assert.strictEqual(callbackCalled, true)
+    })
+  })
 })


### PR DESCRIPTION
There have been requests for an observer-style API, where an application's callback function gets called whenever a certain part of an Automerge document changes. For example, this is useful when integrating a text editing widget with Automerge, where the widget state needs to be updated whenever the Automerge document changes (especially as a result of remote changes arriving from the network).

This PR is based on #288, allowing hooking into patch application, but based on the performance branch rather than main. Moreover, I've extended the API with a new class `Automerge.Observable`, which allows observing individual objects as well as the entire document. The callback is given a description of the change in the [Automerge patch format](https://github.com/automerge/automerge/blob/6fa8b5a5b9bbfb178750c629fc6107b30b9c35a3/BINARY_FORMAT.md#patch-format) (including, for example, a description of which elements to insert or delete in a list or text object), as well as the before and after state of the object, and a flag indicating whether the change is the result of a local call to `Automerge.change` or whether it came form `Automerge.applyChanges` (typically a remote change).

I made `Observable` a separate class because an Automerge document is immutable, and so it doesn't make much sense to register observers on it directly. On the other hand, the Observable class is mutable, allowing observers to be added.

Basic usage example:

```js
let observable = new Automerge.Observable()
let doc = Automerge.from({text: new Automerge.Text()}, {observable})
observable.observe(doc.text, (diff, before, after, local, changes) => {
  // diff.edits is an array of insert or delete actions
  // diff.props contains any updated values in this object
  // before is the state of the object before this update
  // after is the state of the object after this update
  // local is true if this callback is due to a local change
  // changes is an array of binary changes that were applied
})

// Each of these calls the callback above (if the text is changed)
doc = Automerge.change(doc, doc => doc.text.insertAt(0, 'a', 'b', 'c'))
doc = Automerge.applyChanges(doc, changesFromRemoteUser)
```

You can pass an `observable` option to `Automerge.init()`, `Automerge.from()`, or `Automerge.load()`. See [the tests](https://github.com/automerge/automerge/commit/b90500cd543ce490c4be901f1b00fc2cda9789af#diff-bcf1e97d86d189fa557fdb4336cd83e33eee3b553a0570f972318daf52dcfc0b) for some more examples of how to use this API.

Observable is based on a slightly lower-level API (which allows observing only an entire document, not individual objects within it) called `patchCallback`:

```js
let doc = Automerge.init({patchCallback: (patch, before, after, local, changes) => {
  // as before
}})
doc = Automerge.change(doc, doc => { /* ... */ })
```