### PR TITLE
Fix performance issue in OpSet.getMissingChanges

### DIFF
--- a/backend/op_set.js
+++ b/backend/op_set.js
@@ -555,10 +555,13 @@ function getMissingChanges(opSet, haveDeps) {
   stack = haveDeps; seenHashes = {}
   while (!stack.isEmpty()) {
     const hash = stack.last()
-    const deps = opSet.getIn(['hashes', hash, 'depsPast'])
-    if (!deps) throw new RangeError(`hash not found: ${hash}`)
-    stack = stack.pop().concat(deps)
-    seenHashes[hash] = true
+    stack = stack.pop()
+    if (!seenHashes[hash]) {
+      const deps = opSet.getIn(['hashes', hash, 'depsPast'])
+      if (!deps) throw new RangeError(`hash not found: ${hash}`)
+      stack = stack.concat(deps)
+      seenHashes[hash] = true
+    }
   }
 
   return opSet.get('history')


### PR DESCRIPTION
@skokenes I think this fixes your issue #367. Could you give it a try please?

In a history with a lot of branching and merging, the slow path algorithm in `OpSet.getMissingChanges` would traverse a number of paths that grows exponentially in the length of the history. Ooops! Should have been O(n), was actually O(2^n). No wonder it would grind to a halt.