### PR TITLE
Enable a gentle eslint

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -6,6 +6,7 @@
         "node": true,
         "mocha": true
     },
+    "ignorePatterns": "dist/**",
     "extends": "eslint:recommended",
     "parserOptions": {
         "ecmaVersion": 12

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -256,8 +256,8 @@
         ],
         "space-infix-ops": "error",
         "space-unary-ops": "error",
-        "spaced-comment": [ // this is once in fuzz_test
-            "off",
+        "spaced-comment": [
+            "error",
             "always"
         ],
         "strict": [

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -190,7 +190,7 @@
         "no-unreachable-loop": "error",
         "no-unsafe-optional-chaining": "error",
         "no-unused-expressions": "error",
-        "no-unused-vars": "off", // we should turn this back on
+        "no-unused-vars": ["error", { "args": "after-used" }],
         "no-use-before-define": "off",
         "no-useless-backreference": "error",
         "no-useless-call": "error",

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -204,7 +204,7 @@
         "no-warning-comments": "off",
         "no-whitespace-before-property": "off",
         "nonblock-statement-body-position": "error",
-        "object-curly-newline": "off", // just a few cases in frontend_test
+        "object-curly-newline": "error",
         "object-curly-spacing": "off",
         "object-property-newline": "off",
         "object-shorthand": "error",

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,286 @@
+{
+    "env": {
+        "browser": true,
+        "commonjs": true,
+        "es2021": true,
+        "node": true,
+        "mocha": true
+    },
+    "extends": "eslint:recommended",
+    "parserOptions": {
+        "ecmaVersion": 12
+    },
+    "rules": {
+        "accessor-pairs": "error",
+        "array-bracket-newline": "off",
+        "array-bracket-spacing": "off",
+        "array-callback-return": "error",
+        "array-element-newline": "off",
+        "arrow-body-style": "error",
+        "arrow-parens": "off",
+        "arrow-spacing": [
+            "error",
+            {
+                "after": true,
+                "before": true
+            }
+        ],
+        "block-scoped-var": "error",
+        "block-spacing": "error",
+        "brace-style": [
+            "error",
+            "1tbs", { "allowSingleLine": true }
+        ],
+        "camelcase": "off",
+        "capitalized-comments": "off",
+        "class-methods-use-this": "off",
+        "comma-dangle": "off",
+        "comma-spacing": [
+            "error",
+            {
+                "after": true,
+                "before": false
+            }
+        ],
+        "comma-style": [
+            "error",
+            "last"
+        ],
+        "complexity": "off",
+        "computed-property-spacing": [
+            "off",
+            "never"
+        ],
+        "consistent-return": "off",
+        "consistent-this": "error",
+        "curly": "off",
+        "default-case": "off",
+        "default-case-last": "error",
+        "default-param-last": "error",
+        "dot-location": [
+            "error",
+            "property"
+        ],
+        "dot-notation": "error",
+        "eol-last": "error",
+        "eqeqeq": "off",
+        "func-call-spacing": "off",
+        "func-name-matching": "error",
+        "func-names": "off",
+        "func-style": [
+            "error",
+            "declaration"
+        ],
+        "function-paren-newline": "off",
+        "generator-star-spacing": "error",
+        "grouped-accessor-pairs": "error",
+        "guard-for-in": "error",
+        "id-denylist": "error",
+        "id-length": "off",
+        "id-match": "error",
+        "implicit-arrow-linebreak": "off",
+        "indent": "off",
+        "init-declarations": "off",
+        "jsx-quotes": "error",
+        "key-spacing": "off",
+        "keyword-spacing": [
+            "error",
+            {
+                "after": true,
+                "before": true
+            }
+        ],
+        "line-comment-position": "off",
+        "linebreak-style": "off",
+        "lines-around-comment": "off",
+        "lines-between-class-members": "error",
+        "max-classes-per-file": "off",
+        "max-depth": "off",
+        "max-len": "off",
+        "max-lines": "off",
+        "max-lines-per-function": "off",
+        "max-nested-callbacks": "error",
+        "max-params": "off",
+        "max-statements": "off",
+        "max-statements-per-line": "off",
+        "multiline-comment-style": [
+            "error",
+            "separate-lines"
+        ],
+        "new-parens": "error",
+        "newline-per-chained-call": "off",
+        "no-alert": "error",
+        "no-array-constructor": "error",
+        "no-await-in-loop": "error",
+        "no-bitwise": "off",
+        "no-caller": "error",
+        "no-confusing-arrow": "error",
+        "no-console": "error",
+        "no-constant-condition": [
+            "error",
+            {
+                "checkLoops": false
+            }
+        ],
+        "no-constructor-return": "error",
+        "no-continue": "off",
+        "no-div-regex": "error",
+        "no-duplicate-imports": "error",
+        "no-else-return": "off",
+        "no-empty-function": "off",
+        "no-eq-null": "error",
+        "no-eval": "error",
+        "no-extend-native": "error",
+        "no-extra-bind": "error",
+        "no-extra-label": "error",
+        "no-extra-parens": "off",
+        "no-floating-decimal": "error",
+        "no-implicit-coercion": "off",
+        "no-implicit-globals": "error",
+        "no-implied-eval": "error",
+        "no-inline-comments": "off",
+        "no-invalid-this": "error",
+        "no-iterator": "error",
+        "no-label-var": "error",
+        "no-labels": "error",
+        "no-lone-blocks": "error",
+        "no-lonely-if": "off",
+        "no-loop-func": "off",
+        "no-loss-of-precision": "error",
+        "no-magic-numbers": "off",
+        "no-mixed-operators": "off",
+        "no-multi-assign": "error",
+        "no-multi-spaces": "off",
+        "no-multi-str": "error",
+        "no-multiple-empty-lines": "error",
+        "no-negated-condition": "off",
+        "no-nested-ternary": "off",
+        "no-new": "error",
+        "no-new-func": "error",
+        "no-new-object": "error",
+        "no-new-wrappers": "error",
+        "no-nonoctal-decimal-escape": "error",
+        "no-octal-escape": "error",
+        "no-param-reassign": "off",
+        "no-plusplus": "off",
+        "no-promise-executor-return": "error",
+        "no-proto": "error",
+        "no-restricted-exports": "error",
+        "no-restricted-globals": "error",
+        "no-restricted-imports": "error",
+        "no-restricted-properties": "error",
+        "no-restricted-syntax": "error",
+        "no-return-assign": "off",
+        "no-return-await": "error",
+        "no-script-url": "error",
+        "no-self-compare": "error",
+        "no-sequences": "error",
+        "no-shadow": "off",
+        "no-tabs": "error",
+        "no-template-curly-in-string": "error",
+        "no-ternary": "off",
+        "no-throw-literal": "error",
+        "no-trailing-spaces": "error",
+        "no-undef-init": "off",
+        "no-undefined": "off",
+        "no-underscore-dangle": "off",
+        "no-unmodified-loop-condition": "error",
+        "no-unneeded-ternary": "error",
+        "no-unreachable-loop": "error",
+        "no-unsafe-optional-chaining": "error",
+        "no-unused-expressions": "error",
+        "no-unused-vars": "off", // we should turn this back on
+        "no-use-before-define": "off",
+        "no-useless-backreference": "error",
+        "no-useless-call": "error",
+        "no-useless-computed-key": "error",
+        "no-useless-concat": "error",
+        "no-useless-constructor": "error",
+        "no-useless-rename": "error",
+        "no-useless-return": "error",
+        "no-var": "error",
+        "no-void": "error",
+        "no-warning-comments": "off",
+        "no-whitespace-before-property": "off",
+        "nonblock-statement-body-position": "error",
+        "object-curly-newline": "off", // just a few cases in frontend_test
+        "object-curly-spacing": "off",
+        "object-property-newline": "off",
+        "object-shorthand": "error",
+        "one-var": "off",
+        "one-var-declaration-per-line": "off",
+        "operator-assignment": "off",
+        "operator-linebreak": "error",
+        "padded-blocks": "off",
+        "padding-line-between-statements": "error",
+        "prefer-arrow-callback": "off",
+        "prefer-const": "off",
+        "prefer-destructuring": "off",
+        "prefer-exponentiation-operator": "error",
+        "prefer-named-capture-group": "off",
+        "prefer-numeric-literals": "error",
+        "prefer-object-spread": "off",
+        "prefer-promise-reject-errors": "error",
+        "prefer-regex-literals": "error",
+        "prefer-rest-params": "error",
+        "prefer-spread": "error",
+        "prefer-template": "off",
+        "quote-props": "off",
+        "quotes": "off",
+        "radix": "off", // pvh suggests we re-enable this
+        "require-atomic-updates": "error",
+        "require-await": "error",
+        "require-unicode-regexp": "off",
+        "rest-spread-spacing": "error",
+        "semi": "off",
+        "semi-spacing": [
+            "error",
+            {
+                "after": true,
+                "before": false
+            }
+        ],
+        "semi-style": [
+            "error",
+            "first"
+        ],
+        "sort-imports": "error",
+        "sort-keys": "off",
+        "sort-vars": "off",
+        "space-before-blocks": "error",
+        "space-before-function-paren": "off",
+        "space-in-parens": [
+            "error",
+            "never"
+        ],
+        "space-infix-ops": "error",
+        "space-unary-ops": "error",
+        "spaced-comment": [ // this is once in fuzz_test
+            "off",
+            "always"
+        ],
+        "strict": [
+            "error",
+            "never"
+        ],
+        "switch-colon-spacing": "error",
+        "symbol-description": "error",
+        "template-curly-spacing": [
+            "error",
+            "never"
+        ],
+        "template-tag-spacing": "error",
+        "unicode-bom": [
+            "error",
+            "never"
+        ],
+        "vars-on-top": "error",
+        "wrap-iife": "error",
+        "wrap-regex": "off",
+        "yield-star-spacing": "error",
+        "yoda": [
+            "error",
+            "never"
+        ]
+    }
+}

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -228,7 +228,7 @@
         "prefer-template": "off",
         "quote-props": "off",
         "quotes": "off",
-        "radix": "off", // pvh suggests we re-enable this
+        "radix": "error",
         "require-atomic-updates": "error",
         "require-await": "error",
         "require-unicode-regexp": "off",

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: node_js
 node_js:
 - '10'
 - '12'
-script: 'yarn test && yarn build && TEST_DIST=1 yarn test && node -e "const Automerge = require(\"./dist/automerge\")"'
+script: 'yarn lint && yarn test && yarn build && TEST_DIST=1 yarn test && node -e "const Automerge = require(\"./dist/automerge\")"'
 jobs:
   include:
     - stage: browsertest

--- a/backend/backend.js
+++ b/backend/backend.js
@@ -209,7 +209,7 @@ function loadChanges(backend, changes) {
     backend.frozen = true
     return {state, heads: state.heads}
   } else {
-    const [newState, _] = apply(state, changes, null, false)
+    const [newState] = apply(state, changes, null, false)
     backend.frozen = true
     return {state: newState, heads: OpSet.getHeads(newState.get('opSet'))}
   }

--- a/backend/backend.js
+++ b/backend/backend.js
@@ -1,7 +1,5 @@
 const { Map, List } = require('immutable')
-const { copyObject } = require('../src/common')
 const OpSet = require('./op_set')
-const { SkipList } = require('./skip_list')
 const { splitContainers, encodeChange, decodeChanges, encodeDocument, constructPatch, BackendDoc } = require('./columnar')
 const { backendState } = require('./util')
 
@@ -229,7 +227,7 @@ function getPatch(backend) {
       maxOp: state.maxOp,
       clock: state.clock,
       deps: state.heads,
-      diffs: diffs
+      diffs
     }
   } else {
     const diffs = constructPatch(save(backend))

--- a/backend/columnar.js
+++ b/backend/columnar.js
@@ -516,7 +516,7 @@ function decoderByColumnId(columnId, buffer) {
 function makeDecoders(columns, columnSpec) {
   // By default, every column decodes an empty byte array
   const emptyBuf = Uint8Array.of(), decoders = {}
-  for (let [/*columnName*/, columnId] of Object.entries(columnSpec)) {
+  for (let [/* columnName */, columnId] of Object.entries(columnSpec)) {
     decoders[columnId] = decoderByColumnId(columnId, emptyBuf)
   }
   for (let column of columns) {
@@ -525,7 +525,7 @@ function makeDecoders(columns, columnSpec) {
 
   let result = []
   for (let columnId of Object.keys(decoders).map(id => parseInt(id)).sort((a, b) => a - b)) {
-    let [columnName] = Object.entries(columnSpec).find(([/*name*/, id]) => id === columnId)
+    let [columnName] = Object.entries(columnSpec).find(([/* name */, id]) => id === columnId)
     if (!columnName) columnName = columnId.toString()
     result.push({columnId, columnName, decoder: decoders[columnId]})
   }
@@ -1279,9 +1279,9 @@ function constructPatch(documentBuffer) {
  *     elements that precede the position where the new operations should be applied.
  */
 function seekToOp(ops, docCols, actorIds) {
-  const { objActor, objCtr, keyActor, keyCtr, keyStr, idActor, idCtr, insert /*, action, consecutiveOps*/ } = ops
+  const { objActor, objCtr, keyActor, keyCtr, keyStr, idActor, idCtr, insert /* , action, consecutiveOps */ } = ops
   const [objActorD, objCtrD, /* keyActorD */, /* keyCtrD */, keyStrD, idActorD, idCtrD, insertD, actionD,
-    /* valLenD */, /* valRawD */, /* chldActorD */, /*chldCtrD*/, succNumD] = docCols.map(col => col.decoder)
+    /* valLenD */, /* valRawD */, /* chldActorD */, /* chldCtrD */, succNumD] = docCols.map(col => col.decoder)
   let skipCount = 0, visibleCount = 0, elemVisible = false, nextObjActor = null, nextObjCtr = null
   let nextIdActor = null, nextIdCtr = null, nextKeyStr = null, nextInsert = null, nextSuccNum = 0
 
@@ -1594,7 +1594,7 @@ function appendOperation(outCols, inCols, operation) {
  */
 function groupRelatedOps(change, changeCols, objectMeta) {
   const currentActor = change.actorIds[0]
-  const [objActorD, objCtrD, keyActorD, keyCtrD, keyStrD, /*idActorD*/, /*idCtrD*/, insertD, actionD] =
+  const [objActorD, objCtrD, keyActorD, keyCtrD, keyStrD, /* idActorD */, /* idCtrD */, insertD, actionD] =
     changeCols.map(col => col.decoder)
   let objIdSeen = {}, firstOp = null, lastOp = null, opIdCtr = change.startOp
   let opSequences = [], objectIds = {}

--- a/backend/columnar.js
+++ b/backend/columnar.js
@@ -516,7 +516,7 @@ function decoderByColumnId(columnId, buffer) {
 function makeDecoders(columns, columnSpec) {
   // By default, every column decodes an empty byte array
   const emptyBuf = Uint8Array.of(), decoders = {}
-  for (let [/* columnName */, columnId] of Object.entries(columnSpec)) {
+  for (let columnId of Object.values(columnSpec)) {
     decoders[columnId] = decoderByColumnId(columnId, emptyBuf)
   }
   for (let column of columns) {
@@ -1279,7 +1279,7 @@ function constructPatch(documentBuffer) {
  *     elements that precede the position where the new operations should be applied.
  */
 function seekToOp(ops, docCols, actorIds) {
-  const { objActor, objCtr, keyActor, keyCtr, keyStr, idActor, idCtr, insert /* , action, consecutiveOps */ } = ops
+  const { objActor, objCtr, keyActor, keyCtr, keyStr, idActor, idCtr, insert } = ops
   const [objActorD, objCtrD, /* keyActorD */, /* keyCtrD */, keyStrD, idActorD, idCtrD, insertD, actionD,
     /* valLenD */, /* valRawD */, /* chldActorD */, /* chldCtrD */, succNumD] = docCols.map(col => col.decoder)
   let skipCount = 0, visibleCount = 0, elemVisible = false, nextObjActor = null, nextObjCtr = null
@@ -2123,7 +2123,7 @@ class BackendDoc {
       }
     }
     for (let col of changeCols) allCols[col.columnId] = true
-    for (let [, columnId] of Object.entries(DOC_OPS_COLUMNS)) allCols[columnId] = true
+    for (let columnId of Object.values(DOC_OPS_COLUMNS)) allCols[columnId] = true
 
     // Final document should contain any columns in either the document or the change, except for
     // pred, since the document encoding uses succ instead of pred

--- a/backend/columnar.js
+++ b/backend/columnar.js
@@ -516,7 +516,7 @@ function decoderByColumnId(columnId, buffer) {
 function makeDecoders(columns, columnSpec) {
   // By default, every column decodes an empty byte array
   const emptyBuf = Uint8Array.of(), decoders = {}
-  for (let [columnName, columnId] of Object.entries(columnSpec)) {
+  for (let [/*columnName*/, columnId] of Object.entries(columnSpec)) {
     decoders[columnId] = decoderByColumnId(columnId, emptyBuf)
   }
   for (let column of columns) {
@@ -525,7 +525,7 @@ function makeDecoders(columns, columnSpec) {
 
   let result = []
   for (let columnId of Object.keys(decoders).map(id => parseInt(id)).sort((a, b) => a - b)) {
-    let [columnName, _] = Object.entries(columnSpec).find(([name, id]) => id === columnId)
+    let [columnName] = Object.entries(columnSpec).find(([/*name*/, id]) => id === columnId)
     if (!columnName) columnName = columnId.toString()
     result.push({columnId, columnName, decoder: decoders[columnId]})
   }
@@ -1279,9 +1279,9 @@ function constructPatch(documentBuffer) {
  *     elements that precede the position where the new operations should be applied.
  */
 function seekToOp(ops, docCols, actorIds) {
-  const { objActor, objCtr, keyActor, keyCtr, keyStr, idActor, idCtr, insert, action, consecutiveOps } = ops
-  const [objActorD, objCtrD, keyActorD, keyCtrD, keyStrD, idActorD, idCtrD, insertD, actionD,
-    valLenD, valRawD, chldActorD, chldCtrD, succNumD] = docCols.map(col => col.decoder)
+  const { objActor, objCtr, keyActor, keyCtr, keyStr, idActor, idCtr, insert /*, action, consecutiveOps*/ } = ops
+  const [objActorD, objCtrD, /* keyActorD */, /* keyCtrD */, keyStrD, idActorD, idCtrD, insertD, actionD,
+    /* valLenD */, /* valRawD */, /* chldActorD */, /*chldCtrD*/, succNumD] = docCols.map(col => col.decoder)
   let skipCount = 0, visibleCount = 0, elemVisible = false, nextObjActor = null, nextObjCtr = null
   let nextIdActor = null, nextIdCtr = null, nextKeyStr = null, nextInsert = null, nextSuccNum = 0
 
@@ -1594,7 +1594,7 @@ function appendOperation(outCols, inCols, operation) {
  */
 function groupRelatedOps(change, changeCols, objectMeta) {
   const currentActor = change.actorIds[0]
-  const [objActorD, objCtrD, keyActorD, keyCtrD, keyStrD, idActorD, idCtrD, insertD, actionD] =
+  const [objActorD, objCtrD, keyActorD, keyCtrD, keyStrD, /*idActorD*/, /*idCtrD*/, insertD, actionD] =
     changeCols.map(col => col.decoder)
   let objIdSeen = {}, firstOp = null, lastOp = null, opIdCtr = change.startOp
   let opSequences = [], objectIds = {}
@@ -1732,8 +1732,8 @@ class BackendDoc {
    */
   updatePatchProperty(patches, ops, op, docState, propState, listIndex, oldSuccNum) {
     // FIXME: these constants duplicate those at the beginning of mergeDocChangeOps()
-    const objActor = 0, objCtr = 1, keyActor = 2, keyCtr = 3, keyStr = 4, idActor = 5, idCtr = 6, insert = 7, action = 8,
-      valLen = 9, valRaw = 10, predNum = 13, predActor = 14, predCtr = 15, succNum = 13, succActor = 14, succCtr = 15
+    const objActor = 0, objCtr = 1, keyActor = 2, keyCtr = 3, keyStr = 4, idActor = 5, idCtr = 6, insert = 7, action = 8, // eslint-disable-line
+      valLen = 9, valRaw = 10, predNum = 13, predActor = 14, predCtr = 15, succNum = 13, succActor = 14, succCtr = 15 // eslint-disable-line
 
     const objectId = ops.objId
     const elemId = op[keyStr] ? op[keyStr]
@@ -2123,7 +2123,7 @@ class BackendDoc {
       }
     }
     for (let col of changeCols) allCols[col.columnId] = true
-    for (let [columnName, columnId] of Object.entries(DOC_OPS_COLUMNS)) allCols[columnId] = true
+    for (let [, columnId] of Object.entries(DOC_OPS_COLUMNS)) allCols[columnId] = true
 
     // Final document should contain any columns in either the document or the change, except for
     // pred, since the document encoding uses succ instead of pred
@@ -2183,7 +2183,7 @@ class BackendDoc {
               keyActor: elem.actorId, keyCtr: elem.counter,
               keyStr:   null,         insert: false
             }
-            const {skipCount, visibleCount} = seekToOp(seekPos, docState.opsCols, docState.actorIds)
+            const { visibleCount } = seekToOp(seekPos, docState.opsCols, docState.actorIds)
             key = visibleCount
           }
           if (!patches[objectId].props[key]) patches[objectId].props[key] = {}

--- a/backend/columnar.js
+++ b/backend/columnar.js
@@ -1736,9 +1736,9 @@ class BackendDoc {
       valLen = 9, valRaw = 10, predNum = 13, predActor = 14, predCtr = 15, succNum = 13, succActor = 14, succCtr = 15
 
     const objectId = ops.objId
-    const elemId = op[keyStr] ? op[keyStr] : // eslint-disable-line
-                   op[insert] ? `${op[idCtr]}@${docState.actorIds[op[idActor]]}`
-                              : `${op[keyCtr]}@${docState.actorIds[op[keyActor]]}`
+    const elemId = op[keyStr] ? op[keyStr]
+                              : op[insert] ? `${op[idCtr]}@${docState.actorIds[op[idActor]]}`
+                                           : `${op[keyCtr]}@${docState.actorIds[op[keyActor]]}`
 
     // An operation to be overwritten if it is a document operation that has at least one successor
     const isOverwritten = (oldSuccNum !== undefined && op[succNum] > 0)

--- a/backend/columnar.js
+++ b/backend/columnar.js
@@ -524,7 +524,7 @@ function makeDecoders(columns, columnSpec) {
   }
 
   let result = []
-  for (let columnId of Object.keys(decoders).map(id => parseInt(id)).sort((a, b) => a - b)) {
+  for (let columnId of Object.keys(decoders).map(id => parseInt(id, 10)).sort((a, b) => a - b)) {
     let [columnName] = Object.entries(columnSpec).find(([/* name */, id]) => id === columnId)
     if (!columnName) columnName = columnId.toString()
     result.push({columnId, columnName, decoder: decoders[columnId]})
@@ -2130,7 +2130,7 @@ class BackendDoc {
     delete allCols[CHANGE_COLUMNS.predNum]
     delete allCols[CHANGE_COLUMNS.predActor]
     delete allCols[CHANGE_COLUMNS.predCtr]
-    return Object.keys(allCols).map(id => parseInt(id)).sort((a, b) => a - b)
+    return Object.keys(allCols).map(id => parseInt(id, 10)).sort((a, b) => a - b)
   }
 
   /**

--- a/backend/columnar.js
+++ b/backend/columnar.js
@@ -82,7 +82,7 @@ const DOC_OPS_COLUMNS = Object.assign({
 }, COMMON_COLUMNS)
 
 const DOC_OPS_COLUMNS_REV = Object.entries(DOC_OPS_COLUMNS)
-  .reduce((acc, [k, v]) => {acc[v] = k; return acc}, [])
+  .reduce((acc, [k, v]) => { acc[v] = k; return acc }, [])
 
 const DOCUMENT_COLUMNS = {
   actor:     0 << 4 | COLUMN_TYPE.ACTOR_ID,
@@ -634,7 +634,7 @@ function encodeContainer(chunkType, encodeContentsCallback) {
   bodyBuf.set(MAGIC_BYTES, HEADER_SPACE - headerBuf.byteLength - CHECKSUM_SIZE - MAGIC_BYTES.byteLength)
   bodyBuf.set(checksum,    HEADER_SPACE - headerBuf.byteLength - CHECKSUM_SIZE)
   bodyBuf.set(headerBuf,   HEADER_SPACE - headerBuf.byteLength)
-  return {hash, bytes: bodyBuf.subarray( HEADER_SPACE - headerBuf.byteLength - CHECKSUM_SIZE - MAGIC_BYTES.byteLength)}
+  return {hash, bytes: bodyBuf.subarray(HEADER_SPACE - headerBuf.byteLength - CHECKSUM_SIZE - MAGIC_BYTES.byteLength)}
 }
 
 function decodeContainerHeader(decoder, computeHash) {
@@ -1594,8 +1594,8 @@ function appendOperation(outCols, inCols, operation) {
  */
 function groupRelatedOps(change, changeCols, objectMeta) {
   const currentActor = change.actorIds[0]
-  const [objActorD, objCtrD, keyActorD, keyCtrD, keyStrD, idActorD, idCtrD, insertD, actionD]
-    = changeCols.map(col => col.decoder)
+  const [objActorD, objCtrD, keyActorD, keyCtrD, keyStrD, idActorD, idCtrD, insertD, actionD] =
+    changeCols.map(col => col.decoder)
   let objIdSeen = {}, firstOp = null, lastOp = null, opIdCtr = change.startOp
   let opSequences = [], objectIds = {}
 
@@ -1736,7 +1736,7 @@ class BackendDoc {
       valLen = 9, valRaw = 10, predNum = 13, predActor = 14, predCtr = 15, succNum = 13, succActor = 14, succCtr = 15
 
     const objectId = ops.objId
-    const elemId = op[keyStr] ? op[keyStr] :
+    const elemId = op[keyStr] ? op[keyStr] : // eslint-disable-line
                    op[insert] ? `${op[idCtr]}@${docState.actorIds[op[idActor]]}`
                               : `${op[keyCtr]}@${docState.actorIds[op[keyActor]]}`
 
@@ -1925,7 +1925,7 @@ class BackendDoc {
       const keyMatches      = docOp && docOp[keyStr] !== null && docOp[keyStr] === changeOp[keyStr]
       const listElemMatches = docOp && docOp[keyStr] === null && changeOp[keyStr] === null &&
         ((!docOp[insert] && docOp[keyActor] === changeOp[keyActor] && docOp[keyCtr] === changeOp[keyCtr]) ||
-         ( docOp[insert] && docOp[idActor]  === changeOp[keyActor] && docOp[idCtr]  === changeOp[keyCtr]))
+          (docOp[insert] && docOp[idActor]  === changeOp[keyActor] && docOp[idCtr]  === changeOp[keyCtr]))
 
       // We keep going until we run out of ops in the change, except that even when we run out, we
       // keep going until we have processed all doc ops for the current key/list element.
@@ -2091,9 +2091,7 @@ class BackendDoc {
     docState.lastIndex[ops.objId] = visibleCount
     for (let col of docState.opsCols) col.decoder.reset()
 
-    let outCols = docState.allCols.map(columnId => {
-      return {columnId, encoder: encoderByColumnId(columnId)}
-    })
+    let outCols = docState.allCols.map(columnId => ({columnId, encoder: encoderByColumnId(columnId)}))
     copyColumns(outCols, docState.opsCols, skipCount)
     const {opsAppended, docOpsConsumed} = this.mergeDocChangeOps(patches, outCols, ops, changeCols, docState, visibleCount)
     copyColumns(outCols, docState.opsCols, docState.numOps - skipCount - docOpsConsumed)

--- a/backend/op_set.js
+++ b/backend/op_set.js
@@ -317,7 +317,7 @@ function finalizePatch(opSet, patch) {
  * is mutated to describe the changes. Returns the updated `opSet`.
  */
 function applyOps(opSet, change, patch) {
-  const actor = change.get('actor'), seq = change.get('seq'), startOp = change.get('startOp')
+  const actor = change.get('actor'), startOp = change.get('startOp')
   let newObjects = Set()
   change.get('ops').forEach((op, index) => {
     const action = op.get('action'), obj = op.get('obj'), insert = op.get('insert')

--- a/backend/op_set.js
+++ b/backend/op_set.js
@@ -613,7 +613,7 @@ function getPrevious(opSet, objectId, key) {
   const parentId = getParent(opSet, objectId, key)
   let children = insertionsAfter(opSet, objectId, parentId)
   if (children.first() === key) {
-    if (parentId === '_head') return null; else return parentId;
+    if (parentId === '_head') return null; else return parentId
   }
 
   let prevId

--- a/backend/skip_list.js
+++ b/backend/skip_list.js
@@ -114,7 +114,7 @@ class SkipList {
   constructor (randomSource) {
     const head = new Node(null, null, 1, [], [null], [], [null])
     const random = randomSource ? randomSource() : randomLevel()
-    return makeInstance(0, Map().set(null, head), random)
+    return makeInstance(0, Map().set(null, head), random) // eslint-disable-line
   }
 
   get headNode () {

--- a/backend/sync.js
+++ b/backend/sync.js
@@ -21,8 +21,8 @@ const { backendState } = require('./util')
 const Backend = require('./backend')
 const OpSet = require('./op_set')
 const { hexStringToBytes, bytesToHexString, Encoder, Decoder } = require('./encoding')
-const { decodeChangeMeta, getChangeChecksum } = require('./columnar')
-const { copyObject, equalBytes } = require('../src/common')
+const { decodeChangeMeta } = require('./columnar')
+const { copyObject } = require('../src/common')
 
 const HASH_SIZE = 32 // 256 bits = 32 bytes
 const MESSAGE_TYPE_SYNC = 0x42 // first byte of a sync message, for identification
@@ -167,7 +167,6 @@ function encodeSyncMessage(message) {
     encodeHashes(encoder, have.lastSync)
     encoder.appendPrefixedBytes(have.bloom)
   }
-  const changes = message.changes || []
   encoder.appendUint32(message.changes.length)
   for (let change of message.changes) {
     encoder.appendPrefixedBytes(change)

--- a/backend/sync.js
+++ b/backend/sync.js
@@ -440,7 +440,7 @@ function receiveSyncMessage(backend, oldSyncState, binaryMessage) {
   // changes without applying them. The set of changes may also be incomplete if the sender decided
   // to break a large set of changes into chunks.
   if (message.changes.length > 0) {
-    ;[backend, patch] = Backend.applyChanges(backend, message.changes)
+    [backend, patch] = Backend.applyChanges(backend, message.changes)
     sharedHeads = advanceHeads(beforeHeads, Backend.getHeads(backend), sharedHeads)
   }
 

--- a/frontend/apply_patch.js
+++ b/frontend/apply_patch.js
@@ -1,7 +1,7 @@
 const { isObject, copyObject, parseOpId } = require('../src/common')
-const { OPTIONS, OBJECT_ID, CONFLICTS, ELEM_IDS } = require('./constants')
-const { Text, instantiateText } = require('./text')
-const { Table, instantiateTable } = require('./table')
+const { OBJECT_ID, CONFLICTS, ELEM_IDS } = require('./constants')
+const { instantiateText } = require('./text')
+const { instantiateTable } = require('./table')
 const { Counter } = require('./counter')
 
 /**
@@ -174,7 +174,7 @@ function updateTableObject(patch, obj, updated) {
   const object = updated[objectId]
 
   for (let key of Object.keys(patch.props || {})) {
-    const values = {}, opIds = Object.keys(patch.props[key])
+    const opIds = Object.keys(patch.props[key])
 
     if (opIds.length === 0) {
       object.remove(key)

--- a/frontend/context.js
+++ b/frontend/context.js
@@ -3,7 +3,7 @@ const { interpretPatch } = require('./apply_patch')
 const { Text } = require('./text')
 const { Table } = require('./table')
 const { Counter, getWriteableCounter } = require('./counter')
-const { isObject, copyObject } = require('../src/common')
+const { isObject } = require('../src/common')
 const uuid = require('../src/uuid')
 
 

--- a/frontend/index.js
+++ b/frontend/index.js
@@ -87,8 +87,8 @@ function makeChange(doc, context, options) {
     seq: state.seq,
     startOp: state.maxOp + 1,
     deps: state.deps,
-    time: (options && typeof options.time === 'number') ? options.time : // eslint-disable-line
-          Math.round(new Date().getTime() / 1000),
+    time: (options && typeof options.time === 'number') ? options.time
+                                                        : Math.round(new Date().getTime() / 1000),
     message: (options && typeof options.message === 'string') ? options.message : '',
     ops: context.ops
   }

--- a/frontend/index.js
+++ b/frontend/index.js
@@ -87,7 +87,7 @@ function makeChange(doc, context, options) {
     seq: state.seq,
     startOp: state.maxOp + 1,
     deps: state.deps,
-    time: (options && typeof options.time === 'number') ? options.time :
+    time: (options && typeof options.time === 'number') ? options.time : // eslint-disable-line
           Math.round(new Date().getTime() / 1000),
     message: (options && typeof options.message === 'string') ? options.message : '',
     ops: context.ops
@@ -216,7 +216,7 @@ function change(doc, options, callback) {
     throw new TypeError('Calls to Automerge.change cannot be nested')
   }
   if (typeof options === 'function' && callback === undefined) {
-    ;[options, callback] = [callback, options]
+    [options, callback] = [callback, options]
   }
   if (typeof options === 'string') {
     options = {message: options}

--- a/frontend/observable.js
+++ b/frontend/observable.js
@@ -1,5 +1,4 @@
 const { OBJECT_ID, CONFLICTS } = require('./constants')
-const { isObject } = require('../src/common')
 
 /**
  * Allows an application to register a callback when a particular object in

--- a/frontend/observable.js
+++ b/frontend/observable.js
@@ -50,7 +50,7 @@ class Observable {
           childAfter = after && after.byId(propName)
 
         } else if (diff.type === 'list') {
-          const index = parseInt(propName)
+          const index = parseInt(propName, 10)
           // Don't try to get the child object before if the indexes might have changed
           if (!diff.edits || diff.edits.length === 0) {
             childBefore = before && before[CONFLICTS] && before[CONFLICTS][index] &&
@@ -60,7 +60,7 @@ class Observable {
             after[CONFLICTS][index][opId]
 
         } else if (diff.type === 'text') {
-          const index = parseInt(propName)
+          const index = parseInt(propName, 10)
           // Don't try to get the child object before if the indexes might have changed
           if (!diff.edits || diff.edits.length === 0) {
             childBefore = before && before.get(index)

--- a/frontend/proxies.js
+++ b/frontend/proxies.js
@@ -3,7 +3,7 @@ const { Text } = require('./text')
 const { Table } = require('./table')
 
 function parseListIndex(key) {
-  if (typeof key === 'string' && /^[0-9]+$/.test(key)) key = parseInt(key)
+  if (typeof key === 'string' && /^[0-9]+$/.test(key)) key = parseInt(key, 10)
   if (typeof key !== 'number') {
     throw new TypeError('A list index must be a number, but you passed ' + JSON.stringify(key))
   }

--- a/frontend/proxies.js
+++ b/frontend/proxies.js
@@ -89,7 +89,7 @@ function listMethods(context, listId, path) {
     methods[method] = (...args) => {
       const list = context.getObject(listId)
         .map((item, index) => context.getObjectField(path, listId, index))
-      return list[method].call(list, ...args) // eslint-disable-line
+      return list[method](list, ...args)
     }
   }
 

--- a/frontend/proxies.js
+++ b/frontend/proxies.js
@@ -1,5 +1,4 @@
 const { OBJECT_ID, CHANGE, STATE } = require('./constants')
-const { Counter } = require('./counter')
 const { Text } = require('./text')
 const { Table } = require('./table')
 
@@ -106,7 +105,7 @@ const MapHandler = {
   },
 
   set (target, key, value) {
-    const { context, objectId, path, readonly } = target
+    const { context, path, readonly } = target
     if (Array.isArray(readonly) && readonly.indexOf(key) >= 0) {
       throw new RangeError(`Object property "${key}" cannot be modified`)
     }
@@ -115,7 +114,7 @@ const MapHandler = {
   },
 
   deleteProperty (target, key) {
-    const { context, objectId, path, readonly } = target
+    const { context, path, readonly } = target
     if (Array.isArray(readonly) && readonly.indexOf(key) >= 0) {
       throw new RangeError(`Object property "${key}" cannot be modified`)
     }
@@ -156,19 +155,19 @@ const ListHandler = {
   },
 
   set (target, key, value) {
-    const [context, objectId, path] = target
+    const [context, /*objectId*/, path] = target
     context.setListIndex(path, parseListIndex(key), value)
     return true
   },
 
   deleteProperty (target, key) {
-    const [context, objectId, path] = target
+    const [context, /*objectId*/, path] = target
     context.splice(path, parseListIndex(key), 1, [])
     return true
   },
 
   has (target, key) {
-    const [context, objectId, path] = target
+    const [context, objectId, /*path*/] = target
     if (typeof key === 'string' && /^[0-9]+$/.test(key)) {
       return parseListIndex(key) < context.getObject(objectId).length
     }
@@ -179,7 +178,7 @@ const ListHandler = {
     if (key === 'length') return {writable: true}
     if (key === OBJECT_ID) return {configurable: false, enumerable: false}
 
-    const [context, objectId, path] = target
+    const [context, objectId, /*path*/] = target
     const object = context.getObject(objectId)
 
     if (typeof key === 'string' && /^[0-9]+$/.test(key)) {
@@ -189,7 +188,7 @@ const ListHandler = {
   },
 
   ownKeys (target) {
-    const [context, objectId, path] = target
+    const [context, objectId, /*path*/] = target
     const object = context.getObject(objectId)
     let keys = ['length']
     for (let key of Object.keys(object)) keys.push(key)

--- a/frontend/proxies.js
+++ b/frontend/proxies.js
@@ -155,19 +155,19 @@ const ListHandler = {
   },
 
   set (target, key, value) {
-    const [context, /*objectId*/, path] = target
+    const [context, /* objectId */, path] = target
     context.setListIndex(path, parseListIndex(key), value)
     return true
   },
 
   deleteProperty (target, key) {
-    const [context, /*objectId*/, path] = target
+    const [context, /* objectId */, path] = target
     context.splice(path, parseListIndex(key), 1, [])
     return true
   },
 
   has (target, key) {
-    const [context, objectId, /*path*/] = target
+    const [context, objectId, /* path */] = target
     if (typeof key === 'string' && /^[0-9]+$/.test(key)) {
       return parseListIndex(key) < context.getObject(objectId).length
     }
@@ -178,7 +178,7 @@ const ListHandler = {
     if (key === 'length') return {writable: true}
     if (key === OBJECT_ID) return {configurable: false, enumerable: false}
 
-    const [context, objectId, /*path*/] = target
+    const [context, objectId, /* path */] = target
     const object = context.getObject(objectId)
 
     if (typeof key === 'string' && /^[0-9]+$/.test(key)) {
@@ -188,7 +188,7 @@ const ListHandler = {
   },
 
   ownKeys (target) {
-    const [context, objectId, /*path*/] = target
+    const [context, objectId, /* path */] = target
     const object = context.getObject(objectId)
     let keys = ['length']
     for (let key of Object.keys(object)) keys.push(key)

--- a/frontend/proxies.js
+++ b/frontend/proxies.js
@@ -89,7 +89,7 @@ function listMethods(context, listId, path) {
     methods[method] = (...args) => {
       const list = context.getObject(listId)
         .map((item, index) => context.getObjectField(path, listId, index))
-      return list[method](list, ...args)
+      return list[method](...args)
     }
   }
 

--- a/frontend/proxies.js
+++ b/frontend/proxies.js
@@ -89,7 +89,7 @@ function listMethods(context, listId, path) {
     methods[method] = (...args) => {
       const list = context.getObject(listId)
         .map((item, index) => context.getObjectField(path, listId, index))
-      return list[method].call(list, ...args)
+      return list[method].call(list, ...args) // eslint-disable-line
     }
   }
 

--- a/frontend/text.js
+++ b/frontend/text.js
@@ -169,7 +169,7 @@ for (let method of ['concat', 'every', 'filter', 'find', 'findIndex', 'forEach',
                     'slice', 'some', 'toLocaleString']) {
   Text.prototype[method] = function (...args) {
     const array = [...this]
-    return array[method](array, ...args)
+    return array[method](...args)
   }
 }
 

--- a/frontend/text.js
+++ b/frontend/text.js
@@ -169,7 +169,7 @@ for (let method of ['concat', 'every', 'filter', 'find', 'findIndex', 'forEach',
                     'slice', 'some', 'toLocaleString']) {
   Text.prototype[method] = function (...args) {
     const array = [...this]
-    return array[method].call(array, ...args) // eslint-disable-line
+    return array[method](array, ...args)
   }
 }
 

--- a/frontend/text.js
+++ b/frontend/text.js
@@ -5,12 +5,12 @@ class Text {
   constructor (text) {
     if (typeof text === 'string') {
       const elems = [...text].map(value => ({value}))
-      return instantiateText(undefined, elems)
+      return instantiateText(undefined, elems) // eslint-disable-line
     } else if (Array.isArray(text)) {
       const elems = text.map(value => ({value}))
-      return instantiateText(undefined, elems)
+      return instantiateText(undefined, elems) // eslint-disable-line
     } else if (text === undefined) {
-      return instantiateText(undefined, [])
+      return instantiateText(undefined, []) // eslint-disable-line
     } else {
       throw new TypeError(`Unsupported initial value for Text: ${text}`)
     }
@@ -169,7 +169,7 @@ for (let method of ['concat', 'every', 'filter', 'find', 'findIndex', 'forEach',
                     'slice', 'some', 'toLocaleString']) {
   Text.prototype[method] = function (...args) {
     const array = [...this]
-    return array[method].call(array, ...args)
+    return array[method].call(array, ...args) // eslint-disable-line
   }
 }
 

--- a/karma.sauce.js
+++ b/karma.sauce.js
@@ -1,6 +1,6 @@
 module.exports = function(config) {
   if (!process.env.SAUCE_USERNAME || !process.env.SAUCE_ACCESS_KEY) {
-    console.log('Make sure the SAUCE_USERNAME and SAUCE_ACCESS_KEY environment variables are set.')
+    console.log('Make sure the SAUCE_USERNAME and SAUCE_ACCESS_KEY environment variables are set.') // eslint-disable-line
     process.exit(1)
   }
 
@@ -54,7 +54,7 @@ module.exports = function(config) {
       startConnect: false, // Sauce Connect is started via setting in .travis.yml
       tunnelIdentifier: process.env.TRAVIS_JOB_NUMBER
     },
-    customLaunchers: customLaunchers,
+    customLaunchers,
     browsers: Object.keys(customLaunchers),
     reporters: ['progress', 'saucelabs'],
     singleRun: true

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "test": "mocha",
     "testwasm": "mocha --file test/wasm.js",
     "build": "webpack && copyfiles --flat @types/automerge/index.d.ts dist",
-    "prepublishOnly": "npm run-script build"
+    "prepublishOnly": "npm run-script build",
+    "lint": "eslint ."
   },
   "author": "",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "babel-preset-env": "^1.7.0",
     "browserify": "^16.5.0",
     "copyfiles": "^2.2.0",
+    "eslint": "^7.24.0",
     "jsverify": "^0.8.4",
     "karma": "^4.4.1",
     "karma-browserify": "^7.0.0",

--- a/src/automerge.js
+++ b/src/automerge.js
@@ -31,12 +31,12 @@ function from(initialState, options) {
 }
 
 function change(doc, options, callback) {
-  const [newDoc, change] = Frontend.change(doc, options, callback)
+  const [newDoc] = Frontend.change(doc, options, callback)
   return newDoc
 }
 
 function emptyChange(doc, options) {
-  const [newDoc, change] = Frontend.emptyChange(doc, options)
+  const [newDoc] = Frontend.emptyChange(doc, options)
   return newDoc
 }
 
@@ -63,7 +63,7 @@ function merge(localDoc, remoteDoc) {
     throw new RangeError('Cannot merge an actor with itself')
   }
   // Just copy all changes from the remote doc; any duplicates will be ignored
-  const [updatedDoc, patch] = applyChanges(localDoc, getAllChanges(remoteDoc))
+  const [updatedDoc] = applyChanges(localDoc, getAllChanges(remoteDoc))
   return updatedDoc
 }
 

--- a/src/automerge.js
+++ b/src/automerge.js
@@ -5,7 +5,11 @@ const { encodeChange, decodeChange } = require('../backend/columnar')
 const { isObject } = require('./common')
 let backend = require('../backend') // mutable: can be overridden with setDefaultBackend()
 
-///// Automerge.* API
+/**
+ * Automerge.* API
+ * The functions in this file constitute the publicly facing Automerge API which combines
+ * the features of the Frontend (a document interface) and the backend (CRDT operations)
+ */
 
 function init(options) {
   if (typeof options === 'string') {
@@ -102,8 +106,7 @@ function equals(val1, val2) {
 function getHistory(doc) {
   const actor = Frontend.getActorId(doc)
   const history = getAllChanges(doc)
-  return history.map((change, index) => {
-    return {
+  return history.map((change, index) => ({
       get change () {
         return decodeChange(change)
       },
@@ -111,8 +114,8 @@ function getHistory(doc) {
         const state = backend.loadChanges(backend.init(), history.slice(0, index + 1))
         return Frontend.applyPatch(init(actor), backend.getPatch(state), state)
       }
-    }
-  })
+    })
+  )
 }
 
 function generateSyncMessage(doc, syncState) {

--- a/src/common.js
+++ b/src/common.js
@@ -24,7 +24,7 @@ function parseOpId(opId) {
   if (!match) {
     throw new RangeError(`Not a valid opId: ${opId}`)
   }
-  return {counter: parseInt(match[1]), actorId: match[2]}
+  return {counter: parseInt(match[1], 10), actorId: match[2]}
 }
 
 /**

--- a/test/backend_test.js
+++ b/test/backend_test.js
@@ -214,7 +214,7 @@ describe('Automerge.Backend', () => {
       const [s3, patch3] = Backend.applyChanges(s2, [encodeChange(change3)])
       assert.deepStrictEqual(patch3, {
         clock: {[actor1]: 1, [actor2]: 2}, maxOp: 2, pendingChanges: 0,
-        deps: [hash(change1), hash(change3)].sort(), 
+        deps: [hash(change1), hash(change3)].sort(),
         diffs: {objectId: '_root', type: 'map', props: {conflict: {
           [`1@${actor1}`]: {objectId: `1@${actor1}`, type: 'list'},
           [`1@${actor2}`]: {objectId: `1@${actor2}`, type: 'map', props: {sparrows: {[`2@${actor2}`]: {value: 12}}}}
@@ -290,7 +290,7 @@ describe('Automerge.Backend', () => {
       assert.deepStrictEqual(patch1, {
         actor: '111111', seq: 1, clock: {'111111': 1}, deps: [], maxOp: 1, pendingChanges: 0,
         diffs: {objectId: '_root', type: 'map', props: {
-          bird: {['1@111111']: {value: 'magpie'}}
+          bird: {'1@111111': {value: 'magpie'}}
         }}
       })
       assert.deepStrictEqual(changes01, [{
@@ -441,10 +441,9 @@ describe('Automerge.Backend', () => {
       assert.deepStrictEqual(patch2, {
         actor: '111111', seq: 2, clock: {'111111': 2}, deps: [], maxOp: 3, pendingChanges: 0,
         diffs: {objectId: '_root', type: 'map', props: {
-          birds: {['1@111111']: {objectId: '1@111111', type: 'list',
+          birds: {'1@111111': {objectId: '1@111111', type: 'list',
             edits: [{action: 'insert', index: 0, elemId: '2@111111'}, {action: 'remove', index: 0}],
-            props: {}
-          }}
+            props: {}}}
         }}
       })
       assert.deepStrictEqual(changes, [{
@@ -473,7 +472,7 @@ describe('Automerge.Backend', () => {
       assert.deepStrictEqual(patch2, {
         clock: {'111111': 1}, deps: [hash(change1)], maxOp: 1, pendingChanges: 0,
         diffs: {objectId: '_root', type: 'map', props: {
-          longString: {['1@111111']: {value: longString}}
+          longString: {'1@111111': {value: longString}}
         }}
       })
     })
@@ -508,7 +507,7 @@ describe('Automerge.Backend', () => {
       assert.deepStrictEqual(patch, {
         clock: {'111111': 1}, deps: [hash(change1)], maxOp: 1, pendingChanges: 0,
         diffs: {objectId: '_root', type: 'map', props: {
-          longString: {['1@111111']: {value: longString}}
+          longString: {'1@111111': {value: longString}}
         }}
       })
     })

--- a/test/backend_test.js
+++ b/test/backend_test.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-unused-vars */
 const assert = require('assert')
 const Automerge = process.env.TEST_DIST === '1' ? require('../dist/automerge') : require('../src/automerge')
 const Backend = Automerge.Backend

--- a/test/columnar_test.js
+++ b/test/columnar_test.js
@@ -5,7 +5,7 @@ const uuid = require('../src/uuid')
 
 function checkColumns(actualCols, expectedCols) {
   for (let actual of actualCols) {
-    const [colName] = Object.entries(DOC_OPS_COLUMNS).find(([/*name*/, id]) => id === actual.columnId)
+    const [colName] = Object.entries(DOC_OPS_COLUMNS).find(([/* name */, id]) => id === actual.columnId)
     if (expectedCols[colName]) {
       checkEncoded(actual.decoder.buf, expectedCols[colName], `${colName} column`)
     }

--- a/test/columnar_test.js
+++ b/test/columnar_test.js
@@ -5,7 +5,7 @@ const uuid = require('../src/uuid')
 
 function checkColumns(actualCols, expectedCols) {
   for (let actual of actualCols) {
-    const [colName, colId] = Object.entries(DOC_OPS_COLUMNS).find(([name, id]) => id === actual.columnId)
+    const [colName] = Object.entries(DOC_OPS_COLUMNS).find(([/*name*/, id]) => id === actual.columnId)
     if (expectedCols[colName]) {
       checkEncoded(actual.decoder.buf, expectedCols[colName], `${colName} column`)
     }

--- a/test/context_test.js
+++ b/test/context_test.js
@@ -208,7 +208,6 @@ describe('Proxying context', () => {
     it('should do nothing if the key does not exist', () => {
       context.cache._root = {[OBJECT_ID]: '_root', goldfinches: 3, [CONFLICTS]: {goldfinches: {'1@actor1': 3}}}
       context.deleteMapKey([], 'sparrows')
-      const expected = {objectId: '_root', type: 'map'}
       assert(applyPatch.notCalled)
       assert.deepStrictEqual(context.ops, [])
     })

--- a/test/frontend_test.js
+++ b/test/frontend_test.js
@@ -86,7 +86,7 @@ describe('Automerge.Frontend', () => {
     it('should delete keys in maps', () => {
       const actor = uuid()
       const [doc1, change1] = Frontend.change(Frontend.init(actor), doc => { doc.magpies = 2; doc.sparrows = 15 })
-      const [doc2, change2] = Frontend.change(doc1, doc => delete doc['magpies'])
+      const [doc2, change2] = Frontend.change(doc1, doc => delete doc['magpies']) // eslint-disable-line
       assert.deepStrictEqual(doc1, {magpies: 2, sparrows: 15})
       assert.deepStrictEqual(doc2, {sparrows: 15})
       assert.deepStrictEqual(change2, {

--- a/test/frontend_test.js
+++ b/test/frontend_test.js
@@ -324,8 +324,7 @@ describe('Automerge.Frontend', () => {
         diffs: {objectId: '_root', type: 'map', props: {
           birds: {[actor]: {objectId: birds, type: 'list',
             edits: [{action: 'insert', index: 0}],
-            props: {0: {[actor]: {value: 'goldfinch'}}}
-          }}
+            props: {0: {[actor]: {value: 'goldfinch'}}}}}
         }}
       })
       assert.deepStrictEqual(doc1, {birds: ['goldfinch']})
@@ -343,8 +342,7 @@ describe('Automerge.Frontend', () => {
         diffs: {objectId: '_root', type: 'map', props: {
           birds: {[actor]: {objectId: birds, type: 'list',
             edits: [{action: 'insert', index: 1}],
-            props: {1: {[remoteActor]: {value: 'bullfinch'}}}
-          }}
+            props: {1: {[remoteActor]: {value: 'bullfinch'}}}}}
         }}
       })
       // The addition of 'bullfinch' does not take effect yet: it is queued up until the pending
@@ -356,8 +354,7 @@ describe('Automerge.Frontend', () => {
         diffs: {objectId: '_root', type: 'map', props: {
           birds: {[actor]: {objectId: birds, type: 'list',
             edits: [{action: 'insert', index: 0}, {action: 'insert', index: 2}],
-            props: {0: {[actor]: {value: 'chaffinch'}}, 2: {[actor]: {value: 'greenfinch'}}}
-          }}
+            props: {0: {[actor]: {value: 'chaffinch'}}, 2: {[actor]: {value: 'greenfinch'}}}}}
         }}
       })
       assert.deepStrictEqual(doc4, {birds: ['chaffinch', 'goldfinch', 'greenfinch', 'bullfinch']})
@@ -664,8 +661,7 @@ describe('Automerge.Frontend', () => {
             props: {0: {[actor]: {objectId: detail1, type: 'map', props: {
               species: {[actor]: {value: 'magpie'}},
               family:  {[actor]: {value: 'corvidae'}}
-            }}}}
-          }}
+          }}}}}}
         }}
       }
       const patch2 = {
@@ -677,8 +673,7 @@ describe('Automerge.Frontend', () => {
           details: {[actor]: {objectId: details, type: 'list', edits: [],
             props: {0: {[actor]: {objectId: detail1, type: 'map', props: {
               species: {[actor]: {value: 'Eurasian magpie'}}
-            }}}}
-          }}
+          }}}}}}
         }}
       }
       const doc1 = Frontend.applyPatch(Frontend.init(), patch1)

--- a/test/frontend_test.js
+++ b/test/frontend_test.js
@@ -86,7 +86,7 @@ describe('Automerge.Frontend', () => {
     it('should delete keys in maps', () => {
       const actor = uuid()
       const [doc1, change1] = Frontend.change(Frontend.init(actor), doc => { doc.magpies = 2; doc.sparrows = 15 })
-      const [doc2, change2] = Frontend.change(doc1, doc => delete doc['magpies']) // eslint-disable-line
+      const [doc2, change2] = Frontend.change(doc1, doc => delete doc.magpies)
       assert.deepStrictEqual(doc1, {magpies: 2, sparrows: 15})
       assert.deepStrictEqual(doc2, {sparrows: 15})
       assert.deepStrictEqual(change2, {

--- a/test/frontend_test.js
+++ b/test/frontend_test.js
@@ -376,9 +376,9 @@ describe('Automerge.Frontend', () => {
         ]
       })
       const state0 = Backend.init()
-      const [/*state1*/, patch1, /*binChange1*/] = Backend.applyLocalChange(state0, change1)
+      const [/* state1 */, patch1, /* binChange1 */] = Backend.applyLocalChange(state0, change1)
       const doc2a = Frontend.applyPatch(doc2, patch1)
-      const [/*doc3*/, change3] = Frontend.change(doc2a, doc => doc.number = 3)
+      const [/* doc3 */, change3] = Frontend.change(doc2a, doc => doc.number = 3)
       assert.deepStrictEqual(change3, {
         actor, seq: 3, startOp: 3, time: change3.time, message: '', deps: [], ops: [
           {obj: '_root', action: 'set', key: 'number', insert: false, value: 3, pred: [`2@${actor}`]}
@@ -388,8 +388,8 @@ describe('Automerge.Frontend', () => {
 
     it('deps are filled in if the frontend does not have the latest patch', () => {
       const actor1 = uuid(), actor2 = uuid()
-      const [/*doc1*/, change1] = Frontend.change(Frontend.init(actor1), doc => doc.number = 1)
-      const [/*state1*/, /*patch1*/, binChange1] = Backend.applyLocalChange(Backend.init(), change1)
+      const [/* doc1 */, change1] = Frontend.change(Frontend.init(actor1), doc => doc.number = 1)
+      const [/* state1 */, /* patch1 */, binChange1] = Backend.applyLocalChange(Backend.init(), change1)
 
       const [state1a, patch1a] = Backend.applyChanges(Backend.init(), [binChange1])
       const doc1a = Frontend.applyPatch(Frontend.init(actor2), patch1a)
@@ -415,13 +415,13 @@ describe('Automerge.Frontend', () => {
 
       const doc2a = Frontend.applyPatch(doc3, patch2)
       const doc3a = Frontend.applyPatch(doc2a, patch3)
-      const [/*doc4*/, change4] = Frontend.change(doc3a, doc => doc.number = 4)
+      const [/* doc4 */, change4] = Frontend.change(doc3a, doc => doc.number = 4)
       assert.deepStrictEqual(change4, {
         actor: actor2, seq: 3, startOp: 4, time: change4.time, message: '', deps: [], ops: [
           {obj: '_root', action: 'set', key: 'number', insert: false, value: 4, pred: [`3@${actor2}`]}
         ]
       })
-      const [/*state4*/, /*patch4*/, binChange4] = Backend.applyLocalChange(state3, change4)
+      const [/* state4 */, /* patch4 */, binChange4] = Backend.applyLocalChange(state3, change4)
       assert.deepStrictEqual(decodeChange(binChange4).deps, [decodeChange(binChange3).hash])
     })
   })

--- a/test/frontend_test.js
+++ b/test/frontend_test.js
@@ -98,7 +98,7 @@ describe('Automerge.Frontend', () => {
 
     it('should create lists', () => {
       const [doc, change] = Frontend.change(Frontend.init(), doc => doc.birds = ['chaffinch'])
-      const /* birds = Frontend.getObjectId(doc.birds), */ actor = Frontend.getActorId(doc)
+      const actor = Frontend.getActorId(doc)
       assert.deepStrictEqual(doc, {birds: ['chaffinch']})
       assert.deepStrictEqual(change, {
         actor, seq: 1, time: change.time, message: '', startOp: 1, deps: [], ops: [

--- a/test/fuzz_test.js
+++ b/test/fuzz_test.js
@@ -131,7 +131,7 @@ class Micromerge {
   compareOpIds(id1, id2) {
     const regex = /^([0-9]+)@(.*)$/
     const match1 = regex.exec(id1), match2 = regex.exec(id2)
-    const counter1 = parseInt(match1[1]), counter2 = parseInt(match2[1])
+    const counter1 = parseInt(match1[1], 10), counter2 = parseInt(match2[1], 10)
     return (counter1 < counter2) || (counter1 === counter2 && match1[2] < match2[2])
   }
 }

--- a/test/fuzz_test.js
+++ b/test/fuzz_test.js
@@ -119,7 +119,7 @@ class Micromerge {
       if (!meta[index].deleted) visible++
       index++
     }
-    if (index === meta.length) throw new RangeError(`List element not found: ${op.key}`)
+    if (index === meta.length) throw new RangeError(`List element not found: ${op.key}`) /* this is a bug! */ // eslint-disable-line 
     return {index, visible}
   }
 

--- a/test/fuzz_test.js
+++ b/test/fuzz_test.js
@@ -137,7 +137,7 @@ class Micromerge {
 }
 
 
-/********** TESTS *************/
+/* TESTS */
 
 const assert = require('assert')
 

--- a/test/fuzz_test.js
+++ b/test/fuzz_test.js
@@ -119,7 +119,7 @@ class Micromerge {
       if (!meta[index].deleted) visible++
       index++
     }
-    if (index === meta.length) throw new RangeError(`List element not found: ${op.key}`) /* this is a bug! */ // eslint-disable-line 
+    if (index === meta.length) throw new RangeError(`List element not found: ${elemId}`)
     return {index, visible}
   }
 

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -1,6 +1,5 @@
 const assert = require('assert')
 const { Encoder } = require('../backend/encoding')
-const { decodeChanges } = require('../backend/columnar')
 
 // Assertion that succeeds if the first argument deepStrictEquals at least one of the
 // subsequent arguments (but we don't care which one)

--- a/test/observable_test.js
+++ b/test/observable_test.js
@@ -49,7 +49,7 @@ describe('Automerge.Observable', () => {
   it('should call the callback when applying remote changes', () => {
     let observable = new Automerge.Observable(), callbackChanges
     let local = Automerge.from({text: new Automerge.Text()}, {observable})
-    let remote = Automerge.init(), patch
+    let remote = Automerge.init()
     const localId = Automerge.getActorId(local), remoteId = Automerge.getActorId(remote)
     observable.observe(local.text, (diff, before, after, local, changes) => {
       callbackChanges = changes
@@ -62,10 +62,10 @@ describe('Automerge.Observable', () => {
       assert.deepStrictEqual(after.toString(), 'a')
       assert.deepStrictEqual(local, false)
     })
-    ;[remote, patch] = Automerge.applyChanges(remote, Automerge.getAllChanges(local))
+    ;[remote] = Automerge.applyChanges(remote, Automerge.getAllChanges(local))
     remote = Automerge.change(remote, doc => doc.text.insertAt(0, 'a'))
     const allChanges = Automerge.getAllChanges(remote)
-    ;[local, patch] = Automerge.applyChanges(local, allChanges)
+    ;[local] = Automerge.applyChanges(local, allChanges)
     assert.strictEqual(callbackChanges, allChanges)
   })
 
@@ -128,7 +128,7 @@ describe('Automerge.Observable', () => {
 
   it('should observe nested objects inside text', () => {
     let observable = new Automerge.Observable(), callbackCalled = false
-    let doc = Automerge.init({observable}), actor = Automerge.getActorId(doc), rowId
+    let doc = Automerge.init({observable}), actor = Automerge.getActorId(doc)
     doc = Automerge.change(doc, doc => {
       doc.text = new Automerge.Text()
       doc.text.insertAt(0, 'a', 'b', {start: 'bold'}, 'c', {end: 'bold'})
@@ -147,7 +147,7 @@ describe('Automerge.Observable', () => {
   })
 
   it('should not allow observers on non-document objects', () => {
-    let observable = new Automerge.Observable(), callbackCalled = false
+    let observable = new Automerge.Observable()
     let doc = Automerge.init({observable})
     assert.throws(() => {
       Automerge.change(doc, doc => {
@@ -161,8 +161,8 @@ describe('Automerge.Observable', () => {
   it('should allow multiple observers', () => {
     let observable = new Automerge.Observable(), called1 = false, called2 = false
     let doc = Automerge.init({observable})
-    observable.observe(doc, patch => { called1 = true })
-    observable.observe(doc, patch => { called2 = true })
+    observable.observe(doc, () => { called1 = true })
+    observable.observe(doc, () => { called2 = true })
     Automerge.change(doc, doc => doc.foo = 'bar')
     assert.strictEqual(called1, true)
     assert.strictEqual(called2, true)

--- a/test/proxies_test.js
+++ b/test/proxies_test.js
@@ -1,4 +1,3 @@
-/* eslint-disable-file dot-notation */
 const assert = require('assert')
 const Automerge = process.env.TEST_DIST === '1' ? require('../dist/automerge') : require('../src/automerge')
 const { assertEqualsOneOf } = require('./helpers')
@@ -24,13 +23,11 @@ describe('Automerge proxy API', () => {
       Automerge.change(Automerge.init(), doc => {
         doc.key1 = 'value1'
         assert.strictEqual(doc.key1, 'value1')
-        assert.strictEqual(doc.key1, 'value1')
       })
     })
 
     it('should return undefined for unknown properties', () => {
       Automerge.change(Automerge.init(), doc => {
-        assert.strictEqual(doc.someProperty, undefined)
         assert.strictEqual(doc.someProperty, undefined)
       })
     })
@@ -129,7 +126,6 @@ describe('Automerge proxy API', () => {
         assert.strictEqual(doc.list[3],   undefined)
         assert.strictEqual(doc.list['3'], undefined)
         assert.strictEqual(doc.list[-1],  undefined)
-        assert.strictEqual(doc.list.someProperty,    undefined)
         assert.strictEqual(doc.list.someProperty, undefined)
       })
     })
@@ -200,7 +196,8 @@ describe('Automerge proxy API', () => {
           assert.strictEqual(doc.list.every(val => val > 0), true)
           assert.strictEqual(doc.list.every(val => val > 2), false)
           assert.strictEqual(doc.list.every((val, index) => index < 3), true)
-          doc.list.every(function () { assert.strictEqual(this.hello, 'world') }, {hello: 'world'}) // eslint-disable-line
+          // check that in the callback, 'this' is set to the second argument of 'every'
+          doc.list.every(function () { assert.strictEqual(this.hello, 'world'); return true }, {hello: 'world'})
         })
       })
 
@@ -209,7 +206,7 @@ describe('Automerge proxy API', () => {
           assert.deepStrictEqual(doc.empty.filter(() => false), [])
           assert.deepStrictEqual(doc.list.filter(num => num % 2 === 1), [1, 3])
           assert.deepStrictEqual(doc.list.filter(() => true), [1, 2, 3])
-          doc.list.filter(function () { assert.strictEqual(this.hello, 'world') }, {hello: 'world'}) // eslint-disable-line
+          doc.list.filter(function () { assert.strictEqual(this.hello, 'world'); return true }, {hello: 'world'})
         })
       })
 
@@ -218,7 +215,7 @@ describe('Automerge proxy API', () => {
           assert.strictEqual(doc.empty.find(() => true), undefined)
           assert.strictEqual(doc.list.find(num => num >= 2), 2)
           assert.strictEqual(doc.list.find(num => num >= 4), undefined)
-          doc.list.find(function () { assert.strictEqual(this.hello, 'world') }, {hello: 'world'}) // eslint-disable-line
+          doc.list.find(function () { assert.strictEqual(this.hello, 'world'); return true }, {hello: 'world'})
         })
       })
 
@@ -227,7 +224,7 @@ describe('Automerge proxy API', () => {
           assert.strictEqual(doc.empty.findIndex(() => true), -1)
           assert.strictEqual(doc.list.findIndex(num => num >= 2), 1)
           assert.strictEqual(doc.list.findIndex(num => num >= 4), -1)
-          doc.list.findIndex(function () { assert.strictEqual(this.hello, 'world') }, {hello: 'world'}) // eslint-disable-line
+          doc.list.findIndex(function () { assert.strictEqual(this.hello, 'world'); return true }, {hello: 'world'})
         })
       })
 
@@ -237,7 +234,7 @@ describe('Automerge proxy API', () => {
           let binary = []
           doc.list.forEach(num => binary.push(num.toString(2)))
           assert.deepStrictEqual(binary, ['1', '10', '11'])
-          doc.list.forEach(function () { assert.strictEqual(this.hello, 'world') }, {hello: 'world'}) // eslint-disable-line
+          doc.list.forEach(function () { assert.strictEqual(this.hello, 'world'); return true }, {hello: 'world'})
         })
       })
 
@@ -294,7 +291,7 @@ describe('Automerge proxy API', () => {
           assert.deepStrictEqual(doc.empty.map(num => num * 2), [])
           assert.deepStrictEqual(doc.list.map(num => num * 2), [2, 4, 6])
           assert.deepStrictEqual(doc.list.map((num, index) => index + '->' + num), ['0->1', '1->2', '2->3'])
-          doc.list.map(function () { assert.strictEqual(this.hello, 'world') }, {hello: 'world'}) // eslint-disable-line
+          doc.list.map(function () { assert.strictEqual(this.hello, 'world'); return true }, {hello: 'world'})
         })
       })
 
@@ -335,7 +332,7 @@ describe('Automerge proxy API', () => {
           assert.strictEqual(doc.list.some(val => val > 2), true)
           assert.strictEqual(doc.list.some(val => val > 4), false)
           assert.strictEqual(doc.list.some((val, index) => index > 2), false)
-          doc.list.some(function () { assert.strictEqual(this.hello, 'world') }, {hello: 'world'}) // eslint-disable-line
+          doc.list.some(function () { assert.strictEqual(this.hello, 'world'); return true }, {hello: 'world'})
         })
       })
 

--- a/test/proxies_test.js
+++ b/test/proxies_test.js
@@ -208,7 +208,7 @@ describe('Automerge proxy API', () => {
         Automerge.change(root, doc => {
           assert.deepStrictEqual(doc.empty.filter(() => false), [])
           assert.deepStrictEqual(doc.list.filter(num => num % 2 === 1), [1, 3])
-          assert.deepStrictEqual(doc.list.filter(num => true), [1, 2, 3])
+          assert.deepStrictEqual(doc.list.filter(() => true), [1, 2, 3])
           doc.list.filter(function () { assert.strictEqual(this.hello, 'world') }, {hello: 'world'}) // eslint-disable-line
         })
       })

--- a/test/proxies_test.js
+++ b/test/proxies_test.js
@@ -1,3 +1,4 @@
+/* eslint-disable-file dot-notation */
 const assert = require('assert')
 const Automerge = process.env.TEST_DIST === '1' ? require('../dist/automerge') : require('../src/automerge')
 const { assertEqualsOneOf } = require('./helpers')
@@ -23,14 +24,14 @@ describe('Automerge proxy API', () => {
       Automerge.change(Automerge.init(), doc => {
         doc.key1 = 'value1'
         assert.strictEqual(doc.key1, 'value1')
-        assert.strictEqual(doc['key1'], 'value1')
+        assert.strictEqual(doc.key1, 'value1')
       })
     })
 
     it('should return undefined for unknown properties', () => {
       Automerge.change(Automerge.init(), doc => {
         assert.strictEqual(doc.someProperty, undefined)
-        assert.strictEqual(doc['someProperty'], undefined)
+        assert.strictEqual(doc.someProperty, undefined)
       })
     })
 
@@ -129,7 +130,7 @@ describe('Automerge proxy API', () => {
         assert.strictEqual(doc.list['3'], undefined)
         assert.strictEqual(doc.list[-1],  undefined)
         assert.strictEqual(doc.list.someProperty,    undefined)
-        assert.strictEqual(doc.list['someProperty'], undefined)
+        assert.strictEqual(doc.list.someProperty, undefined)
       })
     })
 
@@ -199,7 +200,7 @@ describe('Automerge proxy API', () => {
           assert.strictEqual(doc.list.every(val => val > 0), true)
           assert.strictEqual(doc.list.every(val => val > 2), false)
           assert.strictEqual(doc.list.every((val, index) => index < 3), true)
-          doc.list.every(function () { assert.strictEqual(this.hello, 'world') }, {hello: 'world'})
+          doc.list.every(function () { assert.strictEqual(this.hello, 'world') }, {hello: 'world'}) // eslint-disable-line
         })
       })
 
@@ -208,7 +209,7 @@ describe('Automerge proxy API', () => {
           assert.deepStrictEqual(doc.empty.filter(() => false), [])
           assert.deepStrictEqual(doc.list.filter(num => num % 2 === 1), [1, 3])
           assert.deepStrictEqual(doc.list.filter(num => true), [1, 2, 3])
-          doc.list.filter(function () { assert.strictEqual(this.hello, 'world') }, {hello: 'world'})
+          doc.list.filter(function () { assert.strictEqual(this.hello, 'world') }, {hello: 'world'}) // eslint-disable-line
         })
       })
 
@@ -217,7 +218,7 @@ describe('Automerge proxy API', () => {
           assert.strictEqual(doc.empty.find(() => true), undefined)
           assert.strictEqual(doc.list.find(num => num >= 2), 2)
           assert.strictEqual(doc.list.find(num => num >= 4), undefined)
-          doc.list.find(function () { assert.strictEqual(this.hello, 'world') }, {hello: 'world'})
+          doc.list.find(function () { assert.strictEqual(this.hello, 'world') }, {hello: 'world'}) // eslint-disable-line
         })
       })
 
@@ -226,7 +227,7 @@ describe('Automerge proxy API', () => {
           assert.strictEqual(doc.empty.findIndex(() => true), -1)
           assert.strictEqual(doc.list.findIndex(num => num >= 2), 1)
           assert.strictEqual(doc.list.findIndex(num => num >= 4), -1)
-          doc.list.findIndex(function () { assert.strictEqual(this.hello, 'world') }, {hello: 'world'})
+          doc.list.findIndex(function () { assert.strictEqual(this.hello, 'world') }, {hello: 'world'}) // eslint-disable-line
         })
       })
 
@@ -236,7 +237,7 @@ describe('Automerge proxy API', () => {
           let binary = []
           doc.list.forEach(num => binary.push(num.toString(2)))
           assert.deepStrictEqual(binary, ['1', '10', '11'])
-          doc.list.forEach(function () { assert.strictEqual(this.hello, 'world') }, {hello: 'world'})
+          doc.list.forEach(function () { assert.strictEqual(this.hello, 'world') }, {hello: 'world'}) // eslint-disable-line
         })
       })
 
@@ -293,7 +294,7 @@ describe('Automerge proxy API', () => {
           assert.deepStrictEqual(doc.empty.map(num => num * 2), [])
           assert.deepStrictEqual(doc.list.map(num => num * 2), [2, 4, 6])
           assert.deepStrictEqual(doc.list.map((num, index) => index + '->' + num), ['0->1', '1->2', '2->3'])
-          doc.list.map(function () { assert.strictEqual(this.hello, 'world') }, {hello: 'world'})
+          doc.list.map(function () { assert.strictEqual(this.hello, 'world') }, {hello: 'world'}) // eslint-disable-line
         })
       })
 
@@ -303,7 +304,7 @@ describe('Automerge proxy API', () => {
           assert.strictEqual(doc.list.reduce((sum, val) => sum + val, 0), 6)
           assert.strictEqual(doc.list.reduce((sum, val) => sum + val, ''), '123')
           assert.strictEqual(doc.list.reduce((sum, val) => sum + val), 6)
-          assert.strictEqual(doc.list.reduce((sum, val, index) => (index % 2 === 0) ? (sum + val) : sum, 0), 4)
+          assert.strictEqual(doc.list.reduce((sum, val, index) => ((index % 2 === 0) ? (sum + val) : sum), 0), 4)
         })
       })
 
@@ -313,7 +314,7 @@ describe('Automerge proxy API', () => {
           assert.strictEqual(doc.list.reduceRight((sum, val) => sum + val, 0), 6)
           assert.strictEqual(doc.list.reduceRight((sum, val) => sum + val, ''), '321')
           assert.strictEqual(doc.list.reduceRight((sum, val) => sum + val), 6)
-          assert.strictEqual(doc.list.reduceRight((sum, val, index) => (index % 2 === 0) ? (sum + val) : sum, 0), 4)
+          assert.strictEqual(doc.list.reduceRight((sum, val, index) => ((index % 2 === 0) ? (sum + val) : sum), 0), 4)
         })
       })
 
@@ -334,7 +335,7 @@ describe('Automerge proxy API', () => {
           assert.strictEqual(doc.list.some(val => val > 2), true)
           assert.strictEqual(doc.list.some(val => val > 4), false)
           assert.strictEqual(doc.list.some((val, index) => index > 2), false)
-          doc.list.some(function () { assert.strictEqual(this.hello, 'world') }, {hello: 'world'})
+          doc.list.some(function () { assert.strictEqual(this.hello, 'world') }, {hello: 'world'}) // eslint-disable-line
         })
       })
 

--- a/test/skip_list_test.js
+++ b/test/skip_list_test.js
@@ -192,11 +192,11 @@ describe('SkipList', () => {
 
     it('should behave like a JS array', () => {
       jsc.assert(jsc.forall(jsc.bless({generator: makeSkipListOps}), function (ops) {
-        let levels = ops.filter(op => op.hasOwnProperty('insertAfter')).map(op => op.level) // eslint-disable-line
+        let levels = ops.filter(op => op.prototype.hasOwnProperty.call('insertAfter')).map(op => op.level)
         let skipList = new SkipList(iter(levels))
         let shadow = []
         for (let op of ops) {
-          if (op.hasOwnProperty('insertAfter')) { // eslint-disable-line
+          if (op.prototype.hasOwnProperty.call('insertAfter')) {
             skipList = skipList.insertAfter(op.insertAfter, op.id, op.id)
             shadow.splice(shadow.indexOf(op.insertAfter) + 1, 0, op.id)
           } else {
@@ -204,18 +204,6 @@ describe('SkipList', () => {
             shadow.splice(shadow.indexOf(op.remove), 1)
           }
         }
-
-        // eslint-disable-next-line
-        /*if (skipList.length !== shadow.length) console.log('list lengths must be equal')
-
-        shadow.forEach((id, index) => {
-          if (skipList.indexOf(id) !== index) {
-            console.log('indexOf(' + id + ') = ' + skipList.indexOf(id) + ', should be ' + index)
-          }
-          if (skipList.keyOf(index) !== id) {
-            console.log('keyOf(' + index + ') = ' + skipList.keyOf(index) + ', should be ' + id)
-          }
-        })*/
 
         return (skipList.length === shadow.length) && shadow.every((id, index) =>
           skipList.indexOf(id) === index && skipList.keyOf(index) === id

--- a/test/skip_list_test.js
+++ b/test/skip_list_test.js
@@ -24,8 +24,8 @@ describe('SkipList', () => {
     })
 
     it('should return length-1 for the last list element', () => {
-      let s = new SkipList().insertAfter(null, 'a', 'a').insertAfter('a', 'b', 'b').
-        insertAfter('b', 'c', 'c').insertAfter('c', 'd', 'd')
+      let s = new SkipList().insertAfter(null, 'a', 'a').insertAfter('a', 'b', 'b')
+        .insertAfter('b', 'c', 'c').insertAfter('c', 'd', 'd')
       assert.strictEqual(s.indexOf('d'), 3)
     })
 
@@ -192,11 +192,11 @@ describe('SkipList', () => {
 
     it('should behave like a JS array', () => {
       jsc.assert(jsc.forall(jsc.bless({generator: makeSkipListOps}), function (ops) {
-        let levels = ops.filter(op => op.hasOwnProperty('insertAfter')).map(op => op.level)
+        let levels = ops.filter(op => op.hasOwnProperty('insertAfter')).map(op => op.level) // eslint-disable-line
         let skipList = new SkipList(iter(levels))
         let shadow = []
         for (let op of ops) {
-          if (op.hasOwnProperty('insertAfter')) {
+          if (op.hasOwnProperty('insertAfter')) { // eslint-disable-line
             skipList = skipList.insertAfter(op.insertAfter, op.id, op.id)
             shadow.splice(shadow.indexOf(op.insertAfter) + 1, 0, op.id)
           } else {
@@ -205,6 +205,7 @@ describe('SkipList', () => {
           }
         }
 
+        // eslint-disable-next-line
         /*if (skipList.length !== shadow.length) console.log('list lengths must be equal')
 
         shadow.forEach((id, index) => {

--- a/test/skip_list_test.js
+++ b/test/skip_list_test.js
@@ -192,11 +192,11 @@ describe('SkipList', () => {
 
     it('should behave like a JS array', () => {
       jsc.assert(jsc.forall(jsc.bless({generator: makeSkipListOps}), function (ops) {
-        let levels = ops.filter(op => op.prototype.hasOwnProperty.call('insertAfter')).map(op => op.level)
+        let levels = ops.filter(op => Object.prototype.hasOwnProperty.call(op, 'insertAfter')).map(op => op.level)
         let skipList = new SkipList(iter(levels))
         let shadow = []
         for (let op of ops) {
-          if (op.prototype.hasOwnProperty.call('insertAfter')) {
+          if (Object.prototype.hasOwnProperty.call(op, 'insertAfter')) {
             skipList = skipList.insertAfter(op.insertAfter, op.id, op.id)
             shadow.splice(shadow.indexOf(op.insertAfter) + 1, 0, op.id)
           } else {

--- a/test/sync_test.js
+++ b/test/sync_test.js
@@ -16,14 +16,14 @@ function sync(a, b, aSyncState = initSyncState(), bSyncState = initSyncState()) 
   const MAX_ITER = 10
   let aToBmsg = null, bToAmsg = null, i = 0
   do {
-    ;[aSyncState, aToBmsg] = Automerge.generateSyncMessage(a, aSyncState)
+    [aSyncState, aToBmsg] = Automerge.generateSyncMessage(a, aSyncState)
     ;[bSyncState, bToAmsg] = Automerge.generateSyncMessage(b, bSyncState)
 
     if (aToBmsg) {
-      ;[b, bSyncState] = Automerge.receiveSyncMessage(b, bSyncState, aToBmsg)
+      [b, bSyncState] = Automerge.receiveSyncMessage(b, bSyncState, aToBmsg)
     }
     if (bToAmsg) {
-      ;[a, aSyncState] = Automerge.receiveSyncMessage(a, aSyncState, bToAmsg)
+      [a, aSyncState] = Automerge.receiveSyncMessage(a, aSyncState, bToAmsg)
     }
 
     if (i++ > MAX_ITER) {
@@ -449,8 +449,8 @@ describe('Data sync protocol', () => {
         const n1us1 = Automerge.change(Automerge.clone(n1, {actorId: '01234567'}), {time: 0}, doc => doc.x = `${i} @ n1`)
         const n2us1 = Automerge.change(Automerge.clone(n2, {actorId: '89abcdef'}), {time: 0}, doc => doc.x = `${i} @ n2`)
         const n1hash1 = getHeads(n1us1)[0], n2hash1 = getHeads(n2us1)[0]
-        const n1us2 = Automerge.change(n1us1, {time: 0}, doc => doc.x = `${i+1} @ n1`)
-        const n2us2 = Automerge.change(n2us1, {time: 0}, doc => doc.x = `${i+1} @ n2`)
+        const n1us2 = Automerge.change(n1us1, {time: 0}, doc => doc.x = `${i + 1} @ n1`)
+        const n2us2 = Automerge.change(n2us1, {time: 0}, doc => doc.x = `${i + 1} @ n2`)
         const n1hash2 = getHeads(n1us2)[0], n2hash2 = getHeads(n2us2)[0]
         const n1up3 = Automerge.change(n1us2, {time: 0}, doc => doc.x = 'final @ n1')
         const n2up3 = Automerge.change(n2us2, {time: 0}, doc => doc.x = 'final @ n2')
@@ -527,7 +527,7 @@ describe('Data sync protocol', () => {
       }
 
       // n1 creates a sync message for n2 with an ill-fated bloom
-      ;[s1, message] = Automerge.generateSyncMessage(n1, s1)
+      [s1, message] = Automerge.generateSyncMessage(n1, s1)
       assert.strictEqual(decodeSyncMessage(message).changes.length, 0)
 
       // n2 receives it and DOESN'T send a change back

--- a/test/sync_test.js
+++ b/test/sync_test.js
@@ -234,11 +234,11 @@ describe('Data sync protocol', () => {
 
       it('should assume sent changes were recieved until we hear otherwise', () => {
         let n1 = Automerge.init('01234567'), n2 = Automerge.init('89abcdef')
-        let s1 = initSyncState() /*, s2 = initSyncState() */ // s2 not used, but preserved for consistency
+        let s1 = initSyncState() /* , s2 = initSyncState() */ // s2 not used, but preserved for consistency
         let message = null
 
         n1 = Automerge.change(n1, {time: 0}, doc => doc.items = [])
-        ;[n1, n2, s1, /*s2*/] = sync(n1, n2)
+        ;[n1, n2, s1, /* s2 */] = sync(n1, n2)
 
         n1 = Automerge.change(n1, {time: 0}, doc => doc.items.push('x'))
         ;[s1, message] = Automerge.generateSyncMessage(n1, s1)

--- a/test/sync_test.js
+++ b/test/sync_test.js
@@ -234,8 +234,7 @@ describe('Data sync protocol', () => {
 
       it('should assume sent changes were recieved until we hear otherwise', () => {
         let n1 = Automerge.init('01234567'), n2 = Automerge.init('89abcdef')
-        let s1 = initSyncState() /* , s2 = initSyncState() */ // s2 not used, but preserved for consistency
-        let message = null
+        let s1 = initSyncState(), message = null
 
         n1 = Automerge.change(n1, {time: 0}, doc => doc.items = [])
         ;[n1, n2, s1, /* s2 */] = sync(n1, n2)

--- a/test/table_test.js
+++ b/test/table_test.js
@@ -20,10 +20,9 @@ describe('Automerge.Table', () => {
   describe('Frontend', () => {
     it('should generate ops to create a table', () => {
       const actor = uuid()
-      const [doc, change] = Frontend.change(Frontend.init(actor), doc => {
+      const [, change] = Frontend.change(Frontend.init(actor), doc => {
         doc.books = new Automerge.Table()
       })
-      const books = Frontend.getObjectId(doc.books)
       assert.deepStrictEqual(change, {
         actor, seq: 1, time: change.time, message: '', startOp: 1, deps: [], ops: [
           {obj: '_root', action: 'makeTable', key: 'books', insert: false, pred: []}
@@ -33,7 +32,7 @@ describe('Automerge.Table', () => {
 
     it('should generate ops to insert a row', () => {
       const actor = uuid()
-      const [doc1, change1] = Frontend.change(Frontend.init(actor), doc => {
+      const [doc1] = Frontend.change(Frontend.init(actor), doc => {
         doc.books = new Automerge.Table()
       })
       let rowId
@@ -165,7 +164,7 @@ describe('Automerge.Table', () => {
     const rsdpWithId = Object.assign({id: rsdp}, RSDP)
     assert.deepStrictEqual(s.books.sort('title'), [ddiaWithId, rsdpWithId])
     assert.deepStrictEqual(s.books.sort(['authors', 'title']), [rsdpWithId, ddiaWithId])
-    assert.deepStrictEqual(s.books.sort((row1, row2) => ((row1.isbn === '1449373321') ? -1 : +1)), [ddiaWithId, rsdpWithId])
+    assert.deepStrictEqual(s.books.sort((row1,) => ((row1.isbn === '1449373321') ? -1 : +1)), [ddiaWithId, rsdpWithId])
   })
 
   it('should allow serialization to JSON', () => {

--- a/test/table_test.js
+++ b/test/table_test.js
@@ -165,9 +165,7 @@ describe('Automerge.Table', () => {
     const rsdpWithId = Object.assign({id: rsdp}, RSDP)
     assert.deepStrictEqual(s.books.sort('title'), [ddiaWithId, rsdpWithId])
     assert.deepStrictEqual(s.books.sort(['authors', 'title']), [rsdpWithId, ddiaWithId])
-    assert.deepStrictEqual(s.books.sort((row1, row2) => {
-      return (row1.isbn === '1449373321') ? -1 : +1
-    }), [ddiaWithId, rsdpWithId])
+    assert.deepStrictEqual(s.books.sort((row1, row2) => ((row1.isbn === '1449373321') ? -1 : +1)), [ddiaWithId, rsdpWithId])
   })
 
   it('should allow serialization to JSON', () => {

--- a/test/table_test.js
+++ b/test/table_test.js
@@ -164,7 +164,7 @@ describe('Automerge.Table', () => {
     const rsdpWithId = Object.assign({id: rsdp}, RSDP)
     assert.deepStrictEqual(s.books.sort('title'), [ddiaWithId, rsdpWithId])
     assert.deepStrictEqual(s.books.sort(['authors', 'title']), [rsdpWithId, ddiaWithId])
-    assert.deepStrictEqual(s.books.sort((row1,) => ((row1.isbn === '1449373321') ? -1 : +1)), [ddiaWithId, rsdpWithId])
+    assert.deepStrictEqual(s.books.sort(row1 => ((row1.isbn === '1449373321') ? -1 : +1)), [ddiaWithId, rsdpWithId])
   })
 
   it('should allow serialization to JSON', () => {

--- a/test/test.js
+++ b/test/test.js
@@ -1,4 +1,3 @@
-/* eslint-disable dot-notation */
 const assert = require('assert')
 const Automerge = process.env.TEST_DIST === '1' ? require('../dist/automerge') : require('../src/automerge')
 const { assertEqualsOneOf } = require('./helpers')
@@ -117,7 +116,7 @@ describe('Automerge', () => {
 
         let deleted = false
         try {
-          deleted = delete s2['foo']
+          deleted = delete s2.foo
         } catch (e) { /* deliberately ignored */ }
         assert.strictEqual(s2.foo, 'bar')
         assert.strictEqual(deleted, false)
@@ -354,7 +353,7 @@ describe('Automerge', () => {
 
       it('should handle root property deletion', () => {
         s1 = Automerge.change(s1, 'set foo', doc => { doc.foo = 'bar'; doc.something = null })
-        s1 = Automerge.change(s1, 'del foo', doc => { delete doc['foo'] })
+        s1 = Automerge.change(s1, 'del foo', doc => { delete doc.foo })
         assert.strictEqual(s1.foo, undefined)
         assert.strictEqual(s1.something, null)
         assert.deepStrictEqual(s1, {something: null})
@@ -364,13 +363,13 @@ describe('Automerge', () => {
         s1 = Automerge.change(s1, 'set foo', doc => { doc.foo = 'bar' })
         let deleted
         s1 = Automerge.change(s1, 'del foo', doc => {
-          deleted = delete doc['foo']
+          deleted = delete doc.foo
         })
         assert.strictEqual(deleted, true)
         let deleted2
         assert.doesNotThrow(() => {
           s1 = Automerge.change(s1, 'del baz', doc => {
-            deleted2 = delete doc['baz']
+            deleted2 = delete doc.baz
           })
         })
         assert.strictEqual(deleted2, true)
@@ -421,9 +420,7 @@ describe('Automerge', () => {
         assert.deepStrictEqual(s1, {nested: {foo: 'bar', one: 1}})
         assert.deepStrictEqual(s1.nested, {foo: 'bar', one: 1})
         assert.strictEqual(s1.nested.foo, 'bar')
-        assert.strictEqual(s1.nested['foo'], 'bar')
         assert.strictEqual(s1.nested.one, 1)
-        assert.strictEqual(s1.nested['one'], 1)
       })
 
       it('should handle assignment of an object literal', () => {
@@ -438,7 +435,7 @@ describe('Automerge', () => {
 
       it('should handle assignment of multiple nested properties', () => {
         s1 = Automerge.change(s1, doc => {
-          doc['textStyle'] = {bold: false, fontSize: 12}
+          doc.textStyle = {bold: false, fontSize: 12}
           Object.assign(doc.textStyle, {typeface: 'Optima', fontSize: 14})
         })
         assert.strictEqual(s1.textStyle.typeface, 'Optima')
@@ -504,7 +501,7 @@ describe('Automerge', () => {
         s1 = Automerge.change(s1, 'set style', doc => {
           doc.textStyle = {typeface: 'Optima', bold: false, fontSize: 12}
         })
-        s1 = Automerge.change(s1, 'non-bold', doc => delete doc.textStyle['bold'])
+        s1 = Automerge.change(s1, 'non-bold', doc => delete doc.textStyle.bold)
         assert.strictEqual(s1.textStyle.bold, undefined)
         assert.deepStrictEqual(s1.textStyle, {typeface: 'Optima', fontSize: 12})
       })
@@ -513,7 +510,7 @@ describe('Automerge', () => {
         s1 = Automerge.change(s1, 'make rich text doc', doc => {
           Object.assign(doc, {title: 'Hello', textStyle: {typeface: 'Optima', fontSize: 12}})
         })
-        s1 = Automerge.change(s1, doc => delete doc['textStyle'])
+        s1 = Automerge.change(s1, doc => delete doc.textStyle)
         assert.strictEqual(s1.textStyle, undefined)
         assert.deepStrictEqual(s1, {title: 'Hello'})
       })
@@ -555,9 +552,9 @@ describe('Automerge', () => {
         assert.strictEqual(s1.noodles[1], 'Ramen!')
         s1 = Automerge.change(s1, doc => doc.noodles['1'] = 'RAMEN!!!')
         assert.strictEqual(s1.noodles[1], 'RAMEN!!!')
-        assert.throws(() => { Automerge.change(s1, doc => doc.noodles['favourite'] = 'udon') }, /list index must be a number/)
-        assert.throws(() => { Automerge.change(s1, doc => doc.noodles[''         ] = 'udon') }, /list index must be a number/)
-        assert.throws(() => { Automerge.change(s1, doc => doc.noodles['1e6'      ] = 'udon') }, /list index must be a number/)
+        assert.throws(() => { Automerge.change(s1, doc => doc.noodles.favourite = 'udon') }, /list index must be a number/)
+        assert.throws(() => { Automerge.change(s1, doc => doc.noodles[''] = 'udon') }, /list index must be a number/)
+        assert.throws(() => { Automerge.change(s1, doc => doc.noodles['1e6'] = 'udon') }, /list index must be a number/)
       })
 
       it('should handle deletion of list elements', () => {
@@ -923,7 +920,7 @@ describe('Automerge', () => {
       // Add-wins semantics
       s1 = Automerge.change(s1, doc => doc.bestBird = 'robin')
       s2 = Automerge.merge(s2, s1)
-      s1 = Automerge.change(s1, doc => delete doc['bestBird'])
+      s1 = Automerge.change(s1, doc => delete doc.bestBird)
       s2 = Automerge.change(s2, doc => doc.bestBird = 'magpie')
       s3 = Automerge.merge(s1, s2)
       assert.deepStrictEqual(s1, {})
@@ -978,7 +975,7 @@ describe('Automerge', () => {
       s1 = Automerge.change(s1, doc => doc.animals = {birds: {pink: 'flamingo', black: 'starling'}, mammals: ['badger']})
       s2 = Automerge.merge(s2, s1)
       s1 = Automerge.change(s1, doc => doc.animals.birds.brown = 'sparrow')
-      s2 = Automerge.change(s2, doc => delete doc.animals['birds'])
+      s2 = Automerge.change(s2, doc => delete doc.animals.birds)
       s3 = Automerge.merge(s1, s2)
       assert.deepStrictEqual(s1.animals, {
         birds: {

--- a/test/test.js
+++ b/test/test.js
@@ -1,3 +1,4 @@
+/* eslint-disable dot-notation */
 const assert = require('assert')
 const Automerge = process.env.TEST_DIST === '1' ? require('../dist/automerge') : require('../src/automerge')
 const { assertEqualsOneOf } = require('./helpers')
@@ -111,20 +112,20 @@ describe('Automerge', () => {
         s2 = Automerge.change(s1, doc => doc.foo = 'bar')
         try {
           s2.foo = 'lemon'
-        } catch (e) {}
+        } catch (e) { /* deliberately ignored */ }
         assert.strictEqual(s2.foo, 'bar')
 
         let deleted = false
         try {
           deleted = delete s2['foo']
-        } catch (e) {}
+        } catch (e) { /* deliberately ignored */ }
         assert.strictEqual(s2.foo, 'bar')
         assert.strictEqual(deleted, false)
 
         Automerge.change(s2, doc => {
           try {
             s2.foo = 'lemon'
-          } catch (e) {}
+          } catch (e) { /* deliberately ignored */ }
           assert.strictEqual(s2.foo, 'bar')
         })
 
@@ -635,9 +636,9 @@ describe('Automerge', () => {
       it('should handle deep nesting', () => {
         s1 = Automerge.change(s1, doc => doc.nesting = {
           maps: { m1: { m2: { foo: "bar", baz: {} }, m2a: { } } },
-          lists: [ [ 1,2,3 ] , [ [ 3,4,5,[6]], 7 ] ],
-          mapsinlists: [ { foo: "bar" } , [ { bar: "baz" } ] ],
-          listsinmaps: { foo: [1,2,3], bar: [ [ { baz: "123" } ] ] }
+          lists: [ [ 1, 2, 3 ], [ [ 3, 4, 5, [6]], 7 ] ],
+          mapsinlists: [ { foo: "bar" }, [ { bar: "baz" } ] ],
+          listsinmaps: { foo: [1, 2, 3], bar: [ [ { baz: "123" } ] ] }
         })
         s1 = Automerge.change(s1, doc => {
           doc.nesting.maps.m1a = "123"
@@ -655,9 +656,9 @@ describe('Automerge', () => {
         })
         assert.deepStrictEqual(s1, { nesting: {
           maps: { m1: { m2: { foo: "bar", baz: { xxx: "123" } } }, m1a: "123" },
-          lists: [ [ [ 3,4,5,100 ], 7 ] ],
+          lists: [ [ [ 3, 4, 5, 100 ], 7 ] ],
           mapsinlists: [ { foo: "baz" } ],
-          listsinmaps: { foo: [1,2,3,4] }
+          listsinmaps: { foo: [1, 2, 3, 4] }
         }})
       })
 
@@ -955,16 +956,16 @@ describe('Automerge', () => {
     })
 
     it('should handle concurrent deletion of the same element', () => {
-      s1 = Automerge.change(s1, doc => doc.birds = ['albatross','buzzard', 'cormorant'])
+      s1 = Automerge.change(s1, doc => doc.birds = ['albatross', 'buzzard', 'cormorant'])
       s2 = Automerge.merge(s2, s1)
       s1 = Automerge.change(s1, doc => doc.birds.deleteAt(1)) // buzzard
       s2 = Automerge.change(s2, doc => doc.birds.deleteAt(1)) // buzzard
       s3 = Automerge.merge(s1, s2)
-      assert.deepStrictEqual(s3.birds, ['albatross','cormorant'])
+      assert.deepStrictEqual(s3.birds, ['albatross', 'cormorant'])
     })
 
     it('should handle concurrent deletion of different elements', () => {
-      s1 = Automerge.change(s1, doc => doc.birds =  ['albatross','buzzard', 'cormorant'])
+      s1 = Automerge.change(s1, doc => doc.birds =  ['albatross', 'buzzard', 'cormorant'])
       s2 = Automerge.merge(s2, s1)
       s1 = Automerge.change(s1, doc => doc.birds.deleteAt(0)) // albatross
       s2 = Automerge.change(s2, doc => doc.birds.deleteAt(1)) // buzzard
@@ -1077,7 +1078,7 @@ describe('Automerge', () => {
     it('should save and load maps with @ symbols in the keys', () => {
       let s1 = Automerge.change(Automerge.init(), doc => doc["123@4567"] = "hello")
       let s2 = Automerge.load(Automerge.save(s1))
-      assert.deepStrictEqual(s2, { ["123@4567"]: "hello" })
+      assert.deepStrictEqual(s2, { "123@4567": "hello" })
     })
 
     it('should reconstitute conflicts', () => {

--- a/test/test.js
+++ b/test/test.js
@@ -121,7 +121,7 @@ describe('Automerge', () => {
         assert.strictEqual(s2.foo, 'bar')
         assert.strictEqual(deleted, false)
 
-        Automerge.change(s2, doc => {
+        Automerge.change(s2, () => {
           try {
             s2.foo = 'lemon'
           } catch (e) { /* deliberately ignored */ }
@@ -155,7 +155,7 @@ describe('Automerge', () => {
       })
 
       it('should return the unchanged state object if nothing changed', () => {
-        s2 = Automerge.change(s1, doc => {})
+        s2 = Automerge.change(s1, () => {})
         assert.strictEqual(s2, s1)
       })
 
@@ -252,8 +252,8 @@ describe('Automerge', () => {
       it('should support Date objects in maps', () => {
         const now = new Date()
         s1 = Automerge.change(s1, doc => doc.now = now)
-        let changes = Automerge.getAllChanges(s1), patch
-        ;[s2, patch] = Automerge.applyChanges(Automerge.init(), changes)
+        let changes = Automerge.getAllChanges(s1)
+        ;[s2] = Automerge.applyChanges(Automerge.init(), changes)
         assert.strictEqual(s2.now instanceof Date, true)
         assert.strictEqual(s2.now.getTime(), now.getTime())
       })
@@ -261,8 +261,8 @@ describe('Automerge', () => {
       it('should support Date objects in lists', () => {
         const now = new Date()
         s1 = Automerge.change(s1, doc => doc.list = [now])
-        let changes = Automerge.getAllChanges(s1), patch
-        ;[s2, patch] = Automerge.applyChanges(Automerge.init(), changes)
+        let changes = Automerge.getAllChanges(s1)
+        ;[s2] = Automerge.applyChanges(Automerge.init(), changes)
         assert.strictEqual(s2.list[0] instanceof Date, true)
         assert.strictEqual(s2.list[0].getTime(), now.getTime())
       })
@@ -1205,7 +1205,7 @@ describe('Automerge', () => {
       let s1 = Automerge.change(Automerge.init(), 'Add Chaffinch', doc => doc.birds = ['Chaffinch'])
       let s2 = Automerge.change(s1, 'Add Bullfinch', doc => doc.birds.push('Bullfinch'))
       let changes = Automerge.getAllChanges(s2)
-      let [s3, patch] = Automerge.applyChanges(Automerge.init(), changes)
+      let [s3] = Automerge.applyChanges(Automerge.init(), changes)
       assert.deepStrictEqual(s3.birds, ['Chaffinch', 'Bullfinch'])
     })
 
@@ -1223,8 +1223,8 @@ describe('Automerge', () => {
       let changes1 = Automerge.getAllChanges(s1)
       let s2 = Automerge.change(s1, 'Add Bullfinch', doc => doc.birds.push('Bullfinch'))
       let changes2 = Automerge.getChanges(s1, s2)
-      let [s3, patch3] = Automerge.applyChanges(Automerge.init(), changes1)
-      let [s4, patch4] = Automerge.applyChanges(s3, changes2)
+      let [s3] = Automerge.applyChanges(Automerge.init(), changes1)
+      let [s4] = Automerge.applyChanges(s3, changes2)
       assert.deepStrictEqual(s3.birds, ['Chaffinch'])
       assert.deepStrictEqual(s4.birds, ['Chaffinch', 'Bullfinch'])
     })
@@ -1254,7 +1254,7 @@ describe('Automerge', () => {
       let s3 = Automerge.change(s2, doc => doc.test = ['c'])
       let changes23 = Automerge.getChanges(s2, s3)
       let s4 = Automerge.init()
-      let [s5, patch5] = Automerge.applyChanges(s4, changes23)
+      let [s5] = Automerge.applyChanges(s4, changes23)
       let [s6, patch6] = Automerge.applyChanges(s5, changes12)
       assert.deepStrictEqual(Automerge.Backend.getMissingDeps(Automerge.Frontend.getBackendState(s6)),
                              [decodeChange(changes01[0]).hash])

--- a/test/text_test.js
+++ b/test/text_test.js
@@ -182,15 +182,14 @@ function applyInsertOp(text, offset, op) {
 // XXX: uhhhhh, why can't I pass in text?
 function applyDeltaDocToAutomergeText(delta, doc) {
   let offset = 0
-  let text = doc.text
 
   delta.forEach(op => {
     if (op.retain) {
-      [text, offset] = applyRetainOp(doc.text, offset, op)
+      [, offset] = applyRetainOp(doc.text, offset, op)
     } else if (op.delete) {
-      [text, offset] = applyDeleteOp(doc.text, offset, op)
+      [, offset] = applyDeleteOp(doc.text, offset, op)
     } else if (op.insert) {
-      [text, offset] = applyInsertOp(doc.text, offset, op)
+      [, offset] = applyInsertOp(doc.text, offset, op)
     }
   })
 }
@@ -317,14 +316,14 @@ describe('Automerge.Text', () => {
       const s1 = Automerge.from({text: new Automerge.Text('init')})
       const changes = Automerge.getAllChanges(s1)
       assert.strictEqual(changes.length, 1)
-      const [s2, patch] = Automerge.applyChanges(Automerge.init(), changes)
+      const [s2] = Automerge.applyChanges(Automerge.init(), changes)
       assert.strictEqual(s2.text instanceof Automerge.Text, true)
       assert.strictEqual(s2.text.toString(), 'init')
       assert.strictEqual(s2.text.join(''), 'init')
     })
 
     it('should allow immediate access to the value', () => {
-      let s1 = Automerge.change(Automerge.init(), doc => {
+      Automerge.change(Automerge.init(), doc => {
         const text = new Automerge.Text('init')
         assert.strictEqual(text.length, 4)
         assert.strictEqual(text.get(0), 'i')

--- a/test/text_test.js
+++ b/test/text_test.js
@@ -13,15 +13,15 @@ function attributeStateToAttributes(accumulatedAttributes) {
 }
 
 function isEquivalent(a, b) {
-  var aProps = Object.getOwnPropertyNames(a)
-  var bProps = Object.getOwnPropertyNames(b)
+  const aProps = Object.getOwnPropertyNames(a)
+  const bProps = Object.getOwnPropertyNames(b)
 
   if (aProps.length != bProps.length) {
       return false
   }
 
-  for (var i = 0; i < aProps.length; i++) {
-      var propName = aProps[i]
+  for (let i = 0; i < aProps.length; i++) {
+    const propName = aProps[i]
       if (a[propName] !== b[propName]) {
           return false
       }
@@ -396,13 +396,13 @@ describe('Automerge.Text', () => {
     })
 
     describe('spans interface to Text', () => {
-      it('should return a simple string as a single span', () =>{
+      it('should return a simple string as a single span', () => {
         let s1 = Automerge.change(Automerge.init(), doc => {
           doc.text = new Automerge.Text('hello world')
         })
         assert.deepEqual(s1.text.toSpans(), ['hello world'])
       })
-      it('should return an empty string as an empty array', () =>{
+      it('should return an empty string as an empty array', () => {
         let s1 = Automerge.change(Automerge.init(), doc => {
           doc.text = new Automerge.Text()
         })
@@ -447,8 +447,8 @@ describe('Automerge.Text', () => {
         let s1 = Automerge.change(Automerge.init(), doc => {
           doc.text = new Automerge.Text('Gandalf the Grey')
           doc.text.insertAt(0,  { attributes: { bold: true } })
-          doc.text.insertAt(7+1, { attributes: { bold: null } })
-          doc.text.insertAt(12+2, { attributes: { color: '#cccccc' } })
+          doc.text.insertAt(7 + 1, { attributes: { bold: null } })
+          doc.text.insertAt(12 + 2, { attributes: { color: '#cccccc' } })
         })
 
         let deltaDoc = automergeTextToDeltaDoc(s1.text)
@@ -498,12 +498,12 @@ describe('Automerge.Text', () => {
 
         let s3 = Automerge.change(s1, doc => {
           doc.text.insertAt(8,  { attributes: { bold: true } })
-          doc.text.insertAt(16+1, { attributes: { bold: null } })
+          doc.text.insertAt(16 + 1, { attributes: { bold: null } })
         })
 
         let s4 = Automerge.change(s2, doc => {
           doc.text.insertAt(0,  { attributes: { bold: true } })
-          doc.text.insertAt(11+1, { attributes: { bold: null } })
+          doc.text.insertAt(11 + 1, { attributes: { bold: null } })
         })
 
         let merged = Automerge.merge(s3, s4)
@@ -527,12 +527,12 @@ describe('Automerge.Text', () => {
 
         let s3 = Automerge.change(s1, doc => {
           doc.text.insertAt(0,  { attributes: { bold: true } })
-          doc.text.insertAt(16+1, { attributes: { bold: null } })
+          doc.text.insertAt(16 + 1, { attributes: { bold: null } })
         })
 
         let s4 = Automerge.change(s2, doc => {
           doc.text.insertAt(8,  { attributes: { bold: null } })
-          doc.text.insertAt(11+1, { attributes: { bold: true } })
+          doc.text.insertAt(11 + 1, { attributes: { bold: true } })
         })
 
 
@@ -560,18 +560,18 @@ describe('Automerge.Text', () => {
 
         let s3 = Automerge.change(s1, doc => {
           doc.text.insertAt(0,  { attributes: { bold: true } })
-          doc.text.insertAt(16+1, { attributes: { bold: null } })
+          doc.text.insertAt(16 + 1, { attributes: { bold: null } })
         })
 
         let s4 = Automerge.change(s2, doc => {
           doc.text.insertAt(8,  { attributes: { bold: null } })
-          doc.text.insertAt(11+1, { attributes: { bold: true } })
+          doc.text.insertAt(11 + 1, { attributes: { bold: true } })
         })
 
         let merged = Automerge.merge(s3, s4)
 
         let final = Automerge.change(merged, doc => {
-          doc.text.insertAt(3+1, { attributes: { bold: null } })
+          doc.text.insertAt(3 + 1, { attributes: { bold: null } })
           doc.text.insertAt(doc.text.length, { attributes: { bold: true } })
         })
 

--- a/test/uuid_test.js
+++ b/test/uuid_test.js
@@ -25,8 +25,8 @@ describe('uuid', () => {
     beforeEach(() => counter = 0)
 
     it('invokes the custom factory', () => {
-      assert.equal(uuid(), 'custom-uuid-0');
-      assert.equal(uuid(), 'custom-uuid-1');
+      assert.equal(uuid(), 'custom-uuid-0')
+      assert.equal(uuid(), 'custom-uuid-1')
     })
   })
 })

--- a/test/wasm.js
+++ b/test/wasm.js
@@ -189,9 +189,7 @@ function interopTests(sourceBackend, destBackend) {
   })
 
   it('should be able to serialize and deserialize with javascript', () => {
-    console.log(source)
-    const [doc,request] = Frontend.from({ number: 1.0 });
-    console.log(request)
+    const [doc, request] = Frontend.from({ number: 1.0 })
     const [source1, p1, change1] = sourceBackend.applyLocalChange(source, request)
     const saved = sourceBackend.save(source1)
     decodeDocument(saved)

--- a/test/wasm.js
+++ b/test/wasm.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-unused-vars */
 // This file is used for running the test suite against an alternative backend
 // implementation, such as the WebAssembly version compiled from Rust.
 // It needs to be loaded before the test suite files, which can be done with

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,4 +1,4 @@
-var path = require('path');
+const path = require('path')
 
 module.exports = {
   entry: './src/automerge.js',

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,13 @@
 # yarn lockfile v1
 
 
+"@babel/code-frame@7.12.11":
+  version "7.12.11"
+  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.12.11.tgz#f4ad435aa263db935b8f10f2c552d23fb716a63f"
+  integrity sha512-Zt1yodBx1UcyiePMSkWnU4hPqhwq7hGi2nFL1LeA3EUl+q2LQx16MISgJ0+z7dnmgvP9QtIleuETGOiOH1RcIw==
+  dependencies:
+    "@babel/highlight" "^7.10.4"
+
 "@babel/code-frame@^7.8.3":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.8.3.tgz#33e25903d7481181534e12ec0a25f16b6fcf419e"
@@ -63,6 +70,11 @@
   dependencies:
     "@babel/types" "^7.8.3"
 
+"@babel/helper-validator-identifier@^7.12.11":
+  version "7.12.11"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz#c9a1f021917dcb5ccf0d4e453e399022981fc9ed"
+  integrity sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw==
+
 "@babel/helpers@^7.8.4":
   version "7.8.4"
   resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.8.4.tgz#754eb3ee727c165e0a240d6c207de7c455f36f73"
@@ -71,6 +83,15 @@
     "@babel/template" "^7.8.3"
     "@babel/traverse" "^7.8.4"
     "@babel/types" "^7.8.3"
+
+"@babel/highlight@^7.10.4":
+  version "7.13.10"
+  resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.13.10.tgz#a8b2a66148f5b27d666b15d81774347a731d52d1"
+  integrity sha512-5aPpe5XQPzflQrFwL1/QoeHkP2MsA4JCntcXHRhEsdsfPVkvPi2w7Qix4iV7t5S/oC9OodGrggd8aco1g3SZFg==
+  dependencies:
+    "@babel/helper-validator-identifier" "^7.12.11"
+    chalk "^2.0.0"
+    js-tokens "^4.0.0"
 
 "@babel/highlight@^7.8.3":
   version "7.8.3"
@@ -118,6 +139,21 @@
     esutils "^2.0.2"
     lodash "^4.17.13"
     to-fast-properties "^2.0.0"
+
+"@eslint/eslintrc@^0.4.0":
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-0.4.0.tgz#99cc0a0584d72f1df38b900fb062ba995f395547"
+  integrity sha512-2ZPCc+uNbjV5ERJr+aKSPRwZgKd2z11x0EgLvb1PURmUrn9QNRXFqje0Ldq454PfAVyaJYyrDvvIKSFP4NnBog==
+  dependencies:
+    ajv "^6.12.4"
+    debug "^4.1.1"
+    espree "^7.3.0"
+    globals "^12.1.0"
+    ignore "^4.0.6"
+    import-fresh "^3.2.1"
+    js-yaml "^3.13.1"
+    minimatch "^3.0.4"
+    strip-json-comments "^3.1.1"
 
 "@istanbuljs/load-nyc-config@^1.0.0":
   version "1.1.0"
@@ -363,6 +399,11 @@ accepts@~1.3.4:
     mime-types "~2.1.24"
     negotiator "0.6.2"
 
+acorn-jsx@^5.3.1:
+  version "5.3.1"
+  resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.3.1.tgz#fc8661e11b7ac1539c47dbfea2e72b3af34d267b"
+  integrity sha512-K0Ptm/47OKfQRpNQ2J/oIN/3QYiK6FwW+eJbILhsdxh2WTLdl+30o8aGdTbm5JbffpFFAg/g+zi1E+jvJha5ng==
+
 acorn-node@^1.2.0, acorn-node@^1.3.0, acorn-node@^1.5.2, acorn-node@^1.6.1:
   version "1.8.2"
   resolved "https://registry.yarnpkg.com/acorn-node/-/acorn-node-1.8.2.tgz#114c95d64539e53dede23de8b9d96df7c7ae2af8"
@@ -386,6 +427,11 @@ acorn@^7.0.0, acorn@^7.1.0:
   version "7.1.1"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.1.1.tgz#e35668de0b402f359de515c5482a1ab9f89a69bf"
   integrity sha512-add7dgA5ppRPxCFJoAGfMDi7PIBXq1RtGo7BhbLaxwrXPOmw8gq48Y9ozT01hUKy9byMjlR20EJhu5zlkErEkg==
+
+acorn@^7.4.0:
+  version "7.4.1"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.4.1.tgz#feaed255973d2e77555b83dbc08851a6c63520fa"
+  integrity sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==
 
 adm-zip@~0.4.3:
   version "0.4.14"
@@ -432,10 +478,35 @@ ajv@^6.1.0, ajv@^6.10.2:
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
 
+ajv@^6.10.0, ajv@^6.12.4:
+  version "6.12.6"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.6.tgz#baf5a62e802b07d977034586f8c3baf5adf26df4"
+  integrity sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==
+  dependencies:
+    fast-deep-equal "^3.1.1"
+    fast-json-stable-stringify "^2.0.0"
+    json-schema-traverse "^0.4.1"
+    uri-js "^4.2.2"
+
+ajv@^8.0.1:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.1.0.tgz#45d5d3d36c7cdd808930cc3e603cf6200dbeb736"
+  integrity sha512-B/Sk2Ix7A36fs/ZkuGLIR86EdjbgR6fsAcbx9lOP/QBSXujDNbVmIS/U4Itz5k8fPFDeVZl/zQ/gJW4Jrq6XjQ==
+  dependencies:
+    fast-deep-equal "^3.1.1"
+    json-schema-traverse "^1.0.0"
+    require-from-string "^2.0.2"
+    uri-js "^4.2.2"
+
 ansi-colors@3.2.3:
   version "3.2.3"
   resolved "https://registry.yarnpkg.com/ansi-colors/-/ansi-colors-3.2.3.tgz#57d35b8686e851e2cc04c403f1c00203976a1813"
   integrity sha512-LEHHyuhlPY3TmuUYMh2oz89lTShfvgbmzaBcxve9t/9Wuy7Dwf4yoAKcND7KFT1HAQfqZ12qtc+DUrBMeKF9nw==
+
+ansi-colors@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/ansi-colors/-/ansi-colors-4.1.1.tgz#cbb9ae256bf750af1eab344f229aa27fe94ba348"
+  integrity sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==
 
 ansi-regex@^2.0.0:
   version "2.1.1"
@@ -475,6 +546,13 @@ ansi-styles@^4.0.0:
   integrity sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==
   dependencies:
     "@types/color-name" "^1.1.1"
+    color-convert "^2.0.1"
+
+ansi-styles@^4.1.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-4.3.0.tgz#edd803628ae71c04c85ae7a0906edad34b648937"
+  integrity sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==
+  dependencies:
     color-convert "^2.0.1"
 
 anymatch@^2.0.0:
@@ -578,6 +656,11 @@ assign-symbols@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/assign-symbols/-/assign-symbols-1.0.0.tgz#59667f41fadd4f20ccbc2bb96b8d4f7f78ec0367"
   integrity sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=
+
+astral-regex@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/astral-regex/-/astral-regex-2.0.0.tgz#483143c567aeed4785759c0865786dc77d7d2e31"
+  integrity sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==
 
 async-each@^1.0.1:
   version "1.0.3"
@@ -1516,6 +1599,11 @@ callsite@1.0.0:
   resolved "https://registry.yarnpkg.com/callsite/-/callsite-1.0.0.tgz#280398e5d664bd74038b6f0905153e6e8af1bc20"
   integrity sha1-KAOY5dZkvXQDi28JBRU+borxvCA=
 
+callsites@^3.0.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/callsites/-/callsites-3.1.0.tgz#b3630abd8943432f54b3f0519238e33cd7df2f73"
+  integrity sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==
+
 camelcase@^5.0.0, camelcase@^5.3.1:
   version "5.3.1"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-5.3.1.tgz#e3c9b31569e106811df242f715725a1f4c494320"
@@ -1545,6 +1633,14 @@ chalk@^1.1.3:
     has-ansi "^2.0.0"
     strip-ansi "^3.0.0"
     supports-color "^2.0.0"
+
+chalk@^4.0.0:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.1.tgz#c80b3fab28bf6371e6863325eee67e618b77e6ad"
+  integrity sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==
+  dependencies:
+    ansi-styles "^4.1.0"
+    supports-color "^7.1.0"
 
 chokidar@3.3.0:
   version "3.3.0"
@@ -1868,7 +1964,7 @@ cross-spawn@6.0.5, cross-spawn@^6.0.0:
     shebang-command "^1.2.0"
     which "^1.2.9"
 
-cross-spawn@^7.0.0:
+cross-spawn@^7.0.0, cross-spawn@^7.0.2:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.3.tgz#f73a85b9d5d41d045551c177e2882d4ac85728a6"
   integrity sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==
@@ -1933,6 +2029,13 @@ debug@3.2.6, debug@^3.0.0, debug@^3.1.0, debug@^3.2.6:
   dependencies:
     ms "^2.1.1"
 
+debug@^4.0.1:
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.1.tgz#f0d229c505e0c6d8c49ac553d1b13dc183f6b2ee"
+  integrity sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==
+  dependencies:
+    ms "2.1.2"
+
 debug@^4.1.0, debug@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.1.1.tgz#3b72260255109c6b589cee050f1d516139664791"
@@ -1956,6 +2059,11 @@ decode-uri-component@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/decode-uri-component/-/decode-uri-component-0.2.0.tgz#eb3913333458775cb84cd1a1fae062106bb87545"
   integrity sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=
+
+deep-is@^0.1.3:
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34"
+  integrity sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=
 
 default-require-extensions@^3.0.0:
   version "3.0.0"
@@ -2072,6 +2180,13 @@ diffie-hellman@^5.0.0:
     bn.js "^4.1.0"
     miller-rabin "^4.0.0"
     randombytes "^2.0.0"
+
+doctrine@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-3.0.0.tgz#addebead72a6574db783639dc87a121773973961"
+  integrity sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==
+  dependencies:
+    esutils "^2.0.2"
 
 dom-serialize@^2.2.0:
   version "2.2.1"
@@ -2223,6 +2338,13 @@ enhanced-resolve@^4.1.0:
     memory-fs "^0.5.0"
     tapable "^1.0.0"
 
+enquirer@^2.3.5:
+  version "2.3.6"
+  resolved "https://registry.yarnpkg.com/enquirer/-/enquirer-2.3.6.tgz#2a7fe5dd634a1e4125a975ec994ff5456dc3734d"
+  integrity sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==
+  dependencies:
+    ansi-colors "^4.1.1"
+
 ent@~2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/ent/-/ent-2.2.0.tgz#e964219325a21d05f44466a2f686ed6ce5f5dd1d"
@@ -2301,10 +2423,94 @@ eslint-scope@^4.0.3:
     esrecurse "^4.1.0"
     estraverse "^4.1.1"
 
+eslint-scope@^5.1.1:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-5.1.1.tgz#e786e59a66cb92b3f6c1fb0d508aab174848f48c"
+  integrity sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==
+  dependencies:
+    esrecurse "^4.3.0"
+    estraverse "^4.1.1"
+
+eslint-utils@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/eslint-utils/-/eslint-utils-2.1.0.tgz#d2de5e03424e707dc10c74068ddedae708741b27"
+  integrity sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==
+  dependencies:
+    eslint-visitor-keys "^1.1.0"
+
+eslint-visitor-keys@^1.1.0, eslint-visitor-keys@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz#30ebd1ef7c2fdff01c3a4f151044af25fab0523e"
+  integrity sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==
+
+eslint-visitor-keys@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-2.0.0.tgz#21fdc8fbcd9c795cc0321f0563702095751511a8"
+  integrity sha512-QudtT6av5WXels9WjIM7qz1XD1cWGvX4gGXvp/zBn9nXG02D0utdU3Em2m/QjTnrsk6bBjmCygl3rmj118msQQ==
+
+eslint@^7.24.0:
+  version "7.24.0"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-7.24.0.tgz#2e44fa62d93892bfdb100521f17345ba54b8513a"
+  integrity sha512-k9gaHeHiFmGCDQ2rEfvULlSLruz6tgfA8DEn+rY9/oYPFFTlz55mM/Q/Rij1b2Y42jwZiK3lXvNTw6w6TXzcKQ==
+  dependencies:
+    "@babel/code-frame" "7.12.11"
+    "@eslint/eslintrc" "^0.4.0"
+    ajv "^6.10.0"
+    chalk "^4.0.0"
+    cross-spawn "^7.0.2"
+    debug "^4.0.1"
+    doctrine "^3.0.0"
+    enquirer "^2.3.5"
+    eslint-scope "^5.1.1"
+    eslint-utils "^2.1.0"
+    eslint-visitor-keys "^2.0.0"
+    espree "^7.3.1"
+    esquery "^1.4.0"
+    esutils "^2.0.2"
+    file-entry-cache "^6.0.1"
+    functional-red-black-tree "^1.0.1"
+    glob-parent "^5.0.0"
+    globals "^13.6.0"
+    ignore "^4.0.6"
+    import-fresh "^3.0.0"
+    imurmurhash "^0.1.4"
+    is-glob "^4.0.0"
+    js-yaml "^3.13.1"
+    json-stable-stringify-without-jsonify "^1.0.1"
+    levn "^0.4.1"
+    lodash "^4.17.21"
+    minimatch "^3.0.4"
+    natural-compare "^1.4.0"
+    optionator "^0.9.1"
+    progress "^2.0.0"
+    regexpp "^3.1.0"
+    semver "^7.2.1"
+    strip-ansi "^6.0.0"
+    strip-json-comments "^3.1.0"
+    table "^6.0.4"
+    text-table "^0.2.0"
+    v8-compile-cache "^2.0.3"
+
+espree@^7.3.0, espree@^7.3.1:
+  version "7.3.1"
+  resolved "https://registry.yarnpkg.com/espree/-/espree-7.3.1.tgz#f2df330b752c6f55019f8bd89b7660039c1bbbb6"
+  integrity sha512-v3JCNCE64umkFpmkFGqzVKsOT0tN1Zr+ueqLZfpV1Ob8e+CEgPWa+OxCoGH3tnhimMKIaBm4m/vaRpJ/krRz2g==
+  dependencies:
+    acorn "^7.4.0"
+    acorn-jsx "^5.3.1"
+    eslint-visitor-keys "^1.3.0"
+
 esprima@^4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.1.tgz#13b04cdb3e6c5d19df91ab6987a8695619b0aa71"
   integrity sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==
+
+esquery@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/esquery/-/esquery-1.4.0.tgz#2148ffc38b82e8c7057dfed48425b3e61f0f24a5"
+  integrity sha512-cCDispWt5vHHtwMY2YrAQ4ibFkAL8RbH5YGBnZBc90MolvvfkkQcJro/aZiAQUlQ3qgrYS6D6v8Gc5G5CQsc9w==
+  dependencies:
+    estraverse "^5.1.0"
 
 esrecurse@^4.1.0:
   version "4.2.1"
@@ -2313,10 +2519,22 @@ esrecurse@^4.1.0:
   dependencies:
     estraverse "^4.1.0"
 
+esrecurse@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/esrecurse/-/esrecurse-4.3.0.tgz#7ad7964d679abb28bee72cec63758b1c5d2c9921"
+  integrity sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==
+  dependencies:
+    estraverse "^5.2.0"
+
 estraverse@^4.1.0, estraverse@^4.1.1:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-4.3.0.tgz#398ad3f3c5a24948be7725e83d11a7de28cdbd1d"
   integrity sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==
+
+estraverse@^5.1.0, estraverse@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-5.2.0.tgz#307df42547e6cc7324d3cf03c155d5cdb8c53880"
+  integrity sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==
 
 esutils@^2.0.2:
   version "2.0.3"
@@ -2423,6 +2641,11 @@ fast-json-stable-stringify@^2.0.0:
   resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz#874bf69c6f404c2b5d99c481341399fd55892633"
   integrity sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==
 
+fast-levenshtein@^2.0.6:
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
+  integrity sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=
+
 fast-safe-stringify@^2.0.7:
   version "2.0.7"
   resolved "https://registry.yarnpkg.com/fast-safe-stringify/-/fast-safe-stringify-2.0.7.tgz#124aa885899261f68aedb42a7c080de9da608743"
@@ -2437,6 +2660,13 @@ figgy-pudding@^3.5.1:
   version "3.5.1"
   resolved "https://registry.yarnpkg.com/figgy-pudding/-/figgy-pudding-3.5.1.tgz#862470112901c727a0e495a80744bd5baa1d6790"
   integrity sha512-vNKxJHTEKNThjfrdJwHc7brvM6eVevuO5nTj6ez8ZQ1qbXTvGthucRF7S4vf2cr71QVnT70V34v0S1DyQsti0w==
+
+file-entry-cache@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/file-entry-cache/-/file-entry-cache-6.0.1.tgz#211b2dd9659cb0394b073e7323ac3c933d522027"
+  integrity sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==
+  dependencies:
+    flat-cache "^3.0.4"
 
 file-uri-to-path@1.0.0:
   version "1.0.0"
@@ -2532,6 +2762,14 @@ findup-sync@3.0.0:
     micromatch "^3.0.4"
     resolve-dir "^1.0.1"
 
+flat-cache@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/flat-cache/-/flat-cache-3.0.4.tgz#61b0338302b2fe9f957dcc32fc2a87f1c3048b11"
+  integrity sha512-dm9s5Pw7Jc0GvMYbshN6zchCA9RgQlzzEZX3vylR9IqFfS8XciblUXOKfW6SiuJ0e13eDYZoZV5wdrev7P3Nwg==
+  dependencies:
+    flatted "^3.1.0"
+    rimraf "^3.0.2"
+
 flat@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/flat/-/flat-4.1.0.tgz#090bec8b05e39cba309747f1d588f04dbaf98db2"
@@ -2543,6 +2781,11 @@ flatted@^2.0.0, flatted@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-2.0.1.tgz#69e57caa8f0eacbc281d2e2cb458d46fdb449e08"
   integrity sha512-a1hQMktqW9Nmqr5aktAux3JMNqaucxGcjtjWnZLHX7yyPCmlSV3M54nGYbqT8K+0GhF3NBgmJCc3ma+WOgX8Jg==
+
+flatted@^3.1.0:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.1.1.tgz#c4b489e80096d9df1dfc97c79871aea7c617c469"
+  integrity sha512-zAoAQiudy+r5SvnSw3KJy5os/oRJYHzrzja/tBDqrZtNhUw8bt6y8OBzMWcjWr+8liV8Eb6yOhw8WZ7VFZ5ZzA==
 
 flush-write-stream@^1.0.0:
   version "1.1.1"
@@ -2643,6 +2886,11 @@ function-bind@^1.1.1:
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.1.tgz#a56899d3ea3c9bab874bb9773b7c5ede92f4895d"
   integrity sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==
 
+functional-red-black-tree@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz#1b0ab3bd553b2a0d6399d29c0e3ea0b252078327"
+  integrity sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=
+
 gensync@^1.0.0-beta.1:
   version "1.0.0-beta.1"
   resolved "https://registry.yarnpkg.com/gensync/-/gensync-1.0.0-beta.1.tgz#58f4361ff987e5ff6e1e7a210827aa371eaac269"
@@ -2682,6 +2930,13 @@ glob-parent@^3.1.0:
   dependencies:
     is-glob "^3.1.0"
     path-dirname "^1.0.0"
+
+glob-parent@^5.0.0:
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-5.1.2.tgz#869832c58034fe68a4093c17dc15e8340d8401c4"
+  integrity sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==
+  dependencies:
+    is-glob "^4.0.1"
 
 glob-parent@~5.1.0:
   version "5.1.0"
@@ -2754,6 +3009,20 @@ globals@^11.1.0:
   version "11.12.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-11.12.0.tgz#ab8795338868a0babd8525758018c2a7eb95c42e"
   integrity sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==
+
+globals@^12.1.0:
+  version "12.4.0"
+  resolved "https://registry.yarnpkg.com/globals/-/globals-12.4.0.tgz#a18813576a41b00a24a97e7f815918c2e19925f8"
+  integrity sha512-BWICuzzDvDoH54NHKCseDanAhE3CeDorgDL5MT6LMXXj2WCnd9UC2szdk4AWLfjdgNBCXLUanXYcpBBKOSWGwg==
+  dependencies:
+    type-fest "^0.8.1"
+
+globals@^13.6.0:
+  version "13.8.0"
+  resolved "https://registry.yarnpkg.com/globals/-/globals-13.8.0.tgz#3e20f504810ce87a8d72e55aecf8435b50f4c1b3"
+  integrity sha512-rHtdA6+PDBIjeEvA91rpqzEvk/k3/i7EeNQiryiWuJH0Hw9cpyJMAt2jtbAwUaRdhD+573X4vWw6IcjKPasi9Q==
+  dependencies:
+    type-fest "^0.20.2"
 
 globals@^9.18.0:
   version "9.18.0"
@@ -2968,6 +3237,11 @@ iferr@^0.1.5:
   resolved "https://registry.yarnpkg.com/iferr/-/iferr-0.1.5.tgz#c60eed69e6d8fdb6b3104a1fcbca1c192dc5b501"
   integrity sha1-xg7taebY/bazEEofy8ocGS3FtQE=
 
+ignore@^4.0.6:
+  version "4.0.6"
+  resolved "https://registry.yarnpkg.com/ignore/-/ignore-4.0.6.tgz#750e3db5862087b4737ebac8207ffd1ef27b25fc"
+  integrity sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==
+
 immediate@~3.0.5:
   version "3.0.6"
   resolved "https://registry.yarnpkg.com/immediate/-/immediate-3.0.6.tgz#9db1dbd0faf8de6fbe0f5dd5e56bb606280de69b"
@@ -2977,6 +3251,14 @@ immutable@^3.8.2:
   version "3.8.2"
   resolved "https://registry.yarnpkg.com/immutable/-/immutable-3.8.2.tgz#c2439951455bb39913daf281376f1530e104adf3"
   integrity sha1-wkOZUUVbs5kT2vKBN28VMOEErfM=
+
+import-fresh@^3.0.0, import-fresh@^3.2.1:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/import-fresh/-/import-fresh-3.3.0.tgz#37162c25fcb9ebaa2e6e53d5b4d88ce17d9e0c2b"
+  integrity sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==
+  dependencies:
+    parent-module "^1.0.0"
+    resolve-from "^4.0.0"
 
 import-local@2.0.0:
   version "2.0.0"
@@ -3447,6 +3729,16 @@ json-schema-traverse@^0.4.1:
   resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz#69f6a87d9513ab8bb8fe63bdb0979c448e684660"
   integrity sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==
 
+json-schema-traverse@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz#ae7bcb3656ab77a73ba5c49bf654f38e6b6860e2"
+  integrity sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==
+
+json-stable-stringify-without-jsonify@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz#9db7b59496ad3f3cfef30a75142d2d930ad72651"
+  integrity sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=
+
 json-stable-stringify@~0.0.0:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/json-stable-stringify/-/json-stable-stringify-0.0.1.tgz#611c23e814db375527df851193db59dd2af27f45"
@@ -3692,6 +3984,14 @@ lcid@^2.0.0:
   dependencies:
     invert-kv "^2.0.0"
 
+levn@^0.4.1:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/levn/-/levn-0.4.1.tgz#ae4562c007473b932a6200d403268dd2fffc6ade"
+  integrity sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==
+  dependencies:
+    prelude-ls "^1.2.1"
+    type-check "~0.4.0"
+
 lie@~3.3.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/lie/-/lie-3.3.0.tgz#dcf82dee545f46074daf200c7c1c5a08e0f40f6a"
@@ -3745,6 +4045,16 @@ locate-path@^5.0.0:
   dependencies:
     p-locate "^4.1.0"
 
+lodash.clonedeep@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz#e23f3f9c4f8fbdde872529c1071857a086e5ccef"
+  integrity sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=
+
+lodash.flatten@^4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/lodash.flatten/-/lodash.flatten-4.4.0.tgz#f31c22225a9632d2bbf8e4addbef240aa765a61f"
+  integrity sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8=
+
 lodash.flattendeep@^4.4.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz#fb030917f86a3134e5bc9bec0d69e0013ddfedb2"
@@ -3760,10 +4070,20 @@ lodash.memoize@~3.0.3:
   resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-3.0.4.tgz#2dcbd2c287cbc0a55cc42328bd0c736150d53e3f"
   integrity sha1-LcvSwofLwKVcxCMovQxzYVDVPj8=
 
+lodash.truncate@^4.4.2:
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/lodash.truncate/-/lodash.truncate-4.4.2.tgz#5a350da0b1113b837ecfffd5812cbe58d6eae193"
+  integrity sha1-WjUNoLERO4N+z//VgSy+WNbq4ZM=
+
 lodash@^4.16.6, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.4:
   version "4.17.15"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
   integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
+
+lodash@^4.17.21:
+  version "4.17.21"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
+  integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
 
 log-symbols@3.0.0:
   version "3.0.0"
@@ -3815,6 +4135,13 @@ lru-cache@^5.1.1:
   integrity sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==
   dependencies:
     yallist "^3.0.2"
+
+lru-cache@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-6.0.0.tgz#6d6fe6570ebd96aaf90fcad1dafa3b2566db3a94"
+  integrity sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==
+  dependencies:
+    yallist "^4.0.0"
 
 make-dir@^1.0.0:
   version "1.3.0"
@@ -4098,7 +4425,7 @@ ms@2.1.1:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.1.tgz#30a5864eb3ebb0a66f2ebe6d727af06a09d86e0a"
   integrity sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==
 
-ms@^2.1.1:
+ms@2.1.2, ms@^2.1.1:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
@@ -4124,6 +4451,11 @@ nanomatch@^1.2.9:
     regex-not "^1.0.0"
     snapdragon "^0.8.1"
     to-regex "^3.0.1"
+
+natural-compare@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
+  integrity sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=
 
 negotiator@0.6.2:
   version "0.6.2"
@@ -4343,6 +4675,18 @@ optimist@^0.6.1:
     minimist "~0.0.1"
     wordwrap "~0.0.2"
 
+optionator@^0.9.1:
+  version "0.9.1"
+  resolved "https://registry.yarnpkg.com/optionator/-/optionator-0.9.1.tgz#4f236a6373dae0566a6d43e1326674f50c291499"
+  integrity sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==
+  dependencies:
+    deep-is "^0.1.3"
+    fast-levenshtein "^2.0.6"
+    levn "^0.4.1"
+    prelude-ls "^1.2.1"
+    type-check "^0.4.0"
+    word-wrap "^1.2.3"
+
 os-browserify@^0.3.0, os-browserify@~0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/os-browserify/-/os-browserify-0.3.0.tgz#854373c7f5c2315914fc9bfc6bd8238fdda1ec27"
@@ -4488,6 +4832,13 @@ parallel-transform@^1.1.0:
     cyclist "^1.0.1"
     inherits "^2.0.3"
     readable-stream "^2.1.5"
+
+parent-module@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/parent-module/-/parent-module-1.0.1.tgz#691d2709e78c79fae3a156622452d00762caaaa2"
+  integrity sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==
+  dependencies:
+    callsites "^3.0.0"
 
 parents@^1.0.0, parents@^1.0.1:
   version "1.0.1"
@@ -4646,6 +4997,11 @@ posix-character-classes@^0.1.0:
   resolved "https://registry.yarnpkg.com/posix-character-classes/-/posix-character-classes-0.1.1.tgz#01eac0fe3b5af71a2a6c02feabb8c1fef7e00eab"
   integrity sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=
 
+prelude-ls@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.2.1.tgz#debc6489d7a6e6b0e7611888cec880337d316396"
+  integrity sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==
+
 private@^0.1.6, private@^0.1.8:
   version "0.1.8"
   resolved "https://registry.yarnpkg.com/private/-/private-0.1.8.tgz#2381edb3689f7a53d653190060fcf822d2f368ff"
@@ -4667,6 +5023,11 @@ process@^0.11.10, process@~0.11.0:
   version "0.11.10"
   resolved "https://registry.yarnpkg.com/process/-/process-0.11.10.tgz#7332300e840161bda3e69a1d1d91a7d4bc16f182"
   integrity sha1-czIwDoQBYb2j5podHZGn1LwW8YI=
+
+progress@^2.0.0:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.3.tgz#7e8cf8d8f5b8f239c1bc68beb4eb78567d572ef8"
+  integrity sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==
 
 promise-inflight@^1.0.1:
   version "1.0.1"
@@ -4879,6 +5240,11 @@ regex-not@^1.0.0, regex-not@^1.0.2:
     extend-shallow "^3.0.2"
     safe-regex "^1.1.0"
 
+regexpp@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-3.1.0.tgz#206d0ad0a5648cffbdb8ae46438f3dc51c9f78e2"
+  integrity sha512-ZOIzd8yVsQQA7j8GCSlPGXwg5PfmA1mrq0JP4nGhh54LaKN3xdai/vHUDu74pKwV8OxseMS65u2NImosQcSD0Q==
+
 regexpu-core@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/regexpu-core/-/regexpu-core-2.0.0.tgz#49d038837b8dcf8bfa5b9a42139938e6ea2ae240"
@@ -4934,6 +5300,11 @@ require-directory@^2.1.1:
   resolved "https://registry.yarnpkg.com/require-directory/-/require-directory-2.1.1.tgz#8c64ad5fd30dab1c976e2344ffe7f792a6a6df42"
   integrity sha1-jGStX9MNqxyXbiNE/+f3kqam30I=
 
+require-from-string@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/require-from-string/-/require-from-string-2.0.2.tgz#89a7fdd938261267318eafe14f9c32e598c36909"
+  integrity sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==
+
 require-main-filename@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-2.0.0.tgz#d0b329ecc7cc0f61649f62215be69af54aa8989b"
@@ -4963,6 +5334,11 @@ resolve-from@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-3.0.0.tgz#b22c7af7d9d6881bc8b6e653335eebcb0a188748"
   integrity sha1-six699nWiBvItuZTM17rywoYh0g=
+
+resolve-from@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-4.0.0.tgz#4abcd852ad32dd7baabfe9b40e00a36db5f392e6"
+  integrity sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==
 
 resolve-from@^5.0.0:
   version "5.0.0"
@@ -5003,7 +5379,7 @@ rimraf@^2.5.4, rimraf@^2.6.0, rimraf@^2.6.3, rimraf@^2.7.1:
   dependencies:
     glob "^7.1.3"
 
-rimraf@^3.0.0:
+rimraf@^3.0.0, rimraf@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.2.tgz#f1a5402ba6220ad52cc1282bac1ae3aa49fd061a"
   integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
@@ -5092,6 +5468,13 @@ semver@^6.0.0, semver@^6.3.0:
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
+
+semver@^7.2.1:
+  version "7.3.5"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.5.tgz#0b621c879348d8998e4b0e4be94b3f12e6018ef7"
+  integrity sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==
+  dependencies:
+    lru-cache "^6.0.0"
 
 serialize-javascript@^2.1.2:
   version "2.1.2"
@@ -5212,6 +5595,15 @@ slash@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/slash/-/slash-1.0.0.tgz#c41f2f6c39fc16d1cd17ad4b5d896114ae470d55"
   integrity sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=
+
+slice-ansi@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-4.0.0.tgz#500e8dd0fd55b05815086255b3195adf2a45fe6b"
+  integrity sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==
+  dependencies:
+    ansi-styles "^4.0.0"
+    astral-regex "^2.0.0"
+    is-fullwidth-code-point "^3.0.0"
 
 snapdragon-node@^2.0.1:
   version "2.1.1"
@@ -5571,6 +5963,11 @@ strip-json-comments@2.0.1:
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
   integrity sha1-PFMZQukIwml8DsNEhYwobHygpgo=
 
+strip-json-comments@^3.1.0, strip-json-comments@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.1.1.tgz#31f1281b3832630434831c310c01cccda8cbe006"
+  integrity sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==
+
 subarg@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/subarg/-/subarg-1.0.0.tgz#f62cf17581e996b48fc965699f54c06ae268b8d2"
@@ -5618,6 +6015,18 @@ syntax-error@^1.1.1:
   dependencies:
     acorn-node "^1.2.0"
 
+table@^6.0.4:
+  version "6.4.0"
+  resolved "https://registry.yarnpkg.com/table/-/table-6.4.0.tgz#9501324358c313162cf52b2843a8b221e75fbefc"
+  integrity sha512-/Vfr23BDjJT2kfsCmYtnJqEPdD/8Dh/MDIQxfcbe+09lZUel6gluquwdMTrLERBw623Nv34DLGZ11krWn5AAqw==
+  dependencies:
+    ajv "^8.0.1"
+    lodash.clonedeep "^4.5.0"
+    lodash.flatten "^4.4.0"
+    lodash.truncate "^4.4.2"
+    slice-ansi "^4.0.0"
+    string-width "^4.2.0"
+
 tapable@^1.0.0, tapable@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/tapable/-/tapable-1.1.3.tgz#a1fccc06b58db61fd7a45da2da44f5f3a3e67ba2"
@@ -5655,6 +6064,11 @@ test-exclude@^6.0.0:
     "@istanbuljs/schema" "^0.1.2"
     glob "^7.1.4"
     minimatch "^3.0.4"
+
+text-table@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
+  integrity sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=
 
 through2@^2.0.0, through2@^2.0.1:
   version "2.0.5"
@@ -5807,12 +6221,24 @@ tty-browserify@0.0.1, tty-browserify@^0.0.1:
   resolved "https://registry.yarnpkg.com/tty-browserify/-/tty-browserify-0.0.1.tgz#3f05251ee17904dfd0677546670db9651682b811"
   integrity sha512-C3TaO7K81YvjCgQH9Q1S3R3P3BtN3RIM8n+OvX4il1K1zgE8ZhI0op7kClgkxtutIE8hQrcrHBXvIheqKUUCxw==
 
+type-check@^0.4.0, type-check@~0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/type-check/-/type-check-0.4.0.tgz#07b8203bfa7056c0657050e3ccd2c37730bab8f1"
+  integrity sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==
+  dependencies:
+    prelude-ls "^1.2.1"
+
 type-detect@4.0.8, type-detect@^4.0.8:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.8.tgz#7646fb5f18871cfbb7749e69bd39a6388eb7450c"
   integrity sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==
 
-type-fest@^0.8.0:
+type-fest@^0.20.2:
+  version "0.20.2"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.20.2.tgz#1bf207f4b28f91583666cb5fbd327887301cd5f4"
+  integrity sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==
+
+type-fest@^0.8.0, type-fest@^0.8.1:
   version "0.8.1"
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.8.1.tgz#09e249ebde851d3b1e48d27c105444667f17b83d"
   integrity sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==
@@ -5999,6 +6425,11 @@ v8-compile-cache@2.0.3:
   resolved "https://registry.yarnpkg.com/v8-compile-cache/-/v8-compile-cache-2.0.3.tgz#00f7494d2ae2b688cfe2899df6ed2c54bef91dbe"
   integrity sha512-CNmdbwQMBjwr9Gsmohvm0pbL954tJrNzf6gWL3K+QMQf00PF7ERGrEiLgjuU3mKreLC2MeGhUsNV9ybTbLgd3w==
 
+v8-compile-cache@^2.0.3:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz#2de19618c66dc247dcfb6f99338035d8245a2cee"
+  integrity sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==
+
 vm-browserify@^1.0.0, vm-browserify@^1.0.1, vm-browserify@^1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/vm-browserify/-/vm-browserify-1.1.2.tgz#78641c488b8e6ca91a75f511e7a3b32a86e5dda0"
@@ -6118,6 +6549,11 @@ wide-align@1.1.3:
   dependencies:
     string-width "^1.0.2 || 2"
 
+word-wrap@^1.2.3:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.3.tgz#610636f6b1f703891bd34771ccb17fb93b47079c"
+  integrity sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==
+
 wordwrap@~0.0.2:
   version "0.0.3"
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-0.0.3.tgz#a3d5da6cd5c0bc0008d37234bbaf1bed63059107"
@@ -6196,6 +6632,11 @@ yallist@^3.0.2:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.1.1.tgz#dbb7daf9bfd8bac9ab45ebf602b8cbad0d5d08fd"
   integrity sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==
+
+yallist@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
+  integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
 
 yargs-parser@13.1.2, yargs-parser@^13.1.0, yargs-parser@^13.1.2:
   version "13.1.2"


### PR DESCRIPTION
This is a draft patch enabling `eslint` for Automerge. This first patch leaves a number of known bugs and problems found by eslint in place in the interest of first making some decisions about whether we want to move forward with this approach or not.

In almost every case I've either disabled an eslint rule project-wide or on the particular line where the complaint from the linter occurred, but in a few cases I decided the fixes were uncontroversial enough just to tidy up on the spot.

In particular, the most important rule I think we still ought to enable is `no-unused-vars`. That will require making a decision about tests which have loads of unused variables that are kept around for visual consistency. I think it would be a fine compromise to enable no-unused-vars overall but consider leaving it disabled for tests (at least for the time being.)

I'll add some comments on the patch below. If we can reach an agreeable set of eslint rules and land them we can always tune them later, either adding new rules to improve consistency (many of the rules I disabled from the base were only triggered by one or two cases) or to better suit Martin's preferred style.