### PR TITLE
Support creating text with unicode chars

### DIFF
--- a/frontend/text.js
+++ b/frontend/text.js
@@ -4,7 +4,7 @@ const { isObject } = require('../src/common')
 class Text {
   constructor (text) {
     if (typeof text === 'string') {
-      const elems = text.split('').map(value => ({value}))
+      const elems = [...text].map(value => ({value}))
       return instantiateText(undefined, elems)
     } else if (Array.isArray(text)) {
       const elems = text.map(value => ({value}))

--- a/test/text_test.js
+++ b/test/text_test.js
@@ -688,4 +688,11 @@ describe('Automerge.Text', () => {
       })
     })
   })
+
+  it('should support unicode when creating text', () => {
+    s1 = Automerge.from({
+      text: new Automerge.Frontend.Text('🐦')
+    })
+    assert.strictEqual(s1.text.get(0), '🐦')
+  })
 })


### PR DESCRIPTION
Creating a text with a unicode character results in the unicode characted being split. If used with the rust backend it results in an ugly runtime error.

See: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/split

There is a warning in there:

> Warning: When the empty string ("") is used as a separator, the string is not split by user-perceived characters (grapheme clusters) or unicode characters (codepoints), but by UTF-16 codeunits. This destroys surrogate pairs. See “How do you get a string to a character array in JavaScript?” on StackOverflow.

I did not do an extensive check of the codebase for this issue, just fixed the most critical path for us at this point.