### PR TITLE
Fix wasm tests

### DIFF
--- a/backend/columnar.js
+++ b/backend/columnar.js
@@ -1225,7 +1225,7 @@ function addPatchProperty(objects, property) {
   // If the counter had any successor operation that was not an increment, that means the counter
   // must have been deleted, so we omit it from the patch.
   if (counter && Object.keys(counter.succ).length === 0) {
-    values[counter.opId] = {type: 'value', value: counter.value, datatype: 'counter'}
+    values[counter.opId] = {value: counter.value, datatype: 'counter'}
   }
 
   if (Object.keys(values).length > 0) {
@@ -1965,7 +1965,7 @@ class BackendDoc {
       delete counterState.succs[opId]
 
       if (Object.keys(counterState.succs).length === 0 && patch.props[key]) {
-        patch.props[key][counterState.opId] = {type: 'value', datatype: 'counter', value: counterState.value}
+        patch.props[key][counterState.opId] = {datatype: 'counter', value: counterState.value}
         // TODO if the counter is in a list element, we need to add a 'remove' action when deleted
       }
 

--- a/backend/columnar.js
+++ b/backend/columnar.js
@@ -1225,7 +1225,7 @@ function addPatchProperty(objects, property) {
   // If the counter had any successor operation that was not an increment, that means the counter
   // must have been deleted, so we omit it from the patch.
   if (counter && Object.keys(counter.succ).length === 0) {
-    values[counter.opId] = {value: counter.value, datatype: 'counter'}
+    values[counter.opId] = {type: 'value', value: counter.value, datatype: 'counter'}
   }
 
   if (Object.keys(values).length > 0) {

--- a/backend/columnar.js
+++ b/backend/columnar.js
@@ -1225,7 +1225,7 @@ function addPatchProperty(objects, property) {
   // If the counter had any successor operation that was not an increment, that means the counter
   // must have been deleted, so we omit it from the patch.
   if (counter && Object.keys(counter.succ).length === 0) {
-    values[counter.opId] = {value: counter.value, datatype: 'counter'}
+    values[counter.opId] = {type: 'value', value: counter.value, datatype: 'counter'}
   }
 
   if (Object.keys(values).length > 0) {
@@ -1965,7 +1965,7 @@ class BackendDoc {
       delete counterState.succs[opId]
 
       if (Object.keys(counterState.succs).length === 0 && patch.props[key]) {
-        patch.props[key][counterState.opId] = {datatype: 'counter', value: counterState.value}
+        patch.props[key][counterState.opId] = {type: 'value', datatype: 'counter', value: counterState.value}
         // TODO if the counter is in a list element, we need to add a 'remove' action when deleted
       }
 

--- a/test/backend_test.js
+++ b/test/backend_test.js
@@ -844,7 +844,7 @@ describe('Automerge.Backend', () => {
       assert.deepStrictEqual(Backend.getPatch(s1), {
         clock: {[actor]: 2}, deps: [hash(change2)], maxOp: 2, pendingChanges: 0,
         diffs: {objectId: '_root', type: 'map', props: {
-          counter: {[`1@${actor}`]: {value: 3, datatype: 'counter'}}
+          counter: {[`1@${actor}`]: {type: 'value', value: 3, datatype: 'counter'}}
         }}
       })
     })

--- a/test/columnar_test.js
+++ b/test/columnar_test.js
@@ -1003,19 +1003,19 @@ describe('BackendDoc applying changes', () => {
     assert.deepStrictEqual(backend.applyChanges([encodeChange(change1)]), {
       maxOp: 1, clock: {[actor]: 1}, deps: [hash(change1)],
       diffs: {objectId: '_root', type: 'map', props: {
-        counter: {[`1@${actor}`]: {value: 1, datatype: 'counter'}}
+        counter: {[`1@${actor}`]: {type: 'value', value: 1, datatype: 'counter'}}
       }}
     })
     assert.deepStrictEqual(backend.applyChanges([encodeChange(change2)]), {
       maxOp: 2, clock: {[actor]: 2}, deps: [hash(change2)],
       diffs: {objectId: '_root', type: 'map', props: {
-        counter: {[`1@${actor}`]: {value: 3, datatype: 'counter'}}
+        counter: {[`1@${actor}`]: {type: 'value', value: 3, datatype: 'counter'}}
       }}
     })
     assert.deepStrictEqual(backend.applyChanges([encodeChange(change3)]), {
       maxOp: 3, clock: {[actor]: 3}, deps: [hash(change3)],
       diffs: {objectId: '_root', type: 'map', props: {
-        counter: {[`1@${actor}`]: {value: 6, datatype: 'counter'}}
+        counter: {[`1@${actor}`]: {type: 'value', value: 6, datatype: 'counter'}}
       }}
     })
     checkColumns(backend.docColumns, {
@@ -1051,14 +1051,14 @@ describe('BackendDoc applying changes', () => {
       diffs: {objectId: '_root', type: 'map', props: {list: {[`1@${actor}`]: {
         objectId: `1@${actor}`, type: 'list',
         edits: [{action: 'insert', index: 0, elemId: `2@${actor}`}],
-        props: {0: {[`2@${actor}`]: {value: 1, datatype: 'counter'}}}
+        props: {0: {[`2@${actor}`]: {type: 'value', value: 1, datatype: 'counter'}}}
       }}}}
     })
     assert.deepStrictEqual(backend.applyChanges([encodeChange(change2)]), {
       maxOp: 3, clock: {[actor]: 2}, deps: [hash(change2)],
       diffs: {objectId: '_root', type: 'map', props: {list: {[`1@${actor}`]: {
         objectId: `1@${actor}`, type: 'list', edits: [],
-        props: {0: {[`2@${actor}`]: {value: 3, datatype: 'counter'}}}
+        props: {0: {[`2@${actor}`]: {type: 'value', value: 3, datatype: 'counter'}}}
       }}}}
     })
     checkColumns(backend.docColumns, {
@@ -1095,7 +1095,7 @@ describe('BackendDoc applying changes', () => {
     assert.deepStrictEqual(backend.applyChanges([encodeChange(change2)]), {
       maxOp: 2, clock: {[actor]: 2}, deps: [hash(change2)],
       diffs: {objectId: '_root', type: 'map', props: {
-        counter: {[`1@${actor}`]: {value: 3, datatype: 'counter'}}
+        counter: {[`1@${actor}`]: {type: 'value', value: 3, datatype: 'counter'}}
       }}
     })
     assert.deepStrictEqual(backend.applyChanges([encodeChange(change3)]), {

--- a/test/columnar_test.js
+++ b/test/columnar_test.js
@@ -1003,19 +1003,19 @@ describe('BackendDoc applying changes', () => {
     assert.deepStrictEqual(backend.applyChanges([encodeChange(change1)]), {
       maxOp: 1, clock: {[actor]: 1}, deps: [hash(change1)],
       diffs: {objectId: '_root', type: 'map', props: {
-        counter: {[`1@${actor}`]: {type: 'value', value: 1, datatype: 'counter'}}
+        counter: {[`1@${actor}`]: {value: 1, datatype: 'counter'}}
       }}
     })
     assert.deepStrictEqual(backend.applyChanges([encodeChange(change2)]), {
       maxOp: 2, clock: {[actor]: 2}, deps: [hash(change2)],
       diffs: {objectId: '_root', type: 'map', props: {
-        counter: {[`1@${actor}`]: {type: 'value', value: 3, datatype: 'counter'}}
+        counter: {[`1@${actor}`]: {value: 3, datatype: 'counter'}}
       }}
     })
     assert.deepStrictEqual(backend.applyChanges([encodeChange(change3)]), {
       maxOp: 3, clock: {[actor]: 3}, deps: [hash(change3)],
       diffs: {objectId: '_root', type: 'map', props: {
-        counter: {[`1@${actor}`]: {type: 'value', value: 6, datatype: 'counter'}}
+        counter: {[`1@${actor}`]: {value: 6, datatype: 'counter'}}
       }}
     })
     checkColumns(backend.docColumns, {
@@ -1051,14 +1051,14 @@ describe('BackendDoc applying changes', () => {
       diffs: {objectId: '_root', type: 'map', props: {list: {[`1@${actor}`]: {
         objectId: `1@${actor}`, type: 'list',
         edits: [{action: 'insert', index: 0, elemId: `2@${actor}`}],
-        props: {0: {[`2@${actor}`]: {type: 'value', value: 1, datatype: 'counter'}}}
+        props: {0: {[`2@${actor}`]: {value: 1, datatype: 'counter'}}}
       }}}}
     })
     assert.deepStrictEqual(backend.applyChanges([encodeChange(change2)]), {
       maxOp: 3, clock: {[actor]: 2}, deps: [hash(change2)],
       diffs: {objectId: '_root', type: 'map', props: {list: {[`1@${actor}`]: {
         objectId: `1@${actor}`, type: 'list', edits: [],
-        props: {0: {[`2@${actor}`]: {type: 'value', value: 3, datatype: 'counter'}}}
+        props: {0: {[`2@${actor}`]: {value: 3, datatype: 'counter'}}}
       }}}}
     })
     checkColumns(backend.docColumns, {
@@ -1095,7 +1095,7 @@ describe('BackendDoc applying changes', () => {
     assert.deepStrictEqual(backend.applyChanges([encodeChange(change2)]), {
       maxOp: 2, clock: {[actor]: 2}, deps: [hash(change2)],
       diffs: {objectId: '_root', type: 'map', props: {
-        counter: {[`1@${actor}`]: {type: 'value', value: 3, datatype: 'counter'}}
+        counter: {[`1@${actor}`]: {value: 3, datatype: 'counter'}}
       }}
     })
     assert.deepStrictEqual(backend.applyChanges([encodeChange(change3)]), {

--- a/test/wasm.js
+++ b/test/wasm.js
@@ -106,10 +106,10 @@ function interopTests(sourceBackend, destBackend) {
     assert.deepStrictEqual(patch1, {
       clock: {[actor]: 1}, deps: [decodeChange(change1).hash], maxOp: 2, pendingChanges: 0,
       diffs: {objectId: '_root', type: 'map', props: {birds: {[`1@${actor}`]: {
-        objectId: `1@${actor}`, type: 'list',
-        edits: [{action: 'insert', index: 0, elemId: `2@${actor}`,
-          opId: `2@${actor}`, value: {type: 'value', value: 'chaffinch'}
-        }],
+        objectId: `1@${actor}`, type: 'list', edits: [
+          {action: 'insert', index: 0, elemId: `2@${actor}`, opId: `2@${actor}`,
+            value: {type: 'value', value: 'chaffinch'}}
+        ]
       }}}}
     })
   })

--- a/test/wasm.js
+++ b/test/wasm.js
@@ -152,15 +152,8 @@ function interopTests(sourceBackend, destBackend) {
       clock: {[actor]: 1}, deps: [decodeChange(change1).hash], maxOp: 4, pendingChanges: 0,
       diffs: {objectId: '_root', type: 'map', props: {text: {[`1@${actor}`]: {
         objectId: `1@${actor}`, type: 'text', edits: [
-          {action: 'insert', index: 0, elemId: `2@${actor}`},
-          {action: 'insert', index: 1, elemId: `3@${actor}`},
-          {action: 'insert', index: 2, elemId: `4@${actor}`}
+          {action: 'multi-insert', index: 0, elemId: `2@${actor}`, values: ['a', 'b', 'c']},
         ],
-        props: {
-          0: {[`2@${actor}`]: {type: 'value', value: 'a'}},
-          1: {[`3@${actor}`]: {type: 'value', value: 'b'}},
-          2: {[`4@${actor}`]: {type: 'value', value: 'c'}},
-        }
       }}}}
     })
   })

--- a/test/wasm.js
+++ b/test/wasm.js
@@ -52,7 +52,7 @@ function interopTests(sourceBackend, destBackend) {
     assert.deepStrictEqual(patch, {
       clock: {[actor]: 1}, deps: [decodeChange(change1).hash], maxOp: 1, pendingChanges: 0,
       diffs: {objectId: '_root', type: 'map', props: {
-        bird: {[`1@${actor}`]: {value: 'magpie'}}
+        bird: {[`1@${actor}`]: {type: 'value', value: 'magpie'}}
       }}
     })
   })
@@ -89,7 +89,7 @@ function interopTests(sourceBackend, destBackend) {
     assert.deepStrictEqual(patch1, {
       clock: {[actor]: 1}, deps: [decodeChange(change1).hash], maxOp: 2, pendingChanges: 0,
       diffs: {objectId: '_root', type: 'map', props: {birds: {[`1@${actor}`]: {
-        objectId: `1@${actor}`, type: 'map', props: {wrens: {[`2@${actor}`]: {value: 3}}}
+        objectId: `1@${actor}`, type: 'map', props: {wrens: {[`2@${actor}`]: {type: 'value', value: 3}}}
       }}}}
     })
   })
@@ -108,7 +108,7 @@ function interopTests(sourceBackend, destBackend) {
       diffs: {objectId: '_root', type: 'map', props: {birds: {[`1@${actor}`]: {
         objectId: `1@${actor}`, type: 'list',
         edits: [{action: 'insert', index: 0, elemId: `2@${actor}`}],
-        props: {0: {[`2@${actor}`]: {value: 'chaffinch'}}}
+        props: {0: {[`2@${actor}`]: {type: 'value', value: 'chaffinch'}}}
       }}}}
     })
   })
@@ -131,8 +131,8 @@ function interopTests(sourceBackend, destBackend) {
     assert.deepStrictEqual(patch2, {
       clock: {[actor]: 2}, deps: [decodeChange(change2).hash], maxOp: 3, pendingChanges: 0,
       diffs: {objectId: '_root', type: 'map', props: {birds: {[`1@${actor}`]: {
-        objectId: `1@${actor}`, type: 'list', props: {},
-        edits: [{action: 'remove', index: 0}]
+        objectId: `1@${actor}`, type: 'list',
+        edits: [{action: 'remove', index: 0, count: 1}]
       }}}}
     })
   })
@@ -157,9 +157,9 @@ function interopTests(sourceBackend, destBackend) {
           {action: 'insert', index: 2, elemId: `4@${actor}`}
         ],
         props: {
-          0: {[`2@${actor}`]: {value: 'a'}},
-          1: {[`3@${actor}`]: {value: 'b'}},
-          2: {[`4@${actor}`]: {value: 'c'}},
+          0: {[`2@${actor}`]: {type: 'value', value: 'a'}},
+          1: {[`3@${actor}`]: {type: 'value', value: 'b'}},
+          2: {[`4@${actor}`]: {type: 'value', value: 'c'}},
         }
       }}}}
     })
@@ -181,8 +181,8 @@ function interopTests(sourceBackend, destBackend) {
       diffs: {objectId: '_root', type: 'map', props: {birds: {[`1@${actor}`]: {
         objectId: `1@${actor}`, type: 'table', props: {[rowId]: {[`2@${actor}`]: {
           objectId: `2@${actor}`, type: 'map', props: {
-            species: {[`3@${actor}`]: {value: 'Chaffinch'}},
-            colour:  {[`4@${actor}`]: {value: 'brown'}}
+            species: {[`3@${actor}`]: {type: 'value', value: 'Chaffinch'}},
+            colour:  {[`4@${actor}`]: {type: 'value', value: 'brown'}}
           }
         }}}
       }}}}
@@ -213,7 +213,7 @@ function interopTests(sourceBackend, destBackend) {
     assert.deepStrictEqual(patch2, {
       clock: {[actor]: 2}, deps: [decodeChange(change2).hash], maxOp: 2, pendingChanges: 0,
       diffs: {objectId: '_root', type: 'map', props: {
-        counter: {[`1@${actor}`]: {value: 3, datatype: 'counter'}}
+        counter: {[`1@${actor}`]: {type: 'value', value: 3, datatype: 'counter'}}
       }}
     })
   })
@@ -229,7 +229,7 @@ function interopTests(sourceBackend, destBackend) {
     assert.deepStrictEqual(patch1, {
       clock: {[actor]: 1}, deps: [decodeChange(change1).hash], maxOp: 1, pendingChanges: 0,
       diffs: {objectId: '_root', type: 'map', props: {
-        now: {[`1@${actor}`]: {value: now.getTime(), datatype: 'timestamp'}}
+        now: {[`1@${actor}`]: {type: 'value', value: now.getTime(), datatype: 'timestamp'}}
       }}
     })
   })
@@ -247,7 +247,7 @@ function interopTests(sourceBackend, destBackend) {
     assert.deepStrictEqual(patch1, {
       clock: {[actor]: 1}, deps: [decodeChange(change1).hash], maxOp: 1, pendingChanges: 0,
       diffs: {objectId: '_root', type: 'map', props: {
-        longString: {[`1@${actor}`]: {value: longString}}
+        longString: {[`1@${actor}`]: {type: 'value', value: longString}}
       }}
     })
   })
@@ -265,7 +265,7 @@ function interopTests(sourceBackend, destBackend) {
       assert.deepStrictEqual(patch, {
         clock: {[actor]: 1}, deps: [decodeChange(change1).hash], maxOp: 1, pendingChanges: 0,
         diffs: {objectId: '_root', type: 'map', props: {
-          bird: {[`1@${actor}`]: {value: 'magpie'}}
+          bird: {[`1@${actor}`]: {type: 'value', value: 'magpie'}}
         }}
       })
     })
@@ -284,7 +284,7 @@ function interopTests(sourceBackend, destBackend) {
       assert.deepStrictEqual(patch, {
         clock: {[actor]: 1}, deps: [decodeChange(change1).hash], maxOp: 1, pendingChanges: 0,
         diffs: {objectId: '_root', type: 'map', props: {
-          longString: {[`1@${actor}`]: {value: longString}}
+          longString: {[`1@${actor}`]: {type: 'value', value: longString}}
         }}
       })
     })

--- a/test/wasm.js
+++ b/test/wasm.js
@@ -107,8 +107,9 @@ function interopTests(sourceBackend, destBackend) {
       clock: {[actor]: 1}, deps: [decodeChange(change1).hash], maxOp: 2, pendingChanges: 0,
       diffs: {objectId: '_root', type: 'map', props: {birds: {[`1@${actor}`]: {
         objectId: `1@${actor}`, type: 'list',
-        edits: [{action: 'insert', index: 0, elemId: `2@${actor}`}],
-        props: {0: {[`2@${actor}`]: {type: 'value', value: 'chaffinch'}}}
+        edits: [{action: 'insert', index: 0, elemId: `2@${actor}`,
+          opId: `2@${actor}`, value: {type: 'value', value: 'chaffinch'}
+        }],
       }}}}
     })
   })


### PR DESCRIPTION
This fixes some of the wasm tests that I'm finding issues with while implementing the new patch format in https://github.com/automerge/automerge-rs/pull/88.

Seems it also brings to light some missing `type: 'value'`s in the js code too. (I'd appreciate someone with more intimate knowledge of the js implementation to help me with the errors here as trying to change a couple of the places in the code makes more things fail).