### PR TITLE
Speedup hashesbyactor

### DIFF
--- a/backend/backend.js
+++ b/backend/backend.js
@@ -17,11 +17,11 @@ function numHashesByActor(state, actorId) {
   }
 }
 
-function hashByActor(state, actorId,i) {
+function hashByActor(state, actorId, index) {
   if (USE_NEW_BACKEND) {
-    return (state.hashesByActor[actorId] || [])[i]
+    return (state.hashesByActor[actorId] || [])[index]
   } else {
-    return state.getIn(['opSet', 'states', actorId, i], List())
+    return state.getIn(['opSet', 'states', actorId, index])
   }
 }
 

--- a/backend/backend.js
+++ b/backend/backend.js
@@ -9,11 +9,19 @@ const { backendState } = require('./util')
 // byte-array-based data structures. New data structures are not yet fully working.
 const USE_NEW_BACKEND = false
 
-function hashesByActor(state, actorId) {
+function numHashesByActor(state, actorId) {
   if (USE_NEW_BACKEND) {
-    return state.hashesByActor[actorId] || []
+    return (state.hashesByActor[actorId] || []).length
   } else {
-    return state.getIn(['opSet', 'states', actorId], List()).toJS()
+    return state.getIn(['opSet', 'states', actorId], List()).size
+  }
+}
+
+function hashByActor(state, actorId,i) {
+  if (USE_NEW_BACKEND) {
+    return (state.hashesByActor[actorId] || [])[i]
+  } else {
+    return state.getIn(['opSet', 'states', actorId, i], List())
   }
 }
 
@@ -115,7 +123,7 @@ function applyChanges(backend, changes) {
  */
 function applyLocalChange(backend, change) {
   const state = backendState(backend)
-  if (change.seq <= hashesByActor(state, change.actor).length) {
+  if (change.seq <= numHashesByActor(state, change.actor)) {
     throw new RangeError('Change request has already been applied')
   }
 
@@ -133,7 +141,7 @@ function applyLocalChange(backend, change) {
   // necessary to add this dependency. However, it doesn't do any harm either (only
   // using a few extra bytes of storage).
   if (change.seq > 1) {
-    const lastHash = hashesByActor(state, change.actor)[change.seq - 2]
+    const lastHash = hashByActor(state, change.actor, change.seq - 2)
     if (!lastHash) {
       throw new RangeError(`Cannot find hash of localChange before seq=${change.seq}`)
     }
@@ -149,7 +157,7 @@ function applyLocalChange(backend, change) {
     backend.frozen = true
 
     // On the patch we send out, omit the last local change hash
-    const lastHash = hashesByActor(state, change.actor)[change.seq - 1]
+    const lastHash = hashByActor(state, change.actor, change.seq - 1)
     patch.deps = patch.deps.filter(head => head !== lastHash)
     return [{state, heads: state.heads}, patch, binaryChange]
 


### PR DESCRIPTION
Was running a benchmark doing 1 char insert per change over 50,000 chars and it ran in 80 seconds - this change makes it run in 16 seconds.