### PR TITLE
Add DEFLATE compression

### DIFF
--- a/backend/columnar.js
+++ b/backend/columnar.js
@@ -31,11 +31,18 @@ const CHUNK_TYPE_DEFLATE = 2 // like CHUNK_TYPE_CHANGE but with DEFLATE compress
 // compressing very short values since compression may actually make them bigger)
 const DEFLATE_MIN_SIZE = 256
 
+// The least-significant 3 bits of a columnId indicate its datatype
 const COLUMN_TYPE = {
   GROUP_CARD: 0, ACTOR_ID: 1, INT_RLE: 2, INT_DELTA: 3, BOOLEAN: 4,
   STRING_RLE: 5, VALUE_LEN: 6, VALUE_RAW: 7
 }
 
+// The 4th-least-significant bit of a columnId is set if the column is DEFLATE-compressed
+const COLUMN_TYPE_DEFLATE = 8
+
+// In the values in a column of type VALUE_LEN, the bottom four bits indicate the type of the value,
+// one of the following types in VALUE_TYPE. The higher bits indicate the length of the value in the
+// associated VALUE_RAW column (in bytes).
 const VALUE_TYPE = {
   NULL: 0, FALSE: 1, TRUE: 2, LEB128_UINT: 3, LEB128_INT: 4, IEEE754: 5,
   UTF8: 6, BYTES: 7, COUNTER: 8, TIMESTAMP: 9, MIN_UNKNOWN: 10, MAX_UNKNOWN: 15
@@ -47,46 +54,46 @@ const ACTIONS = ['makeMap', 'set', 'makeList', 'del', 'makeText', 'inc', 'makeTa
 const OBJECT_TYPE = {makeMap: 'map', makeList: 'list', makeText: 'text', makeTable: 'table'}
 
 const COMMON_COLUMNS = {
-  objActor:  0 << 3 | COLUMN_TYPE.ACTOR_ID,
-  objCtr:    0 << 3 | COLUMN_TYPE.INT_RLE,
-  keyActor:  1 << 3 | COLUMN_TYPE.ACTOR_ID,
-  keyCtr:    1 << 3 | COLUMN_TYPE.INT_DELTA,
-  keyStr:    1 << 3 | COLUMN_TYPE.STRING_RLE,
-  idActor:   2 << 3 | COLUMN_TYPE.ACTOR_ID,
-  idCtr:     2 << 3 | COLUMN_TYPE.INT_DELTA,
-  insert:    3 << 3 | COLUMN_TYPE.BOOLEAN,
-  action:    4 << 3 | COLUMN_TYPE.INT_RLE,
-  valLen:    5 << 3 | COLUMN_TYPE.VALUE_LEN,
-  valRaw:    5 << 3 | COLUMN_TYPE.VALUE_RAW,
-  chldActor: 6 << 3 | COLUMN_TYPE.ACTOR_ID,
-  chldCtr:   6 << 3 | COLUMN_TYPE.INT_DELTA
+  objActor:  0 << 4 | COLUMN_TYPE.ACTOR_ID,
+  objCtr:    0 << 4 | COLUMN_TYPE.INT_RLE,
+  keyActor:  1 << 4 | COLUMN_TYPE.ACTOR_ID,
+  keyCtr:    1 << 4 | COLUMN_TYPE.INT_DELTA,
+  keyStr:    1 << 4 | COLUMN_TYPE.STRING_RLE,
+  idActor:   2 << 4 | COLUMN_TYPE.ACTOR_ID,
+  idCtr:     2 << 4 | COLUMN_TYPE.INT_DELTA,
+  insert:    3 << 4 | COLUMN_TYPE.BOOLEAN,
+  action:    4 << 4 | COLUMN_TYPE.INT_RLE,
+  valLen:    5 << 4 | COLUMN_TYPE.VALUE_LEN,
+  valRaw:    5 << 4 | COLUMN_TYPE.VALUE_RAW,
+  chldActor: 6 << 4 | COLUMN_TYPE.ACTOR_ID,
+  chldCtr:   6 << 4 | COLUMN_TYPE.INT_DELTA
 }
 
 const CHANGE_COLUMNS = Object.assign({
-  predNum:   7 << 3 | COLUMN_TYPE.GROUP_CARD,
-  predActor: 7 << 3 | COLUMN_TYPE.ACTOR_ID,
-  predCtr:   7 << 3 | COLUMN_TYPE.INT_DELTA
+  predNum:   7 << 4 | COLUMN_TYPE.GROUP_CARD,
+  predActor: 7 << 4 | COLUMN_TYPE.ACTOR_ID,
+  predCtr:   7 << 4 | COLUMN_TYPE.INT_DELTA
 }, COMMON_COLUMNS)
 
 const DOC_OPS_COLUMNS = Object.assign({
-  succNum:   8 << 3 | COLUMN_TYPE.GROUP_CARD,
-  succActor: 8 << 3 | COLUMN_TYPE.ACTOR_ID,
-  succCtr:   8 << 3 | COLUMN_TYPE.INT_DELTA
+  succNum:   8 << 4 | COLUMN_TYPE.GROUP_CARD,
+  succActor: 8 << 4 | COLUMN_TYPE.ACTOR_ID,
+  succCtr:   8 << 4 | COLUMN_TYPE.INT_DELTA
 }, COMMON_COLUMNS)
 
 const DOC_OPS_COLUMNS_REV = Object.entries(DOC_OPS_COLUMNS)
   .reduce((acc, [k, v]) => {acc[v] = k; return acc}, [])
 
 const DOCUMENT_COLUMNS = {
-  actor:     0 << 3 | COLUMN_TYPE.ACTOR_ID,
-  seq:       0 << 3 | COLUMN_TYPE.INT_DELTA,
-  maxOp:     1 << 3 | COLUMN_TYPE.INT_DELTA,
-  time:      2 << 3 | COLUMN_TYPE.INT_DELTA,
-  message:   3 << 3 | COLUMN_TYPE.STRING_RLE,
-  depsNum:   4 << 3 | COLUMN_TYPE.GROUP_CARD,
-  depsIndex: 4 << 3 | COLUMN_TYPE.INT_DELTA,
-  extraLen:  5 << 3 | COLUMN_TYPE.VALUE_LEN,
-  extraRaw:  5 << 3 | COLUMN_TYPE.VALUE_RAW
+  actor:     0 << 4 | COLUMN_TYPE.ACTOR_ID,
+  seq:       0 << 4 | COLUMN_TYPE.INT_DELTA,
+  maxOp:     1 << 4 | COLUMN_TYPE.INT_DELTA,
+  time:      2 << 4 | COLUMN_TYPE.INT_DELTA,
+  message:   3 << 4 | COLUMN_TYPE.STRING_RLE,
+  depsNum:   4 << 4 | COLUMN_TYPE.GROUP_CARD,
+  depsIndex: 4 << 4 | COLUMN_TYPE.INT_DELTA,
+  extraLen:  5 << 4 | COLUMN_TYPE.VALUE_LEN,
+  extraRaw:  5 << 4 | COLUMN_TYPE.VALUE_RAW
 }
 
 /**
@@ -532,8 +539,8 @@ function decodeColumns(columns, actorIds, columnSpec) {
     let row = {}, col = 0
     while (col < columns.length) {
       const columnId = columns[col].columnId
-      let groupId = columnId >> 3, groupCols = 1
-      while (col + groupCols < columns.length && columns[col + groupCols].columnId >> 3 === groupId) {
+      let groupId = columnId >> 4, groupCols = 1
+      while (col + groupCols < columns.length && columns[col + groupCols].columnId >> 4 === groupId) {
         groupCols++
       }
 
@@ -693,6 +700,9 @@ function decodeChangeColumns(buffer) {
   const change = decodeChangeHeader(chunkDecoder)
   const columns = decodeColumnInfo(chunkDecoder)
   for (let i = 0; i < columns.length; i++) {
+    if ((columns[i].columnId & COLUMN_TYPE_DEFLATE) !== 0) {
+      throw new RangeError('change must not contain deflated columns')
+    }
     columns[i].buffer = chunkDecoder.readRawBytes(columns[i].bufferLen)
   }
   if (!chunkDecoder.done) {
@@ -1049,6 +1059,8 @@ function encodeDocument(binaryChanges) {
   const { changes, actorIds } = parseAllOpIds(decodeChanges(binaryChanges), false)
   const { changesColumns, heads } = encodeDocumentChanges(changes)
   const opsColumns = encodeOps(groupDocumentOps(changes), true)
+  for (let column of changesColumns) deflateColumn(column)
+  for (let column of opsColumns) deflateColumn(column)
 
   return encodeContainer(CHUNK_TYPE_DOCUMENT, encoder => {
     encoder.appendUint53(actorIds.length)
@@ -1086,9 +1098,11 @@ function decodeDocumentHeader(buffer) {
   const opsColumns = decodeColumnInfo(decoder)
   for (let i = 0; i < changesColumns.length; i++) {
     changesColumns[i].buffer = decoder.readRawBytes(changesColumns[i].bufferLen)
+    inflateColumn(changesColumns[i])
   }
   for (let i = 0; i < opsColumns.length; i++) {
     opsColumns[i].buffer = decoder.readRawBytes(opsColumns[i].bufferLen)
+    inflateColumn(opsColumns[i])
   }
 
   const extraBytes = decoder.readRawBytes(decoder.buf.byteLength - decoder.offset)
@@ -1102,6 +1116,26 @@ function decodeDocument(buffer) {
   groupChangeOps(changes, ops)
   decodeDocumentChanges(changes, heads)
   return changes
+}
+
+/**
+ * DEFLATE-compresses the given column if it is large enough to make the compression worthwhile.
+ */
+function deflateColumn(column) {
+  if (column.encoder.buffer.byteLength >= DEFLATE_MIN_SIZE) {
+    column.encoder = {buffer: pako.deflateRaw(column.encoder.buffer)}
+    column.id |= COLUMN_TYPE_DEFLATE
+  }
+}
+
+/**
+ * Decompresses the given column if it is DEFLATE-compressed.
+ */
+function inflateColumn(column) {
+  if ((column.columnId & COLUMN_TYPE_DEFLATE) !== 0) {
+    column.buffer = pako.inflateRaw(column.buffer)
+    column.columnId ^= COLUMN_TYPE_DEFLATE
+  }
 }
 
 /**
@@ -1390,10 +1424,10 @@ function copyColumns(outCols, inCols, count) {
         inCols[inIndex].decoder.buf.byteLength > 0) {
       inCol = inCols[inIndex].decoder
     }
-    const colCount = (outCol.columnId >> 3 === lastGroup) ? lastCardinality : count
+    const colCount = (outCol.columnId >> 4 === lastGroup) ? lastCardinality : count
 
     if (outCol.columnId % 8 === COLUMN_TYPE.GROUP_CARD) {
-      lastGroup = outCol.columnId >> 3
+      lastGroup = outCol.columnId >> 4
       if (inCol) {
         lastCardinality = outCol.encoder.copyFrom(inCol, {count, sumValues: true}).sum
       } else {
@@ -1444,10 +1478,10 @@ function readOperation(columns, actorTable) {
       if (col.columnId !== valueColumn) throw new RangeError('unexpected VALUE_RAW column')
       colValue = col.decoder.readRawBytes(valueBytes)
     } else if (col.columnId % 8 === COLUMN_TYPE.GROUP_CARD) {
-      lastGroup = col.columnId >> 3
+      lastGroup = col.columnId >> 4
       lastCardinality = col.decoder.readValue() || 0
       colValue = lastCardinality
-    } else if (col.columnId >> 3 === lastGroup) {
+    } else if (col.columnId >> 4 === lastGroup) {
       colValue = []
       if (col.columnId % 8 === COLUMN_TYPE.VALUE_LEN) {
         valueColumn = col.columnId + 1
@@ -1492,10 +1526,10 @@ function appendOperation(outCols, inCols, operation) {
     if (inIndex < inCols.length && inCols[inIndex].columnId === outCol.columnId) {
       const colValue = operation[inIndex]
       if (outCol.columnId % 8 === COLUMN_TYPE.GROUP_CARD) {
-        lastGroup = outCol.columnId >> 3
+        lastGroup = outCol.columnId >> 4
         lastCardinality = colValue
         outCol.encoder.appendValue(colValue)
-      } else if (outCol.columnId >> 3 === lastGroup) {
+      } else if (outCol.columnId >> 4 === lastGroup) {
         if (!Array.isArray(colValue) || colValue.length !== lastCardinality) {
           throw new RangeError('bad group value')
         }
@@ -1506,11 +1540,11 @@ function appendOperation(outCols, inCols, operation) {
         outCol.encoder.appendValue(colValue)
       }
     } else if (outCol.columnId % 8 === COLUMN_TYPE.GROUP_CARD) {
-      lastGroup = outCol.columnId >> 3
+      lastGroup = outCol.columnId >> 4
       lastCardinality = 0
       outCol.encoder.appendValue(0)
     } else if (outCol.columnId % 8 !== COLUMN_TYPE.VALUE_RAW) {
-      const count = (outCol.columnId >> 3 === lastGroup) ? lastCardinality : 1
+      const count = (outCol.columnId >> 4 === lastGroup) ? lastCardinality : 1
       let blankValue = null
       if (outCol.columnId % 8 === COLUMN_TYPE.BOOLEAN) blankValue = false
       if (outCol.columnId % 8 === COLUMN_TYPE.VALUE_LEN) blankValue = 0

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "dependencies": {
     "fast-sha256": "^1.3.0",
     "immutable": "^3.8.2",
+    "pako": "^2.0.3",
     "uuid": "^3.4.0"
   },
   "devDependencies": {

--- a/test/backend_test.js
+++ b/test/backend_test.js
@@ -294,7 +294,7 @@ describe('Automerge.Backend', () => {
         }}
       })
       assert.deepStrictEqual(changes01, [{
-        hash: '6fc48e6635e2bab050a340119fff7a559679ed4f26734623c2b4738815f48371',
+        hash: '2c2845859ce4336936f56410f9161a09ba269f48aee5826782f1c389ec01d054',
         actor: '111111', seq: 1, startOp: 1, time: 0, message: '', deps: [], ops: [
           {action: 'set', obj: '_root', key: 'bird', insert: false, value: 'magpie', pred: []}
         ]
@@ -332,15 +332,15 @@ describe('Automerge.Backend', () => {
       const [s3, patch3] = Backend.applyLocalChange(s2, local2)
       const changes = Backend.getAllChanges(s3).map(decodeChange)
       assert.deepStrictEqual(changes, [
-        {hash: '6fc48e6635e2bab050a340119fff7a559679ed4f26734623c2b4738815f48371',
+        {hash: '2c2845859ce4336936f56410f9161a09ba269f48aee5826782f1c389ec01d054',
         actor: '111111', seq: 1, startOp: 1, time: 0, message: '', deps: [], ops: [
           {action: 'set', obj: '_root', key: 'bird', insert: false, value: 'magpie', pred: []}
         ]},
-        {hash: 'aca4a51a8d538f2b16b6f9b923cf6dd5a4bb5ad550b6e618aa529a036b45ea1f',
+        {hash: 'efc7e9b1b809364fb1b7029d2838dd3c7cf539eea595b22f9ae665505187f6c4',
         actor: '222222', seq: 1, startOp: 1, time: 0, message: '', deps: [], ops: [
           {action: 'set', obj: '_root', key: 'fish', insert: false, value: 'goldfish', pred: []}
         ]},
-        {hash: '1caeeaf4fb120b8bed4c6c92311f679264f070637b5531979e95ec8249499f5a',
+        {hash: 'e7ed7a790432aba39fe7ad75fa9e02a9fc8d8e9ee4ec8c81dcc93da15a561f8a',
         actor: '111111', seq: 2, startOp: 2, time: 0, message: '', deps: [changes[0].hash], ops: [
           {action: 'set', obj: '_root', key: 'bird', insert: false, value: 'jay', pred: ['1@111111']}
         ]}
@@ -372,7 +372,7 @@ describe('Automerge.Backend', () => {
         }}
       })
       assert.deepStrictEqual(changes[2], {
-        hash: 'b6f22ff5606622a9b8f4efed87a5202128bc5e35021d09e04529b9076ec98d0e',
+        hash: '7a00e28d7fbf179708a1b0045c7f9bad93366c0e69f9af15e830dae9970a9d19',
         actor: '111111', seq: 2, startOp: 2, time: 0, message: '', deps: [changes[0].hash], ops: [
           {action: 'set', obj: '_root', key: 'bird', insert: false, value: 'jay', pred: ['1@111111']}
         ]
@@ -404,19 +404,19 @@ describe('Automerge.Backend', () => {
       const [s5, patch5] = Backend.applyLocalChange(s4, local3)
       const changes = Backend.getAllChanges(s5).map(decodeChange)
       assert.deepStrictEqual(changes[1], {
-        hash: '96db9a3bb6471912a2acbe3948365d202b89145816efa37bd0ccaa3be8ebee14',
+        hash: '06392148c4a0dfff8b346ad58a3261cc15187cbf8a58779f78d54251126d4ccc',
         actor: '111111', seq: 1, startOp: 2, time: 0, message: '', deps: [hash(remote1)], ops: [
           {obj: '1@222222', action: 'set', elemId: '_head', insert: true, value: 'goldfinch', pred: []}
         ]
       })
       assert.deepStrictEqual(changes[3], {
-        hash: '57e8ec00028e0a0a1ae325ad2c86dd4d8f63ace7c3ccb67a351682f0f6879cfd',
+        hash: '2801c386ec2a140376f3bef285a6e6d294a2d8fb7a180da4fbb6e2bc4f550dd9',
         actor: '111111', seq: 2, startOp: 3, time: 0, message: '', deps: [changes[1].hash], ops: [
           {obj: '1@222222', action: 'set', elemId: '2@111111', insert: true, value: 'wagtail', pred: []}
         ]
       })
       assert.deepStrictEqual(changes[4], {
-        hash: 'd999eeeb5f69689f65b0e47b1f4dcc69c29b4b3ccaca69884425e5a6443e8d5d',
+        hash: '734f1dad5fb2f10970bae2baa6ce100c3b85b43072b3799d8f2e15bcd21297fc',
         actor: '111111', seq: 3, startOp: 4, time: 0, message: '',
         deps: [hash(remote2), changes[3].hash].sort(), ops: [
           {obj: '1@222222', action: 'set', elemId: '2@222222', insert: false, value: 'Magpie',    pred: ['2@222222']},
@@ -451,7 +451,7 @@ describe('Automerge.Backend', () => {
           {obj: '_root', action: 'makeList', key: 'birds', insert: false, pred: []}
         ]
       }, {
-        hash: 'd96f0023f949581eb10459c2ad8467148857f1d230abc0f0fd446ab95fdbf7ea',
+        hash: 'deef4c9b9ca378844144c4bbc5d82a52f30c95a8624f13f243fe8f1214e8e833',
         actor: '111111', seq: 2, startOp: 2, time: 0, message: '', deps: [changes[0].hash], ops: [
           {obj: '1@111111', action: 'set', elemId: '_head', insert: true, value: 'magpie', pred: []},
           {obj: '1@111111', action: 'del', elemId: '2@111111', insert: false, pred: ['2@111111']}
@@ -493,6 +493,23 @@ describe('Automerge.Backend', () => {
       const s1 = Backend.loadChanges(Backend.init(), [change1, change2, change3].map(encodeChange))
       const s2 = Backend.load(Backend.save(s1))
       assert.deepStrictEqual(Backend.getHeads(s2), [hash(change3)])
+    })
+
+    it('should compress columns with DEFLATE', () => {
+      let longString = ''
+      for (let i = 0; i < 1024; i++) longString += 'a'
+      const change1 = {actor: '111111', seq: 1, time: 0, startOp: 1, deps: [], ops: [
+        {action: 'set', obj: '_root', key: 'longString', value: longString, pred: []}
+      ]}
+      const doc = Backend.save(Backend.loadChanges(Backend.init(), [encodeChange(change1)]))
+      const patch = Backend.getPatch(Backend.load(doc))
+      assert.ok(doc.byteLength < 200)
+      assert.deepStrictEqual(patch, {
+        clock: {'111111': 1}, deps: [hash(change1)], maxOp: 1,
+        diffs: {objectId: '_root', type: 'map', props: {
+          longString: {['1@111111']: {value: longString}}
+        }}
+      })
     })
   })
 

--- a/test/columnar_test.js
+++ b/test/columnar_test.js
@@ -27,14 +27,14 @@ describe('change encoding', () => {
     ]}
     checkEncoded(encodeChange(change1), [
       0x85, 0x6f, 0x4a, 0x83, // magic bytes
-      0xcf, 0xc7, 0x77, 0xe2, // checksum
+      0xe2, 0xbd, 0xfb, 0xf5, // checksum
       1, 94, 0, 2, 0xaa, 0xaa, // chunkType: change, length, deps, actor 'aaaa'
       1, 1, 9, 0, 0, // seq, startOp, time, message, actor list
-      12, 1, 4, 2, 4, // column count, objActor, objCtr
-      9, 8, 11, 7, 13, 8, // keyActor, keyCtr, keyStr
-      28, 4, 34, 6, // insert, action
-      46, 6, 47, 3, // valLen, valRaw
-      56, 6, 57, 2, 59, 2, // predNum, predActor, predCtr
+      12, 0x01, 4, 0x02, 4, // column count, objActor, objCtr
+      0x11, 8, 0x13, 7, 0x15, 8, // keyActor, keyCtr, keyStr
+      0x34, 4, 0x42, 6, // insert, action
+      0x56, 6, 0x57, 3, // valLen, valRaw
+      0x70, 6, 0x71, 2, 0x73, 2, // predNum, predActor, predCtr
       0, 1, 4, 0, // objActor column: null, 0, 0, 0, 0
       0, 1, 4, 1, // objCtr column: null, 1, 1, 1, 1
       0, 2, 0x7f, 0, 0, 1, 0x7f, 0, // keyActor column: null, null, 0, null, 0
@@ -55,13 +55,13 @@ describe('change encoding', () => {
   describe('with trailing bytes', () => {
     let change = Uint8Array.from([
       0x85, 0x6f, 0x4a, 0x83, // magic bytes
-      0x15, 0x72, 0xa6, 0x6c, // checksum
+      0xb2, 0x98, 0x9e, 0xa9, // checksum
       1, 61, 0, 2, 0x12, 0x34, // chunkType: change, length, deps, actor '1234'
       1, 1, 252, 250, 220, 255, 5, // seq, startOp, time
       14, 73, 110, 105, 116, 105, 97, 108, 105, 122, 97, 116, 105, 111, 110, // message: 'Initialization'
       0, 6, // actor list, column count
-      13, 3, 28, 1, 34, 2, // keyStr, insert, action
-      46, 2, 47, 1, 56, 2, // valLen, valRaw, predNum
+      0x15, 3, 0x34, 1, 0x42, 2, // keyStr, insert, action
+      0x56, 2, 0x57, 1, 0x70, 2, // valLen, valRaw, predNum
       0x7f, 1, 0x78, // keyStr: 'x'
       1, // insert: false
       0x7f, 1, // action: set

--- a/yarn.lock
+++ b/yarn.lock
@@ -4470,6 +4470,11 @@ pad@^3.2.0:
   dependencies:
     wcwidth "^1.0.1"
 
+pako@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/pako/-/pako-2.0.3.tgz#cdf475e31b678565251406de9e759196a0ea7a43"
+  integrity sha512-WjR1hOeg+kki3ZIOjaf4b5WVcay1jaliKSYiEaB1XzwhMQZJxRdQRv0V31EKBYlxb4T7SK3hjfc/jxyU64BoSw==
+
 pako@~1.0.2, pako@~1.0.5:
   version "1.0.11"
   resolved "https://registry.yarnpkg.com/pako/-/pako-1.0.11.tgz#6c9599d340d54dfd3946380252a35705a6b992bf"


### PR DESCRIPTION
This PR adds support for DEFLATE compression. As explained in #317, compression can be used in two places:

* On an individual change, the whole change can be compressed. The change hash is computed on the uncompressed change, and the checksum included in the change is based on the uncompressed change. We do this because two different compressors given the same input do not necessarily produce the same compressed byte stream.
* On a compressed document, one column at a time can be compressed. I changed the definition of the columnId to reserve one bit to indicate whether the column is compressed. We do this so that it is possible to load only a subset of columns of a document.

Compression is only enabled when the data is larger than some threshold (currently 256 bytes) since it's not worth it on very short values.

@alexjg could I leave the implementation on the Rust side with you?