### PR TITLE
Do not chunk the output in webpack config

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -10,6 +10,8 @@ module.exports = {
     path: path.resolve(__dirname, 'dist'),
     // https://github.com/webpack/webpack/issues/6525
     globalObject: 'this',
+    // https://github.com/webpack/webpack/issues/11660
+    chunkLoading: false,
   },
   devtool: 'source-map',
   module: {rules: []},


### PR DESCRIPTION
The browser tests broke during the refactor at #396 complaining about not being able to iterate over undefined "chunks":

```
  Uncaught TypeError: Cannot read property 'webpackChunkAutomerge' of undefined
```

That reminded me of the issue that was noted in that original PR where setting this `chunkLoading` property didn't seem to make a difference for running webpack, but it looks like it _does_ matter for actually using the bundle! 😅 

I've run `yarn run browsertest` locally and it seems to work, so hopefully this fixes the issue.