### PR TITLE
Include startOp into TypeScript definition of Change

### DIFF
--- a/@types/automerge/index.d.ts
+++ b/@types/automerge/index.d.ts
@@ -219,6 +219,7 @@ declare module 'automerge' {
     actor: string
     time: number
     seq: number
+    startOp: number
     deps: Hash[]
     ops: Op[]
   }


### PR DESCRIPTION
(follow-up on #424)

When generation `automerge.Change`, we need to include `startOp` field to be able to encode it using `automerge.encodeChange`. In order to do this, we need to include `startOp` into TypeScript interface of `Change`.