### PR TITLE
Fix invalid opSet getMissingChanges return value

### DIFF
--- a/backend/op_set.js
+++ b/backend/op_set.js
@@ -564,7 +564,7 @@ function getMissingChanges(opSet, haveDeps) {
   return opSet.get('history')
     .filter(hash => !seenHashes[hash])
     .map(hash => getChangeByHash(opSet, hash))
-    .toJSON()
+    .toArray()
 }
 
 /**


### PR DESCRIPTION
Automerge 1.0.1-preview.0 has been occasionally (hard to consistently reproduce) crashing for me with the following message:
```
TypeError: Not a byte array: [object Object]
    at new Decoder (automerge-backend/node_modules/automerge-preview/dist/webpack:/Automerge/backend/encoding.js:304:13)
    at decodeChangeMeta (automerge-backend/node_modules/automerge-preview/dist/webpack:/Automerge/backend/columnar.js:778:40)
    at map (automerge-backend/node_modules/automerge-preview/dist/webpack:/Automerge/backend/sync.js:263:20)
    at Array.map (<anonymous>)
    at getChangesToSend (automerge-backend/node_modules/automerge-preview/dist/webpack:/Automerge/backend/sync.js:263:6)
```

After some debugging I found out that even though the `Decoder` constructor expects an `ArrayBuffer`, it would sometimes be passed an object of the form `{type: "Buffer", data: [...]}` causing the above crash.

I managed to track the issue down to the `getMissingChanges` function.  It looks like `getMissingChanges` is supposed to always return an array of arraybuffers, but it in some rare cases it returns an array of objects instead (causing the decoder crash). Compare the return type of the branch [here](https://github.com/automerge/automerge/blob/fcee822dc60034c3350c031d27774cf4d2bb0fd2/backend/op_set.js#L550) with this [one](https://github.com/automerge/automerge/blob/fcee822dc60034c3350c031d27774cf4d2bb0fd2/backend/op_set.js#L564).

The issue was caused by calling `.toJSON()` on its final result. The `.toJSON()` method does deep conversion on the result,  transforming array buffers into objects of the form `{type: "Buffer", data: [...]}` instead of keeping them as ArrayBuffers.

Replacing `.toJSON()` with `.toArray()` fixes this behavior.