### PR TITLE
Alternative implementation of cursors

### DIFF
--- a/backend/op_set.js
+++ b/backend/op_set.js
@@ -255,9 +255,13 @@ function setPatchProps(opSet, objectId, key, patch) {
     ops[opId] = true
 
     if (op.get('action') === 'set') {
-      patch.props[key][opId] = {value: op.get('value')}
-      if (op.get('datatype')) {
-        patch.props[key][opId].datatype = op.get('datatype')
+      if (op.get('datatype') === 'cursor') {
+        patch.props[key][opId] = {elemId: op.get('ref'), datatype: 'cursor'}
+      } else {
+        patch.props[key][opId] = {value: op.get('value')}
+        if (op.get('datatype')) {
+          patch.props[key][opId].datatype = op.get('datatype')
+        }
       }
     } else if (isChildOp(op)) {
       if (!patch.props[key][opId]) {

--- a/backend/op_set.js
+++ b/backend/op_set.js
@@ -112,8 +112,7 @@ function updateListElement(opSet, objectId, elemId, patch) {
  * Returns true if the operation `op` introduces a child object.
  */
 function isChildOp(op) {
-  const action = op.get('action')
-  return action.startsWith('make') || action === 'link'
+  return op.get('action').startsWith('make')
 }
 
 /**
@@ -136,7 +135,7 @@ function getOperationKey(op) {
 }
 
 /**
- * Processes a 'set', 'del', 'make*', 'link', or 'inc' operation. Mutates `patch`
+ * Processes a 'set', 'del', 'make*', or 'inc' operation. Mutates `patch`
  * to describe the change and returns an updated `opSet`.
  */
 function applyAssign(opSet, op, patch) {
@@ -169,9 +168,6 @@ function applyAssign(opSet, op, patch) {
     } else {
       opSet = applyMake(opSet, op)
     }
-  }
-  if (action === 'link' && patch) {
-    patch.props[key][op.get('opId')] = constructObject(opSet, getChildId(op))
   }
 
   const ops = getFieldOps(opSet, objectId, key)
@@ -320,7 +316,7 @@ function applyOps(opSet, change, patch) {
   let newObjects = Set()
   change.get('ops').forEach((op, index) => {
     const action = op.get('action'), obj = op.get('obj'), insert = op.get('insert')
-    if (!['set', 'del', 'inc', 'link', 'makeMap', 'makeList', 'makeText', 'makeTable'].includes(action)) {
+    if (!['set', 'del', 'inc', 'makeMap', 'makeList', 'makeText', 'makeTable'].includes(action)) {
       throw new RangeError(`Unknown operation action: ${action}`)
     }
     if (!op.get('pred')) {

--- a/frontend/apply_patch.js
+++ b/frontend/apply_patch.js
@@ -3,6 +3,7 @@ const { OPTIONS, OBJECT_ID, CONFLICTS, ELEM_IDS } = require('./constants')
 const { Text, instantiateText } = require('./text')
 const { Table, instantiateTable } = require('./table')
 const { Counter } = require('./counter')
+const { Cursor } = require('./cursor')
 
 /**
  * Reconstructs the value from the patch object `patch`.
@@ -20,6 +21,8 @@ function getValue(patch, object, updated) {
     return new Date(patch.value)
   } else if (patch.datatype === 'counter') {
     return new Counter(patch.value)
+  } else if (patch.datatype === 'cursor') {
+    return new Cursor('', patch.index, patch.elemId)
   } else if (patch.datatype !== undefined) {
     throw new TypeError(`Unknown datatype: ${patch.datatype}`)
   } else {

--- a/frontend/context.js
+++ b/frontend/context.js
@@ -3,6 +3,7 @@ const { interpretPatch } = require('./apply_patch')
 const { Text } = require('./text')
 const { Table } = require('./table')
 const { Counter, getWriteableCounter } = require('./counter')
+const { Cursor } = require('./cursor')
 const { isObject, copyObject } = require('../src/common')
 const uuid = require('../src/uuid')
 
@@ -50,8 +51,10 @@ class Context {
         return {value: value.getTime(), datatype: 'timestamp'}
 
       } else if (value instanceof Counter) {
-        // Counter object
         return {value: value.value, datatype: 'counter'}
+
+      } else if (value instanceof Cursor) {
+        return {elemId: value.elemId, datatype: 'cursor'}
 
       } else {
         // Nested object (map, list, text, or table)
@@ -175,6 +178,9 @@ class Context {
     if (object[key] instanceof Counter) {
       return getWriteableCounter(object[key].value, this, path, objectId, key)
 
+    } else if (object[key] instanceof Cursor) {
+      return object[key].getWriteable(context, path)
+
     } else if (isObject(object[key])) {
       const childId = object[key][OBJECT_ID]
       const subpath = path.concat([{key, objectId: childId}])
@@ -264,16 +270,24 @@ class Context {
       throw new RangeError('The key of a map entry must not be an empty string')
     }
 
-    if (isObject(value) && !(value instanceof Date) && !(value instanceof Counter)) {
-      // Nested object (map, list, text, or table)
-      return this.createNestedObjects(objectId, key, value, insert, pred, elemId)
-    } else {
-      // Date or counter object, or primitive value (number, string, boolean, or null)
+    if (!isObject(value) || value instanceof Date || value instanceof Counter || value instanceof Cursor) {
+      // Date/counter/cursor object, or primitive value (number, string, boolean, or null)
       const description = this.getValueDescription(value)
       const op = elemId ? {action: 'set', obj: objectId, elemId, insert, pred}
                         : {action: 'set', obj: objectId, key, insert, pred}
-      this.addOp(Object.assign(op, description))
+
+      if (description.datatype === 'cursor') {
+        op.ref = description.elemId
+        op.datatype = 'cursor'
+      } else {
+        op.value = description.value
+        if (description.datatype) op.datatype = description.datatype
+      }
+      this.addOp(op)
       return description
+    } else {
+      // Nested object (map, list, text, or table)
+      return this.createNestedObjects(objectId, key, value, insert, pred, elemId)
     }
   }
 

--- a/frontend/cursor.js
+++ b/frontend/cursor.js
@@ -9,6 +9,7 @@ const { isObject } = require('../src/common')
 class Cursor {
   constructor(object, index, elemId = undefined) {
     if (Array.isArray(object) && object[ELEM_IDS] && typeof index === 'number') {
+      if (index < 0 || index >= object[ELEM_IDS].length) throw new RangeError('list index out of bounds')
       this.objectId = object[OBJECT_ID]
       this.elemId = object[ELEM_IDS][index]
       this.index = index

--- a/frontend/cursor.js
+++ b/frontend/cursor.js
@@ -1,0 +1,40 @@
+const { OBJECT_ID, ELEM_IDS } = require('./constants')
+const { isObject } = require('../src/common')
+
+/**
+ * A cursor references a particular element in a list, or a character in an
+ * Automerge.Text object. As list elements get inserted/deleted ahead of the
+ * cursor position, the index of the cursor is automatically recomputed.
+ */
+class Cursor {
+  constructor(object, index, elemId = undefined) {
+    if (Array.isArray(object) && object[ELEM_IDS] && typeof index === 'number') {
+      this.objectId = object[OBJECT_ID]
+      this.elemId = object[ELEM_IDS][index]
+      this.index = index
+    } else if (isObject(object) && object.getElemId && typeof index === 'number') {
+      this.objectId = object[OBJECT_ID]
+      this.elemId = object.getElemId(index)
+      this.index = index
+    } else if (typeof object == 'string' && /*typeof index === 'number' &&*/ typeof elemId === 'string') {
+      this.objectId = object
+      this.elemId = elemId
+      this.index = index
+    } else {
+      throw new TypeError('Construct a cursor using a list/text object and index')
+    }
+  }
+
+  /**
+   * Called when a cursor is accessed within a change callback. `context` is the
+   * proxy context that keeps track of any mutations.
+   */
+  getWriteable(context, path) {
+    const instance = new Cursor(this.objectId, this.index, this.elemId)
+    instance.context = context
+    instance.path = path
+    return instance
+  }
+}
+
+module.exports = { Cursor }

--- a/frontend/index.js
+++ b/frontend/index.js
@@ -7,6 +7,7 @@ const { Context } = require('./context')
 const { Text } = require('./text')
 const { Table } = require('./table')
 const { Counter } = require('./counter')
+const { Cursor } = require('./cursor')
 
 /**
  * Actor IDs must consist only of hexadecimal digits so that they can be encoded
@@ -370,5 +371,5 @@ module.exports = {
   init, from, change, emptyChange, applyPatch,
   getObjectId, getObjectById, getActorId, setActorId, getConflicts, getLastLocalChange,
   getBackendState, getElementIds,
-  Text, Table, Counter
+  Text, Table, Counter, Cursor
 }

--- a/frontend/proxies.js
+++ b/frontend/proxies.js
@@ -1,4 +1,4 @@
-const { OBJECT_ID, CHANGE, STATE } = require('./constants')
+const { OBJECT_ID, CHANGE, STATE, ELEM_IDS } = require('./constants')
 const { Counter } = require('./counter')
 const { Text } = require('./text')
 const { Table } = require('./table')
@@ -148,6 +148,7 @@ const ListHandler = {
     if (key === Symbol.iterator) return context.getObject(objectId)[Symbol.iterator]
     if (key === OBJECT_ID) return objectId
     if (key === CHANGE) return context
+    if (key === ELEM_IDS) return context.getObject(objectId)[ELEM_IDS]
     if (key === 'length') return context.getObject(objectId).length
     if (typeof key === 'string' && /^[0-9]+$/.test(key)) {
       return context.getObjectField(path, objectId, parseListIndex(key))

--- a/frontend/text.js
+++ b/frontend/text.js
@@ -33,6 +33,7 @@ class Text {
   }
 
   getElemId (index) {
+    if (index < 0 || index >= this.elems.length) throw new RangeError('text index out of bounds')
     return this.elems[index].elemId
   }
 

--- a/frontend/text.js
+++ b/frontend/text.js
@@ -1,5 +1,6 @@
 const { OBJECT_ID } = require('./constants')
 const { isObject } = require('../src/common')
+const { Cursor } = require('./cursor')
 
 class Text {
   constructor (text) {
@@ -33,6 +34,10 @@ class Text {
 
   getElemId (index) {
     return this.elems[index].elemId
+  }
+
+  getCursorAt (index) {
+    return new Cursor(this, index)
   }
 
   /**

--- a/src/automerge.js
+++ b/src/automerge.js
@@ -132,6 +132,7 @@ module.exports = {
 }
 
 for (let name of ['getObjectId', 'getObjectById', 'getActorId',
-     'setActorId', 'getConflicts', 'getLastLocalChange', 'Text', 'Table', 'Counter']) {
+     'setActorId', 'getConflicts', 'getLastLocalChange',
+     'Text', 'Table', 'Counter', 'Cursor']) {
   module.exports[name] = Frontend[name]
 }

--- a/test/backend_test.js
+++ b/test/backend_test.js
@@ -254,6 +254,27 @@ describe('Automerge.Backend', () => {
         }}}}
       })
     })
+
+    it('should support Cursor objects', () => {
+      const actor = uuid()
+      const change = {actor, seq: 1, startOp: 1, time: 0, deps: [], ops: [
+        {action: 'makeList', obj: '_root', key: 'list', pred: []},
+        {action: 'set', obj: `1@${actor}`, elemId: '_head', insert: true, value: 'fish', pred: []},
+        {action: 'set', obj: '_root', key: 'cursor', ref: `2@${actor}`, datatype: 'cursor', pred: []}
+      ]}
+      const [s1, patch] = Backend.applyChanges(Backend.init(), [encodeChange(change)])
+      assert.deepStrictEqual(patch, {
+        clock: {[actor]: 1}, deps: [hash(change)], maxOp: 3,
+        diffs: {objectId: '_root', type: 'map', props: {
+          list: {[`1@${actor}`]: {
+            objectId: `1@${actor}`, type: 'list',
+            edits: [{action: 'insert', index: 0, elemId: `2@${actor}`}],
+            props: {0: {[`2@${actor}`]: {value: 'fish'}}}
+          }},
+          cursor: {[`3@${actor}`]: {elemId: `2@${actor}`, datatype: 'cursor'}}
+        }}
+      })
+    })
   })
 
   describe('applyLocalChange()', () => {
@@ -628,6 +649,27 @@ describe('Automerge.Backend', () => {
           edits: [{action: 'insert', index: 0, elemId: `2@${actor}`}],
           props: {0: {[`2@${actor}`]: {value: now.getTime(), datatype: 'timestamp'}}}
         }}}}
+      })
+    })
+
+    it('should include Cursor objects', () => {
+      const actor = uuid()
+      const change = {actor, seq: 1, startOp: 1, time: 0, deps: [], ops: [
+        {action: 'makeList', obj: '_root', key: 'list', pred: []},
+        {action: 'set', obj: `1@${actor}`, elemId: '_head', insert: true, value: 'fish', pred: []},
+        {action: 'set', obj: '_root', key: 'cursor', ref: `2@${actor}`, datatype: 'cursor', pred: []}
+      ]}
+      const [s1, patch] = Backend.applyChanges(Backend.init(), [encodeChange(change)])
+      assert.deepStrictEqual(patch, {
+        clock: {[actor]: 1}, deps: [hash(change)], maxOp: 3,
+        diffs: {objectId: '_root', type: 'map', props: {
+          list: {[`1@${actor}`]: {
+            objectId: `1@${actor}`, type: 'list',
+            edits: [{action: 'insert', index: 0, elemId: `2@${actor}`}],
+            props: {0: {[`2@${actor}`]: {value: 'fish'}}}
+          }},
+          cursor: {[`3@${actor}`]: {elemId: `2@${actor}`, datatype: 'cursor'}}
+        }}
       })
     })
   })

--- a/test/cursor_test.js
+++ b/test/cursor_test.js
@@ -1,0 +1,42 @@
+const assert = require('assert')
+const Automerge = process.env.TEST_DIST === '1' ? require('../dist/automerge') : require('../src/automerge')
+
+describe('Automerge.Cursor', () => {
+  it('should allow a cursor on a list element', () => {
+    let s1 = Automerge.change(Automerge.init(), doc => {
+      doc.list = [1,2,3]
+      doc.cursor = new Automerge.Cursor(doc.list, 2)
+      assert.ok(doc.cursor instanceof Automerge.Cursor)
+      assert.strictEqual(doc.cursor.elemId, `4@${Automerge.getActorId(doc)}`)
+    })
+    assert.ok(s1.cursor instanceof Automerge.Cursor)
+    assert.strictEqual(s1.cursor.elemId, `4@${Automerge.getActorId(s1)}`)
+
+    let s2 = Automerge.applyChanges(Automerge.init(), Automerge.getAllChanges(s1))
+    assert.ok(s2.cursor instanceof Automerge.Cursor)
+    assert.strictEqual(s2.cursor.elemId, `4@${Automerge.getActorId(s1)}`)
+
+    let s3 = Automerge.load(Automerge.save(s1))
+    assert.ok(s3.cursor instanceof Automerge.Cursor)
+    assert.strictEqual(s3.cursor.elemId, `4@${Automerge.getActorId(s1)}`)
+  })
+
+  it('should allow a cursor on a text character', () => {
+    let s1 = Automerge.change(Automerge.init(), doc => {
+      doc.text = new Automerge.Text(['a', 'b', 'c'])
+      doc.cursor = doc.text.getCursorAt(2)
+      assert.ok(doc.cursor instanceof Automerge.Cursor)
+      assert.strictEqual(doc.cursor.elemId, `4@${Automerge.getActorId(doc)}`)
+    })
+    assert.ok(s1.cursor instanceof Automerge.Cursor)
+    assert.strictEqual(s1.cursor.elemId, `4@${Automerge.getActorId(s1)}`)
+
+    let s2 = Automerge.applyChanges(Automerge.init(), Automerge.getAllChanges(s1))
+    assert.ok(s2.cursor instanceof Automerge.Cursor)
+    assert.strictEqual(s2.cursor.elemId, `4@${Automerge.getActorId(s1)}`)
+
+    let s3 = Automerge.load(Automerge.save(s1))
+    assert.ok(s3.cursor instanceof Automerge.Cursor)
+    assert.strictEqual(s3.cursor.elemId, `4@${Automerge.getActorId(s1)}`)
+  })
+})

--- a/test/cursor_test.js
+++ b/test/cursor_test.js
@@ -39,4 +39,19 @@ describe('Automerge.Cursor', () => {
     assert.ok(s3.cursor instanceof Automerge.Cursor)
     assert.strictEqual(s3.cursor.elemId, `4@${Automerge.getActorId(s1)}`)
   })
+
+  it('should not allow an index beyond the length of the list', () => {
+    assert.throws(() => {
+      Automerge.change(Automerge.init(), doc => {
+        doc.list = [1]
+        doc.cursor = new Automerge.Cursor(doc.list, 1)
+      })
+    }, /index out of bounds/)
+    assert.throws(() => {
+      Automerge.change(Automerge.init(), doc => {
+        doc.text = new Automerge.Text('a')
+        doc.cursor = doc.text.getCursorAt(1)
+      })
+    }, /index out of bounds/)
+  })
 })


### PR DESCRIPTION
This PR is work in progress.

The implementation of cursors on #307 requires a direct call from the frontend into the backend, which is inconvenient when frontend and backend are on different threads. This PR is an alternative implementation that is integrated with the existing frontend-backend protocol, making it compatible with multiple threads.

More detail to come.