### PR TITLE
adds failing test

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -92,6 +92,17 @@ describe('Automerge', () => {
       assert.strictEqual(Automerge.getConflicts(s1, 'foo'), undefined)
     })
 
+    it('should hancle muliple counter increments', () => {
+      s1 = Automerge.change(s1, doc => doc.counter = new Automerge.Counter(0))
+      s1 = Automerge.change(s1, function(doc) {
+        doc.counter.increment(2)
+        doc.counter.increment(-1)
+        doc.counter.increment(3)
+      })
+     
+      assert.deepStrictEqual(s1, {counter: new Automerge.Counter(4)})
+    })
+
     describe('changes', () => {
       it('should group several changes', () => {
         s2 = Automerge.change(s1, 'change message', doc => {


### PR DESCRIPTION
Lukas found a issue and wrote a test for it - I think this may be a result of taking out the op coalescing frontend but we had no tests catching it.

Perhaps we need to put the op coalescing back in or make the backend properly handle multiple increments in the same change.