### PR TITLE
Sync fails if one node experiences complete data loss but another node has a stale sync state

### DIFF
--- a/backend/sync.js
+++ b/backend/sync.js
@@ -430,7 +430,7 @@ function receiveSyncMessage(backend, oldSyncState, binaryMessage) {
     throw new Error("generateSyncMessage requires a syncState, which can be created with initSyncState()")
   }
 
-  let { sharedHeads, lastSentHeads } = oldSyncState, patch = null
+  let { sharedHeads, lastSentHeads, sentHashes } = oldSyncState, patch = null
   const message = decodeSyncMessage(binaryMessage)
   const beforeHeads = Backend.getHeads(backend)
 
@@ -453,6 +453,10 @@ function receiveSyncMessage(backend, oldSyncState, binaryMessage) {
   const knownHeads = message.heads.filter(head => Backend.getChangeByHash(backend, head))
   if (knownHeads.length === message.heads.length) {
     sharedHeads = message.heads
+    if (message.heads.length === 0) {
+      lastSentHeads = [];
+      sentHashes = [];
+    }
   } else {
     // If some remote heads are unknown to us, we add all the remote heads we know to
     // sharedHeads, but don't remove anything from sharedHeads. This might cause sharedHeads to
@@ -467,7 +471,7 @@ function receiveSyncMessage(backend, oldSyncState, binaryMessage) {
     theirHave: message.have, // the information we need to calculate the changes they need
     theirHeads: message.heads,
     theirNeed: message.need,
-    sentHashes: oldSyncState.sentHashes,
+    sentHashes: sentHashes,
   }
   return [backend, syncState, patch]
 }

--- a/backend/sync.js
+++ b/backend/sync.js
@@ -453,9 +453,10 @@ function receiveSyncMessage(backend, oldSyncState, binaryMessage) {
   const knownHeads = message.heads.filter(head => Backend.getChangeByHash(backend, head))
   if (knownHeads.length === message.heads.length) {
     sharedHeads = message.heads
+    // If the remote peer has lost all its data, reset our state to perform a full resync
     if (message.heads.length === 0) {
-      lastSentHeads = [];
-      sentHashes = [];
+      lastSentHeads = []
+      sentHashes = []
     }
   } else {
     // If some remote heads are unknown to us, we add all the remote heads we know to
@@ -471,7 +472,7 @@ function receiveSyncMessage(backend, oldSyncState, binaryMessage) {
     theirHave: message.have, // the information we need to calculate the changes they need
     theirHeads: message.heads,
     theirNeed: message.need,
-    sentHashes: sentHashes,
+    sentHashes
   }
   return [backend, syncState, patch]
 }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "browsertest": "karma start",
     "coverage": "nyc --reporter=html --reporter=text mocha",
-    "test": "mocha",
+    "test": "mocha --file test/sync_test.js",
     "testwasm": "mocha --file test/wasm.js",
     "build": "webpack && copyfiles --flat @types/automerge/index.d.ts dist",
     "prepublishOnly": "npm run-script build",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "browsertest": "karma start",
     "coverage": "nyc --reporter=html --reporter=text mocha",
-    "test": "mocha --file test/sync_test.js",
+    "test": "mocha",
     "testwasm": "mocha --file test/wasm.js",
     "build": "webpack && copyfiles --flat @types/automerge/index.d.ts dist",
     "prepublishOnly": "npm run-script build",

--- a/test/sync_test.js
+++ b/test/sync_test.js
@@ -18,10 +18,7 @@ function sync(a, b, aSyncState = initSyncState(), bSyncState = initSyncState()) 
   do {
     [aSyncState, aToBmsg] = Automerge.generateSyncMessage(a, aSyncState)
     ;[bSyncState, bToAmsg] = Automerge.generateSyncMessage(b, bSyncState)
-    console.log(i)
-    console.log("A SYNC", aSyncState);
-    console.log("B SYNC", bSyncState);
-    console.log("\n\n\n");
+
 
     if (aToBmsg) {
       [b, bSyncState] = Automerge.receiveSyncMessage(b, bSyncState, aToBmsg)
@@ -367,12 +364,12 @@ describe('Data sync protocol', () => {
       assert.deepStrictEqual(getHeads(n1), getHeads(r))
       assert.deepStrictEqual(n1, r)
     })
-    it.only('should resync after one node experiences data loss and needs to start from scratch', () => {
+    it('should resync after one node experiences data loss and needs to start from scratch', () => {
       let n1 = Automerge.init('01234567'), n2 = Automerge.init('89abcdef')
       let s1 = initSyncState(), s2 = initSyncState()
 
       // n1 makes three changes, which we sync to n2
-      for (let i = 0; i < 3; i++) n1 = Automerge.change(n1, {time: 0}, doc => doc.x = i)
+      for (let i = 0; i < 1; i++) n1 = Automerge.change(n1, {time: 0}, doc => doc.x = i)
       ;[n1, n2, s1, s2] = sync(n1, n2, s1, s2)
 
       assert.deepStrictEqual(getHeads(n1), getHeads(n2))

--- a/test/sync_test.js
+++ b/test/sync_test.js
@@ -377,6 +377,7 @@ describe('Data sync protocol', () => {
 
       let n2AfterDataLoss = Automerge.init('89abcdef');
 
+      // "n2" now has no data, but n1 still thinks it does
       ;[n1, n2, s1, s2] = sync(n1, n2AfterDataLoss, s1, initSyncState())
       assert.deepStrictEqual(getHeads(n1), getHeads(n2))
       assert.deepStrictEqual(n1, n2)

--- a/test/sync_test.js
+++ b/test/sync_test.js
@@ -369,17 +369,13 @@ describe('Data sync protocol', () => {
       let s1 = initSyncState(), s2 = initSyncState()
 
       // n1 makes three changes, which we sync to n2
-      for (let i = 0; i < 1; i++) n1 = Automerge.change(n1, {time: 0}, doc => doc.x = i)
+      for (let i = 0; i < 3; i++) n1 = Automerge.change(n1, {time: 0}, doc => doc.x = i)
       ;[n1, n2, s1, s2] = sync(n1, n2, s1, s2)
 
       assert.deepStrictEqual(getHeads(n1), getHeads(n2))
       assert.deepStrictEqual(n1, n2)
 
       let n2AfterDataLoss = Automerge.init('89abcdef');
-      // THIS WILL PASS
-      // const [goodN1, goodN2] = sync(n1, n2AfterDataLoss)
-      // assert.deepStrictEqual(getHeads(goodN1), getHeads(goodN2))
-      // assert.deepStrictEqual(n1, n2)
 
       ;[n1, n2, s1, s2] = sync(n1, n2AfterDataLoss, s1, initSyncState())
       assert.deepStrictEqual(getHeads(n1), getHeads(n2))

--- a/test/sync_test.js
+++ b/test/sync_test.js
@@ -378,14 +378,14 @@ describe('Data sync protocol', () => {
       assert.deepStrictEqual(getHeads(n1), getHeads(n2))
       assert.deepStrictEqual(n1, n2)
 
+      let n2AfterDataLoss = Automerge.init('89abcdef');
       // THIS WILL PASS
-      // let n2AfterDataLoss = Automerge.init('89abcdef');
       // const [goodN1, goodN2] = sync(n1, n2AfterDataLoss)
       // assert.deepStrictEqual(getHeads(goodN1), getHeads(goodN2))
       // assert.deepStrictEqual(n1, n2)
 
       // THIS WILL NOT
-      ;[n1, n2, s1, s2] = sync(n1, n2AfterDataLoss, s1, s2)
+      ;[n1, n2, s1, s2] = sync(n1, n2AfterDataLoss, s1, initSyncState())
       assert.deepStrictEqual(getHeads(n1), getHeads(n2))
       assert.deepStrictEqual(n1, n2)
       // save a copy of n2 as "r" to simulate recovering from crash

--- a/test/sync_test.js
+++ b/test/sync_test.js
@@ -381,8 +381,8 @@ describe('Data sync protocol', () => {
       // assert.deepStrictEqual(n1, n2)
 
       ;[n1, n2, s1, s2] = sync(n1, n2AfterDataLoss, s1, initSyncState())
-      assert.deepStrictEqual(getHeads(n1), getHeads(n2))
-      assert.deepStrictEqual(n1, n2)
+      assert.deepStrictEqual(getHeads(n1), getHeads(n2AfterDataLoss))
+      assert.deepStrictEqual(n1, n2AfterDataLoss)
     })
   })
 

--- a/test/sync_test.js
+++ b/test/sync_test.js
@@ -363,11 +363,7 @@ describe('Data sync protocol', () => {
       assert.deepStrictEqual(getHeads(n1), getHeads(r))
       assert.deepStrictEqual(n1, r)
     })
-    it('different edge case from above test', () => {
-      // Scenario:     (r)                  (n2)                 (n1)
-      // c0 <-- c1 <-- c2 <-- c3 <-- c4 <-- c5 <-- c6 <-- c7 <-- c8
-      // n2 has changes {c0, c1, c2}, n1's lastSync is c5, and n2's lastSync is c2.
-      // we want to successfully sync (n1) with (r), even though (n1) believes it's talking to (n2)
+    it('should resync after one node experiences data loss and needs to start from scratch', () => {
       let n1 = Automerge.init('01234567'), n2 = Automerge.init('89abcdef')
       let s1 = initSyncState(), s2 = initSyncState()
 
@@ -384,11 +380,9 @@ describe('Data sync protocol', () => {
       // assert.deepStrictEqual(getHeads(goodN1), getHeads(goodN2))
       // assert.deepStrictEqual(n1, n2)
 
-      // THIS WILL NOT
       ;[n1, n2, s1, s2] = sync(n1, n2AfterDataLoss, s1, initSyncState())
       assert.deepStrictEqual(getHeads(n1), getHeads(n2))
       assert.deepStrictEqual(n1, n2)
-      // save a copy of n2 as "r" to simulate recovering from crash
     })
   })
 

--- a/test/sync_test.js
+++ b/test/sync_test.js
@@ -19,7 +19,6 @@ function sync(a, b, aSyncState = initSyncState(), bSyncState = initSyncState()) 
     [aSyncState, aToBmsg] = Automerge.generateSyncMessage(a, aSyncState)
     ;[bSyncState, bToAmsg] = Automerge.generateSyncMessage(b, bSyncState)
 
-
     if (aToBmsg) {
       [b, bSyncState] = Automerge.receiveSyncMessage(b, bSyncState, aToBmsg)
     }
@@ -364,7 +363,8 @@ describe('Data sync protocol', () => {
       assert.deepStrictEqual(getHeads(n1), getHeads(r))
       assert.deepStrictEqual(n1, r)
     })
-    it('should resync after one node experiences data loss and needs to start from scratch', () => {
+
+    it('should resync after one node experiences data loss without disconnecting', () => {
       let n1 = Automerge.init('01234567'), n2 = Automerge.init('89abcdef')
       let s1 = initSyncState(), s2 = initSyncState()
 
@@ -375,9 +375,10 @@ describe('Data sync protocol', () => {
       assert.deepStrictEqual(getHeads(n1), getHeads(n2))
       assert.deepStrictEqual(n1, n2)
 
-      let n2AfterDataLoss = Automerge.init('89abcdef');
+      let n2AfterDataLoss = Automerge.init('89abcdef')
 
-      // "n2" now has no data, but n1 still thinks it does
+      // "n2" now has no data, but n1 still thinks it does. Note we don't do
+      // decodeSyncState(encodeSyncState(s1)) in order to simulate data loss without disconnecting
       ;[n1, n2, s1, s2] = sync(n1, n2AfterDataLoss, s1, initSyncState())
       assert.deepStrictEqual(getHeads(n1), getHeads(n2))
       assert.deepStrictEqual(n1, n2)

--- a/test/sync_test.js
+++ b/test/sync_test.js
@@ -18,6 +18,10 @@ function sync(a, b, aSyncState = initSyncState(), bSyncState = initSyncState()) 
   do {
     [aSyncState, aToBmsg] = Automerge.generateSyncMessage(a, aSyncState)
     ;[bSyncState, bToAmsg] = Automerge.generateSyncMessage(b, bSyncState)
+    console.log(i)
+    console.log("A SYNC", aSyncState);
+    console.log("B SYNC", bSyncState);
+    console.log("\n\n\n");
 
     if (aToBmsg) {
       [b, bSyncState] = Automerge.receiveSyncMessage(b, bSyncState, aToBmsg)
@@ -363,7 +367,7 @@ describe('Data sync protocol', () => {
       assert.deepStrictEqual(getHeads(n1), getHeads(r))
       assert.deepStrictEqual(n1, r)
     })
-    it('should resync after one node experiences data loss and needs to start from scratch', () => {
+    it.only('should resync after one node experiences data loss and needs to start from scratch', () => {
       let n1 = Automerge.init('01234567'), n2 = Automerge.init('89abcdef')
       let s1 = initSyncState(), s2 = initSyncState()
 
@@ -381,8 +385,8 @@ describe('Data sync protocol', () => {
       // assert.deepStrictEqual(n1, n2)
 
       ;[n1, n2, s1, s2] = sync(n1, n2AfterDataLoss, s1, initSyncState())
-      assert.deepStrictEqual(getHeads(n1), getHeads(n2AfterDataLoss))
-      assert.deepStrictEqual(n1, n2AfterDataLoss)
+      assert.deepStrictEqual(getHeads(n1), getHeads(n2))
+      assert.deepStrictEqual(n1, n2)
     })
   })
 


### PR DESCRIPTION
What I'm trying to simulate here is if one node loses all of it's data including document data as well as any previous sync state information.

The test i've created here goes into an infinite loop.  I believe I'm experiencing this in a real world app but I'm not 100% sure I've captured it accurately in the test.

I'm wondering if this is something application developers should be proactive about (sending a sync message for a blank document) or if this is an actual bug in the sync protocol.

I am able to sync these docs when they both reset their sync state to `initialSyncState()`.  So the question is how should the node that has intact state react to the "bad" sync request from the errant peer?


EDIT: I made the test pass but I'm not sure what kind of damage my "fix" may have caused.  It seems reasonable that if the incoming message is saying "I have nothing" that the entire sync protocol should begin anew?