### PR TITLE
Use named imports for the uuid library

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -35,6 +35,11 @@ module.exports = function(config) {
     // Webpack can handle Typescript via ts-loader
     karmaTypescriptConfig: {
       tsconfig: './tsconfig.json',
+      bundlerOptions: {
+        resolve: {
+          alias: { automerge: './src/automerge.js' }
+        }
+      },
       compilerOptions: {
         allowJs: true,
         sourceMap: true,

--- a/src/uuid.js
+++ b/src/uuid.js
@@ -1,4 +1,4 @@
-const uuid = require('uuid/v4')
+const { v4: uuid } = require('uuid')
 
 function defaultFactory() {
   return uuid().replace(/-/g, '')

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,7 @@
     "lib": ["dom", "esnext.asynciterable", "es2017", "es2016", "es2015"],
     "module": "commonjs",
     "moduleResolution": "node",
-    "paths": { "*": ["src/*", "*", "frontend/*", "backend/*"] },
+    "paths": { "automerge": ["*"]},
     "rootDir": "",
     "target": "es2016",
     "typeRoots": ["./@types", "./node_modules/@types"]


### PR DESCRIPTION
Deep importing from the `uuid` library is [deprecated](https://github.com/uuidjs/uuid#deep-requires-now-deprecated) and [breaks](https://github.com/uuidjs/uuid/issues/575) some browser builds.