### PR TITLE
Pass a path to the observed object to observable callback

### DIFF
--- a/@types/automerge/index.d.ts
+++ b/@types/automerge/index.d.ts
@@ -30,8 +30,9 @@ declare module 'automerge' {
       observable?: Observable
     }
 
-  type PatchCallback<T> = (patch: Patch, before: T, after: T, local: boolean, changes: Uint8Array[]) => void
-  type ObserverCallback<T> = (diff: ObjectDiff, before: T, after: T, local: boolean, changes: Uint8Array[]) => void
+  type JSONPath = (string | number)[]
+  type PatchCallback<T> = (patch: Patch, before: T, after: T, local: boolean, changes: Uint8Array[], path: JSONPath) => void
+  type ObserverCallback<T> = (diff: ObjectDiff, before: T, after: T, local: boolean, changes: Uint8Array[], path: JSONPath) => void
 
   class Observable {
     observe<T>(object: T, callback: ObserverCallback<T>): void

--- a/test/typescript_test.ts
+++ b/test/typescript_test.ts
@@ -583,7 +583,7 @@ describe('TypeScript support', () => {
       let observable = new Automerge.Observable(), callbackCalled = false
       let doc = Automerge.from({text: new Automerge.Text()}, {observable})
       let actor = Automerge.getActorId(doc)
-      observable.observe(doc.text, (diff, before, after, local, changes) => {
+      observable.observe(doc.text, (diff, before, after, local, changes, path) => {
         callbackCalled = true
         assert.deepStrictEqual(diff.edits, [{action: 'insert', index: 0, elemId: `2@${actor}`}])
         assert.deepStrictEqual(diff.props, {0: {[`2@${actor}`]: {value: 'a'}}})
@@ -592,6 +592,7 @@ describe('TypeScript support', () => {
         assert.strictEqual(local, true)
         assert.strictEqual(changes.length, 1)
         assert.ok(changes[0] instanceof Uint8Array)
+        assert.deepStrictEqual(path, ['text'])
       })
       doc = Automerge.change(doc, doc => doc.text.insertAt(0, 'a'))
       assert.strictEqual(callbackCalled, true)


### PR DESCRIPTION
Quick extension to the Observable API (#308) requested by @echarles: the callback function now receives an additional parameter containing the path from the root object to the object being observed. For example, if the observed object is `root.todos[3].nested' then the path is `['todos', 3, 'nested']`.