### PR TITLE
Implement the new sequence patch format, fixes #311

### DIFF
--- a/@types/automerge/index.d.ts
+++ b/@types/automerge/index.d.ts
@@ -266,7 +266,8 @@ declare module 'automerge' {
     action: 'insert'
     index: number   // the list index at which to insert the new element
     elemId: OpId    // the unique element ID of the new list element
-    value: MapDiff | ListDiff | ValueDiff 
+    opId: OpId      // ID of the operation that assigned this value
+    value: MapDiff | ListDiff | ValueDiff
   }
 
   // Describes the insertion of a consecutive sequence of primitive values into
@@ -289,8 +290,8 @@ declare module 'automerge' {
   interface UpdateEdit {
     action: 'update'
     index: number   // the list index to update
-    opId: OpId      // ID of the operation that performed this update
-    value: MapDiff | ListDiff | ValueDiff 
+    opId: OpId      // ID of the operation that assigned this value
+    value: MapDiff | ListDiff | ValueDiff
   }
 
   // Describes the deletion of one or more consecutive elements from a list or

--- a/@types/automerge/index.d.ts
+++ b/@types/automerge/index.d.ts
@@ -39,7 +39,7 @@ declare module 'automerge' {
     }
 
   type PatchCallback<T> = (patch: Patch, before: T, after: T, local: boolean, changes: BinaryChange[]) => void
-  type ObserverCallback<T> = (diff: MapDiff | ListDiff | ValueDiff , before: T, after: T, local: boolean, changes: BinaryChange[]) => void
+  type ObserverCallback<T> = (diff: MapDiff | ListDiff | ValueDiff, before: T, after: T, local: boolean, changes: BinaryChange[]) => void
 
   class Observable {
     observe<T>(object: T, callback: ObserverCallback<T>): void

--- a/@types/automerge/index.d.ts
+++ b/@types/automerge/index.d.ts
@@ -39,7 +39,7 @@ declare module 'automerge' {
     }
 
   type PatchCallback<T> = (patch: Patch, before: T, after: T, local: boolean, changes: BinaryChange[]) => void
-  type ObserverCallback<T> = (diff: ObjectDiff, before: T, after: T, local: boolean, changes: BinaryChange[]) => void
+  type ObserverCallback<T> = (diff: MapDiff | ListDiff | ValueDiff , before: T, after: T, local: boolean, changes: BinaryChange[]) => void
 
   class Observable {
     observe<T>(object: T, callback: ObserverCallback<T>): void
@@ -226,6 +226,8 @@ declare module 'automerge' {
     value?: number | boolean | string | null
     datatype?: DataType
     pred?: OpId[]
+    values?: (number | boolean | string | null)[]
+    multiOp?: number
   }
 
   interface Patch {
@@ -234,25 +236,77 @@ declare module 'automerge' {
     pendingChanges: number
     clock: Clock
     deps: Hash[]
-    diffs: ObjectDiff
+    diffs: MapDiff
   }
 
-  interface ObjectDiff {
-    objectId: OpId
-    type: CollectionType
-    edits?: Edit[]
-    props?: {[propName: string]: {[opId: string]: ObjectDiff | ValueDiff}}
+  // Describes changes to a map (in which case propName represents a key in the
+  // map) or a table object (in which case propName is the primary key of a row).
+  interface MapDiff {
+    objectId: OpId        // ID of object being updated
+    type: 'map' | 'table' // type of object being updated
+    // For each key/property that is changing, props contains one entry
+    // (properties that are not changing are not listed). The nested object is
+    // empty if the property is being deleted, contains one opId if it is set to
+    // a single value, and contains multiple opIds if there is a conflict.
+    props: {[propName: string]: {[opId: string]: MapDiff | ListDiff | ValueDiff }}
   }
 
+  // Describes changes to a list or Automerge.Text object, in which each element
+  // is identified by its index.
+  interface ListDiff {
+    objectId: OpId        // ID of object being updated
+    type: 'list' | 'text' // type of objct being updated
+    // This array contains edits in the order they should be applied.
+    edits: (SingleInsertEdit | MultiInsertEdit | UpdateEdit | RemoveEdit)[]
+  }
+
+  // Describes the insertion of a single element into a list or text object.
+  // The element can be a nested object.
+  interface SingleInsertEdit {
+    action: 'insert'
+    index: number   // the list index at which to insert the new element
+    elemId: OpId    // the unique element ID of the new list element
+    value: MapDiff | ListDiff | ValueDiff 
+  }
+
+  // Describes the insertion of a consecutive sequence of primitive values into
+  // a list or text object. In the case of text, the values are strings (each
+  // character as a separate string value). Each inserted value is given a
+  // consecutive element ID: starting with `elemId` for the first value, the
+  // subsequent values are given elemIds with the same actor ID and incrementing
+  // counters. To insert non-primitive values, use SingleInsertEdit.
+  interface MultiInsertEdit {
+    action: 'multi-insert'
+    index: number   // the list index at which to insert the first value
+    elemId: OpId    // the unique ID of the first inserted element
+    values: (number | boolean | string | null)[] // list of values to insert
+  }
+
+  // Describes the update of the value or nested object at a particular index
+  // of a list or text object. In the case where there are multiple conflicted
+  // values at the same list index, multiple UpdateEdits with the same index
+  // (but different opIds) appear in the edits array of ListDiff.
+  interface UpdateEdit {
+    action: 'update'
+    index: number   // the list index to update
+    opId: OpId      // ID of the operation that performed this update
+    value: MapDiff | ListDiff | ValueDiff 
+  }
+
+  // Describes the deletion of one or more consecutive elements from a list or
+  // text object.
+  interface RemoveEdit {
+    action: 'remove'
+    index: number   // index of the first list element to remove
+    count: number   // number of list elements to remove
+  }
+
+  // Describes a primitive value, optionally tagged with a datatype that
+  // indicates how the value should be interpreted.
   interface ValueDiff {
+    type: 'value'
     value: number | boolean | string | null
     datatype?: DataType
-  }
-
-  interface Edit {
-    action: 'insert' | 'remove'
-    index: number
-    elemId: OpId
   }
 
   type OpAction =

--- a/backend/backend.js
+++ b/backend/backend.js
@@ -68,7 +68,7 @@ function makePatch(state, diffs, request, isIncremental) {
  * `loadChanges()`.
  */
 function apply(state, changes, request, isIncremental) {
-  let diffs = isIncremental ? {objectId: '_root', type: 'map'} : null
+  let diffs = isIncremental ? {objectId: '_root', type: 'map', props: {}} : null
   let opSet = state.get('opSet')
   for (let change of changes) {
     for (let chunk of splitContainers(change)) {

--- a/backend/backend.js
+++ b/backend/backend.js
@@ -80,7 +80,6 @@ function apply(state, changes, request, isIncremental) {
     }
   }
 
-  OpSet.finalizePatch(opSet, diffs)
   state = state.set('opSet', opSet)
 
   return [state, isIncremental ? makePatch(state, diffs, request, true) : null]

--- a/backend/backend.js
+++ b/backend/backend.js
@@ -80,6 +80,7 @@ function apply(state, changes, request, isIncremental) {
     }
   }
 
+  OpSet.finalizePatch(diffs)
   state = state.set('opSet', opSet)
 
   return [state, isIncremental ? makePatch(state, diffs, request, true) : null]

--- a/backend/columnar.js
+++ b/backend/columnar.js
@@ -1243,7 +1243,7 @@ function addPatchProperty(objects, property) {
       if (!obj.props) obj.props = {}
       obj.props[property.key] = values
     } else if (obj.type === 'list' || obj.type === 'text') {
-      makeListEdits(obj, values, property.index)
+      makeListEdits(obj, values, property.key, property.index)
     }
     return true
   } else {
@@ -1254,15 +1254,16 @@ function addPatchProperty(objects, property) {
 /**
  * When constructing a patch to instantiate a loaded document, this function adds the edits to
  * insert one list element. Usually there is one value, but in the case of a conflict there may be
- * several values. `index` is the list index at which the value(s) should be placed.
+ * several values. `elemId` is the ID of the list element, and `index` is the list index at which
+ * the value(s) should be placed.
  */
-function makeListEdits(list, values, index) {
+function makeListEdits(list, values, elemId, index) {
   if (!list.edits) list.edits = []
   let firstValue = true
   const opIds = Object.keys(values).sort((id1, id2) => compareParsedOpIds(parseOpId(id1), parseOpId(id2)))
   for (const opId of opIds) {
     if (firstValue) {
-      list.edits.push({action: 'insert', value: values[opId], elemId: opId, index})
+      list.edits.push({action: 'insert', value: values[opId], elemId, opId, index})
     } else {
       list.edits.push({action: 'update', value: values[opId], opId, index})
     }

--- a/backend/columnar.js
+++ b/backend/columnar.js
@@ -472,16 +472,13 @@ function expandMultiOps(ops, startOp, actor) {
         lastElemId = `${opNum}@${actor}`
         opNum += 1
       }
-    } else if (op.action === 'del' && op.multiOp) {
-      let startElemId = parseOpId(op.elemId)
-      for (i = 0; i < op.multiOp; i++){
-        let elemId = `${startElemId.counter + i}@${startElemId.actorId}`
-        expandedOps.push({
-          action: 'del',
-          obj: op.obj,
-          elemId,
-          pred: op.pred,
-        })
+    } else if (op.action === 'del' && op.multiOp > 1) {
+      if (op.pred.length !== 1) throw new RangeError('multiOp deletion must have exactly one pred')
+      const startElemId = parseOpId(op.elemId), startPred = parseOpId(op.pred[0])
+      for (let i = 0; i < op.multiOp; i++){
+        const elemId = `${startElemId.counter + i}@${startElemId.actorId}`
+        const pred = [`${startPred.counter + i}@${startPred.actorId}`]
+        expandedOps.push({action: 'del', obj: op.obj, elemId, pred})
         opNum += 1
       }
     } else {

--- a/backend/columnar.js
+++ b/backend/columnar.js
@@ -1342,7 +1342,7 @@ function constructPatch(documentBuffer) {
     const action = col.action.readValue(), actionName = ACTIONS[action]
     if (action % 2 === 0) { // even-numbered actions are object creation
       const type = OBJECT_TYPE[actionName] || 'unknown'
-      if (['list', 'text'].includes(type)) {
+      if (type === 'list' || type === 'text') {
         objects[opId] = {objectId: opId, type, edits: []}
       } else {
         objects[opId] = {objectId: opId, type, props: {}}

--- a/backend/columnar.js
+++ b/backend/columnar.js
@@ -1,5 +1,5 @@
 const pako = require('pako')
-const { copyObject, parseOpId, equalBytes } = require('../src/common')
+const { copyObject, parseOpId, equalBytes, appendEdit } = require('../src/common')
 const {
   utf8ToString, hexStringToBytes, bytesToHexString,
   Encoder, Decoder, RLEEncoder, RLEDecoder, DeltaEncoder, DeltaDecoder, BooleanEncoder, BooleanDecoder
@@ -154,6 +154,7 @@ function parseAllOpIds(changes, single) {
   for (let change of changes) {
     change = copyObject(change)
     actors[change.actor] = true
+    change.ops = expandMultiOps(change.ops, change.startOp, change.actor)
     change.ops = change.ops.map(op => {
       op = copyObject(op)
       if (op.obj !== '_root') op.obj = parseOpId(op.obj)
@@ -450,6 +451,44 @@ function encodeOps(ops, forDocument) {
     if (columns[name]) columnList.push({id, name, encoder: columns[name]})
   }
   return columnList.sort((a, b) => a.id - b.id)
+}
+
+function expandMultiOps(ops, startOp, actor) {
+  let opNum = startOp
+  let expandedOps = []
+  for (const op of ops) {
+    if (op.action === 'set' && op.values && op.insert) {
+      let lastElemId = op.elemId
+      for (const value of op.values) {
+        expandedOps.push({
+          action: 'set',
+          obj: op.obj,
+          elemId: lastElemId,
+          value,
+          pred: op.pred,
+          insert: true,
+        })
+        lastElemId = `${opNum}@${actor}`
+        opNum += 1
+      }
+    } else if (op.action === 'del' && op.multiOp) {
+      let startElemId = parseOpId(op.elemId)
+      for (i = 0; i < op.multiOp; i++){
+        let elemId = `${startElemId.counter + i}@${startElemId.actorId}`
+        expandedOps.push({
+          action: 'del',
+          obj: op.obj,
+          elemId,
+          pred: op.pred,
+        })
+        opNum += 1
+      }
+    } else {
+      expandedOps.push(op)
+      opNum += 1
+    }
+  }
+  return expandedOps
 }
 
 /**
@@ -1174,7 +1213,10 @@ function addPatchProperty(objects, property) {
       if (op.actionName.startsWith('make')) {
         values[op.opId] = objects[op.opId]
       } else if (op.actionName === 'set') {
-        values[op.opId] = op.value
+        values[op.opId] = {value: op.value.value, type: 'value'}
+        if (op.value.datatype) {
+          values[op.opId].datatype = op.value.datatype
+        }
       } else if (op.actionName === 'link') {
         // NB. This assumes that the ID of the child object is greater than the ID of the current
         // object. This is true as long as link operations are only used to redo undone make*
@@ -1195,13 +1237,51 @@ function addPatchProperty(objects, property) {
 
   if (Object.keys(values).length > 0) {
     let obj = objects[property.objId]
-    if (!obj.props) obj.props = {}
     if (obj.type === 'map' || obj.type === 'table') {
+      if (!obj.props) obj.props = {}
       obj.props[property.key] = values
     } else if (obj.type === 'list' || obj.type === 'text') {
-      if (!obj.edits) obj.edits = []
-      obj.props[obj.edits.length] = values
-      obj.edits.push({action: 'insert', index: obj.edits.length, elemId: property.key})
+      makeListEdits(obj, values)
+    }
+  }
+}
+
+function makeListEdits(list, values) {
+  if (!list.edits) list.edits = []
+  const index = list.edits.length
+  const edits = []
+  for (const opId of Object.keys(values)) {
+    const value = values[opId]
+    if (edits.length === 0){
+      edits.push({
+        action: 'insert',
+        value: value,
+        elemId: opId,
+        index,
+      })
+    } else {
+      edits.push({
+        action: 'update',
+        value: value,
+        opId,
+        index,
+      })
+    }
+  }
+  list.edits.push(...edits)
+}
+
+function condenseEdits(diff) {
+  if ((diff.type === 'list' || diff.type === 'text') && diff.edits) {
+    diff.edits.forEach(e => condenseEdits(e.value))
+    let newEdits = diff.edits
+    diff.edits = []
+    for (const edit of newEdits) appendEdit(diff.edits, edit)
+  } else if ((diff.type === 'map' || diff.type === 'table') && diff.props) {
+    for (const prop of Object.keys(diff.props)) {
+      for (const opId of Object.keys(diff.props[prop])) {
+        condenseEdits(diff.props[prop][opId])
+      }
     }
   }
 }
@@ -1223,7 +1303,12 @@ function constructPatch(documentBuffer) {
     const opId = `${col.idCtr.readValue()}@${actorIds[col.idActor.readValue()]}`
     const action = col.action.readValue(), actionName = ACTIONS[action]
     if (action % 2 === 0) { // even-numbered actions are object creation
-      objects[opId] = {objectId: opId, type: OBJECT_TYPE[actionName] || 'unknown'}
+      const type = OBJECT_TYPE[actionName] || 'unknown'
+      objects[opId] = {objectId: opId, type}
+      if (['list', 'text'].includes(type)) {
+        objects[opId].edits = []
+      }
+
     }
 
     const objActor = col.objActor.readValue(), objCtr = col.objCtr.readValue()
@@ -1267,6 +1352,7 @@ function constructPatch(documentBuffer) {
   }
 
   if (property) addPatchProperty(objects, property)
+  condenseEdits(objects._root)
   return objects._root
 }
 

--- a/backend/columnar.js
+++ b/backend/columnar.js
@@ -461,14 +461,7 @@ function expandMultiOps(ops, startOp, actor) {
       if (op.pred.length !== 0) throw new RangeError('multi-insert pred must be empty')
       let lastElemId = op.elemId
       for (const value of op.values) {
-        expandedOps.push({
-          action: 'set',
-          obj: op.obj,
-          elemId: lastElemId,
-          value,
-          pred: [],
-          insert: true,
-        })
+        expandedOps.push({action: 'set', obj: op.obj, elemId: lastElemId, value, pred: [], insert: true})
         lastElemId = `${opNum}@${actor}`
         opNum += 1
       }

--- a/backend/columnar.js
+++ b/backend/columnar.js
@@ -458,6 +458,7 @@ function expandMultiOps(ops, startOp, actor) {
   let expandedOps = []
   for (const op of ops) {
     if (op.action === 'set' && op.values && op.insert) {
+      if (op.pred.length !== 0) throw new RangeError('multi-insert pred must be empty')
       let lastElemId = op.elemId
       for (const value of op.values) {
         expandedOps.push({
@@ -465,7 +466,7 @@ function expandMultiOps(ops, startOp, actor) {
           obj: op.obj,
           elemId: lastElemId,
           value,
-          pred: op.pred,
+          pred: [],
           insert: true,
         })
         lastElemId = `${opNum}@${actor}`

--- a/backend/op_set.js
+++ b/backend/op_set.js
@@ -237,12 +237,14 @@ function initializePatch(opSet, pathOp, patch) {
   if (patch.type !== type) {
     throw new RangeError(`object type mismatch in path: ${patch.type} != ${type}`)
   }
-  if (['map', 'table'].includes(patch.type)) {
+
+  if (type === 'map' || type === 'table') {
     setPatchPropsForMap(opSet, objectId, key, patch)
     if (patch.props[key][opId] === undefined) {
       throw new RangeError(`field ops for ${key} did not contain opId ${opId}`)
     }
     return patch.props[key][opId]
+
   } else {
     let elemIds = opSet.getIn(['byObject', objectId, '_elemIds'])
     let index = elemIds.indexOf(key)

--- a/backend/op_set.js
+++ b/backend/op_set.js
@@ -161,7 +161,7 @@ function applyAssign(opSet, op, patch) {
     if (patch) {
       const valuePatch = {}
       opSet = applyMake(opSet, op, valuePatch)
-      if (['map', 'table'].includes(type)) {
+      if (type === 'map' || type === 'table') {
         patch.props[key][op.get('opId')] = valuePatch
       }
     } else {

--- a/backend/op_set.js
+++ b/backend/op_set.js
@@ -343,6 +343,7 @@ function makeListEditsForIndex(opSet, listId, elemId, index, insert) {
         action: 'insert',
         value: valuePatch,
         elemId: opId,
+        opId,
         index,
       })
     } else {

--- a/backend/op_set.js
+++ b/backend/op_set.js
@@ -313,15 +313,14 @@ function setPatchEditsForList(opSet, listId, elemId, index, insert, patch) {
     insert = (previousEdit.action === 'insert')
   }
 
-  let firstOp = true
   for (const opId of Object.keys(patch.props[elemId]).sort(opIdCompare)) {
     const value = patch.props[elemId][opId]
-    if (insert && firstOp) {
+    if (insert) {
       appendEdit(patch.edits, {action: 'insert', index, elemId, opId, value})
     } else {
       appendEdit(patch.edits, {action: 'update', index, opId, value})
     }
-    firstOp = false
+    insert = false
   }
 }
 

--- a/backend/op_set.js
+++ b/backend/op_set.js
@@ -1,7 +1,7 @@
 const { Map, List, Set, fromJS } = require('immutable')
 const { SkipList } = require('./skip_list')
-const { decodeChange, decodeChangeMeta } = require('./columnar')
-const { parseOpId, appendEdit } = require('../src/common')
+const { decodeChange, decodeChangeMeta, appendEdit } = require('./columnar')
+const { parseOpId } = require('../src/common')
 
 // Returns true if all changes that causally precede the given change
 // have already been applied in `opSet`.

--- a/backend/op_set.js
+++ b/backend/op_set.js
@@ -319,7 +319,7 @@ function setPatchPropsForMap(opSet, objectId, key, patch) {
 }
 
 function makeListEditsForIndex(opSet, listId, elemId, index, insert) {
-  edits = []
+  let edits = []
   for (let op of getFieldOps(opSet, listId, elemId)) {
     let valuePatch = {}
     const opId = op.get('opId')

--- a/backend/op_set.js
+++ b/backend/op_set.js
@@ -1,7 +1,7 @@
 const { Map, List, Set, fromJS } = require('immutable')
 const { SkipList } = require('./skip_list')
 const { decodeChange, decodeChangeMeta } = require('./columnar')
-const { parseOpId } = require('../src/common')
+const { parseOpId, appendEdit } = require('../src/common')
 
 // Returns true if all changes that causally precede the given change
 // have already been applied in `opSet`.
@@ -49,6 +49,9 @@ function applyMake(opSet, op, patch) {
   let object = Map({_init: op, _inbound: Set(), _keys: Map()})
   if (action === 'makeList' || action === 'makeText') {
     object = object.set('_elemIds', new SkipList())
+    if (patch && !patch.edits) {
+      patch.edits = []
+    }
   }
   opSet = opSet.setIn(['byObject', objectId], object)
 
@@ -84,9 +87,10 @@ function updateListElement(opSet, objectId, elemId, patch) {
   if (index >= 0) {
     if (ops.isEmpty()) {
       elemIds = elemIds.removeIndex(index)
-      if (patch) patch.edits.push({action: 'remove', index})
+      if (patch) appendEdit(patch.edits, {action: 'remove', index, count: 1})
     } else {
       elemIds = elemIds.setValue(elemId, ops.first().get('value'))
+      if (patch) mergeEdits(patch.edits, makeListEditsForIndex(opSet, objectId, elemId, index, false))
     }
 
   } else {
@@ -104,7 +108,9 @@ function updateListElement(opSet, objectId, elemId, patch) {
 
     index += 1
     elemIds = elemIds.insertIndex(index, elemId, ops.first().get('value'))
-    if (patch) patch.edits.push({action: 'insert', index, elemId})
+    if (patch) {
+      mergeEdits(patch.edits, makeListEditsForIndex(opSet, objectId, elemId, index, true))
+    }
   }
   return opSet.setIn(['byObject', objectId, '_elemIds'], elemIds)
 }
@@ -150,11 +156,17 @@ function applyAssign(opSet, op, patch) {
     if (patch.objectId !== objectId) {
       throw new RangeError(`objectId mismatch in patch: ${patch.objectId} != ${objectId}`)
     }
-    if (patch.props === undefined) {
-      patch.props = {}
-    }
-    if (patch.props[key] === undefined) {
-      patch.props[key] = {}
+    if (['map', 'table'].includes(type)) {
+      if (patch.props === undefined) {
+        patch.props = {}
+      }
+      if (patch.props[key] === undefined) {
+        patch.props[key] = {}
+      }
+    } else {
+      if (!patch.edits) {
+        patch.edits = []
+      }
     }
 
     patch.type = patch.type || type
@@ -165,8 +177,11 @@ function applyAssign(opSet, op, patch) {
 
   if (action.startsWith('make')) {
     if (patch) {
-      patch.props[key][op.get('opId')] = {}
-      opSet = applyMake(opSet, op, patch.props[key][op.get('opId')])
+      const valuePatch = {}
+      opSet = applyMake(opSet, op, valuePatch)
+      if (['map', 'table'].includes(type)) {
+        patch.props[key][op.get('opId')] = valuePatch
+      }
     } else {
       opSet = applyMake(opSet, op)
     }
@@ -207,10 +222,11 @@ function applyAssign(opSet, op, patch) {
   }
   remaining = remaining.sort(lamportCompare).reverse()
   opSet = opSet.setIn(['byObject', objectId, '_keys', key], remaining)
-  setPatchProps(opSet, objectId, key, patch)
 
   if (type === 'list' || type === 'text') {
     opSet = updateListElement(opSet, objectId, key, patch)
+  } else {
+    setPatchPropsForMap(opSet, objectId, key, patch)
   }
   return opSet
 }
@@ -233,19 +249,37 @@ function initializePatch(opSet, pathOp, patch) {
   if (patch.type !== type) {
     throw new RangeError(`object type mismatch in path: ${patch.type} != ${type}`)
   }
-  setPatchProps(opSet, objectId, key, patch)
-
-  if (patch.props[key][opId] === undefined) {
-    throw new RangeError(`field ops for ${key} did not contain opId ${opId}`)
+  if (['map', 'table'].includes(patch.type)) {
+    setPatchPropsForMap(opSet, objectId, key, patch)
+    if (patch.props[key][opId] === undefined) {
+      throw new RangeError(`field ops for ${key} did not contain opId ${opId}`)
+    }
+    return patch.props[key][opId]
+  } else {
+    let elemIds = opSet.getIn(['byObject', objectId, '_elemIds'])
+    let index = elemIds.indexOf(key)
+    if (!patch.edits) patch.edits = []
+    let elemPatch = patch.edits.find(e => e.opId === key || e.elemId === key)
+    if (elemPatch) {
+      return elemPatch.value
+    } else {
+      const edits = makeListEditsForIndex(opSet, objectId, key, index, false)
+      let elemPatch = edits.find(e => e.opId === opId || e.elemId === opId)
+      if (elemPatch === undefined) {
+        throw new RangeError(`field ops for ${key} did not contain opId ${opId}`)
+      }
+      patch.edits.push(...edits)
+      return elemPatch.value
+    }
   }
-  return patch.props[key][opId]
+
 }
 
 /**
  * Updates `patch` to include all the values (including conflicts) for the field
  * `key` of the object with ID `objectId`.
  */
-function setPatchProps(opSet, objectId, key, patch) {
+function setPatchPropsForMap(opSet, objectId, key, patch) {
   if (!patch) return
   if (patch.props === undefined) {
     patch.props = {}
@@ -260,14 +294,16 @@ function setPatchProps(opSet, objectId, key, patch) {
     ops[opId] = true
 
     if (op.get('action') === 'set') {
-      patch.props[key][opId] = {value: op.get('value')}
+      patch.props[key][opId] = {type: 'value', value: op.get('value')}
       if (op.get('datatype')) {
         patch.props[key][opId].datatype = op.get('datatype')
       }
     } else if (isChildOp(op)) {
       if (!patch.props[key][opId]) {
         const childId = getChildId(op)
-        patch.props[key][opId] = {objectId: childId, type: getObjectType(opSet, childId)}
+        const type = getObjectType(opSet, childId)
+        patch.props[key][opId] = {objectId: childId, type}
+        if (type === "list" || type === "text") patch.props[key][opId].edits = []
       }
     } else {
       throw new RangeError(`Unexpected operation in field ops: ${op.get('action')}`)
@@ -282,33 +318,49 @@ function setPatchProps(opSet, objectId, key, patch) {
   }
 }
 
-/**
- * Mutates `patch`, changing elemId-based addressing of lists to index-based
- * addressing. (This can only be done once all the changes have been applied,
- * since the indexes are still in flux until that point.)
- */
-function finalizePatch(opSet, patch) {
-  if (!patch || !patch.props) return
+function makeListEditsForIndex(opSet, listId, elemId, index, insert) {
+  edits = []
+  for (let op of getFieldOps(opSet, listId, elemId)) {
+    let valuePatch = {}
+    const opId = op.get('opId')
 
-  if (patch.type === 'list' || patch.type === 'text') {
-    const elemIds = opSet.getIn(['byObject', patch.objectId, '_elemIds'])
-    const newProps = {}
-    for (let elemId of Object.keys(patch.props)) {
-      if (/^[0-9]+$/.test(elemId)) {
-        newProps[elemId] = patch.props[elemId]
-      } else if (Object.keys(patch.props[elemId]).length > 0) {
-        const index = elemIds.indexOf(elemId)
-        if (index < 0) throw new RangeError(`List element has no index: ${elemId}`)
-        newProps[index] = patch.props[elemId]
+    if (op.get('action') === 'set') {
+      valuePatch = {type: 'value', value: op.get('value')}
+      if (op.get('datatype')) {
+        valuePatch.datatype = op.get('datatype')
       }
+    } else if (isChildOp(op)) {
+      const childId = getChildId(op)
+      const type = getObjectType(opSet, childId)
+      valuePatch = {objectId: childId, type}
+      if (type === 'list' || type === 'text') valuePatch.edits = []
+    } else {
+      throw new RangeError(`Unexpected operation in field ops: ${op.get('action')}`)
     }
-    patch.props = newProps
+
+    if (edits.length === 0 && insert) {
+      edits.push({
+        action: 'insert',
+        value: valuePatch,
+        elemId: opId,
+        index,
+      })
+    } else {
+      edits.push({
+        action: 'update',
+        value: valuePatch,
+        opId: opId,
+        index,
+      })
+    }
   }
 
-  for (let key of Object.keys(patch.props)) {
-    for (let opId of Object.keys(patch.props[key])) {
-      finalizePatch(opSet, patch.props[key][opId])
-    }
+  return edits
+}
+
+function mergeEdits(existingEdits, newEdits) {
+  for (const edit of newEdits) {
+    appendEdit(existingEdits, edit)
   }
 }
 
@@ -666,7 +718,6 @@ function constructList(opSet, objectId, type) {
 
     const fieldOps = getFieldOps(opSet, objectId, elemId)
     if (!fieldOps.isEmpty()) {
-      patch.edits.push({action: 'insert', index, elemId})
       patch.props[index] = {}
       for (let op of fieldOps) {
         patch.props[index][op.get('opId')] = constructField(opSet, op)
@@ -690,5 +741,5 @@ function constructObject(opSet, objectId) {
 module.exports = {
   init, addChange, addLocalChange, getHeads,
   getChangeByHash, getMissingChanges, getMissingDeps,
-  constructObject, getFieldOps, getOperationKey, finalizePatch
+  constructObject, getFieldOps, getOperationKey
 }

--- a/backend/op_set.js
+++ b/backend/op_set.js
@@ -302,6 +302,15 @@ function setPatchEditsForList(opSet, listId, elemId, index, insert, patch) {
   setPatchPropsForMap(opSet, listId, elemId, patch)
   if (Object.keys(patch.props[elemId]).length === 0) {
     appendEdit(patch.edits, {action: 'remove', index, count: 1})
+    return
+  }
+
+  // If the most recent existing edit is for the same index, we need to remove it, since the patch
+  // format for lists treats several consecutive updates for the same index as a conflict.
+  while (!insert && patch.edits.length > 0 && patch.edits[patch.edits.length - 1].index === index &&
+         ['insert', 'update'].includes(patch.edits[patch.edits.length - 1].action)) {
+    const previousEdit = patch.edits.pop()
+    insert = (previousEdit.action === 'insert')
   }
 
   let firstOp = true

--- a/frontend/apply_patch.js
+++ b/frontend/apply_patch.js
@@ -222,7 +222,7 @@ function updateListObject(patch, obj, updated) {
       let value = getValue(edit.value, undefined, updated)
       elemIds.splice(edit.index, 0, edit.elemId)
       list.splice(edit.index, 0, value)
-      conflicts.splice(edit.index, 0, {[edit.elemId]: value})
+      conflicts.splice(edit.index, 0, {[edit.opId]: value})
       oldConflicts.splice(edit.index, 0, undefined)
       elemIdsInthisPatch.add(edit.elemId)
     } else if (edit.action === 'multi-insert') {
@@ -300,7 +300,7 @@ function updateTextObject(patch, obj, updated) {
       }
       let elem = {
         elemId: edit.elemId,
-        pred: [edit.elemId],
+        pred: [edit.opId],
         value,
       }
       updatedElemIds.add(edit.elemId)

--- a/frontend/apply_patch.js
+++ b/frontend/apply_patch.js
@@ -81,58 +81,6 @@ function applyProperties(props, object, conflicts, updated) {
 }
 
 /**
- * `edits` is an array of edits to a list data structure, each of which is an object of the form
- * either `{action: 'insert', index, elemId}` or `{action: 'remove', index}`. This merges adjacent
- * edits and calls `insertCallback(index, elemIds)` or `removeCallback(index, count)`, as
- * appropriate, for each sequence of insertions or removals.
- */
-function iterateEdits(edits, insertCallback, removeCallback) {
-  if (!edits) return
-  let splicePos = -1, deletions, insertions
-
-  for (let i = 0; i < edits.length; i++) {
-    const { action, index, elemId } = edits[i]
-
-    if (action === 'insert') {
-      if (splicePos < 0) {
-        splicePos = index
-        deletions = 0
-        insertions = []
-      }
-      insertions.push(elemId)
-
-      // If there are multiple consecutive insertions at successive indexes,
-      // accumulate them and then process them in a single insertCallback
-      if (i === edits.length - 1 ||
-          edits[i + 1].action !== 'insert' ||
-          edits[i + 1].index  !== index + 1) {
-        insertCallback(splicePos, insertions)
-        splicePos = -1
-      }
-
-    } else if (action === 'remove') {
-      if (splicePos < 0) {
-        splicePos = index
-        deletions = 0
-        insertions = []
-      }
-      deletions += 1
-
-      // If there are multiple consecutive removals of the same index,
-      // accumulate them and then process them in a single removeCallback
-      if (i === edits.length - 1 ||
-          edits[i + 1].action !== 'remove' ||
-          edits[i + 1].index  !== index) {
-        removeCallback(splicePos, deletions)
-        splicePos = -1
-      }
-    } else {
-      throw new RangeError(`Unknown list edit action: ${action}`)
-    }
-  }
-}
-
-/**
  * Creates a writable copy of an immutable map object. If `originalObject`
  * is undefined, creates an empty object with ID `objectId`.
  */

--- a/frontend/apply_patch.js
+++ b/frontend/apply_patch.js
@@ -315,7 +315,8 @@ function updateTextObject(patch, obj, updated) {
  */
 function interpretPatch(patch, obj, updated) {
   // Return original object if it already exists and isn't being modified
-  if (isObject(obj) && !patch.props && !patch.edits && !updated[patch.objectId]) {
+  if (isObject(obj) && (!patch.props || Object.keys(patch.props).length === 0) &&
+      (!patch.edits || patch.edits.length === 0) && !updated[patch.objectId]) {
     return obj
   }
 

--- a/frontend/apply_patch.js
+++ b/frontend/apply_patch.js
@@ -214,22 +214,61 @@ function updateListObject(patch, obj, updated) {
   }
 
   const list = updated[objectId], conflicts = list[CONFLICTS], elemIds = list[ELEM_IDS]
+  const oldConflicts = conflicts.slice()
+  const elemIdsInthisPatch = new Set()
 
-  iterateEdits(patch.edits,
-    (index, newElems) => { // insertion
-      const blanks = new Array(newElems.length)
-      elemIds  .splice(index, 0, ...newElems)
-      list     .splice(index, 0, ...blanks)
-      conflicts.splice(index, 0, ...blanks)
-    },
-    (index, count) => { // deletion
-      elemIds  .splice(index, count)
-      list     .splice(index, count)
-      conflicts.splice(index, count)
+  for (const edit of patch.edits) {
+    if (edit.action === 'insert') {
+      let value = getValue(edit.value, undefined, updated)
+      elemIds.splice(edit.index, 0, edit.elemId)
+      list.splice(edit.index, 0, value)
+      conflicts.splice(edit.index, 0, {[edit.elemId]: value})
+      oldConflicts.splice(edit.index, 0, undefined)
+      elemIdsInthisPatch.add(edit.elemId)
+    } else if (edit.action === 'multi-insert') {
+      let startOpId = parseOpId(edit.elemId)
+      let newElems = []
+      let newValues = []
+      let newConflicts = []
+      edit.values.forEach((value, index) => {
+        let counter = startOpId.counter + index
+        let opid = `${counter}@${startOpId.actorId}`
+        newElems.push(opid)
+        newConflicts.push({[opid]: {value, type: 'value'}})
+        newValues.push(value)
+        elemIdsInthisPatch.add(opid)
+      })
+      list.splice(edit.index, 0, ...newValues)
+      conflicts.splice(edit.index, 0, ...newConflicts)
+      oldConflicts.splice(edit.index, 0, Array(edit.count))
+      elemIds.splice(edit.index, 0, ...newElems)
+    } else if (edit.action === 'update') {
+      elemIdsInthisPatch.add(edit.opId)
+      let elemConflicts = conflicts[edit.index]
+      let oldElemConflicts = oldConflicts[edit.index] || {}
+      oldConflicts[edit.index] = oldElemConflicts
+      const currentValue = elemConflicts[edit.opId] || oldElemConflicts[edit.opId] || undefined
+      const value = getValue(edit.value, currentValue, updated)
+
+      let newConflicts = {}
+      for (const opId of Object.keys(elemConflicts)) {
+        if (elemIdsInthisPatch.has(opId)) {
+          newConflicts[opId] = elemConflicts[opId]
+        }
+      }
+      newConflicts[edit.opId] = value
+
+      const opIds = Object.keys(newConflicts).sort(lamportCompare).reverse()
+      conflicts[edit.index] = newConflicts
+      list[edit.index] = newConflicts[opIds[0]]
+    } else if (edit.action === 'remove') {
+      elemIds.splice(edit.index, edit.count)
+      list.splice(edit.index, edit.count)
+      conflicts.splice(edit.index, edit.count)
+      oldConflicts.splice(edit.index, edit.count)
     }
-  )
+  }
 
-  applyProperties(patch.props, list, conflicts, updated)
   return list
 }
 
@@ -249,25 +288,60 @@ function updateTextObject(patch, obj, updated) {
     elems = []
   }
 
-  iterateEdits(patch.edits,
-    (index, elemIds) => { // insertion
-      const blanks = elemIds.map(elemId => ({elemId}))
-      elems.splice(index, 0, ...blanks)
-    },
-    (index, deletions) => { // deletion
-      elems.splice(index, deletions)
-    }
-  )
+  const updatedElemIds = new Set()
 
-  for (let key of Object.keys(patch.props || {})) {
-    const pred = Object.keys(patch.props[key])
-    const opId = pred.sort(lamportCompare).reverse()[0]
-    if (!opId) throw new RangeError(`No default value at index ${key}`)
-
-    elems[key] = {
-      elemId: elems[key].elemId,
-      pred,
-      value: getValue(patch.props[key][opId], elems[key].value, updated)
+  for (const edit of patch.edits) {
+    if (edit.action === 'insert') {
+      let value 
+      if (edit.value.type === 'value') {
+        value = edit.value.value
+      } else {
+        value = getValue(edit.value, undefined, updated)
+      }
+      let elem = {
+        elemId: edit.elemId,
+        pred: [edit.elemId],
+        value,
+      }
+      updatedElemIds.add(edit.elemId)
+      elems.splice(edit.index, 0, elem)
+    } else if (edit.action === 'multi-insert') {
+      let startOpId = parseOpId(edit.elemId)
+      let newElems = []
+      edit.values.forEach((value, index) => {
+        let counter = startOpId.counter + index
+        let elemId = `${counter}@${startOpId.actorId}`
+        let elem = {
+          elemId,
+          pred: [elemId],
+          value,
+        }
+        newElems.push(elem)
+        updatedElemIds.add(elemId)
+      })
+      elems.splice(edit.index, 0, ...newElems)
+    } else if (edit.action === 'update') {
+      let current = elems[edit.index]
+      if (lamportCompare(current.elemId, edit.opId) >= 0){
+        if (updatedElemIds.has(current.elemId)) {
+          continue
+        }
+      }
+      let value 
+      if (edit.value.type === 'value') {
+        value = edit.value.value
+      } else {
+        value = getValue(edit.value, elems[edit.index].value, updated)
+      }
+      let newElem = {
+        elemId: edit.opId,
+        pred: [edit.opId],
+        value,
+      }
+      updatedElemIds.add(newElem.elemId)
+      elems[edit.index] = newElem
+    } else if (edit.action === 'remove') {
+      elems.splice(edit.index, edit.count)
     }
   }
 

--- a/frontend/context.js
+++ b/frontend/context.js
@@ -397,7 +397,7 @@ class Context {
         let nextElemId = this.nextOpId()
         const valuePatch = this.setValue(subpatch.objectId, index + offset, values[offset], true, [], elemId)
         elemId = nextElemId
-        subpatch.edits.push({action: 'insert', index: index + offset, elemId, value: valuePatch})
+        subpatch.edits.push({action: 'insert', index: index + offset, elemId, opId: elemId, value: valuePatch})
       }
     }
   }

--- a/frontend/context.js
+++ b/frontend/context.js
@@ -128,11 +128,8 @@ class Context {
    * by mutating the patch object. Returns the subpatch at the given path.
    */
   getSubpatch(patch, path) {
-    if (path.length == 0) {
-      return patch
-    }
+    if (path.length == 0) return patch
     let subpatch = patch, object = this.getObject('_root')
-
 
     for (let pathElem of path) {
       let values = this.getValuesDescriptions(path, object, pathElem.key)
@@ -142,12 +139,7 @@ class Context {
         }
       } else if (subpatch.edits) {
         for (const opId of Object.keys(values)) {
-          subpatch.edits.push({
-            action: 'update',
-            index: pathElem.key,
-            value: values[opId],
-            opId,
-          })
+          subpatch.edits.push({action: 'update', index: pathElem.key, opId, value: values[opId]})
         }
       }
 
@@ -160,6 +152,7 @@ class Context {
       if (!nextOpId) {
         throw new RangeError(`Cannot find path object with objectId ${pathElem.objectId}`)
       }
+
       subpatch = values[nextOpId]
       object = this.getPropertyValue(object, pathElem.key, nextOpId)
     }
@@ -363,7 +356,6 @@ class Context {
    * `subpatch` to reflect the sequence of values.
    */
   insertListItems(subpatch, index, values, newObject) {
-
     const list = newObject ? [] : this.getObject(subpatch.objectId)
     if (index < 0 || index > list.length) {
       throw new RangeError(`List index ${index} is out of bounds for list of length ${list.length}`)
@@ -376,12 +368,7 @@ class Context {
     if (allPrimitive && values.length > 1) {
       let nextElemId = this.nextOpId()
       this.addOp({action: 'set', obj: subpatch.objectId, elemId, insert: true, values, pred: []})
-      subpatch.edits.push({
-        index,
-        action: 'multi-insert',
-        elemId: nextElemId,
-        values,
-      })
+      subpatch.edits.push({action: 'multi-insert', elemId: nextElemId, index, values})
     } else {
       for (let offset = 0; offset < values.length; offset++) {
         let nextElemId = this.nextOpId()
@@ -416,12 +403,7 @@ class Context {
         const pred = getPred(list, index)
         const opId = this.nextOpId()
         const valuePatch = this.setValue(objectId, index, value, false, pred, getElemId(list, index))
-        subpatch.edits.push({
-          action: 'update',
-          index,
-          value: valuePatch,
-          opId,
-        })
+        subpatch.edits.push({action: 'update', index, opId, value: valuePatch})
       })
     }
   }
@@ -557,12 +539,7 @@ class Context {
 
     this.applyAtPath(path, subpatch => {
       if (type === 'list' || type === 'text') {
-        subpatch.edits.push({
-          action: 'update',
-          opId,
-          index: key,
-          value: {value, datatype: 'counter'}
-        })
+        subpatch.edits.push({action: 'update', index: key, opId, value: {value, datatype: 'counter'}})
       } else {
         subpatch.props[key] = {[opId]: {value, datatype: 'counter'}}
       }

--- a/frontend/context.js
+++ b/frontend/context.js
@@ -33,7 +33,17 @@ class Context {
    * Returns the operation ID of the next operation to be added to the context.
    */
   nextOpId() {
-    return `${this.maxOp + this.ops.length + 1}@${this.actorId}`
+    let opNum = this.maxOp + 1
+    for (const op of this.ops) {
+      if (op.action === 'set' && op.values) {
+        opNum += op.values.length
+      } else if (op.action === 'del' && op.multiOp) {
+        opNum += op.multiOp
+      } else {
+        opNum += 1
+      }
+    }
+    return `${opNum}@${this.actorId}`
   }
 
   /**
@@ -47,11 +57,11 @@ class Context {
     if (isObject(value)) {
       if (value instanceof Date) {
         // Date object, represented as milliseconds since epoch
-        return {value: value.getTime(), datatype: 'timestamp'}
+        return {type: 'value', value: value.getTime(), datatype: 'timestamp'}
 
       } else if (value instanceof Counter) {
         // Counter object
-        return {value: value.value, datatype: 'counter'}
+        return {type: 'value', value: value.value, datatype: 'counter'}
 
       } else {
         // Nested object (map, list, text, or table)
@@ -63,7 +73,7 @@ class Context {
       }
     } else {
       // Primitive value (number, string, boolean, or null)
-      return {value}
+      return {type: 'value', value}
     }
   }
 
@@ -80,7 +90,8 @@ class Context {
     } else if (object instanceof Text) {
       // Text objects don't support conflicts
       const value = object.get(key)
-      return value ? {[key]: this.getValueDescription(value)} : {}
+      const elemId = object.getElemId(key)
+      return value ? {[elemId]: this.getValueDescription(value)} : {}
     } else {
       // Map or list objects
       const conflicts = object[CONFLICTS][key], values = {}
@@ -113,17 +124,30 @@ class Context {
    * by mutating the patch object. Returns the subpatch at the given path.
    */
   getSubpatch(patch, path) {
-    let subpatch = patch.diffs, object = this.getObject('_root')
+    if (path.length == 0) {
+      return patch
+    }
+    let subpatch = patch, object = this.getObject('_root')
+
 
     for (let pathElem of path) {
-      if (!subpatch.props) {
-        subpatch.props = {}
-      }
-      if (!subpatch.props[pathElem.key]) {
-        subpatch.props[pathElem.key] = this.getValuesDescriptions(path, object, pathElem.key)
+      let values = this.getValuesDescriptions(path, object, pathElem.key)
+      if (subpatch.props) {
+        if (!subpatch.props[pathElem.key]) {
+          subpatch.props[pathElem.key] = values
+        }
+      } else if (subpatch.edits) {
+        for (const opId of Object.keys(values)) {
+          subpatch.edits.push({
+            action: 'update',
+            index: pathElem.key,
+            value: values[opId],
+            opId,
+          })
+        }
       }
 
-      let nextOpId = null, values = subpatch.props[pathElem.key]
+      let nextOpId = null
       for (let opId of Object.keys(values)) {
         if (values[opId].objectId === pathElem.objectId) {
           nextOpId = opId
@@ -134,11 +158,21 @@ class Context {
       }
       subpatch = values[nextOpId]
       object = this.getPropertyValue(object, pathElem.key, nextOpId)
+      if (object instanceof Text) {
+        subpatch.type = "text"
+        subpatch.edits = []
+      } else if (object instanceof Table) {
+        subpatch.type = "table"
+        subpatch.props = {}
+      } else if (Array.isArray(object)) {
+        subpatch.type = "list"
+        subpatch.edits = []
+      } else if (isObject(object)) {
+        subpatch.type = "map"
+        subpatch.props = {}
+      }
     }
 
-    if (!subpatch.props) {
-      subpatch.props = {}
-    }
     return subpatch
   }
 
@@ -207,7 +241,7 @@ class Context {
       // Create a new Text object
       this.addOp(elemId ? {action: 'makeText', obj, elemId, insert, pred}
                         : {action: 'makeText', obj, key, insert, pred})
-      const subpatch = {objectId, type: 'text', edits: [], props: {}}
+      const subpatch = {objectId, type: 'text', edits: []}
       this.insertListItems(subpatch, 0, [...value], true)
       return subpatch
 
@@ -224,7 +258,7 @@ class Context {
       // Create a new list object
       this.addOp(elemId ? {action: 'makeList', obj, elemId, insert, pred}
                         : {action: 'makeList', obj, key, insert, pred})
-      const subpatch = {objectId, type: 'list', edits: [], props: {}}
+      const subpatch = {objectId, type: 'list', edits: []}
       this.insertListItems(subpatch, 0, value, true)
       return subpatch
 
@@ -270,9 +304,13 @@ class Context {
     } else {
       // Date or counter object, or primitive value (number, string, boolean, or null)
       const description = this.getValueDescription(value)
+      const opDescription = copyObject(description)
+      if (opDescription.type === 'value') {
+        delete opDescription.type
+      }
       const op = elemId ? {action: 'set', obj: objectId, elemId, insert, pred}
                         : {action: 'set', obj: objectId, key, insert, pred}
-      this.addOp(Object.assign(op, description))
+      this.addOp(Object.assign(op, opDescription))
       return description
     }
   }
@@ -282,9 +320,9 @@ class Context {
    * and then immediately applies the patch to the document.
    */
   applyAtPath(path, callback) {
-    let patch = {diffs: {objectId: '_root', type: 'map'}}
-    callback(this.getSubpatch(patch, path))
-    this.applyPatch(patch.diffs, this.cache._root, this.updated)
+    let diff = {objectId: '_root', type: 'map', props: {}}
+    callback(this.getSubpatch(diff, path))
+    this.applyPatch(diff, this.cache._root, this.updated)
   }
 
   /**
@@ -337,18 +375,30 @@ class Context {
    * `subpatch` to reflect the sequence of values.
    */
   insertListItems(subpatch, index, values, newObject) {
+
     const list = newObject ? [] : this.getObject(subpatch.objectId)
     if (index < 0 || index > list.length) {
       throw new RangeError(`List index ${index} is out of bounds for list of length ${list.length}`)
     }
 
     let elemId = getElemId(list, index, true)
-    for (let offset = 0; offset < values.length; offset++) {
+    const allPrimitive = values.every(v => typeof v === 'string' || typeof v === 'number')
+    if (allPrimitive && values.length > 1) {
       let nextElemId = this.nextOpId()
-      const valuePatch = this.setValue(subpatch.objectId, index + offset, values[offset], true, [], elemId)
-      elemId = nextElemId
-      subpatch.edits.push({action: 'insert', index: index + offset, elemId})
-      subpatch.props[index + offset] = {[elemId]: valuePatch}
+      this.addOp({action: 'set', obj: subpatch.objectId, elemId, insert: true, values, pred: []})
+      subpatch.edits.push({
+        index,
+        action: 'multi-insert',
+        elemId: nextElemId,
+        values,
+      })
+    } else {
+      for (let offset = 0; offset < values.length; offset++) {
+        let nextElemId = this.nextOpId()
+        const valuePatch = this.setValue(subpatch.objectId, index + offset, values[offset], true, [], elemId)
+        elemId = nextElemId
+        subpatch.edits.push({action: 'insert', index: index + offset, elemId, value: valuePatch})
+      }
     }
   }
 
@@ -376,7 +426,12 @@ class Context {
         const pred = getPred(list, index)
         const opId = this.nextOpId()
         const valuePatch = this.setValue(objectId, index, value, false, pred, getElemId(list, index))
-        subpatch.props[index] = {[opId]: valuePatch}
+        subpatch.edits.push({
+          action: 'update',
+          index,
+          value: valuePatch,
+          opId,
+        })
       })
     }
   }
@@ -393,11 +448,20 @@ class Context {
     }
     if (deletions === 0 && insertions.length === 0) return
 
-    let patch = {diffs: {objectId: '_root', type: 'map'}}
-    let subpatch = this.getSubpatch(patch, path)
+    let patch = {diffs: {objectId: '_root', type: 'map', props: {}}}
+    let subpatch = this.getSubpatch(patch.diffs, path)
     if (!subpatch.edits) subpatch.edits = []
 
     if (deletions > 0) {
+      let op = {
+        action: 'del',
+        obj: objectId,
+        elemId: getElemId(list, start),
+        insert: false,
+        pred: [],
+        multiOp: deletions
+      }
+      let edit = {action: 'remove', index: start, count: deletions}
       for (let i = 0; i < deletions; i++) {
         if (this.getObjectField(path, objectId, start + i) instanceof Counter) {
           // This may seem bizarre, but it's really fiddly to implement deletion of counters from
@@ -417,12 +481,13 @@ class Context {
           // future, hopefully the above description will be enough to get you started. Good luck!
           throw new TypeError('Unsupported operation: deleting a counter from a list')
         }
-
-        const elemId = getElemId(list, start + i)
-        const pred = getPred(list, start + i)
-        this.addOp({action: 'del', obj: objectId, elemId, insert: false, pred})
-        subpatch.edits.push({action: 'remove', index: start})
+        op.pred.push(...getPred(list, start + i))
       }
+      if (op.multiOp === 1) {
+        delete op.multiOp
+      }
+      this.addOp(op)
+      subpatch.edits.push(edit)
     }
 
     if (insertions.length > 0) {
@@ -494,7 +559,16 @@ class Context {
     }
 
     this.applyAtPath(path, subpatch => {
-      subpatch.props[key] = {[opId]: {value, datatype: 'counter'}}
+      if (type === 'list' || type === 'text') {
+        subpatch.edits.push({
+          action: 'update',
+          opId,
+          index: key,
+          value: {value, datatype: 'counter'}
+        })
+      } else {
+        subpatch.props[key] = {[opId]: {value, datatype: 'counter'}}
+      }
     })
   }
 }

--- a/frontend/index.js
+++ b/frontend/index.js
@@ -117,7 +117,7 @@ function makeChange(doc, context, options) {
 }
 
 function countOps(ops) {
-  count = 0
+  let count = 0
   for (const op of ops) {
     if (op.action === 'set' && op.values) {
       count += op.values.length

--- a/frontend/index.js
+++ b/frontend/index.js
@@ -110,10 +110,22 @@ function makeChange(doc, context, options) {
   } else {
     const queuedRequest = {actor, seq: change.seq, before: doc}
     state.requests = state.requests.concat([queuedRequest])
-    state.maxOp = state.maxOp + change.ops.length
+    state.maxOp = state.maxOp + countOps(change.ops)
     state.deps = []
     return [updateRootObject(doc, context ? context.updated : {}, state), change]
   }
+}
+
+function countOps(ops) {
+  count = 0
+  for (const op of ops) {
+    if (op.action === 'set' && op.values) {
+      count += op.values.length
+    } else {
+      count += 1
+    }
+  }
+  return count
 }
 
 /**

--- a/src/common.js
+++ b/src/common.js
@@ -41,6 +41,42 @@ function equalBytes(array1, array2) {
   return true
 }
 
+function appendEdit(existingEdits, nextEdit) {
+  if (existingEdits.length === 0) {
+    existingEdits.push(nextEdit)
+    return
+  }
+  let lastEdit = existingEdits[existingEdits.length - 1]
+  if (nextEdit.action === 'insert') {
+    if (lastEdit.action === 'insert' && lastEdit.index === nextEdit.index - 1){
+      if (lastEdit.value.type === 'value') {
+        if (nextEdit.value.type === 'value') {
+          lastEdit.values = [lastEdit.value.value, nextEdit.value.value]
+          lastEdit.action = 'multi-insert'
+          delete lastEdit.value
+          return
+        }
+      }
+    } else if (lastEdit.action === 'multi-insert') {
+      if (lastEdit.index + lastEdit.values.length === nextEdit.index) {
+        if (nextEdit.value.type === 'value') {
+          lastEdit.values.push(nextEdit.value.value)
+          return
+        }
+      }
+    }
+  }
+  if (nextEdit.action === 'remove') {
+    if (lastEdit.action === 'remove') {
+      if (lastEdit.index === nextEdit.index) {
+        lastEdit.count += nextEdit.count
+        return
+      }
+    }
+  }
+  existingEdits.push(nextEdit)
+}
+
 module.exports = {
-  isObject, copyObject, parseOpId, equalBytes
+  isObject, copyObject, parseOpId, equalBytes, appendEdit
 }

--- a/src/common.js
+++ b/src/common.js
@@ -54,14 +54,16 @@ function appendEdit(existingEdits, nextEdit) {
   let lastEdit = existingEdits[existingEdits.length - 1]
   if (lastEdit.action === 'insert' && nextEdit.action === 'insert' &&
       lastEdit.index === nextEdit.index - 1 &&
-      lastEdit.value.type === 'value' && nextEdit.value.type === 'value') {
+      lastEdit.value.type === 'value' && nextEdit.value.type === 'value' &&
+      lastEdit.elemId === lastEdit.opId && nextEdit.elemId === nextEdit.opId) {
     lastEdit.action = 'multi-insert'
     lastEdit.values = [lastEdit.value.value, nextEdit.value.value]
     delete lastEdit.value
+    delete lastEdit.opId
 
   } else if (lastEdit.action === 'multi-insert' && nextEdit.action === 'insert' &&
              lastEdit.index + lastEdit.values.length === nextEdit.index &&
-             nextEdit.value.type === 'value') {
+             nextEdit.value.type === 'value' && nextEdit.elemId === nextEdit.opId) {
     lastEdit.values.push(nextEdit.value.value)
 
   } else if (lastEdit.action === 'remove' && nextEdit.action === 'remove' &&

--- a/src/common.js
+++ b/src/common.js
@@ -28,6 +28,15 @@ function parseOpId(opId) {
 }
 
 /**
+ * Returns true if the two given operation IDs have the same actor ID, and the counter of `id2` is
+ * exactly `delta` greater than the counter of `id1`.
+ */
+function opIdDelta(id1, id2, delta = 1) {
+  const parsed1 = parseOpId(id1), parsed2 = parseOpId(id2)
+  return parsed1.actorId === parsed2.actorId && parsed1.counter + delta === parsed2.counter
+}
+
+/**
  * Returns true if the two byte arrays contain the same data, false if not.
  */
 function equalBytes(array1, array2) {
@@ -55,7 +64,8 @@ function appendEdit(existingEdits, nextEdit) {
   if (lastEdit.action === 'insert' && nextEdit.action === 'insert' &&
       lastEdit.index === nextEdit.index - 1 &&
       lastEdit.value.type === 'value' && nextEdit.value.type === 'value' &&
-      lastEdit.elemId === lastEdit.opId && nextEdit.elemId === nextEdit.opId) {
+      lastEdit.elemId === lastEdit.opId && nextEdit.elemId === nextEdit.opId &&
+      opIdDelta(lastEdit.elemId, nextEdit.elemId, 1)) {
     lastEdit.action = 'multi-insert'
     lastEdit.values = [lastEdit.value.value, nextEdit.value.value]
     delete lastEdit.value
@@ -63,7 +73,8 @@ function appendEdit(existingEdits, nextEdit) {
 
   } else if (lastEdit.action === 'multi-insert' && nextEdit.action === 'insert' &&
              lastEdit.index + lastEdit.values.length === nextEdit.index &&
-             nextEdit.value.type === 'value' && nextEdit.elemId === nextEdit.opId) {
+             nextEdit.value.type === 'value' && nextEdit.elemId === nextEdit.opId &&
+             opIdDelta(lastEdit.elemId, nextEdit.elemId, lastEdit.values.length)) {
     lastEdit.values.push(nextEdit.value.value)
 
   } else if (lastEdit.action === 'remove' && nextEdit.action === 'remove' &&

--- a/src/common.js
+++ b/src/common.js
@@ -41,40 +41,36 @@ function equalBytes(array1, array2) {
   return true
 }
 
+/**
+ * Appends a list edit operation (insert, update, remove) to an array of existing operations. If the
+ * last existing operation can be extended (as a multi-op), we do that.
+ */
 function appendEdit(existingEdits, nextEdit) {
   if (existingEdits.length === 0) {
     existingEdits.push(nextEdit)
     return
   }
+
   let lastEdit = existingEdits[existingEdits.length - 1]
-  if (nextEdit.action === 'insert') {
-    if (lastEdit.action === 'insert' && lastEdit.index === nextEdit.index - 1){
-      if (lastEdit.value.type === 'value') {
-        if (nextEdit.value.type === 'value') {
-          lastEdit.values = [lastEdit.value.value, nextEdit.value.value]
-          lastEdit.action = 'multi-insert'
-          delete lastEdit.value
-          return
-        }
-      }
-    } else if (lastEdit.action === 'multi-insert') {
-      if (lastEdit.index + lastEdit.values.length === nextEdit.index) {
-        if (nextEdit.value.type === 'value') {
-          lastEdit.values.push(nextEdit.value.value)
-          return
-        }
-      }
-    }
+  if (lastEdit.action === 'insert' && nextEdit.action === 'insert' &&
+      lastEdit.index === nextEdit.index - 1 &&
+      lastEdit.value.type === 'value' && nextEdit.value.type === 'value') {
+    lastEdit.action = 'multi-insert'
+    lastEdit.values = [lastEdit.value.value, nextEdit.value.value]
+    delete lastEdit.value
+
+  } else if (lastEdit.action === 'multi-insert' && nextEdit.action === 'insert' &&
+             lastEdit.index + lastEdit.values.length === nextEdit.index &&
+             nextEdit.value.type === 'value') {
+    lastEdit.values.push(nextEdit.value.value)
+
+  } else if (lastEdit.action === 'remove' && nextEdit.action === 'remove' &&
+             lastEdit.index === nextEdit.index) {
+    lastEdit.count += nextEdit.count
+
+  } else {
+    existingEdits.push(nextEdit)
   }
-  if (nextEdit.action === 'remove') {
-    if (lastEdit.action === 'remove') {
-      if (lastEdit.index === nextEdit.index) {
-        lastEdit.count += nextEdit.count
-        return
-      }
-    }
-  }
-  existingEdits.push(nextEdit)
 }
 
 module.exports = {

--- a/src/common.js
+++ b/src/common.js
@@ -28,15 +28,6 @@ function parseOpId(opId) {
 }
 
 /**
- * Returns true if the two given operation IDs have the same actor ID, and the counter of `id2` is
- * exactly `delta` greater than the counter of `id1`.
- */
-function opIdDelta(id1, id2, delta = 1) {
-  const parsed1 = parseOpId(id1), parsed2 = parseOpId(id2)
-  return parsed1.actorId === parsed2.actorId && parsed1.counter + delta === parsed2.counter
-}
-
-/**
  * Returns true if the two byte arrays contain the same data, false if not.
  */
 function equalBytes(array1, array2) {
@@ -50,42 +41,6 @@ function equalBytes(array1, array2) {
   return true
 }
 
-/**
- * Appends a list edit operation (insert, update, remove) to an array of existing operations. If the
- * last existing operation can be extended (as a multi-op), we do that.
- */
-function appendEdit(existingEdits, nextEdit) {
-  if (existingEdits.length === 0) {
-    existingEdits.push(nextEdit)
-    return
-  }
-
-  let lastEdit = existingEdits[existingEdits.length - 1]
-  if (lastEdit.action === 'insert' && nextEdit.action === 'insert' &&
-      lastEdit.index === nextEdit.index - 1 &&
-      lastEdit.value.type === 'value' && nextEdit.value.type === 'value' &&
-      lastEdit.elemId === lastEdit.opId && nextEdit.elemId === nextEdit.opId &&
-      opIdDelta(lastEdit.elemId, nextEdit.elemId, 1)) {
-    lastEdit.action = 'multi-insert'
-    lastEdit.values = [lastEdit.value.value, nextEdit.value.value]
-    delete lastEdit.value
-    delete lastEdit.opId
-
-  } else if (lastEdit.action === 'multi-insert' && nextEdit.action === 'insert' &&
-             lastEdit.index + lastEdit.values.length === nextEdit.index &&
-             nextEdit.value.type === 'value' && nextEdit.elemId === nextEdit.opId &&
-             opIdDelta(lastEdit.elemId, nextEdit.elemId, lastEdit.values.length)) {
-    lastEdit.values.push(nextEdit.value.value)
-
-  } else if (lastEdit.action === 'remove' && nextEdit.action === 'remove' &&
-             lastEdit.index === nextEdit.index) {
-    lastEdit.count += nextEdit.count
-
-  } else {
-    existingEdits.push(nextEdit)
-  }
-}
-
 module.exports = {
-  isObject, copyObject, parseOpId, equalBytes, appendEdit
+  isObject, copyObject, parseOpId, equalBytes
 }

--- a/test/backend_test.js
+++ b/test/backend_test.js
@@ -151,12 +151,9 @@ describe('Automerge.Backend', () => {
       assert.deepStrictEqual(patch2, {
         clock: {[actor]: 2}, deps: [hash(change2)], maxOp: 3, pendingChanges: 0,
         diffs: {objectId: '_root', type: 'map', props: {birds: {[`1@${actor}`]: {
-            objectId: `1@${actor}`, type: 'list', edits: [{
-                action: 'update',
-                opId: `3@${actor}`,
-                value: {type: 'value', value: 'greenfinch'},
-                index: 0,
-            }],
+          objectId: `1@${actor}`, type: 'list', edits: [
+            {action: 'update', opId: `3@${actor}`, index: 0, value: {type: 'value', value: 'greenfinch'}}
+          ]
         }}}}
       })
     })
@@ -176,8 +173,9 @@ describe('Automerge.Backend', () => {
       assert.deepStrictEqual(patch2, {
         clock: {[actor]: 2}, deps: [hash(change2)], maxOp: 3, pendingChanges: 0,
         diffs: {objectId: '_root', type: 'map', props: {birds: {[`1@${actor}`]: {
-          objectId: `1@${actor}`, type: 'list',
-          edits: [{action: 'remove', index: 0, count: 1}]
+          objectId: `1@${actor}`, type: 'list', edits: [
+            {action: 'remove', index: 0, count: 1}
+          ]
         }}}}
       })
     })
@@ -563,7 +561,7 @@ describe('Automerge.Backend', () => {
       const actor = uuid() 
       const localChange = {actor, seq: 1, startOp: 1, time: 0, deps: [], ops: [
         {action: 'makeList', obj: '_root', key: 'todos', pred: []},
-        {action: 'set', obj: `1@${actor}`, insert: true, elemId: '_head', pred: [], values: [1, 2, 3,  4, 5]},
+        {action: 'set', obj: `1@${actor}`, insert: true, elemId: '_head', pred: [], values: [1, 2, 3, 4, 5]},
       ]}
       const s0 = Backend.init()
       const [s1, patch1] = Backend.applyLocalChange(s0, localChange)
@@ -571,10 +569,9 @@ describe('Automerge.Backend', () => {
       assert.deepStrictEqual(patch1, {
         clock: {[actor]: 1}, deps: [], maxOp: 6, actor, seq: 1, pendingChanges: 0,
         diffs: {objectId: '_root', type: 'map', props: {todos: {[`1@${actor}`]: {
-          objectId: `1@${actor}`, type: 'list',
-          edits: [
-            {action: 'multi-insert', index: 0, elemId: `2@${actor}`, values: [1, 2, 3, 4, 5]},
-          ],
+          objectId: `1@${actor}`, type: 'list', edits: [
+            {action: 'multi-insert', index: 0, elemId: `2@${actor}`, values: [1, 2, 3, 4, 5]}
+          ]
         }}}}
       })
     })
@@ -583,7 +580,7 @@ describe('Automerge.Backend', () => {
       const actor = uuid() 
       const change1 = {actor, seq: 1, startOp: 1, time: 0, deps: [], ops: [
         {action: 'makeList', obj: '_root', key: 'todos', pred: []},
-        {action: 'set', obj: `1@${actor}`, insert: true, elemId: '_head', pred: [], values: [1, 2, 3,  4, 5]}
+        {action: 'set', obj: `1@${actor}`, insert: true, elemId: '_head', pred: [], values: [1, 2, 3, 4, 5]}
       ]}
       const change2 = {actor, seq: 2, startOp: 7, time: 0, deps: [hash(change1)], ops: [
         {action: 'del', obj: `1@${actor}`, elemId: `3@${actor}`, multiOp: 3, pred: [`3@${actor}`]}
@@ -594,10 +591,9 @@ describe('Automerge.Backend', () => {
       assert.deepStrictEqual(patch2, {
         clock: {[actor]: 2}, deps: [], maxOp: 9, actor, seq: 2, pendingChanges: 0,
         diffs: {objectId: '_root', type: 'map', props: {todos: {[`1@${actor}`]: {
-          objectId: `1@${actor}`, type: 'list',
-          edits: [
+          objectId: `1@${actor}`, type: 'list', edits: [
             {action: 'remove', index: 1, count: 3}
-          ],
+          ]
         }}}}
       })
     })

--- a/test/backend_test.js
+++ b/test/backend_test.js
@@ -20,7 +20,7 @@ describe('Automerge.Backend', () => {
       assert.deepStrictEqual(patch1, {
         clock: {[actor]: 1}, deps: [hash(change1)], maxOp: 1, pendingChanges: 0,
         diffs: {objectId: '_root', type: 'map', props: {
-          bird: {[`1@${actor}`]: {value: 'magpie'}}
+          bird: {[`1@${actor}`]: {type: 'value', value: 'magpie'}}
         }}
       })
     })
@@ -39,7 +39,7 @@ describe('Automerge.Backend', () => {
       assert.deepStrictEqual(patch2, {
         clock: {[actor]: 2}, deps: [hash(change2)], maxOp: 2, pendingChanges: 0,
         diffs: {objectId: '_root', type: 'map', props: {
-          counter: {[`1@${actor}`]: {value: 3, datatype: 'counter'}}
+          counter: {[`1@${actor}`]: {type: 'value', value: 3, datatype: 'counter'}}
         }}
       })
     })
@@ -57,7 +57,10 @@ describe('Automerge.Backend', () => {
       assert.deepStrictEqual(patch2, {
         clock: {111111: 1, 222222: 1}, deps: [hash(change2)], maxOp: 2, pendingChanges: 0,
         diffs: {objectId: '_root', type: 'map', props: {
-          bird: {'1@111111': {value: 'magpie'}, '2@222222': {value: 'blackbird'}}
+          bird: {
+            '1@111111': {type: 'value', value: 'magpie'},
+            '2@222222': {type: 'value', value: 'blackbird'}
+          }
         }}
       })
     })
@@ -90,7 +93,7 @@ describe('Automerge.Backend', () => {
       assert.deepStrictEqual(patch1, {
         clock: {[actor]: 1}, deps: [hash(change1)], maxOp: 2, pendingChanges: 0,
         diffs: {objectId: '_root', type: 'map', props: {birds: {[`1@${actor}`]: {
-          objectId: `1@${actor}`, type: 'map', props: {wrens: {[`2@${actor}`]: {value: 3}}}
+          objectId: `1@${actor}`, type: 'map', props: {wrens: {[`2@${actor}`]: {type: 'value', value: 3}}}
         }}}}
       })
     })
@@ -110,7 +113,7 @@ describe('Automerge.Backend', () => {
       assert.deepStrictEqual(patch2, {
         clock: {[actor]: 2}, deps: [hash(change2)], maxOp: 3, pendingChanges: 0,
         diffs: {objectId: '_root', type: 'map', props: {birds: {[`1@${actor}`]: {
-          objectId: `1@${actor}`, type: 'map', props: {sparrows: {[`3@${actor}`]: {value: 15}}}
+          objectId: `1@${actor}`, type: 'map', props: {sparrows: {[`3@${actor}`]: {type: 'value', value: 15}}}
         }}}}
       })
     })
@@ -127,8 +130,7 @@ describe('Automerge.Backend', () => {
         clock: {[actor]: 1}, deps: [hash(change1)], maxOp: 2, pendingChanges: 0,
         diffs: {objectId: '_root', type: 'map', props: {birds: {[`1@${actor}`]: {
           objectId: `1@${actor}`, type: 'list',
-          edits: [{action: 'insert', index: 0, elemId: `2@${actor}`}],
-          props: {0: {[`2@${actor}`]: {value: 'chaffinch'}}}
+          edits: [{action: 'insert', index: 0, elemId: `2@${actor}`, value: {type: 'value', value: 'chaffinch'}}],
         }}}}
       })
     })
@@ -148,8 +150,12 @@ describe('Automerge.Backend', () => {
       assert.deepStrictEqual(patch2, {
         clock: {[actor]: 2}, deps: [hash(change2)], maxOp: 3, pendingChanges: 0,
         diffs: {objectId: '_root', type: 'map', props: {birds: {[`1@${actor}`]: {
-          objectId: `1@${actor}`, type: 'list', edits: [],
-          props: {0: {[`3@${actor}`]: {value: 'greenfinch'}}}
+            objectId: `1@${actor}`, type: 'list', edits: [{
+                action: 'update',
+                opId: `3@${actor}`,
+                value: {type: 'value', value: 'greenfinch'},
+                index: 0,
+            }],
         }}}}
       })
     })
@@ -169,8 +175,8 @@ describe('Automerge.Backend', () => {
       assert.deepStrictEqual(patch2, {
         clock: {[actor]: 2}, deps: [hash(change2)], maxOp: 3, pendingChanges: 0,
         diffs: {objectId: '_root', type: 'map', props: {birds: {[`1@${actor}`]: {
-          objectId: `1@${actor}`, type: 'list', props: {},
-          edits: [{action: 'remove', index: 0}]
+          objectId: `1@${actor}`, type: 'list',
+          edits: [{action: 'remove', index: 0, count: 1}]
         }}}}
       })
     })
@@ -191,8 +197,9 @@ describe('Automerge.Backend', () => {
         clock: {[actor]: 2}, deps: [hash(change2)], maxOp: 3, pendingChanges: 0,
         diffs: {objectId: '_root', type: 'map', props: {birds: {[`1@${actor}`]: {
           objectId: `1@${actor}`, type: 'list', edits: [
-            {action: 'insert', index: 0, elemId: `2@${actor}`}, {action: 'remove', index: 0}
-          ], props: {}
+            {action: 'insert', index: 0, elemId: `2@${actor}`, value: {type: 'value', value: 'chaffinch'}},
+            {action: 'remove', index: 0, count: 1}
+          ], 
         }}}}
       })
     })
@@ -216,8 +223,8 @@ describe('Automerge.Backend', () => {
         clock: {[actor1]: 1, [actor2]: 2}, maxOp: 2, pendingChanges: 0,
         deps: [hash(change1), hash(change3)].sort(), 
         diffs: {objectId: '_root', type: 'map', props: {conflict: {
-          [`1@${actor1}`]: {objectId: `1@${actor1}`, type: 'list'},
-          [`1@${actor2}`]: {objectId: `1@${actor2}`, type: 'map', props: {sparrows: {[`2@${actor2}`]: {value: 12}}}}
+          [`1@${actor1}`]: {objectId: `1@${actor1}`, type: 'list', edits: []},
+          [`1@${actor2}`]: {objectId: `1@${actor2}`, type: 'map', props: {sparrows: {[`2@${actor2}`]: {type: 'value', value: 12}}}}
         }}}
       })
     })
@@ -232,7 +239,7 @@ describe('Automerge.Backend', () => {
       assert.deepStrictEqual(patch, {
         clock: {[actor]: 1}, deps: [hash(change)], maxOp: 1, pendingChanges: 0,
         diffs: {objectId: '_root', type: 'map', props: {
-          now: {[`1@${actor}`]: {value: now.getTime(), datatype: 'timestamp'}}
+          now: {[`1@${actor}`]: {type: 'value', value: now.getTime(), datatype: 'timestamp'}}
         }}
       })
     })
@@ -249,8 +256,7 @@ describe('Automerge.Backend', () => {
         clock: {[actor]: 1}, deps: [hash(change)], maxOp: 2, pendingChanges: 0,
         diffs: {objectId: '_root', type: 'map', props: {list: {[`1@${actor}`]: {
           objectId: `1@${actor}`, type: 'list',
-          edits: [{action: 'insert', index: 0, elemId: `2@${actor}`}],
-          props: {0: {[`2@${actor}`]: {value: now.getTime(), datatype: 'timestamp'}}}
+          edits: [{action: 'insert', index: 0, elemId: `2@${actor}`, value: {type: 'value', value: now.getTime(), datatype: 'timestamp'}}],
         }}}}
       })
     })
@@ -277,6 +283,82 @@ describe('Automerge.Backend', () => {
         diffs: {objectId: '_root', type: 'map'}
       })
     })
+
+    it('should handle nested maps in lists', () => {
+      const actor = uuid()
+      const change1 = {actor, seq: 1, startOp: 1, time: 0, deps: [], ops: [
+        {action: 'makeList', obj: '_root', key: 'todos', pred: []},
+        {action: 'set', obj: `1@${actor}`, insert: true, elemId: '_head', pred: [], value: 'first'},
+        {action: 'makeMap', obj: `1@${actor}`, elemId: `2@${actor}`, insert: true, pred: []},
+        {action: 'set', obj: `3@${actor}`, key: 'title', value: 'water plants', pred: []},
+        {action: 'set', obj: `3@${actor}`, key: 'done', value: false, pred: []}
+      ]}
+      const s0 = Backend.init()
+      const [s1, patch1] = Backend.applyChanges(s0, [encodeChange(change1)])
+      assert.deepStrictEqual(patch1, {
+        clock: {[actor]: 1}, deps: [hash(change1)], maxOp: 5, pendingChanges: 0,
+        diffs: {objectId: '_root', type: 'map', props: {todos: {[`1@${actor}`]: {
+          objectId: `1@${actor}`, type: 'list',
+          edits: [
+            {action: 'insert', index: 0, elemId: `2@${actor}`, value: {type: 'value', value: 'first'}},
+            {action: 'insert', index: 1, elemId: `3@${actor}`, value: {
+              type: 'map',
+              objectId: `3@${actor}`,
+              props: {
+                title: {[`4@${actor}`]: {type: 'value', value: 'water plants'}},
+                done:  {[`5@${actor}`]: {type: 'value', value: false}}
+              }
+            }}
+          ],
+        }}}}
+      })
+    })
+
+    it('should support inserting multiple elements in one op', () => {
+      const actor = uuid() 
+      const change1 = {actor, seq: 1, startOp: 1, time: 0, deps: [], ops: [
+        {action: 'makeList', obj: '_root', key: 'todos', pred: []},
+        {action: 'set', obj: `1@${actor}`, insert: true, elemId: '_head', pred: [], values: [1, 2, 3,  4, 5]},
+      ]}
+      const s0 = Backend.init()
+      const [s1, patch1] = Backend.applyChanges(s0, [encodeChange(change1)])
+      assert.deepStrictEqual(patch1, {
+        clock: {[actor]: 1}, deps: [hash(change1)], maxOp: 6, pendingChanges: 0,
+        diffs: {objectId: '_root', type: 'map', props: {todos: {[`1@${actor}`]: {
+          objectId: `1@${actor}`, type: 'list',
+          edits: [
+            {action: 'multi-insert', index: 0, elemId: `2@${actor}`, values: [1, 2, 3, 4, 5]},
+          ],
+        }}}}
+      })
+    })
+
+    it('should support deleting multiple elements in one op', () => {
+      const actor = uuid() 
+      const change1 = {actor, seq: 1, startOp: 1, time: 0, deps: [], ops: [
+        {action: 'makeList', obj: '_root', key: 'todos', pred: []},
+        {action: 'set', obj: `1@${actor}`, insert: true, elemId: '_head', pred: [], values: [1, 2, 3,  4, 5]},
+      ]}
+      const change2 = {actor, seq: 2, startOp: 7, time: 0, deps: [hash(change1)], ops: [
+        {action: 'del', obj: `1@${actor}`, elemId: `3@${actor}`, multiOp: 3, pred: [
+          `3@${actor}`,
+          `4@${actor}`,
+          `5@${actor}`,
+        ]}
+      ]}
+      const s0 = Backend.init()
+      const [s1, patch1] = Backend.applyChanges(s0, [encodeChange(change1)])
+      const [s2, patch2] = Backend.applyChanges(s1, [encodeChange(change2)])
+      assert.deepStrictEqual(patch2, {
+        clock: {[actor]: 2}, deps: [hash(change2)], maxOp: 9, pendingChanges: 0,
+        diffs: {objectId: '_root', type: 'map', props: {todos: {[`1@${actor}`]: {
+          objectId: `1@${actor}`, type: 'list',
+          edits: [
+            {action: 'remove', index: 1, count: 3}
+          ],
+        }}}}
+      })
+    })
   })
 
   describe('applyLocalChange()', () => {
@@ -290,7 +372,7 @@ describe('Automerge.Backend', () => {
       assert.deepStrictEqual(patch1, {
         actor: '111111', seq: 1, clock: {'111111': 1}, deps: [], maxOp: 1, pendingChanges: 0,
         diffs: {objectId: '_root', type: 'map', props: {
-          bird: {['1@111111']: {value: 'magpie'}}
+          bird: {['1@111111']: {type: 'value', value: 'magpie'}}
         }}
       })
       assert.deepStrictEqual(changes01, [{
@@ -369,7 +451,7 @@ describe('Automerge.Backend', () => {
         actor: '111111', seq: 2, clock: {'111111': 2, '222222': 1},
         deps: [hash(remote1)], maxOp: 2, pendingChanges: 0,
         diffs: {objectId: '_root', type: 'map', props: {
-          bird: {'2@222222': {value: 'magpie'}, '2@111111': {value: 'jay'}}
+          bird: {'2@222222': {type: 'value', value: 'magpie'}, '2@111111': {type: 'value', value: 'jay'}}
         }}
       })
       assert.deepStrictEqual(changes[2], {
@@ -442,8 +524,9 @@ describe('Automerge.Backend', () => {
         actor: '111111', seq: 2, clock: {'111111': 2}, deps: [], maxOp: 3, pendingChanges: 0,
         diffs: {objectId: '_root', type: 'map', props: {
           birds: {['1@111111']: {objectId: '1@111111', type: 'list',
-            edits: [{action: 'insert', index: 0, elemId: '2@111111'}, {action: 'remove', index: 0}],
-            props: {}
+            edits: [
+              {action: 'insert', index: 0, elemId: '2@111111', value: {type: 'value', value: 'magpie'}},
+              {action: 'remove', index: 0, count: 1}],
           }}
         }}
       })
@@ -473,8 +556,55 @@ describe('Automerge.Backend', () => {
       assert.deepStrictEqual(patch2, {
         clock: {'111111': 1}, deps: [hash(change1)], maxOp: 1, pendingChanges: 0,
         diffs: {objectId: '_root', type: 'map', props: {
-          longString: {['1@111111']: {value: longString}}
+          longString: {['1@111111']: {type: 'value', value: longString}}
         }}
+      })
+    })
+
+    it('should support inserting multiple elements in one change', () => {
+      const actor = uuid() 
+      const localChange = {actor, seq: 1, startOp: 1, time: 0, deps: [], ops: [
+        {action: 'makeList', obj: '_root', key: 'todos', pred: []},
+        {action: 'set', obj: `1@${actor}`, insert: true, elemId: '_head', pred: [], values: [1, 2, 3,  4, 5]},
+      ]}
+      const s0 = Backend.init()
+      const [s1, patch1] = Backend.applyLocalChange(s0, localChange)
+      const changes = Backend.getChanges(s1, []).map(decodeChange)
+      assert.deepStrictEqual(patch1, {
+        clock: {[actor]: 1}, deps: [], maxOp: 6, actor, seq: 1, pendingChanges: 0,
+        diffs: {objectId: '_root', type: 'map', props: {todos: {[`1@${actor}`]: {
+          objectId: `1@${actor}`, type: 'list',
+          edits: [
+            {action: 'multi-insert', index: 0, elemId: `2@${actor}`, values: [1, 2, 3, 4, 5]},
+          ],
+        }}}}
+      })
+    })
+
+    it('should support deleting multiple elements in one op', () => {
+      const actor = uuid() 
+      const change1 = {actor, seq: 1, startOp: 1, time: 0, deps: [], ops: [
+        {action: 'makeList', obj: '_root', key: 'todos', pred: []},
+        {action: 'set', obj: `1@${actor}`, insert: true, elemId: '_head', pred: [], values: [1, 2, 3,  4, 5]}
+      ]}
+      const change2 = {actor, seq: 2, startOp: 7, time: 0, deps: [hash(change1)], ops: [
+        {action: 'del', obj: `1@${actor}`, elemId: `3@${actor}`, multiOp: 3, pred: [
+          `3@${actor}`,
+          `4@${actor}`,
+          `5@${actor}`,
+        ]}
+      ]}
+      const s0 = Backend.init()
+      const [s1, patch1] = Backend.applyLocalChange(s0, change1)
+      const [s2, patch2] = Backend.applyLocalChange(s1, change2)
+      assert.deepStrictEqual(patch2, {
+        clock: {[actor]: 2}, deps: [], maxOp: 9, actor, seq: 2, pendingChanges: 0,
+        diffs: {objectId: '_root', type: 'map', props: {todos: {[`1@${actor}`]: {
+          objectId: `1@${actor}`, type: 'list',
+          edits: [
+            {action: 'remove', index: 1, count: 3}
+          ],
+        }}}}
       })
     })
   })
@@ -508,7 +638,7 @@ describe('Automerge.Backend', () => {
       assert.deepStrictEqual(patch, {
         clock: {'111111': 1}, deps: [hash(change1)], maxOp: 1, pendingChanges: 0,
         diffs: {objectId: '_root', type: 'map', props: {
-          longString: {['1@111111']: {value: longString}}
+          longString: {['1@111111']: {type: 'value', value: longString}}
         }}
       })
     })
@@ -527,7 +657,7 @@ describe('Automerge.Backend', () => {
       assert.deepStrictEqual(Backend.getPatch(s1), {
         clock: {[actor]: 2}, deps: [hash(change2)], maxOp: 2, pendingChanges: 0,
         diffs: {objectId: '_root', type: 'map', props: {
-          bird: {[`2@${actor}`]: {value: 'blackbird'}}
+          bird: {[`2@${actor}`]: {type: 'value', value: 'blackbird'}}
         }}
       })
     })
@@ -544,7 +674,7 @@ describe('Automerge.Backend', () => {
         clock: {111111: 1, 222222: 1},
         deps: [hash(change1), hash(change2)].sort(), maxOp: 1, pendingChanges: 0,
         diffs: {objectId: '_root', type: 'map', props: {
-          bird: {'1@111111': {value: 'magpie'}, '1@222222': {value: 'blackbird'}}
+          bird: {'1@111111': {type: 'value', value: 'magpie'}, '1@222222': {type: 'value', value: 'blackbird'}}
         }}
       })
     })
@@ -598,7 +728,7 @@ describe('Automerge.Backend', () => {
       assert.deepStrictEqual(Backend.getPatch(s1), {
         clock: {[actor]: 2}, deps: [hash(change2)], maxOp: 4, pendingChanges: 0,
         diffs: {objectId: '_root', type: 'map', props: {birds: {[`1@${actor}`]: {
-          objectId: `1@${actor}`, type: 'map', props: {sparrows: {[`4@${actor}`]: {value: 15}}}
+          objectId: `1@${actor}`, type: 'map', props: {sparrows: {[`4@${actor}`]: {type: 'value', value: 15}}}
         }}}}
       })
     })
@@ -614,8 +744,7 @@ describe('Automerge.Backend', () => {
         clock: {[actor]: 1}, deps: [hash(change1)], maxOp: 2, pendingChanges: 0,
         diffs: {objectId: '_root', type: 'map', props: {birds: {[`1@${actor}`]: {
           objectId: `1@${actor}`, type: 'list',
-          edits: [{action: 'insert', index: 0, elemId: `2@${actor}`}],
-          props: {0: {[`2@${actor}`]: {value: 'chaffinch'}}}
+          edits: [{action: 'insert', index: 0, elemId: `2@${actor}`, value: {type: 'value', value: 'chaffinch'}}],
         }}}}
       })
     })
@@ -637,8 +766,9 @@ describe('Automerge.Backend', () => {
         clock: {[actor]: 2}, deps: [hash(change2)], maxOp: 6, pendingChanges: 0,
         diffs: {objectId: '_root', type: 'map', props: {birds: {[`1@${actor}`]: {
           objectId: `1@${actor}`, type: 'list',
-          edits: [{action: 'insert', index: 0, elemId: `5@${actor}`}, {action: 'insert', index: 1, elemId: `3@${actor}`}],
-          props: {0: {[`5@${actor}`]: {value: 'greenfinch'}}, 1: {[`6@${actor}`]: {value: 'goldfinches!!'}}}
+          edits: [
+            {action: 'multi-insert', index: 0, elemId: `5@${actor}`, values: ['greenfinch', 'goldfinches!!']},
+          ],
         }}}}
       })
     })
@@ -656,13 +786,16 @@ describe('Automerge.Backend', () => {
         clock: {[actor]: 1}, deps: [hash(change)], maxOp: 4, pendingChanges: 0,
         diffs: {objectId: '_root', type: 'map', props: {todos: {[`1@${actor}`]: {
           objectId: `1@${actor}`, type: 'list',
-          edits: [{action: 'insert', index: 0, elemId: `2@${actor}`}],
-          props: {0: {[`2@${actor}`]: {
-            objectId: `2@${actor}`, type: 'map', props: {
-              title: {[`3@${actor}`]: {value: 'water plants'}},
-              done:  {[`4@${actor}`]: {value: false}}
-            }
-          }}}
+          edits: [
+            {action: 'insert', index: 0, elemId: `2@${actor}`, value: {
+              type: 'map',
+              objectId: `2@${actor}`,
+              props: {
+                title: {[`3@${actor}`]: {type: 'value', value: 'water plants'}},
+                done:  {[`4@${actor}`]: {type: 'value', value: false}}
+              }
+            }}
+          ],
         }}}}
       })
     })
@@ -676,7 +809,7 @@ describe('Automerge.Backend', () => {
       assert.deepStrictEqual(Backend.getPatch(s1), {
         clock: {[actor]: 1}, deps: [hash(change)], maxOp: 1, pendingChanges: 0,
         diffs: {objectId: '_root', type: 'map', props: {
-          now: {[`1@${actor}`]: {value: now.getTime(), datatype: 'timestamp'}}
+          now: {[`1@${actor}`]: {type: 'value', value: now.getTime(), datatype: 'timestamp'}}
         }}
       })
     })
@@ -692,8 +825,33 @@ describe('Automerge.Backend', () => {
         clock: {[actor]: 1}, deps: [hash(change)], maxOp: 2, pendingChanges: 0,
         diffs: {objectId: '_root', type: 'map', props: {list: {[`1@${actor}`]: {
           objectId: `1@${actor}`, type: 'list',
-          edits: [{action: 'insert', index: 0, elemId: `2@${actor}`}],
-          props: {0: {[`2@${actor}`]: {value: now.getTime(), datatype: 'timestamp'}}}
+          edits: [{action: 'insert', index: 0, elemId: `2@${actor}`, 
+            value: {type: 'value', value: now.getTime(), datatype: 'timestamp'}}],
+        }}}}
+      })
+    })
+
+    it('should condense multiple inserts into a single edit', () => {
+      const actor = uuid()
+      const change1 = {actor, seq: 1, startOp: 1, time: 0, deps: [], ops: [
+        {action: 'makeList', obj: '_root', key: 'birds', pred: []},
+        {action: 'set', obj: `1@${actor}`, elemId: '_head',      insert: true, value: 'chaffinch', pred: []},
+        {action: 'set', obj: `1@${actor}`, elemId: `2@${actor}`, insert: true, value: 'goldfinch', pred: []},
+        {action: 'set', obj: `1@${actor}`, elemId: `3@${actor}`, insert: true, values: ['bullfinch', 'greenfinch'], pred: []}
+      ]}
+      const s1 = Backend.loadChanges(Backend.init(), [change1].map(encodeChange))
+      assert.deepStrictEqual(Backend.getPatch(s1), {
+        clock: {[actor]: 1}, deps: [hash(change1)], maxOp: 5, pendingChanges: 0,
+        diffs: {objectId: '_root', type: 'map', props: {birds: {[`1@${actor}`]: {
+          objectId: `1@${actor}`, type: 'list',
+          edits: [
+            {action: 'multi-insert', index: 0, elemId: `2@${actor}`, values: [
+              'chaffinch',
+              'goldfinch',
+              'bullfinch',
+              'greenfinch',
+            ]}
+          ],
         }}}}
       })
     })

--- a/test/backend_test.js
+++ b/test/backend_test.js
@@ -129,8 +129,9 @@ describe('Automerge.Backend', () => {
       assert.deepStrictEqual(patch1, {
         clock: {[actor]: 1}, deps: [hash(change1)], maxOp: 2, pendingChanges: 0,
         diffs: {objectId: '_root', type: 'map', props: {birds: {[`1@${actor}`]: {
-          objectId: `1@${actor}`, type: 'list',
-          edits: [{action: 'insert', index: 0, elemId: `2@${actor}`, value: {type: 'value', value: 'chaffinch'}}],
+          objectId: `1@${actor}`, type: 'list', edits: [
+            {action: 'insert', index: 0, elemId: `2@${actor}`, opId: `2@${actor}`, value: {type: 'value', value: 'chaffinch'}}
+          ]
         }}}}
       })
     })
@@ -197,7 +198,7 @@ describe('Automerge.Backend', () => {
         clock: {[actor]: 2}, deps: [hash(change2)], maxOp: 3, pendingChanges: 0,
         diffs: {objectId: '_root', type: 'map', props: {birds: {[`1@${actor}`]: {
           objectId: `1@${actor}`, type: 'list', edits: [
-            {action: 'insert', index: 0, elemId: `2@${actor}`, value: {type: 'value', value: 'chaffinch'}},
+            {action: 'insert', index: 0, elemId: `2@${actor}`, opId: `2@${actor}`, value: {type: 'value', value: 'chaffinch'}},
             {action: 'remove', index: 0, count: 1}
           ], 
         }}}}
@@ -255,8 +256,9 @@ describe('Automerge.Backend', () => {
       assert.deepStrictEqual(patch, {
         clock: {[actor]: 1}, deps: [hash(change)], maxOp: 2, pendingChanges: 0,
         diffs: {objectId: '_root', type: 'map', props: {list: {[`1@${actor}`]: {
-          objectId: `1@${actor}`, type: 'list',
-          edits: [{action: 'insert', index: 0, elemId: `2@${actor}`, value: {type: 'value', value: now.getTime(), datatype: 'timestamp'}}],
+          objectId: `1@${actor}`, type: 'list', edits: [
+            {action: 'insert', index: 0, elemId: `2@${actor}`, opId: `2@${actor}`, value: {type: 'value', value: now.getTime(), datatype: 'timestamp'}}
+          ]
         }}}}
       })
     })
@@ -300,8 +302,8 @@ describe('Automerge.Backend', () => {
         diffs: {objectId: '_root', type: 'map', props: {todos: {[`1@${actor}`]: {
           objectId: `1@${actor}`, type: 'list',
           edits: [
-            {action: 'insert', index: 0, elemId: `2@${actor}`, value: {type: 'value', value: 'first'}},
-            {action: 'insert', index: 1, elemId: `3@${actor}`, value: {
+            {action: 'insert', index: 0, elemId: `2@${actor}`, opId: `2@${actor}`, value: {type: 'value', value: 'first'}},
+            {action: 'insert', index: 1, elemId: `3@${actor}`, opId: `3@${actor}`, value: {
               type: 'map',
               objectId: `3@${actor}`,
               props: {
@@ -525,7 +527,7 @@ describe('Automerge.Backend', () => {
         diffs: {objectId: '_root', type: 'map', props: {
           birds: {['1@111111']: {objectId: '1@111111', type: 'list',
             edits: [
-              {action: 'insert', index: 0, elemId: '2@111111', value: {type: 'value', value: 'magpie'}},
+              {action: 'insert', index: 0, elemId: '2@111111', opId: '2@111111', value: {type: 'value', value: 'magpie'}},
               {action: 'remove', index: 0, count: 1}],
           }}
         }}
@@ -744,7 +746,7 @@ describe('Automerge.Backend', () => {
         clock: {[actor]: 1}, deps: [hash(change1)], maxOp: 2, pendingChanges: 0,
         diffs: {objectId: '_root', type: 'map', props: {birds: {[`1@${actor}`]: {
           objectId: `1@${actor}`, type: 'list',
-          edits: [{action: 'insert', index: 0, elemId: `2@${actor}`, value: {type: 'value', value: 'chaffinch'}}],
+          edits: [{action: 'insert', index: 0, elemId: `2@${actor}`, opId: `2@${actor}`, value: {type: 'value', value: 'chaffinch'}}],
         }}}}
       })
     })
@@ -767,8 +769,9 @@ describe('Automerge.Backend', () => {
         diffs: {objectId: '_root', type: 'map', props: {birds: {[`1@${actor}`]: {
           objectId: `1@${actor}`, type: 'list',
           edits: [
-            {action: 'multi-insert', index: 0, elemId: `5@${actor}`, values: ['greenfinch', 'goldfinches!!']},
-          ],
+            {action: 'insert', index: 0, elemId: `5@${actor}`, opId: `5@${actor}`, value: {type: 'value', value: 'greenfinch'}},
+            {action: 'insert', index: 1, elemId: `3@${actor}`, opId: `6@${actor}`, value: {type: 'value', value: 'goldfinches!!'}}
+          ]
         }}}}
       })
     })
@@ -792,9 +795,9 @@ describe('Automerge.Backend', () => {
         diffs: {objectId: '_root', type: 'map', props: {birds: {[`1@${actor1}`]: {
           objectId: `1@${actor1}`, type: 'list',
           edits: [
-            {action: 'insert', index: 0, elemId: `4@${actor1}`, value: {type: 'value', value: 'greenfinch'}},
+            {action: 'insert', index: 0, elemId: `2@${actor1}`, opId: `4@${actor1}`, value: {type: 'value', value: 'greenfinch'}},
             {action: 'update', index: 0, opId: `4@${actor2}`, value: {type: 'value', value: 'goldfinch'}},
-            {action: 'insert', index: 1, elemId: `3@${actor1}`, value: {type: 'value', value: 'magpie'}}
+            {action: 'insert', index: 1, elemId: `3@${actor1}`, opId: `3@${actor1}`, value: {type: 'value', value: 'magpie'}}
           ],
         }}}}
       })
@@ -814,7 +817,7 @@ describe('Automerge.Backend', () => {
         diffs: {objectId: '_root', type: 'map', props: {todos: {[`1@${actor}`]: {
           objectId: `1@${actor}`, type: 'list',
           edits: [
-            {action: 'insert', index: 0, elemId: `2@${actor}`, value: {
+            {action: 'insert', index: 0, elemId: `2@${actor}`, opId: `2@${actor}`, value: {
               type: 'map',
               objectId: `2@${actor}`,
               props: {
@@ -851,9 +854,10 @@ describe('Automerge.Backend', () => {
       assert.deepStrictEqual(Backend.getPatch(s1), {
         clock: {[actor]: 1}, deps: [hash(change)], maxOp: 2, pendingChanges: 0,
         diffs: {objectId: '_root', type: 'map', props: {list: {[`1@${actor}`]: {
-          objectId: `1@${actor}`, type: 'list',
-          edits: [{action: 'insert', index: 0, elemId: `2@${actor}`, 
-            value: {type: 'value', value: now.getTime(), datatype: 'timestamp'}}],
+          objectId: `1@${actor}`, type: 'list', edits: [
+            {action: 'insert', index: 0, elemId: `2@${actor}`, opId: `2@${actor}`,
+             value: {type: 'value', value: now.getTime(), datatype: 'timestamp'}}
+          ]
         }}}}
       })
     })

--- a/test/backend_test.js
+++ b/test/backend_test.js
@@ -361,7 +361,7 @@ describe('Automerge.Backend', () => {
           objectId: `1@${actor}`, type: 'list', edits: [
             {action: 'insert', index: 0, elemId: `2@${actor}`, opId: `2@${actor}`, value: {type: 'value', value: 'chaffinch'}},
             {action: 'remove', index: 0, count: 1}
-          ], 
+          ]
         }}}}
       })
     })
@@ -383,7 +383,7 @@ describe('Automerge.Backend', () => {
       const [s3, patch3] = Backend.applyChanges(s2, [encodeChange(change3)])
       assert.deepStrictEqual(patch3, {
         clock: {[actor1]: 1, [actor2]: 2}, maxOp: 2, pendingChanges: 0,
-        deps: [hash(change1), hash(change3)].sort(), 
+        deps: [hash(change1), hash(change3)].sort(),
         diffs: {objectId: '_root', type: 'map', props: {conflict: {
           [`1@${actor1}`]: {objectId: `1@${actor1}`, type: 'list', edits: []},
           [`1@${actor2}`]: {objectId: `1@${actor2}`, type: 'map', props: {sparrows: {[`2@${actor2}`]: {type: 'value', value: 12}}}}
@@ -418,7 +418,8 @@ describe('Automerge.Backend', () => {
         clock: {[actor]: 1}, deps: [hash(change)], maxOp: 2, pendingChanges: 0,
         diffs: {objectId: '_root', type: 'map', props: {list: {[`1@${actor}`]: {
           objectId: `1@${actor}`, type: 'list', edits: [
-            {action: 'insert', index: 0, elemId: `2@${actor}`, opId: `2@${actor}`, value: {type: 'value', value: now.getTime(), datatype: 'timestamp'}}
+            {action: 'insert', index: 0, elemId: `2@${actor}`, opId: `2@${actor}`,
+              value: {type: 'value', value: now.getTime(), datatype: 'timestamp'}}
           ]
         }}}}
       })
@@ -472,13 +473,13 @@ describe('Automerge.Backend', () => {
                 done:  {[`5@${actor}`]: {type: 'value', value: false}}
               }
             }}
-          ],
+          ]
         }}}}
       })
     })
 
     it('should support inserting multiple elements in one op', () => {
-      const actor = uuid() 
+      const actor = uuid()
       const change1 = {actor, seq: 1, startOp: 1, time: 0, deps: [], ops: [
         {action: 'makeList', obj: '_root', key: 'todos', pred: []},
         {action: 'set', obj: `1@${actor}`, insert: true, elemId: '_head', pred: [], values: [1, 2, 3,  4, 5]},
@@ -488,16 +489,15 @@ describe('Automerge.Backend', () => {
       assert.deepStrictEqual(patch1, {
         clock: {[actor]: 1}, deps: [hash(change1)], maxOp: 6, pendingChanges: 0,
         diffs: {objectId: '_root', type: 'map', props: {todos: {[`1@${actor}`]: {
-          objectId: `1@${actor}`, type: 'list',
-          edits: [
-            {action: 'multi-insert', index: 0, elemId: `2@${actor}`, values: [1, 2, 3, 4, 5]},
-          ],
+          objectId: `1@${actor}`, type: 'list', edits: [
+            {action: 'multi-insert', index: 0, elemId: `2@${actor}`, values: [1, 2, 3, 4, 5]}
+          ]
         }}}}
       })
     })
 
     it('should support deleting multiple elements in one op', () => {
-      const actor = uuid() 
+      const actor = uuid()
       const change1 = {actor, seq: 1, startOp: 1, time: 0, deps: [], ops: [
         {action: 'makeList', obj: '_root', key: 'todos', pred: []},
         {action: 'set', obj: `1@${actor}`, insert: true, elemId: '_head', pred: [], values: [1, 2, 3,  4, 5]},
@@ -511,10 +511,9 @@ describe('Automerge.Backend', () => {
       assert.deepStrictEqual(patch2, {
         clock: {[actor]: 2}, deps: [hash(change2)], maxOp: 9, pendingChanges: 0,
         diffs: {objectId: '_root', type: 'map', props: {todos: {[`1@${actor}`]: {
-          objectId: `1@${actor}`, type: 'list',
-          edits: [
+          objectId: `1@${actor}`, type: 'list', edits: [
             {action: 'remove', index: 1, count: 3}
-          ],
+          ]
         }}}}
       })
     })
@@ -721,7 +720,7 @@ describe('Automerge.Backend', () => {
     })
 
     it('should support inserting multiple elements in one change', () => {
-      const actor = uuid() 
+      const actor = uuid()
       const localChange = {actor, seq: 1, startOp: 1, time: 0, deps: [], ops: [
         {action: 'makeList', obj: '_root', key: 'todos', pred: []},
         {action: 'set', obj: `1@${actor}`, insert: true, elemId: '_head', pred: [], values: [1, 2, 3, 4, 5]},
@@ -740,7 +739,7 @@ describe('Automerge.Backend', () => {
     })
 
     it('should support deleting multiple elements in one op', () => {
-      const actor = uuid() 
+      const actor = uuid()
       const change1 = {actor, seq: 1, startOp: 1, time: 0, deps: [], ops: [
         {action: 'makeList', obj: '_root', key: 'todos', pred: []},
         {action: 'set', obj: `1@${actor}`, insert: true, elemId: '_head', pred: [], values: [1, 2, 3, 4, 5]}
@@ -896,8 +895,9 @@ describe('Automerge.Backend', () => {
       assert.deepStrictEqual(Backend.getPatch(s1), {
         clock: {[actor]: 1}, deps: [hash(change1)], maxOp: 2, pendingChanges: 0,
         diffs: {objectId: '_root', type: 'map', props: {birds: {[`1@${actor}`]: {
-          objectId: `1@${actor}`, type: 'list',
-          edits: [{action: 'insert', index: 0, elemId: `2@${actor}`, opId: `2@${actor}`, value: {type: 'value', value: 'chaffinch'}}],
+          objectId: `1@${actor}`, type: 'list', edits: [
+            {action: 'insert', index: 0, elemId: `2@${actor}`, opId: `2@${actor}`, value: {type: 'value', value: 'chaffinch'}}
+          ]
         }}}}
       })
     })
@@ -949,7 +949,7 @@ describe('Automerge.Backend', () => {
             {action: 'insert', index: 0, elemId: `2@${actor1}`, opId: `4@${actor1}`, value: {type: 'value', value: 'greenfinch'}},
             {action: 'update', index: 0, opId: `4@${actor2}`, value: {type: 'value', value: 'goldfinch'}},
             {action: 'insert', index: 1, elemId: `3@${actor1}`, opId: `3@${actor1}`, value: {type: 'value', value: 'magpie'}}
-          ],
+          ]
         }}}}
       })
     })
@@ -976,7 +976,7 @@ describe('Automerge.Backend', () => {
                 done:  {[`4@${actor}`]: {type: 'value', value: false}}
               }
             }}
-          ],
+          ]
         }}}}
       })
     })
@@ -1033,7 +1033,7 @@ describe('Automerge.Backend', () => {
               'bullfinch',
               'greenfinch',
             ]}
-          ],
+          ]
         }}}}
       })
     })

--- a/test/backend_test.js
+++ b/test/backend_test.js
@@ -282,7 +282,7 @@ describe('Automerge.Backend', () => {
       assert.deepStrictEqual(patch3, {
         clock: {[actor1]: 2, [actor2]: 1}, maxOp: 3, pendingChanges: 0,
         deps: [hash(change2), hash(change3)].sort(),
-        diffs: {objectId: '_root', type: 'map'}
+        diffs: {objectId: '_root', type: 'map', props: {}}
       })
     })
 
@@ -704,7 +704,7 @@ describe('Automerge.Backend', () => {
       const s1 = Backend.loadChanges(Backend.init(), [change1, change2, change3].map(encodeChange))
       assert.deepStrictEqual(Backend.getPatch(s1), {
         clock: {[actor]: 3}, deps: [hash(change3)], maxOp: 3, pendingChanges: 0,
-        diffs: {objectId: '_root', type: 'map'}
+        diffs: {objectId: '_root', type: 'map', props: {}}
       })
     })
 

--- a/test/backend_test.js
+++ b/test/backend_test.js
@@ -342,11 +342,7 @@ describe('Automerge.Backend', () => {
         {action: 'set', obj: `1@${actor}`, insert: true, elemId: '_head', pred: [], values: [1, 2, 3,  4, 5]},
       ]}
       const change2 = {actor, seq: 2, startOp: 7, time: 0, deps: [hash(change1)], ops: [
-        {action: 'del', obj: `1@${actor}`, elemId: `3@${actor}`, multiOp: 3, pred: [
-          `3@${actor}`,
-          `4@${actor}`,
-          `5@${actor}`,
-        ]}
+        {action: 'del', obj: `1@${actor}`, elemId: `3@${actor}`, multiOp: 3, pred: [`3@${actor}`]}
       ]}
       const s0 = Backend.init()
       const [s1, patch1] = Backend.applyChanges(s0, [encodeChange(change1)])
@@ -590,11 +586,7 @@ describe('Automerge.Backend', () => {
         {action: 'set', obj: `1@${actor}`, insert: true, elemId: '_head', pred: [], values: [1, 2, 3,  4, 5]}
       ]}
       const change2 = {actor, seq: 2, startOp: 7, time: 0, deps: [hash(change1)], ops: [
-        {action: 'del', obj: `1@${actor}`, elemId: `3@${actor}`, multiOp: 3, pred: [
-          `3@${actor}`,
-          `4@${actor}`,
-          `5@${actor}`,
-        ]}
+        {action: 'del', obj: `1@${actor}`, elemId: `3@${actor}`, multiOp: 3, pred: [`3@${actor}`]}
       ]}
       const s0 = Backend.init()
       const [s1, patch1] = Backend.applyLocalChange(s0, change1)

--- a/test/context_test.js
+++ b/test/context_test.js
@@ -20,7 +20,7 @@ describe('Proxying context', () => {
       context.setMapKey([], 'sparrows', 5)
       assert(applyPatch.calledOnce)
       assert.deepStrictEqual(applyPatch.firstCall.args[0], {objectId: '_root', type: 'map', props: {
-        sparrows: {[`1@${context.actorId}`]: {value: 5}}
+        sparrows: {[`1@${context.actorId}`]: {value: 5, type: 'value'}}
       }})
       assert.deepStrictEqual(context.ops, [
         {obj: '_root', action: 'set', key: 'sparrows', insert: false, value: 5, pred: []}
@@ -39,7 +39,7 @@ describe('Proxying context', () => {
       context.setMapKey([], 'goldfinches', 3)
       assert(applyPatch.calledOnce)
       assert.deepStrictEqual(applyPatch.firstCall.args[0], {objectId: '_root', type: 'map', props: {
-        goldfinches: {[`1@${context.actorId}`]: {value: 3}}
+        goldfinches: {[`1@${context.actorId}`]: {value: 3, type: 'value'}}
       }})
       assert.deepStrictEqual(context.ops, [
         {obj: '_root', action: 'set', key: 'goldfinches', insert: false, value: 3, pred: ['1@actor1', '2@actor2']}
@@ -52,7 +52,7 @@ describe('Proxying context', () => {
       const objectId = applyPatch.firstCall.args[0].props.birds[`1@${context.actorId}`].objectId
       assert.deepStrictEqual(applyPatch.firstCall.args[0], {objectId: '_root', type: 'map', props: {
         birds: {[`1@${context.actorId}`]: {objectId, type: 'map', props: {
-          goldfinches: {[`2@${context.actorId}`]: {value: 3}}
+          goldfinches: {[`2@${context.actorId}`]: {value: 3, type: 'value'}}
         }}}
       }})
       assert.deepStrictEqual(context.ops, [
@@ -69,7 +69,7 @@ describe('Proxying context', () => {
       assert(applyPatch.calledOnce)
       assert.deepStrictEqual(applyPatch.firstCall.args[0], {objectId: '_root', type: 'map', props: {
         birds: {'1@actor1': {objectId, type: 'map', props: {
-          goldfinches: {[`1@${context.actorId}`]: {value: 3}}
+          goldfinches: {[`1@${context.actorId}`]: {value: 3, type: 'value'}}
         }}}
       }})
       assert.deepStrictEqual(context.ops, [
@@ -89,7 +89,7 @@ describe('Proxying context', () => {
       assert.deepStrictEqual(applyPatch.firstCall.args[0], {objectId: '_root', type: 'map', props: {birds: {
         '1@actor1': {objectId: objectId1, type: 'map'},
         '1@actor2': {objectId: objectId2, type: 'map', props: {
-          goldfinches: {[`1@${context.actorId}`]: {value: 3}}
+          goldfinches: {[`1@${context.actorId}`]: {value: 3, type: 'value'}}
         }}
       }}})
       assert.deepStrictEqual(context.ops, [
@@ -106,11 +106,11 @@ describe('Proxying context', () => {
       context.setMapKey([{key: 'values', objectId}], 'goldfinches', 3)
       assert(applyPatch.calledOnce)
       assert.deepStrictEqual(applyPatch.firstCall.args[0], {objectId: '_root', type: 'map', props: {values: {
-        '1@actor1': {value: dateValue.getTime(), datatype: 'timestamp'},
-        '1@actor2': {value: 0, datatype: 'counter'},
-        '1@actor3': {value: 42},
-        '1@actor4': {value: null},
-        '1@actor5': {objectId, type: 'map', props: {goldfinches: {[`1@${context.actorId}`]: {value: 3}}}}
+        '1@actor1': {value: dateValue.getTime(), datatype: 'timestamp', type: 'value'},
+        '1@actor2': {value: 0, datatype: 'counter', type: 'value'},
+        '1@actor3': {value: 42, type: 'value'},
+        '1@actor4': {value: null, type: 'value'},
+        '1@actor5': {objectId, type: 'map', props: {goldfinches: {[`1@${context.actorId}`]: {value: 3, type: 'value'}}}}
       }}})
       assert.deepStrictEqual(context.ops, [
         {obj: objectId, action: 'set', key: 'goldfinches', insert: false, value: 3, pred: []}
@@ -122,18 +122,13 @@ describe('Proxying context', () => {
       assert(applyPatch.calledOnce)
       const objectId = applyPatch.firstCall.args[0].props.birds[`1@${context.actorId}`].objectId
       assert.deepStrictEqual(applyPatch.firstCall.args[0], {objectId: '_root', type: 'map', props: {
-        birds: {[`1@${context.actorId}`]: {objectId, type: 'list', props: {
-          0: {[`2@${context.actorId}`]: {value: 'sparrow'}},
-          1: {[`3@${context.actorId}`]: {value: 'goldfinch'}}
-        }, edits: [
-          {action: 'insert', index: 0, elemId: `2@${context.actorId}`},
-          {action: 'insert', index: 1, elemId: `3@${context.actorId}`}
+        birds: {[`1@${context.actorId}`]: {objectId, type: 'list', edits: [
+          {action: 'multi-insert', index: 0, elemId: `2@${context.actorId}`, values: ['sparrow', 'goldfinch']}
         ]}}
       }})
       assert.deepStrictEqual(context.ops, [
         {obj: '_root', action: 'makeList', key: 'birds', insert: false, pred: []},
-        {obj: objectId, action: 'set', elemId: '_head', insert: true, value: 'sparrow', pred: []},
-        {obj: objectId, action: 'set', elemId: `2@${context.actorId}`, insert: true, value: 'goldfinch', pred: []}
+        {obj: objectId, action: 'set', elemId: '_head', insert: true, values: ['sparrow', 'goldfinch'], pred: []}
       ])
     })
 
@@ -142,18 +137,13 @@ describe('Proxying context', () => {
       const objectId = applyPatch.firstCall.args[0].props.text[`1@${context.actorId}`].objectId
       assert(applyPatch.calledOnce)
       assert.deepStrictEqual(applyPatch.firstCall.args[0], {objectId: '_root', type: 'map', props: {
-        text: {[`1@${context.actorId}`]: {objectId, type: 'text', props: {
-          0: {[`2@${context.actorId}`]: {value: 'h'}},
-          1: {[`3@${context.actorId}`]: {value: 'i'}}
-        }, edits: [
-          {action: 'insert', index: 0, elemId: `2@${context.actorId}`},
-          {action: 'insert', index: 1, elemId: `3@${context.actorId}`}
+        text: {[`1@${context.actorId}`]: {objectId, type: 'text', edits: [
+          {action: 'multi-insert', index: 0, elemId: `2@${context.actorId}`, values: ['h', 'i']}
         ]}}
       }})
       assert.deepStrictEqual(context.ops, [
         {obj: '_root', action: 'makeText', key: 'text', insert: false, pred: []},
-        {obj: objectId, action: 'set', elemId: '_head', insert: true, value: 'h', pred: []},
-        {obj: objectId, action: 'set', elemId: `2@${context.actorId}`, insert: true, value: 'i', pred: []}
+        {obj: objectId, action: 'set', elemId: '_head', insert: true, values: ['h', 'i'], pred: []}
       ])
     })
 
@@ -174,7 +164,7 @@ describe('Proxying context', () => {
       context.setMapKey([], 'now', now)
       assert(applyPatch.calledOnce)
       assert.deepStrictEqual(applyPatch.firstCall.args[0], {objectId: '_root', type: 'map', props: {
-        now: {[`1@${context.actorId}`]: {value: now.getTime(), datatype: 'timestamp'}}
+        now: {[`1@${context.actorId}`]: {value: now.getTime(), datatype: 'timestamp', type: 'value'}}
       }})
       assert.deepStrictEqual(context.ops, [
         {obj: '_root', action: 'set', key: 'now', insert: false, value: now.getTime(), datatype: 'timestamp', pred: []}
@@ -186,7 +176,7 @@ describe('Proxying context', () => {
       context.setMapKey([], 'counter', counter)
       assert(applyPatch.calledOnce)
       assert.deepStrictEqual(applyPatch.firstCall.args[0], {objectId: '_root', type: 'map', props: {
-        counter: {[`1@${context.actorId}`]: {value: 3, datatype: 'counter'}}
+        counter: {[`1@${context.actorId}`]: {value: 3, datatype: 'counter', type: 'value'}}
       }})
       assert.deepStrictEqual(context.ops, [
         {obj: '_root', action: 'set', key: 'counter', insert: false, value: 3, datatype: 'counter', pred: []}
@@ -245,9 +235,14 @@ describe('Proxying context', () => {
       context.setListIndex([{key: 'birds', objectId: listId}], 0, 'starling')
       assert(applyPatch.calledOnce)
       assert.deepStrictEqual(applyPatch.firstCall.args[0], {objectId: '_root', type: 'map', props: {
-        birds: {'1@actor1': {objectId: listId, type: 'list', props: {
-          0: {[`1@${context.actorId}`]: {value: 'starling'}}
-        }}}
+        birds: {'1@actor1': {objectId: listId, type: 'list', edits: [
+          {
+            action: 'update',
+            index: 0,
+            opId: `1@${context.actorId}`,
+            value: {value: 'starling', type: 'value'}
+          }
+        ]}}
       }})
       assert.deepStrictEqual(context.ops, [
         {obj: listId, action: 'set', elemId: '1@xxx', insert: false, value: 'starling', pred: ['1@xxx']}
@@ -257,14 +252,20 @@ describe('Proxying context', () => {
     it('should create nested objects on assignment', () => {
       context.setListIndex([{key: 'birds', objectId: listId}], 1, {english: 'goldfinch', latin: 'carduelis'})
       assert(applyPatch.calledOnce)
-      const nestedId = applyPatch.firstCall.args[0].props.birds['1@actor1'].props[1][`1@${context.actorId}`].objectId
+      const nestedId = applyPatch.firstCall.args[0].props.birds['1@actor1'].edits[0].value.objectId
       assert.deepStrictEqual(applyPatch.firstCall.args[0], {objectId: '_root', type: 'map', props: {
-        birds: {'1@actor1': {objectId: listId, type: 'list', props: {
-          1: {[`1@${context.actorId}`]: {objectId: nestedId, type: 'map', props: {
-            english: {[`2@${context.actorId}`]: {value: 'goldfinch'}},
-            latin: {[`3@${context.actorId}`]: {value: 'carduelis'}}
-          }}}
-        }}}
+        birds: {'1@actor1': {objectId: listId, type: 'list', edits:[{
+          action: 'update',
+          index: 1,
+          opId: `1@${context.actorId}`,
+          value: {
+            objectId: nestedId,
+            type: 'map',
+            props: {
+              english: {[`2@${context.actorId}`]: {value: 'goldfinch', type: 'value'}},
+              latin: {[`3@${context.actorId}`]: {value: 'carduelis', type: 'value'}}
+            }}
+        }]}}
       }})
       assert.deepStrictEqual(context.ops, [
         {obj: listId, action: 'makeMap', elemId: '2@xxx', insert: false, pred: ['2@xxx']},
@@ -276,16 +277,18 @@ describe('Proxying context', () => {
     it('should create nested objects on insertion', () => {
       context.splice([{key: 'birds', objectId: listId}], 2, 0, [{english: 'goldfinch', latin: 'carduelis'}])
       assert(applyPatch.calledOnce)
-      const nestedId = applyPatch.firstCall.args[0].props.birds['1@actor1'].props[2][`1@${context.actorId}`].objectId
+      const nestedId = applyPatch.firstCall.args[0].props.birds['1@actor1'].edits[0].value.objectId
       assert.deepStrictEqual(applyPatch.firstCall.args[0], {objectId: '_root', type: 'map', props: {
         birds: {'1@actor1': {objectId: listId, type: 'list', edits: [
-          {action: 'insert', index: 2, elemId: `1@${context.actorId}`}
-        ], props: {
-          2: {[`1@${context.actorId}`]: {objectId: nestedId, type: 'map', props: {
-            english: {[`2@${context.actorId}`]: {value: 'goldfinch'}},
-            latin: {[`3@${context.actorId}`]: {value: 'carduelis'}}
-          }}}
-        }}}
+          {action: 'insert', index: 2, elemId: `1@${context.actorId}`, value: {
+            objectId: nestedId,
+            type: 'map',
+            props: {
+              english: {[`2@${context.actorId}`]: {value: 'goldfinch', type: 'value'}},
+              latin: {[`3@${context.actorId}`]: {value: 'carduelis', type: 'value'}}
+            }
+          }}
+        ]}}
       }})
       assert.deepStrictEqual(context.ops, [
         {obj: listId, action: 'makeMap', elemId: '2@xxx', insert: true, pred: []},
@@ -294,17 +297,42 @@ describe('Proxying context', () => {
       ])
     })
 
-    it('should support deleting list elements', () => {
-      context.splice([{key: 'birds', objectId: listId}], 0, 2, [])
+    it('should generate multi-inserts when splicing arrays of primitives', () => {
+      context.splice([{key: 'birds', objectId: listId}], 2, 0, ['goldfinch', 'greenfinch'])
       assert(applyPatch.calledOnce)
       assert.deepStrictEqual(applyPatch.firstCall.args[0], {objectId: '_root', type: 'map', props: {
-        birds: {'1@actor1': {objectId: listId, type: 'list', props: {}, edits: [
-          {action: 'remove', index: 0}, {action: 'remove', index: 0}
+        birds: {'1@actor1': {objectId: listId, type: 'list', edits: [
+          {action: 'multi-insert', index: 2, elemId: `1@${context.actorId}`, values: ['goldfinch', 'greenfinch']}
         ]}}
       }})
       assert.deepStrictEqual(context.ops, [
-        {obj: listId, action: 'del', elemId: '1@xxx', insert: false, pred: ['1@xxx']},
-        {obj: listId, action: 'del', elemId: '2@xxx', insert: false, pred: ['2@xxx']}
+        {obj: listId, action: 'set', elemId: '2@xxx', insert: true, values: ['goldfinch', 'greenfinch'], pred: []}
+      ])
+    })
+
+    it('should support deleting list elements', () => {
+      context.splice([{key: 'birds', objectId: listId}], 0, 1, [])
+      assert(applyPatch.calledOnce)
+      assert.deepStrictEqual(applyPatch.firstCall.args[0], {objectId: '_root', type: 'map', props: {
+        birds: {'1@actor1': {objectId: listId, type: 'list', edits: [
+          {action: 'remove', index: 0, count: 1} 
+        ]}}
+      }})
+      assert.deepStrictEqual(context.ops, [
+        {obj: listId, action: 'del', elemId: '1@xxx', insert: false, pred: ['1@xxx']}
+      ])
+    })
+
+    it('should support deleting multiple list elements as a multiOp', () => {
+      context.splice([{key: 'birds', objectId: listId}], 0, 2, [])
+      assert(applyPatch.calledOnce)
+      assert.deepStrictEqual(applyPatch.firstCall.args[0], {objectId: '_root', type: 'map', props: {
+        birds: {'1@actor1': {objectId: listId, type: 'list', edits: [
+          {action: 'remove', index: 0, count: 2}
+        ]}}
+      }})
+      assert.deepStrictEqual(context.ops, [
+        {obj: listId, action: 'del', elemId: '1@xxx', multiOp: 2, insert: false, pred: ['1@xxx', '2@xxx']}
       ])
     })
 
@@ -313,18 +341,13 @@ describe('Proxying context', () => {
       assert(applyPatch.calledOnce)
       assert.deepStrictEqual(applyPatch.firstCall.args[0], {objectId: '_root', type: 'map', props: {
         birds: {'1@actor1': {objectId: listId, type: 'list', edits: [
-          {action: 'remove', index: 0},
-          {action: 'insert', index: 0, elemId: `2@${context.actorId}`},
-          {action: 'insert', index: 1, elemId: `3@${context.actorId}`}
-        ], props: {
-          0: {[`2@${context.actorId}`]: {value: 'starling'}},
-          1: {[`3@${context.actorId}`]: {value: 'goldfinch'}}
-        }}}
+          {action: 'remove', index: 0, count: 1},
+          {action: 'multi-insert', index: 0, elemId: `2@${context.actorId}`, values: ['starling', 'goldfinch']}
+        ]}}
       }})
       assert.deepStrictEqual(context.ops, [
         {obj: listId, action: 'del', elemId: '1@xxx', insert: false, pred: ['1@xxx']},
-        {obj: listId, action: 'set', elemId: '_head', insert: true, value: 'starling', pred: []},
-        {obj: listId, action: 'set', elemId: `2@${context.actorId}`, insert: true, value: 'goldfinch', pred: []}
+        {obj: listId, action: 'set', elemId: '_head', insert: true, values: ['starling', 'goldfinch'], pred: []}
       ])
     })
   })
@@ -345,8 +368,8 @@ describe('Proxying context', () => {
       assert.deepStrictEqual(applyPatch.firstCall.args[0], {objectId: '_root', type: 'map', props: {
         books: {'1@actor1': {objectId: tableId, type: 'table', props: {
           [rowId]: {[`1@${context.actorId}`]: {objectId: `1@${context.actorId}`, type: 'map', props: {
-            author: {[`2@${context.actorId}`]: {value: 'Mary Shelley'}},
-            title: {[`3@${context.actorId}`]: {value: 'Frankenstein'}}
+            author: {[`2@${context.actorId}`]: {value: 'Mary Shelley', type: 'value'}},
+            title: {[`3@${context.actorId}`]: {value: 'Frankenstein', type: 'value'}}
           }}}
         }}}
       }})

--- a/test/context_test.js
+++ b/test/context_test.js
@@ -280,7 +280,7 @@ describe('Proxying context', () => {
       const nestedId = applyPatch.firstCall.args[0].props.birds['1@actor1'].edits[0].value.objectId
       assert.deepStrictEqual(applyPatch.firstCall.args[0], {objectId: '_root', type: 'map', props: {
         birds: {'1@actor1': {objectId: listId, type: 'list', edits: [
-          {action: 'insert', index: 2, elemId: `1@${context.actorId}`, value: {
+          {action: 'insert', index: 2, elemId: `1@${context.actorId}`, opId: `1@${context.actorId}`, value: {
             objectId: nestedId,
             type: 'map',
             props: {

--- a/test/context_test.js
+++ b/test/context_test.js
@@ -236,12 +236,7 @@ describe('Proxying context', () => {
       assert(applyPatch.calledOnce)
       assert.deepStrictEqual(applyPatch.firstCall.args[0], {objectId: '_root', type: 'map', props: {
         birds: {'1@actor1': {objectId: listId, type: 'list', edits: [
-          {
-            action: 'update',
-            index: 0,
-            opId: `1@${context.actorId}`,
-            value: {value: 'starling', type: 'value'}
-          }
+          {action: 'update', index: 0, opId: `1@${context.actorId}`, value: {value: 'starling', type: 'value'}}
         ]}}
       }})
       assert.deepStrictEqual(context.ops, [
@@ -254,17 +249,13 @@ describe('Proxying context', () => {
       assert(applyPatch.calledOnce)
       const nestedId = applyPatch.firstCall.args[0].props.birds['1@actor1'].edits[0].value.objectId
       assert.deepStrictEqual(applyPatch.firstCall.args[0], {objectId: '_root', type: 'map', props: {
-        birds: {'1@actor1': {objectId: listId, type: 'list', edits:[{
-          action: 'update',
-          index: 1,
-          opId: `1@${context.actorId}`,
-          value: {
-            objectId: nestedId,
-            type: 'map',
-            props: {
+        birds: {'1@actor1': {objectId: listId, type: 'list', edits: [{
+          action: 'update', index: 1, opId: `1@${context.actorId}`, value: {
+            objectId: nestedId, type: 'map', props: {
               english: {[`2@${context.actorId}`]: {value: 'goldfinch', type: 'value'}},
               latin: {[`3@${context.actorId}`]: {value: 'carduelis', type: 'value'}}
-            }}
+            }
+          }
         }]}}
       }})
       assert.deepStrictEqual(context.ops, [
@@ -281,9 +272,7 @@ describe('Proxying context', () => {
       assert.deepStrictEqual(applyPatch.firstCall.args[0], {objectId: '_root', type: 'map', props: {
         birds: {'1@actor1': {objectId: listId, type: 'list', edits: [
           {action: 'insert', index: 2, elemId: `1@${context.actorId}`, opId: `1@${context.actorId}`, value: {
-            objectId: nestedId,
-            type: 'map',
-            props: {
+            objectId: nestedId, type: 'map', props: {
               english: {[`2@${context.actorId}`]: {value: 'goldfinch', type: 'value'}},
               latin: {[`3@${context.actorId}`]: {value: 'carduelis', type: 'value'}}
             }

--- a/test/context_test.js
+++ b/test/context_test.js
@@ -304,7 +304,7 @@ describe('Proxying context', () => {
       assert(applyPatch.calledOnce)
       assert.deepStrictEqual(applyPatch.firstCall.args[0], {objectId: '_root', type: 'map', props: {
         birds: {'1@actor1': {objectId: listId, type: 'list', edits: [
-          {action: 'remove', index: 0, count: 1} 
+          {action: 'remove', index: 0, count: 1}
         ]}}
       }})
       assert.deepStrictEqual(context.ops, [

--- a/test/context_test.js
+++ b/test/context_test.js
@@ -87,7 +87,7 @@ describe('Proxying context', () => {
       context.setMapKey([{key: 'birds', objectId: objectId2}], 'goldfinches', 3)
       assert(applyPatch.calledOnce)
       assert.deepStrictEqual(applyPatch.firstCall.args[0], {objectId: '_root', type: 'map', props: {birds: {
-        '1@actor1': {objectId: objectId1, type: 'map'},
+        '1@actor1': {objectId: objectId1, type: 'map', props: {}},
         '1@actor2': {objectId: objectId2, type: 'map', props: {
           goldfinches: {[`1@${context.actorId}`]: {value: 3, type: 'value'}}
         }}

--- a/test/context_test.js
+++ b/test/context_test.js
@@ -332,7 +332,40 @@ describe('Proxying context', () => {
         ]}}
       }})
       assert.deepStrictEqual(context.ops, [
-        {obj: listId, action: 'del', elemId: '1@xxx', multiOp: 2, insert: false, pred: ['1@xxx', '2@xxx']}
+        {obj: listId, action: 'del', elemId: '1@xxx', multiOp: 2, insert: false, pred: ['1@xxx']}
+      ])
+    })
+
+    it('should use multiOps for consecutive runs of elemIds', () => {
+      list.unshift('sparrow')
+      list[ELEM_IDS].unshift('3@xxx')
+      list[CONFLICTS].unshift({'3@xxx': 'sparrow'})
+      context.splice([{key: 'birds', objectId: listId}], 0, 3, [])
+      assert(applyPatch.calledOnce)
+      assert.deepStrictEqual(applyPatch.firstCall.args[0], {objectId: '_root', type: 'map', props: {
+        birds: {'1@actor1': {objectId: listId, type: 'list', edits: [
+          {action: 'remove', index: 0, count: 3}
+        ]}}
+      }})
+      assert.deepStrictEqual(context.ops, [
+        {obj: listId, action: 'del', elemId: '3@xxx', insert: false, pred: ['3@xxx']},
+        {obj: listId, action: 'del', elemId: '1@xxx', multiOp: 2, insert: false, pred: ['1@xxx']}
+      ])
+    })
+
+    it('should use multiOps for consecutive runs of preds', () => {
+      list[1] = 'sparrow'
+      list[CONFLICTS][1] = {'3@xxx': 'sparrow'}
+      context.splice([{key: 'birds', objectId: listId}], 0, 2, [])
+      assert(applyPatch.calledOnce)
+      assert.deepStrictEqual(applyPatch.firstCall.args[0], {objectId: '_root', type: 'map', props: {
+        birds: {'1@actor1': {objectId: listId, type: 'list', edits: [
+          {action: 'remove', index: 0, count: 2}
+        ]}}
+      }})
+      assert.deepStrictEqual(context.ops, [
+        {obj: listId, action: 'del', elemId: '1@xxx', insert: false, pred: ['1@xxx']},
+        {obj: listId, action: 'del', elemId: '2@xxx', insert: false, pred: ['3@xxx']}
       ])
     })
 

--- a/test/frontend_test.js
+++ b/test/frontend_test.js
@@ -576,8 +576,8 @@ describe('Automerge.Frontend', () => {
       const patch2 = {
         clock: {[actor]: 2},
         diffs: {objectId: '_root', type: 'map', props: {birds: {[actor]: {
-          objectId: birds, type: 'list', 
-          edits: [{action: 'update', index: 0, opId: `3@${actor}`, value: {value: 'greenfinch'}}],
+          objectId: birds, type: 'list',
+          edits: [{action: 'update', index: 0, opId: `3@${actor}`, value: {value: 'greenfinch'}}]
         }}}}
       }
       const doc1 = Frontend.applyPatch(Frontend.init(), patch1)
@@ -587,86 +587,48 @@ describe('Automerge.Frontend', () => {
     })
 
     it('should apply updates inside list element conflicts', () => {
-      const initActor = "67bfcc38-2d05-4d1a-9b88-d305c6a2db2f"
-      const actor1 = "133fa34d-4ac2-4824-bbe7-7eaab1ddbad2"
-      const actor2 = "a726c09b-4211-49b9-a788-d99f9a334978"
-      const birds = `1@${initActor}`
+      const actor1 = '01234567', actor2 = '89abcdef', birds = `1@${actor1}`
       const patch1 = {
-        clock: {[initActor]: 1},
-        diffs: {objectId: '_root', type: 'map', props: {birds: {[birds]: {
-          objectId: birds, 
-          type: 'list',
-          edits: [
-            {action: 'insert', index: 0, elemId: `1@${actor1}`, opId: `1@${actor1}`, value: {
-              type: 'map',
-              objectId: `1@${actor1}`,
-              props: {
-                species: {[`2@${actor1}`]: {type: 'value', value: 'woodpecker'}},
-                numSeen: {[`3@${actor1}`]: {type: 'value', value: 1}},
+        clock: {[actor1]: 2, [actor2]: 1}, diffs: {objectId: '_root', type: 'map', props: {birds: {[birds]: {
+          objectId: birds, type: 'list', edits: [
+            {action: 'insert', index: 0, elemId: `2@${actor1}`, opId: `2@${actor1}`, value: {
+              objectId: `2@${actor1}`, type: 'map', props: {
+                species: {[`3@${actor1}`]: {type: 'value', value: 'woodpecker'}},
+                numSeen: {[`4@${actor1}`]: {type: 'value', value: 1}}
               }
             }},
-            {action: 'update', index: 0, opId: `1@${actor2}`, value: {
-              type: 'map',
-              objectId: `1@${actor2}`,
-              props: {
-                species: {[`2@${actor2}`]: {type: 'value', value: 'lapwing'}},
-                numSeen: {[`3@${actor2}`]: {type: 'value', value: 2}},
+            {action: 'update', index: 0, opId: `2@${actor2}`, value: {
+              objectId: `2@${actor2}`, type: 'map', props: {
+                species: {[`3@${actor2}`]: {type: 'value', value: 'lapwing'}},
+                numSeen: {[`4@${actor2}`]: {type: 'value', value: 2}}
               }
-            }},
-          ],
+            }}
+          ]
         }}}}
       }
       const patch2 = {
-        clock: {[initActor]: 2},
-        diffs: {objectId: '_root', type: 'map', props: {birds: {[birds]: {
-          objectId: birds, 
-          type: 'list', edits: [
-            {
-              action: 'update',
-              index: 0,
-              opId: `1@${actor1}`,
-              value: {
-                type: 'map',
-                objectId: `1@${actor1}`,
-                props: {
-                  numSeen: {
-                    [`4@${actor1}`]: {type: 'value', value: 2},
-                  }
-                }
+        clock: {[actor1]: 3, [actor2]: 1}, diffs: {objectId: '_root', type: 'map', props: {birds: {[birds]: {
+          objectId: birds, type: 'list', edits: [
+            {action: 'update', index: 0, opId: `2@${actor1}`, value: {
+              objectId: `2@${actor1}`, type: 'map', props: {
+                numSeen: {[`5@${actor1}`]: {type: 'value', value: 2}}
               }
-            },
-            {
-              action: 'update',
-              index: 0,
-              opId: `1@${actor2}`,
-              value: {
-                type: 'unchanged',
-                objectId: `1@${actor2}`,
-              }
-            }
-          ],
+            }},
+            {action: 'update', index: 0, opId: `2@${actor2}`, value: {
+              objectId: `2@${actor2}`, type: 'map', props: {}
+            }}
+          ]
         }}}}
       }
       const patch3 = {
-        clock: {[initActor]: 3},
-        diffs: {objectId: '_root', type: 'map', props: {birds: {[birds]: {
-          objectId: birds, 
-          type: 'list', edits: [
-            {
-              action: 'update',
-              index: 0,
-              opId: `1@${actor1}`,
-              value: {
-                type: 'map',
-                objectId: `1@${actor1}`,
-                props: {
-                  numSeen: {
-                    [`5@${actor1}`]: {type: 'value', value: 2},
-                  }
-                }
+        clock: {[actor1]: 3, [actor2]: 1}, diffs: {objectId: '_root', type: 'map', props: {birds: {[birds]: {
+          objectId: birds, type: 'list', edits: [
+            {action: 'update', index: 0, opId: `2@${actor1}`, value: {
+              objectId: `2@${actor1}`, type: 'map', props: {
+                numSeen: {[`6@${actor1}`]: {type: 'value', value: 2}}
               }
-            },
-          ],
+            }}
+          ]
         }}}}
       }
       const doc1 = Frontend.applyPatch(Frontend.init(), patch1)
@@ -677,30 +639,23 @@ describe('Automerge.Frontend', () => {
       assert.deepStrictEqual(doc3, {birds: [{species: 'woodpecker', numSeen: 2}]})
       assert.strictEqual(doc1.birds[0], doc2.birds[0])
       assert.deepStrictEqual(Frontend.getConflicts(doc1.birds, 0), {
-        [`1@${actor1}`]: {species: 'woodpecker', numSeen: 1},
-        [`1@${actor2}`]: {species: 'lapwing',    numSeen: 2}
+        [`2@${actor1}`]: {species: 'woodpecker', numSeen: 1},
+        [`2@${actor2}`]: {species: 'lapwing',    numSeen: 2}
       })
       assert.deepStrictEqual(Frontend.getConflicts(doc2.birds, 0), {
-        [`1@${actor1}`]: {species: 'woodpecker', numSeen: 2},
-        [`1@${actor2}`]: {species: 'lapwing',    numSeen: 2}
+        [`2@${actor1}`]: {species: 'woodpecker', numSeen: 2},
+        [`2@${actor2}`]: {species: 'lapwing',    numSeen: 2}
       })
-
       assert.deepStrictEqual(Frontend.getConflicts(doc3.birds, 0), undefined)
     })
 
     it('should apply multiinserts on lists', () => {
-      const actor = "133fa34d-4ac2-4824-bbe7-7eaab1ddbad2"
+      const actor = uuid()
       const patch1 = {
-        clock: {[actor]: 1},
-        diffs: {objectId: '_root', type: 'map', props: {birds: {[`@${actor}`]: {
-          objectId: `1@${actor}`, 
-          type: 'list',
-          edits: [{
-            action: 'multi-insert',
-            index: 0,
-            elemId: `2@${actor}`,
-            values: ["chaffinch", "goldfinch", "wren"],
-          }],
+        clock: {[actor]: 1}, diffs: {objectId: '_root', type: 'map', props: {birds: {[`@${actor}`]: {
+          objectId: `1@${actor}`, type: 'list', edits: [
+            {action: 'multi-insert', index: 0, elemId: `2@${actor}`, values: ["chaffinch", "goldfinch", "wren"]}
+          ]
         }}}}
       }
       const doc = Frontend.applyPatch(Frontend.init(), patch1)
@@ -716,7 +671,7 @@ describe('Automerge.Frontend', () => {
           edits: [
             {action: 'insert', index: 0, elemId: `2@${actor}`, opId: `2@${actor}`, value: {value: 'chaffinch'}},
             {action: 'insert', index: 1, elemId: `3@${actor}`, opId: `3@${actor}`, value: {value: 'goldfinch'}}
-          ],
+          ]
         }}}}
       }
       const patch2 = {
@@ -737,11 +692,10 @@ describe('Automerge.Frontend', () => {
       const patch1 = {
         clock: {[actor]: 1},
         diffs: {objectId: '_root', type: 'map', props: {birds: {[`1@${actor}`]: {
-          objectId: birds, type: 'list',
-          edits: [
+          objectId: birds, type: 'list', edits: [
             {action: 'insert', index: 0, elemId: `2@${actor}`, opId: `2@${actor}`, value: {value: 'chaffinch'}},
             {action: 'insert', index: 1, elemId: `3@${actor}`, opId: `3@${actor}`, value: {value: 'goldfinch'}}
-          ],
+          ]
         }}}}
       }
       const patch2 = {
@@ -767,17 +721,11 @@ describe('Automerge.Frontend', () => {
           }}},
           details: {[`3@${actor}`]: {objectId: `3@${actor}`, type: 'list',
             edits: [{action: 'insert', index: 0, elemId: `4@${actor}`, opId: `4@${actor}`, value: {
-              type: 'map',
-              objectId: `4@${actor}`,
-              props: {
-                species: {
-                  [`5@${actor}`]: {type: 'value', value: 'magpie'}
-                },
-                family: {
-                  [`6@${actor}`]: {type: 'value', value: 'corvidae'}
-                }
+              objectId: `4@${actor}`, type: 'map', props: {
+                species: {[`5@${actor}`]: {type: 'value', value: 'magpie'}},
+                family: {[`6@${actor}`]: {type: 'value', value: 'corvidae'}}
               }
-            }}],
+            }}]
           }}
         }}
       }
@@ -789,14 +737,13 @@ describe('Automerge.Frontend', () => {
           }}},
           details: {[`3@${actor}`]: {objectId: `3@${actor}`, type: 'list', edits: [
             {action: 'update', index: 0, opId: `4@${actor}`, value: {
-              type: 'map',
-              objectId: `4@${actor}`,
-              props: {
+              objectId: `4@${actor}`, type: 'map', props: {
                 species: {[`8@${actor}`]: {type: 'value', value: 'Eurasian magpie'}}
               }
             }}
           ]}}
-      }}}
+        }}
+      }
       const doc1 = Frontend.applyPatch(Frontend.init(), patch1)
       const doc2 = Frontend.applyPatch(doc1, patch2)
       assert.deepStrictEqual(doc1, {counts: {magpies: 2}, details: [{species: 'magpie', family: 'corvidae'}]})
@@ -810,20 +757,9 @@ describe('Automerge.Frontend', () => {
       clock: {[actor]: 1},
       diffs: {objectId: '_root', type: 'map', props: {
         text: {[`1@${actor}`]: {objectId: `1@${actor}`, type: 'text', edits: [
-          {
-            action: 'insert',
-            index: 0,
-            value: {type: 'value', value: '1'},
-            elemId: `2@${actor}`,
-            opId: `2@${actor}`
-          },
-          {
-            action: 'multi-insert',
-            index: 1,
-            values: ['2', '3', '4'],
-            elemId: `3@${actor}`,
-          }
-        ]}},
+          {action: 'insert', index: 0, elemId: `2@${actor}`, opId: `2@${actor}`, value: {type: 'value', value: '1'}},
+          {action: 'multi-insert', index: 1, elemId: `3@${actor}`, values: ['2', '3', '4']}
+        ]}}
       }}
     }
     const doc = Frontend.applyPatch(Frontend.init(), patch1)

--- a/test/frontend_test.js
+++ b/test/frontend_test.js
@@ -323,9 +323,9 @@ describe('Automerge.Frontend', () => {
       doc1 = Frontend.applyPatch(doc1, {
         actor, seq: 1, clock: {[actor]: 1}, maxOp: 2,
         diffs: {objectId: '_root', type: 'map', props: {
-          birds: {[actor]: {objectId: birds, type: 'list',
-            edits: [{action: 'insert', elemId: `2@${actor}`, index: 0, value: {type: 'value', value: 'goldfinch'}}],
-          }}
+          birds: {[actor]: {objectId: birds, type: 'list', edits: [
+            {action: 'insert', elemId: `2@${actor}`, opId: `2@${actor}`, index: 0, value: {type: 'value', value: 'goldfinch'}}
+          ]}}
         }}
       })
       assert.deepStrictEqual(doc1, {birds: ['goldfinch']})
@@ -341,9 +341,9 @@ describe('Automerge.Frontend', () => {
       const doc3 = Frontend.applyPatch(doc2, {
         clock: {[actor]: 1, [remoteActor]: 1}, maxOp: 4,
         diffs: {objectId: '_root', type: 'map', props: {
-          birds: {[actor]: {objectId: birds, type: 'list',
-            edits: [{action: 'insert', elemId: `1@${remoteActor}`, index: 1, value: {type: 'value', value: 'bullfinch'}}],
-          }}
+          birds: {[actor]: {objectId: birds, type: 'list', edits: [
+            {action: 'insert', elemId: `1@${remoteActor}`, opId: `1@${remoteActor}`, index: 1, value: {type: 'value', value: 'bullfinch'}}
+          ]}}
         }}
       })
       // The addition of 'bullfinch' does not take effect yet: it is queued up until the pending
@@ -353,12 +353,10 @@ describe('Automerge.Frontend', () => {
       const doc4 = Frontend.applyPatch(doc3, {
         actor, seq: 2, clock: {[actor]: 2, [remoteActor]: 1}, maxOp: 4,
         diffs: {objectId: '_root', type: 'map', props: {
-          birds: {[actor]: {objectId: birds, type: 'list',
-              edits: [
-                {action: 'insert', index: 0, elemId: `3@${actor}`, value: {type: 'value', value: 'chaffinch'}},
-                {action: 'insert', index: 2, elemId: `4@${actor}`, value: {type: 'value', value: 'greenfinch'}}
-              ],
-          }}
+          birds: {[actor]: {objectId: birds, type: 'list', edits: [
+            {action: 'insert', index: 0, elemId: `3@${actor}`, opId: `3@${actor}`, value: {type: 'value', value: 'chaffinch'}},
+            {action: 'insert', index: 2, elemId: `4@${actor}`, opId: `4@${actor}`, value: {type: 'value', value: 'greenfinch'}}
+          ]}}
         }}
       })
       assert.deepStrictEqual(doc4, {birds: ['chaffinch', 'goldfinch', 'greenfinch', 'bullfinch']})
@@ -556,8 +554,9 @@ describe('Automerge.Frontend', () => {
       const patch = {
         clock: {[actor]: 1},
         diffs: {objectId: '_root', type: 'map', props: {birds: {[actor]: {
-          objectId: birds, type: 'list',
-          edits: [{action: 'insert', index: 0, elemId: `2@${actor}`, value: {value: 'chaffinch'}}],
+          objectId: birds, type: 'list', edits: [
+            {action: 'insert', index: 0, elemId: `2@${actor}`, opId: `2@${actor}`, value: {value: 'chaffinch'}}
+          ]
         }}}}
       }
       const doc = Frontend.applyPatch(Frontend.init(), patch)
@@ -569,8 +568,9 @@ describe('Automerge.Frontend', () => {
       const patch1 = {
         clock: {[actor]: 1},
         diffs: {objectId: '_root', type: 'map', props: {birds: {[actor]: {
-          objectId: birds, type: 'list',
-          edits: [{action: 'insert', index: 0, elemId: `2@${actor}`, value: {value: 'chaffinch'}}],
+          objectId: birds, type: 'list', edits: [
+            {action: 'insert', index: 0, elemId: `2@${actor}`, opId: `2@${actor}`, value: {value: 'chaffinch'}}
+          ]
         }}}}
       }
       const patch2 = {
@@ -597,7 +597,7 @@ describe('Automerge.Frontend', () => {
           objectId: birds, 
           type: 'list',
           edits: [
-            {action: 'insert', index: 0, elemId: `1@${actor1}`, value: {
+            {action: 'insert', index: 0, elemId: `1@${actor1}`, opId: `1@${actor1}`, value: {
               type: 'map',
               objectId: `1@${actor1}`,
               props: {
@@ -714,8 +714,8 @@ describe('Automerge.Frontend', () => {
         diffs: {objectId: '_root', type: 'map', props: {birds: {[`1@${actor}`]: {
           objectId: birds, type: 'list',
           edits: [
-            {action: 'insert', index: 0, elemId: `2@${actor}`, value: {value: 'chaffinch'}},
-            {action: 'insert', index: 1, elemId: `3@${actor}`, value: {value: 'goldfinch'}}
+            {action: 'insert', index: 0, elemId: `2@${actor}`, opId: `2@${actor}`, value: {value: 'chaffinch'}},
+            {action: 'insert', index: 1, elemId: `3@${actor}`, opId: `3@${actor}`, value: {value: 'goldfinch'}}
           ],
         }}}}
       }
@@ -739,8 +739,8 @@ describe('Automerge.Frontend', () => {
         diffs: {objectId: '_root', type: 'map', props: {birds: {[`1@${actor}`]: {
           objectId: birds, type: 'list',
           edits: [
-            {action: 'insert', index: 0, elemId: `2@${actor}`, value: {value: 'chaffinch'}},
-            {action: 'insert', index: 1, elemId: `3@${actor}`, value: {value: 'goldfinch'}}
+            {action: 'insert', index: 0, elemId: `2@${actor}`, opId: `2@${actor}`, value: {value: 'chaffinch'}},
+            {action: 'insert', index: 1, elemId: `3@${actor}`, opId: `3@${actor}`, value: {value: 'goldfinch'}}
           ],
         }}}}
       }
@@ -766,7 +766,7 @@ describe('Automerge.Frontend', () => {
             magpies: {[`2@${actor}`]: {value: 2}}
           }}},
           details: {[`3@${actor}`]: {objectId: `3@${actor}`, type: 'list',
-            edits: [{action: 'insert', index: 0, elemId: `4@${actor}`, value: {
+            edits: [{action: 'insert', index: 0, elemId: `4@${actor}`, opId: `4@${actor}`, value: {
               type: 'map',
               objectId: `4@${actor}`,
               props: {
@@ -815,6 +815,7 @@ describe('Automerge.Frontend', () => {
             index: 0,
             value: {type: 'value', value: '1'},
             elemId: `2@${actor}`,
+            opId: `2@${actor}`
           },
           {
             action: 'multi-insert',

--- a/test/observable_test.js
+++ b/test/observable_test.js
@@ -8,7 +8,7 @@ describe('Automerge.Observable', () => {
     observable.observe(doc, (diff, before, after, local, changes) => {
       callbackChanges = changes
       assert.deepStrictEqual(diff, {
-        objectId: '_root', type: 'map', props: {bird: {[`1@${actor}`]: {value: 'Goldfinch'}}}
+        objectId: '_root', type: 'map', props: {bird: {[`1@${actor}`]: {type: 'value', value: 'Goldfinch'}}}
       })
       assert.deepStrictEqual(before, {})
       assert.deepStrictEqual(after, {bird: 'Goldfinch'})
@@ -29,14 +29,8 @@ describe('Automerge.Observable', () => {
       callbackCalled = true
       assert.deepStrictEqual(diff, {
         objectId: `1@${actor}`, type: 'text', edits: [
-          {action: 'insert', index: 0, elemId: `2@${actor}`},
-          {action: 'insert', index: 1, elemId: `3@${actor}`},
-          {action: 'insert', index: 2, elemId: `4@${actor}`}
-        ], props: {
-          0: {[`2@${actor}`]: {value: 'a'}},
-          1: {[`3@${actor}`]: {value: 'b'}},
-          2: {[`4@${actor}`]: {value: 'c'}}
-        }
+          {action: 'multi-insert', index: 0, elemId: `2@${actor}`, values: ['a', 'b', 'c']}
+        ]
       })
       assert.deepStrictEqual(before.toString(), '')
       assert.deepStrictEqual(after.toString(), 'abc')
@@ -54,9 +48,9 @@ describe('Automerge.Observable', () => {
     observable.observe(local.text, (diff, before, after, local, changes) => {
       callbackChanges = changes
       assert.deepStrictEqual(diff, {
-        objectId: `1@${localId}`, type: 'text',
-        edits: [{action: 'insert', index: 0, elemId: `2@${remoteId}`}],
-        props: {0: {[`2@${remoteId}`]: {value: 'a'}}}
+        objectId: `1@${localId}`, type: 'text', edits: [
+          {action: 'insert', index: 0, elemId: `2@${remoteId}`, value: {type: 'value', value: 'a'}}
+        ]
       })
       assert.deepStrictEqual(before.toString(), '')
       assert.deepStrictEqual(after.toString(), 'a')
@@ -76,7 +70,7 @@ describe('Automerge.Observable', () => {
     observable.observe(doc.todos[0], (diff, before, after, local) => {
       callbackCalled = true
       assert.deepStrictEqual(diff, {
-        objectId: `2@${actor}`, type: 'map', props: {done: {[`5@${actor}`]: {value: true}}}
+        objectId: `2@${actor}`, type: 'map', props: {done: {[`5@${actor}`]: {type: 'value', value: true}}}
       })
       assert.deepStrictEqual(before, {title: 'Buy milk', done: false})
       assert.deepStrictEqual(after, {title: 'Buy milk', done: true})
@@ -86,22 +80,22 @@ describe('Automerge.Observable', () => {
     assert.strictEqual(callbackCalled, true)
   })
 
-  it('should not provide a "before" state if list indexes changed', () => {
+  it('should provide before and after states if list indexes changed', () => {
     let observable = new Automerge.Observable(), callbackCalled = false
     let doc = Automerge.from({todos: [{title: 'Buy milk', done: false}]}, {observable})
     const actor = Automerge.getActorId(doc)
     observable.observe(doc.todos[0], (diff, before, after, local) => {
       callbackCalled = true
       assert.deepStrictEqual(diff, {
-        objectId: `2@${actor}`, type: 'map', props: {done: {[`5@${actor}`]: {value: true}}}
+        objectId: `2@${actor}`, type: 'map', props: {done: {[`8@${actor}`]: {type: 'value', value: true}}}
       })
-      assert.strictEqual(before, undefined)
+      assert.deepStrictEqual(before, {title: 'Buy milk', done: false})
       assert.deepStrictEqual(after, {title: 'Buy milk', done: true})
       assert.strictEqual(local, true)
     })
     doc = Automerge.change(doc, doc => {
-      doc.todos[0].done = true
       doc.todos.unshift({title: 'Water plants', done: false})
+      doc.todos[1].done = true
     })
     assert.strictEqual(callbackCalled, true)
   })
@@ -116,7 +110,7 @@ describe('Automerge.Observable', () => {
     observable.observe(doc.todos.byId(rowId), (diff, before, after, local) => {
       callbackCalled = true
       assert.deepStrictEqual(diff, {
-        objectId: `2@${actor}`, type: 'map', props: {done: {[`5@${actor}`]: {value: true}}}
+        objectId: `2@${actor}`, type: 'map', props: {done: {[`5@${actor}`]: {type: 'value', value: true}}}
       })
       assert.deepStrictEqual(before, {id: rowId, title: 'Buy milk', done: false})
       assert.deepStrictEqual(after, {id: rowId, title: 'Buy milk', done: true})

--- a/test/observable_test.js
+++ b/test/observable_test.js
@@ -49,7 +49,7 @@ describe('Automerge.Observable', () => {
       callbackChanges = changes
       assert.deepStrictEqual(diff, {
         objectId: `1@${localId}`, type: 'text', edits: [
-          {action: 'insert', index: 0, elemId: `2@${remoteId}`, value: {type: 'value', value: 'a'}}
+          {action: 'insert', index: 0, elemId: `2@${remoteId}`, opId: `2@${remoteId}`, value: {type: 'value', value: 'a'}}
         ]
       })
       assert.deepStrictEqual(before.toString(), '')

--- a/test/observable_test.js
+++ b/test/observable_test.js
@@ -136,7 +136,7 @@ describe('Automerge.Observable', () => {
     observable.observe(doc.text.get(2), (diff, before, after, local) => {
       callbackCalled = true
       assert.deepStrictEqual(diff, {
-        objectId: `4@${actor}`, type: 'map', props: {start: {[`9@${actor}`]: {value: 'italic'}}}
+        objectId: `4@${actor}`, type: 'map', props: {start: {[`9@${actor}`]: {type: 'value', value: 'italic'}}}
       })
       assert.deepStrictEqual(before, {start: 'bold'})
       assert.deepStrictEqual(after, {start: 'italic'})

--- a/test/sync_test.js
+++ b/test/sync_test.js
@@ -146,12 +146,12 @@ describe('Data sync protocol', () => {
         ;[n1, s1, patch] = Automerge.receiveSyncMessage(n1, s1, message)
         ;[s1, message] = Automerge.generateSyncMessage(n1, s1)
         assert.deepStrictEqual(decodeSyncMessage(message).changes.length, 5)
-        assert.deepStrictEqual(patch.diffs.props, {y: {'5@def456': {value: 4}}}) // changes arrived
+        assert.deepStrictEqual(patch.diffs.props, {y: {'5@def456': {type: 'value', value: 4}}}) // changes arrived
 
         // n2 applies the changes and sends confirmation ending the exchange
         ;[n2, s2, patch] = Automerge.receiveSyncMessage(n2, s2, message)
         ;[s2, message] = Automerge.generateSyncMessage(n2, s2)
-        assert.deepStrictEqual(patch.diffs.props, {x: {'5@abc123': {value: 4}}}) // changes arrived
+        assert.deepStrictEqual(patch.diffs.props, {x: {'5@abc123': {type: 'value', value: 4}}}) // changes arrived
 
         // n1 receives the message and has nothing more to say
         ;[n1, s1, patch] = Automerge.receiveSyncMessage(n1, s1, message)

--- a/test/test.js
+++ b/test/test.js
@@ -278,8 +278,9 @@ describe('Automerge', () => {
         assert.deepStrictEqual(callbacks[0].patch, {
           actor, seq: 1, maxOp: 2, deps: [], clock: {[actor]: 1}, pendingChanges: 0,
           diffs: {objectId: '_root', type: 'map', props: {birds: {[`1@${actor}`]: {
-            objectId: `1@${actor}`, type: 'list',
-            edits: [{action: 'insert', index: 0, elemId: `2@${actor}`, value: {'type': 'value', value: 'Goldfinch'}}],
+            objectId: `1@${actor}`, type: 'list', edits: [
+              {action: 'insert', index: 0, elemId: `2@${actor}`, opId: `2@${actor}`, value: {'type': 'value', value: 'Goldfinch'}}
+            ]
           }}}}
         })
         assert.strictEqual(callbacks[0].before, s1)
@@ -1271,8 +1272,9 @@ describe('Automerge', () => {
       assert.deepStrictEqual(callbacks[0].patch, {
         maxOp: 2, deps: [decodeChange(Automerge.getAllChanges(s1)[0]).hash], clock: {[actor]: 1}, pendingChanges: 0,
         diffs: {objectId: '_root', type: 'map', props: {birds: {[`1@${actor}`]: {
-          objectId: `1@${actor}`, type: 'list',
-          edits: [{action: 'insert', index: 0, elemId: `2@${actor}`, value: {type: 'value', value: 'Goldfinch'}}],
+          objectId: `1@${actor}`, type: 'list', edits: [
+            {action: 'insert', index: 0, elemId: `2@${actor}`, opId: `2@${actor}`, value: {type: 'value', value: 'Goldfinch'}}
+          ]
         }}}}
       })
       assert.strictEqual(callbacks[0].patch, patch)

--- a/test/test.js
+++ b/test/test.js
@@ -1227,6 +1227,21 @@ describe('Automerge', () => {
       assert.deepStrictEqual(s4.birds, ['Chaffinch', 'Bullfinch'])
     })
 
+    it('should handle updates to a list element', () => {
+      let s1 = Automerge.change(Automerge.init(), doc => doc.birds = ['Chaffinch', 'Bullfinch'])
+      let s2 = Automerge.change(s1, doc => doc.birds[0] = 'Goldfinch')
+      let [s3, patch3] = Automerge.applyChanges(Automerge.init(), Automerge.getAllChanges(s2))
+      assert.deepStrictEqual(s3.birds, ['Goldfinch', 'Bullfinch'])
+      assert.strictEqual(Automerge.getConflicts(s3.birds, 0), undefined)
+    })
+
+    it('should handle updates to a text object', () => {
+      let s1 = Automerge.change(Automerge.init(), doc => doc.text = new Automerge.Text('ab'))
+      let s2 = Automerge.change(s1, doc => doc.text.set(0, 'A'))
+      let [s3, patch3] = Automerge.applyChanges(Automerge.init(), Automerge.getAllChanges(s2))
+      assert.deepStrictEqual([...s3.text], ['A', 'b'])
+    })
+
     it('should report missing dependencies', () => {
       let s1 = Automerge.change(Automerge.init(), doc => doc.birds = ['Chaffinch'])
       let s2 = Automerge.merge(Automerge.init(), s1)

--- a/test/test.js
+++ b/test/test.js
@@ -279,8 +279,7 @@ describe('Automerge', () => {
           actor, seq: 1, maxOp: 2, deps: [], clock: {[actor]: 1}, pendingChanges: 0,
           diffs: {objectId: '_root', type: 'map', props: {birds: {[`1@${actor}`]: {
             objectId: `1@${actor}`, type: 'list',
-            edits: [{action: 'insert', index: 0, elemId: `2@${actor}`}],
-            props: {0: {[`2@${actor}`]: {value: 'Goldfinch'}}}
+            edits: [{action: 'insert', index: 0, elemId: `2@${actor}`, value: {'type': 'value', value: 'Goldfinch'}}],
           }}}}
         })
         assert.strictEqual(callbacks[0].before, s1)
@@ -298,7 +297,7 @@ describe('Automerge', () => {
         assert.strictEqual(callbacks.length, 1)
         assert.deepStrictEqual(callbacks[0].patch, {
           actor, seq: 1, maxOp: 1, deps: [], clock: {[actor]: 1}, pendingChanges: 0,
-          diffs: {objectId: '_root', type: 'map', props: {bird: {[`1@${actor}`]: {value: 'Goldfinch'}}}}
+          diffs: {objectId: '_root', type: 'map', props: {bird: {[`1@${actor}`]: {type: 'value', value: 'Goldfinch'}}}}
         })
         assert.strictEqual(callbacks[0].before, s1)
         assert.strictEqual(callbacks[0].after, s2)
@@ -1138,12 +1137,8 @@ describe('Automerge', () => {
         maxOp: 3, deps: [decodeChange(Automerge.getAllChanges(s2)[1]).hash], clock: {[actor]: 2}, pendingChanges: 0,
         diffs: {objectId: '_root', type: 'map', props: {birds: {[`1@${actor}`]: {
           objectId: `1@${actor}`, type: 'list', edits: [
-            {action: 'insert', index: 0, elemId: `2@${actor}`},
-            {action: 'insert', index: 1, elemId: `3@${actor}`}
-          ], props: {
-            0: {[`2@${actor}`]: {value: 'Goldfinch'}},
-            1: {[`3@${actor}`]: {value: 'Chaffinch'}}
-          }
+            {action: 'multi-insert', index: 0, elemId: `2@${actor}`, values: ['Goldfinch', 'Chaffinch']}
+          ]
         }}}}
       })
       assert.deepStrictEqual(callbacks[0].before, {})
@@ -1277,8 +1272,7 @@ describe('Automerge', () => {
         maxOp: 2, deps: [decodeChange(Automerge.getAllChanges(s1)[0]).hash], clock: {[actor]: 1}, pendingChanges: 0,
         diffs: {objectId: '_root', type: 'map', props: {birds: {[`1@${actor}`]: {
           objectId: `1@${actor}`, type: 'list',
-          edits: [{action: 'insert', index: 0, elemId: `2@${actor}`}],
-          props: {0: {[`2@${actor}`]: {value: 'Goldfinch'}}}
+          edits: [{action: 'insert', index: 0, elemId: `2@${actor}`, value: {type: 'value', value: 'Goldfinch'}}],
         }}}}
       })
       assert.strictEqual(callbacks[0].patch, patch)
@@ -1297,12 +1291,8 @@ describe('Automerge', () => {
         maxOp: 3, deps: [decodeChange(Automerge.getAllChanges(s2)[1]).hash], clock: {[actor]: 2}, pendingChanges: 0,
         diffs: {objectId: '_root', type: 'map', props: {birds: {[`1@${actor}`]: {
           objectId: `1@${actor}`, type: 'list', edits: [
-            {action: 'insert', index: 0, elemId: `2@${actor}`},
-            {action: 'insert', index: 1, elemId: `3@${actor}`}
-          ], props: {
-            0: {[`2@${actor}`]: {value: 'Goldfinch'}},
-            1: {[`3@${actor}`]: {value: 'Chaffinch'}}
-          }
+            {action: 'multi-insert', index: 0, elemId: `2@${actor}`, values: ['Goldfinch', 'Chaffinch']}
+          ]
         }}}}
       }])
     })
@@ -1314,7 +1304,7 @@ describe('Automerge', () => {
       Automerge.applyChanges(before, Automerge.getAllChanges(s1))
       assert.deepStrictEqual(patches, [{
         maxOp: 1, deps: [decodeChange(Automerge.getAllChanges(s1)[0]).hash], clock: {[actor]: 1}, pendingChanges: 0,
-        diffs: {objectId: '_root', type: 'map', props: {bird: {[`1@${actor}`]: {value: 'Goldfinch'}}}}
+        diffs: {objectId: '_root', type: 'map', props: {bird: {[`1@${actor}`]: {type: 'value', value: 'Goldfinch'}}}}
       }])
     })
   })

--- a/test/typescript_test.ts
+++ b/test/typescript_test.ts
@@ -565,8 +565,7 @@ describe('TypeScript support', () => {
         callbackCalled = true
         assert.deepStrictEqual(patch.diffs.props.text[`1@${actor}`], {
           objectId: `1@${actor}`, type: 'text',
-          edits: [{action: 'insert', index: 0, elemId: `2@${actor}`}],
-          props: {0: {[`2@${actor}`]: {value: 'a'}}}
+          edits: [{action: 'insert', index: 0, elemId: `2@${actor}`, value: {type: 'value', value: 'a'}}],
         })
         assert.deepStrictEqual(before, {})
         assert.strictEqual(after.text.toString(), 'a')
@@ -585,8 +584,9 @@ describe('TypeScript support', () => {
       let actor = Automerge.getActorId(doc)
       observable.observe(doc.text, (diff, before, after, local, changes) => {
         callbackCalled = true
-        assert.deepStrictEqual(diff.edits, [{action: 'insert', index: 0, elemId: `2@${actor}`}])
-        assert.deepStrictEqual(diff.props, {0: {[`2@${actor}`]: {value: 'a'}}})
+        if (diff.type == 'list') {
+          assert.deepStrictEqual(diff.edits, [{action: 'insert', index: 0, elemId: `2@${actor}`, value: {type: 'value', value: 'a'}}])
+        }
         assert.strictEqual(before.toString(), '')
         assert.strictEqual(after.toString(), 'a')
         assert.strictEqual(local, true)

--- a/test/typescript_test.ts
+++ b/test/typescript_test.ts
@@ -564,8 +564,9 @@ describe('TypeScript support', () => {
       let doc = Automerge.init<TextDoc>({patchCallback: (patch, before, after, local, changes) => {
         callbackCalled = true
         assert.deepStrictEqual(patch.diffs.props.text[`1@${actor}`], {
-          objectId: `1@${actor}`, type: 'text',
-          edits: [{action: 'insert', index: 0, elemId: `2@${actor}`, value: {type: 'value', value: 'a'}}],
+          objectId: `1@${actor}`, type: 'text', edits: [
+            {action: 'insert', index: 0, elemId: `2@${actor}`, opId: `2@${actor}`, value: {type: 'value', value: 'a'}}
+          ]
         })
         assert.deepStrictEqual(before, {})
         assert.strictEqual(after.text.toString(), 'a')
@@ -584,8 +585,10 @@ describe('TypeScript support', () => {
       let actor = Automerge.getActorId(doc)
       observable.observe(doc.text, (diff, before, after, local, changes) => {
         callbackCalled = true
-        if (diff.type == 'list') {
-          assert.deepStrictEqual(diff.edits, [{action: 'insert', index: 0, elemId: `2@${actor}`, value: {type: 'value', value: 'a'}}])
+        if (diff.type == 'text') {
+          assert.deepStrictEqual(diff.edits, [
+            {action: 'insert', index: 0, elemId: `2@${actor}`, opId: `2@${actor}`, value: {type: 'value', value: 'a'}}
+          ])
         }
         assert.strictEqual(before.toString(), '')
         assert.strictEqual(after.toString(), 'a')


### PR DESCRIPTION
This is a first shot at implementing the new sequence patch format outlined in #311. It's mostly working with the exception of the Observable API. I need to spend some time figuring that out but I wanted to get some eyes on this first.

There is one outstanding question I have which relates to the value of the pred attribute for multiOp delete operations. Consider this operation:

```javascript
{
  obj: listId, 
  action: 'del', 
  elemId: '1@xxx', 
  multiOp: 2,
  insert: false,
}
```

In order for this to work we need to specify the predecessor operations for each element being overwritten. The approach I've gone for in this patch is to flatten the predecessor IDs for the whole set of deleted list elements into one pred array and attached it to the op. This works but it feels clumsy and belies the intent of this protocol change - which is to reduce the size of these operations - as we have to include at least one predecessor ID for every deleted element. Is there a better way? Have I misunderstood the use of the pred attribute in the protocol?