### PR TITLE
Include `elemId` into TypeScript definition of `Op`

### DIFF
--- a/@types/automerge/index.d.ts
+++ b/@types/automerge/index.d.ts
@@ -228,6 +228,7 @@ declare module 'automerge' {
     obj: OpId
     key: string | number
     insert: boolean
+    elemId?: OpId
     child?: OpId
     value?: number | boolean | string | null
     datatype?: DataType


### PR DESCRIPTION
Hey!

It looks like `elemId` is missing from TypeScript definition of `Op`. 

What's weird is that it's actually included in the JS object, e.g. if you do `JSON.stringify(operation)`:
```
{"obj":"2@c8016fb46d8a4093aebefa23af4b6af1","elemId":"4@c8016fb46d8a4093aebefa23af4b6af1","action":"makeMap","insert":true,"pred":[]}
```
But you can't access it in TypeScript, because it's missing from `Op`. 

Ideally, we'd like to have an access to `elemId` to be able to "interpret" changes without using automerge methods (e.g. in a different runtime). Without `elementID` it becomes problematic (if not impossible).

So in this PR I've added `elemId` property to the list of attributes for a TS representation of `Op`.