### PR TITLE
guard against null 'theirHeads'

### DIFF
--- a/backend/sync.js
+++ b/backend/sync.js
@@ -350,7 +350,7 @@ function generateSyncMessage(backend, syncState) {
   // field of the message empty because we just want to fill in the missing dependencies for now.
   // In case 2, or if ourNeed is empty, we send a Bloom filter to request any unsent changes.
   let ourHave = []
-  if (ourNeed.every(hash => theirHeads.includes(hash))) {
+  if (ourNeed.every(hash => theirHeads && theirHeads.includes(hash))) {
     ourHave = [makeBloomFilter(state, sharedHeads)]
   }
 


### PR DESCRIPTION
In my experimentation with they sync protocol I've come across what may be another edge case.  `theirHeads` is sometimes null here when there are pending changes in the doc.  Not sure if my implementation is bad.  Should theirHeads just default to `[]`?