### PR TITLE
Include `maxOp` into TS definition of `Patch`

### DIFF
--- a/@types/automerge/index.d.ts
+++ b/@types/automerge/index.d.ts
@@ -246,6 +246,7 @@ declare module 'automerge' {
     clock: Clock
     deps: Hash[]
     diffs: MapDiff
+    maxOp: number
   }
 
   // Describes changes to a map (in which case propName represents a key in the


### PR DESCRIPTION
`maxOp` is missing from TS definition of `Patch`, but present in the underlying JS object.