### PR TITLE
Polymorphic insertAt for Text

### DIFF
--- a/@types/automerge/index.d.ts
+++ b/@types/automerge/index.d.ts
@@ -91,9 +91,11 @@ declare module 'automerge' {
     deleteAt?(index: number, numDelete?: number): List<T>
   }
 
-  class Text extends List<string> {
+  class Text {
     constructor(text?: string | string[])
-    get(index: number): string
+    get<T>(index: number): string | T
+    insertAt(index: number, characters: string | (string | T)[]): Text
+    deleteAt(index: number, numDelete?: number): Text
     toSpans<T>(): (string | T)[]
   }
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,9 @@ is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
   (UUIDs can still be used, but the hyphens need to be removed).
 - **Changed**: `Automerge.getConflicts()` now returns *all* conflicting values, including the
   value chosen as default resolution.
+- **Changed**: `Automerge.Text.insertAt` now takes two arguments, the index and the characters to
+  insert. The characters can be given either as a string (which will be split into characters),
+  or as an array that is already split into individual characters.
 - **Changed**: Multiple references to the same object in an Automerge document are no longer
   allowed. In other words, the document is now required to be a tree, not a DAG.
 - **Changed**: We no longer assume that the backend state is immutable, giving us greater freedom

--- a/README.md
+++ b/README.md
@@ -484,13 +484,13 @@ Compared to using a regular JavaScript array, `Automerge.Text` offers better per
 > [skintone modifier](http://www.unicode.org/reports/tr51/) is a combining mark).
 
 You can create a Text object inside a change callback. Then you can use `insertAt()` and
-`deleteAt()` to insert and delete characters (same API as for list modifications, shown
+`deleteAt()` to insert and delete characters (similar API as for list modifications, shown
 [above](#updating-a-document)):
 
 ```js
 newDoc = Automerge.change(currentDoc, doc => {
   doc.text = new Automerge.Text()
-  doc.text.insertAt(0, 'h', 'e', 'l', 'l', 'o')
+  doc.text.insertAt(0, 'hello') // splits up the string into 'h', 'e', 'l', 'l', 'o'
   doc.text.deleteAt(0)
   doc.text.insertAt(0, 'H')
 })

--- a/frontend/text.js
+++ b/frontend/text.js
@@ -137,6 +137,9 @@ class Text {
    * Inserts new list items `values` starting at position `index`.
    */
   insertAt(index, ...values) {
+    if (typeof values[0] === 'string' && values[0].length > 1) {
+      values = values[0].split("")
+    }
     if (this.context) {
       this.context.splice(this.path, index, 0, values)
     } else if (!this[OBJECT_ID]) {

--- a/frontend/text.js
+++ b/frontend/text.js
@@ -138,7 +138,7 @@ class Text {
    */
   insertAt(index, ...values) {
     if (typeof values[0] === 'string' && values[0].length > 1) {
-      values = values[0].split("")
+      values = [...values[0]]
     }
     if (this.context) {
       this.context.splice(this.path, index, 0, values)

--- a/frontend/text.js
+++ b/frontend/text.js
@@ -134,16 +134,23 @@ class Text {
   }
 
   /**
-   * Inserts new list items `values` starting at position `index`.
+   * Inserts one or more new characters starting at position `index`. `characters` can either be a
+   * string (in which case it will be split into a sequence of Unicode code points), or an array of
+   * strings (in which case each element of the array is treated as a character and not split any
+   * further). The latter mode is useful if you want to use custom logic for splitting the string,
+   * for example to split it into Unicode grapheme clusters.
    */
-  insertAt(index, ...values) {
-    if (typeof values[0] === 'string' && values[0].length > 1) {
-      values = [...values[0]]
+  insertAt(index, characters) {
+    if (typeof characters === 'string') {
+      characters = [...characters]
+    } else if (!Array.isArray(characters)) {
+      throw new TypeError('Text.insertAt takes either a string or an array of characters')
     }
+
     if (this.context) {
-      this.context.splice(this.path, index, 0, values)
+      this.context.splice(this.path, index, 0, characters)
     } else if (!this[OBJECT_ID]) {
-      this.elems.splice(index, 0, ...values.map(value => ({value})))
+      this.elems.splice(index, 0, ...characters.map(value => ({value})))
     } else {
       throw new TypeError('Automerge.Text object cannot be modified outside of a change block')
     }

--- a/test/observable_test.js
+++ b/test/observable_test.js
@@ -42,7 +42,7 @@ describe('Automerge.Observable', () => {
       assert.deepStrictEqual(after.toString(), 'abc')
       assert.deepStrictEqual(local, true)
     })
-    doc = Automerge.change(doc, doc => doc.text.insertAt(0, 'a', 'b', 'c'))
+    doc = Automerge.change(doc, doc => doc.text.insertAt(0, 'abc'))
     assert.strictEqual(callbackCalled, true)
   })
 
@@ -131,7 +131,7 @@ describe('Automerge.Observable', () => {
     let doc = Automerge.init({observable}), actor = Automerge.getActorId(doc)
     doc = Automerge.change(doc, doc => {
       doc.text = new Automerge.Text()
-      doc.text.insertAt(0, 'a', 'b', {start: 'bold'}, 'c', {end: 'bold'})
+      doc.text.insertAt(0, ['a', 'b', {start: 'bold'}, 'c', {end: 'bold'}])
     })
     observable.observe(doc.text.get(2), (diff, before, after, local) => {
       callbackCalled = true

--- a/test/text_test.js
+++ b/test/text_test.js
@@ -201,7 +201,7 @@ describe('Automerge.Text', () => {
     s2 = Automerge.merge(Automerge.init(), s1)
   })
 
-  it('should support insertion of chacracter', () => {
+  it('should support insertion of character', () => {
     s1 = Automerge.change(s1, doc => doc.text.insertAt(0, 'a'))
     assert.strictEqual(s1.text.length, 1)
     assert.strictEqual(s1.text.get(0), 'a')

--- a/test/text_test.js
+++ b/test/text_test.js
@@ -201,11 +201,24 @@ describe('Automerge.Text', () => {
     s2 = Automerge.merge(Automerge.init(), s1)
   })
 
-  it('should support insertion', () => {
+  it('should support insertion of chacracter', () => {
     s1 = Automerge.change(s1, doc => doc.text.insertAt(0, 'a'))
     assert.strictEqual(s1.text.length, 1)
     assert.strictEqual(s1.text.get(0), 'a')
     assert.strictEqual(s1.text.toString(), 'a')
+    assert.strictEqual(s1.text.getElemId(0), `2@${Automerge.getActorId(s1)}`)
+  })
+
+  it('should support insertion of string', () => {
+    s1 = Automerge.change(s1, doc => doc.text.insertAt(0, 'string'))
+    assert.strictEqual(s1.text.length, 6)
+    assert.strictEqual(s1.text.get(0), 's')
+    assert.strictEqual(s1.text.get(1), 't')
+    assert.strictEqual(s1.text.get(2), 'r')
+    assert.strictEqual(s1.text.get(3), 'i')
+    assert.strictEqual(s1.text.get(4), 'n')
+    assert.strictEqual(s1.text.get(5), 'g')
+    assert.strictEqual(s1.text.toString(), 'string')
     assert.strictEqual(s1.text.getElemId(0), `2@${Automerge.getActorId(s1)}`)
   })
 

--- a/test/text_test.js
+++ b/test/text_test.js
@@ -222,6 +222,20 @@ describe('Automerge.Text', () => {
     assert.strictEqual(s1.text.getElemId(0), `2@${Automerge.getActorId(s1)}`)
   })
 
+  it('should support insertion of string containing a unicode character', () => {
+    s1 = Automerge.change(s1, doc => doc.text.insertAt(0, '🐦string'))
+    assert.strictEqual(s1.text.length, 7)
+    assert.strictEqual(s1.text.get(0), '🐦')
+    assert.strictEqual(s1.text.get(1), 's')
+    assert.strictEqual(s1.text.get(2), 't')
+    assert.strictEqual(s1.text.get(3), 'r')
+    assert.strictEqual(s1.text.get(4), 'i')
+    assert.strictEqual(s1.text.get(5), 'n')
+    assert.strictEqual(s1.text.get(6), 'g')
+    assert.strictEqual(s1.text.toString(), '🐦string')
+    assert.strictEqual(s1.text.getElemId(0), `2@${Automerge.getActorId(s1)}`)
+  })
+
   it('should support deletion', () => {
     s1 = Automerge.change(s1, doc => doc.text.insertAt(0, 'a', 'b', 'c'))
     s1 = Automerge.change(s1, doc => doc.text.deleteAt(1, 1))

--- a/test/typescript_test.ts
+++ b/test/typescript_test.ts
@@ -326,19 +326,31 @@ describe('TypeScript support', () => {
 
     describe('insertAt', () => {
       it('should support inserting a single element', () => {
-        doc = Automerge.change(doc, doc => doc.text.insertAt(0, 'abc'))
+        doc = Automerge.change(doc, doc => doc.text.insertAt(0, ['abc']))
+        assert.strictEqual(doc.text.get(0), 'abc')
         assert.strictEqual(JSON.stringify(doc.text), '"abc"')
       })
 
       it('should support inserting multiple elements', () => {
-        doc = Automerge.change(doc, doc => doc.text.insertAt(0, 'a', 'b', 'c'))
+        doc = Automerge.change(doc, doc => doc.text.insertAt(0, ['a', 'b', 'c']))
+        assert.strictEqual(doc.text.get(0), 'a')
+        assert.strictEqual(doc.text.get(1), 'b')
+        assert.strictEqual(doc.text.get(2), 'c')
+        assert.strictEqual(JSON.stringify(doc.text), '"abc"')
+      })
+
+      it('should split a multi-character string if given', () => {
+        doc = Automerge.change(doc, doc => doc.text.insertAt(0, 'abc'))
+        assert.strictEqual(doc.text.get(0), 'a')
+        assert.strictEqual(doc.text.get(1), 'b')
+        assert.strictEqual(doc.text.get(2), 'c')
         assert.strictEqual(JSON.stringify(doc.text), '"abc"')
       })
     })
 
     describe('deleteAt', () => {
       beforeEach(() => {
-        doc = Automerge.change(doc, doc => doc.text.insertAt(0, 'a', 'b', 'c', 'd', 'e', 'f', 'g'))
+        doc = Automerge.change(doc, doc => doc.text.insertAt(0, 'abcdefg'))
       })
 
       it('should support deleting a single element without specifying `numDelete`', () => {
@@ -354,7 +366,7 @@ describe('TypeScript support', () => {
 
     describe('get', () => {
       it('should get the element at the given index', () => {
-        doc = Automerge.change(doc, doc => doc.text.insertAt(0, 'a', 'b', 'cdefg', 'hi', 'jkl'))
+        doc = Automerge.change(doc, doc => doc.text.insertAt(0, ['a', 'b', 'cdefg', 'hi', 'jkl']))
         assert.strictEqual(doc.text.get(0), 'a')
         assert.strictEqual(doc.text.get(2), 'cdefg')
       })
@@ -363,7 +375,7 @@ describe('TypeScript support', () => {
     describe('delegated read-only operations from `Array`', () => {
       const a = ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i']
       beforeEach(() => {
-        doc = Automerge.change(doc, doc => doc.text.insertAt(0, ...a))
+        doc = Automerge.change(doc, doc => doc.text.insertAt(0, a))
       })
 
       it('supports `indexOf`', () => assert.strictEqual(doc.text.indexOf('c'), 2))
@@ -374,7 +386,7 @@ describe('TypeScript support', () => {
 
     describe('getElementIds', () => {
       it('should return the element ID of each character', () => {
-        doc = Automerge.change(doc, doc => doc.text.insertAt(0, 'a', 'b'))
+        doc = Automerge.change(doc, doc => doc.text.insertAt(0, ['a', 'b']))
         const elemIds = Automerge.Frontend.getElementIds(doc.text)
         assert.deepStrictEqual(elemIds, [`2@${Automerge.getActorId(doc)}`, `3@${Automerge.getActorId(doc)}`])
       })


### PR DESCRIPTION
This could resolve #326. 

It introduces a the possibility to pass normal strings into `insertAt`.
```js
Automerge.change(s1, doc => doc.text.insertAt(0, 'string'))
```

 If one passes a string it gets split up into characters inside `insertAt` and processed as as list of single characters

