### PR TITLE
Fix exception "Zero-length runs are not allowed" in BooleanDecoder

### DIFF
--- a/backend/encoding.js
+++ b/backend/encoding.js
@@ -1190,7 +1190,10 @@ class BooleanDecoder extends Decoder {
       if (this.count === 0) {
         this.count = this.readUint53()
         this.lastValue = !this.lastValue
-        if (this.count === 0) throw new RangeError('Zero-length runs are not allowed')
+        if (this.count === 0 && !this.firstRun) {
+          throw new RangeError('Zero-length runs are not allowed')
+        }
+        this.firstRun = false
       }
       if (this.count < numSkip) {
         numSkip -= this.count


### PR DESCRIPTION
This should fix issue #441. @cgauld, please could you give it a try?