### PR TITLE
Include `hash` to TypeScript definition of `Change`

### DIFF
--- a/@types/automerge/index.d.ts
+++ b/@types/automerge/index.d.ts
@@ -220,6 +220,7 @@ declare module 'automerge' {
     time: number
     seq: number
     startOp: number
+    hash: Hash
     deps: Hash[]
     ops: Op[]
   }

--- a/@types/automerge/index.d.ts
+++ b/@types/automerge/index.d.ts
@@ -220,7 +220,7 @@ declare module 'automerge' {
     time: number
     seq: number
     startOp: number
-    hash: Hash
+    hash?: Hash
     deps: Hash[]
     ops: Op[]
   }


### PR DESCRIPTION
(follow-up on #424 and #426, sorry for that excessive granularity, I'm discovering missing fields as I go deeper into B-F protocol)

Related to #429.

`hash` field stores SHA-256 of a binary encoding of change. It's used to fill up `deps` of the following changes. However, it's missing from TS definition of `Change`, but present in the plain JS object:

```
{
        "actor": "76606470dee9469391163cb3c43c220a",
        "seq": 2,
        "startOp": 2,
        "time": 1629452632,
        "message": "",
        "deps": [
            "f81149f2a77edb5425d64966151d3f8d66a30a907ed29760a47e4c2805439169"
        ],
        "hash": "ae910c6f52b09c9f256be9cc9ba4f5925c8fcb5066c81a4faac226e547e4a8df",
        "ops": [...]
```

So here we expose it, but make it optional, since it's backend responsibility to fill it.