### PR TITLE
Fix insertion position of operations on root object

### DIFF
--- a/backend/new.js
+++ b/backend/new.js
@@ -193,22 +193,25 @@ function seekWithinBlock(ops, docCols, actorIds, resumeInsertion) {
 
 /**
  * Returns the number of list elements that should be added to a list index when skipping over the
- * block with index `blockIndex` in the list object with ID `objectId`.
+ * block with index `blockIndex` in the list object with object ID consisting of actor number
+ * `objActorNum` and counter `objCtr`.
  */
-function visibleListElements(docState, blockIndex, objectId) {
+function visibleListElements(docState, blockIndex, objActorNum, objCtr) {
   const thisBlock = docState.blocks[blockIndex]
   const nextBlock = docState.blocks[blockIndex + 1]
 
-  let blockVisible = thisBlock.numVisible[objectId]
-  if (blockVisible !== undefined) {
-    // If a list element is split across the block boundary, don't double-count it
-    if (thisBlock.lastVisibleActor === nextBlock.firstVisibleActor &&
-        thisBlock.lastVisibleActor !== undefined &&
-        thisBlock.lastVisibleCtr === nextBlock.firstVisibleCtr &&
-        thisBlock.lastVisibleCtr !== undefined) blockVisible -= 1
-    return blockVisible
-  } else {
+  if (thisBlock.lastObjectActor !== objActorNum || thisBlock.lastObjectCtr !== objCtr ||
+      thisBlock.numVisible === undefined) {
     return 0
+
+    // If a list element is split across the block boundary, don't double-count it
+  } else if (thisBlock.lastVisibleActor === nextBlock.firstVisibleActor &&
+             thisBlock.lastVisibleActor !== undefined &&
+             thisBlock.lastVisibleCtr === nextBlock.firstVisibleCtr &&
+             thisBlock.lastVisibleCtr !== undefined) {
+    return thisBlock.numVisible - 1
+  } else {
+    return thisBlock.numVisible
   }
 }
 
@@ -222,7 +225,7 @@ function visibleListElements(docState, blockIndex, objectId) {
  *   elements that precede the position where the new operations should be applied.
  */
 function seekToOp(docState, ops) {
-  const { objActor, objCtr, keyActor, keyCtr, keyStr } = ops
+  const { objActor, objActorNum, objCtr, keyActor, keyCtr, keyStr } = ops
   let blockIndex = 0, totalVisible = 0
 
   // Skip any blocks that contain only objects with lower objectIds
@@ -231,7 +234,7 @@ function seekToOp(docState, ops) {
       const blockActor = docState.blocks[blockIndex].lastObjectActor === undefined ? undefined
         : docState.actorIds[docState.blocks[blockIndex].lastObjectActor]
       const blockCtr = docState.blocks[blockIndex].lastObjectCtr
-      if (blockCtr === undefined || blockCtr < objCtr || (blockCtr === objCtr && blockActor < objActor)) {
+      if (blockCtr === null || blockCtr < objCtr || (blockCtr === objCtr && blockActor < objActor)) {
         blockIndex++
       } else {
         break
@@ -242,8 +245,9 @@ function seekToOp(docState, ops) {
   if (keyStr !== null) {
     // String key is used. First skip any blocks that contain only lower keys
     while (blockIndex < docState.blocks.length - 1) {
-      const blockLastKey = docState.blocks[blockIndex].lastKey[ops.objId]
-      if (blockLastKey !== undefined && blockLastKey < keyStr) blockIndex++; else break
+      const { lastObjectActor, lastObjectCtr, lastKey } = docState.blocks[blockIndex]
+      if (objCtr === lastObjectCtr && objActorNum === lastObjectActor &&
+          lastKey !== undefined && lastKey < keyStr) blockIndex++; else break
     }
 
     // When we have a candidate block, decode it to find the exact insertion position
@@ -265,6 +269,8 @@ function seekToOp(docState, ops) {
       // find the actual insertion position, and that further scan crosses a block boundary.
       if (!insertAtHead && !resumeInsertion) {
         while (blockIndex < docState.blocks.length - 1 &&
+               docState.blocks[blockIndex].lastObjectActor === objActorNum &&
+               docState.blocks[blockIndex].lastObjectCtr === objCtr &&
                !bloomFilterContains(docState.blocks[blockIndex].bloom, keyActorNum, keyCtr)) {
           // If we reach the end of the list object without a Bloom filter hit, the reference element
           // doesn't exist
@@ -273,7 +279,7 @@ function seekToOp(docState, ops) {
           }
 
           // Add up number of visible list elements in any blocks we skip, for list index computation
-          totalVisible += visibleListElements(docState, blockIndex, ops.objId)
+          totalVisible += visibleListElements(docState, blockIndex, objActorNum, objCtr)
           blockIndex++
         }
       }
@@ -284,7 +290,9 @@ function seekToOp(docState, ops) {
                                                                docState.actorIds,
                                                                resumeInsertion)
 
-      if (blockIndex === docState.blocks.length - 1) {
+      if (blockIndex === docState.blocks.length - 1 ||
+          docState.blocks[blockIndex].lastObjectActor !== objActorNum ||
+          docState.blocks[blockIndex].lastObjectCtr !== objCtr) {
         // Last block: if we haven't found the reference element by now, it's an error
         if (found) {
           return {blockIndex, skipCount, visibleCount: totalVisible + visibleCount}
@@ -302,7 +310,7 @@ function seekToOp(docState, ops) {
       // continue scanning the next block to find the actual insertion position.
       // Either way, go back round the loop again to skip blocks until the next Bloom filter hit.
       resumeInsertion = found && ops.insert
-      totalVisible += visibleListElements(docState, blockIndex, ops.objId)
+      totalVisible += visibleListElements(docState, blockIndex, objActorNum, objCtr)
       blockIndex++
     }
   }
@@ -361,9 +369,9 @@ function bloomFilterContains(bloom, elemIdActor, elemIdCtr) {
  */
 function updateBlockMetadata(block, actorIds) {
   block.bloom = new Uint8Array(BLOOM_FILTER_SIZE)
-  block.lastKey = {}
-  block.numVisible = {}
   block.numOps = 0
+  block.lastKey = undefined
+  block.numVisible = undefined
   block.lastObjectActor = undefined
   block.lastObjectCtr = undefined
   block.firstVisibleActor = undefined
@@ -383,17 +391,18 @@ function updateBlockMetadata(block, actorIds) {
     const insert = insertD.readValue(), succNum = succNumD.readValue()
     const objectId = objActor === null ? '_root' : `${objCtr}@${actorIds[objActor]}`
 
-    if (objActor !== null && objCtr !== null) {
+    if (block.lastObjectActor !== objActor || block.lastObjectCtr !== objCtr) {
+      block.numVisible = 0
       block.lastObjectActor = objActor
       block.lastObjectCtr = objCtr
     }
 
     if (keyStr !== null) {
       // Map key: for each object, record the highest key contained in the block
-      block.lastKey[objectId] = keyStr
+      block.lastKey = keyStr
     } else if (insert || keyCtr !== null) {
       // List element
-      if (block.numVisible[objectId] === undefined) block.numVisible[objectId] = 0
+      block.lastKey = undefined
       const elemIdActor = insert ? idActor : keyActor
       const elemIdCtr = insert ? idCtr : keyCtr
       bloomFilterAdd(block.bloom, elemIdActor, elemIdCtr)
@@ -403,10 +412,10 @@ function updateBlockMetadata(block, actorIds) {
         if (block.firstVisibleActor === undefined) block.firstVisibleActor = elemIdActor
         if (block.firstVisibleCtr === undefined) block.firstVisibleCtr = elemIdCtr
         if (block.lastVisibleActor !== elemIdActor || block.lastVisibleCtr !== elemIdCtr) {
-          block.numVisible[objectId] += 1
+          block.numVisible += 1
+          block.lastVisibleActor = elemIdActor
+          block.lastVisibleCtr = elemIdCtr
         }
-        block.lastVisibleActor = elemIdActor
-        block.lastVisibleCtr = elemIdCtr
       }
     }
   }
@@ -415,19 +424,12 @@ function updateBlockMetadata(block, actorIds) {
 /**
  * Updates a block's metadata based on an operation being added to a block.
  */
-function addBlockOperation(block, op, objectId, actorIds, isChangeOp) {
-  // Keep track of the largest objectId contained within a block
-  if (op[objActorIdx] !== null && op[objCtrIdx] !== null &&
-      (block.lastObjectCtr === undefined || block.lastObjectCtr < op[objCtrIdx] ||
-       (block.lastObjectCtr === op[objCtrIdx] && actorIds[block.lastObjectActor] < actorIds[op[objActorIdx]]))) {
-    block.lastObjectActor = op[objActorIdx]
-    block.lastObjectCtr = op[objCtrIdx]
-  }
-
+function addBlockOperation(block, op, actorIds, isChangeOp) {
   if (op[keyStrIdx] !== null) {
     // TODO this comparison should use UTF-8 encoding, not JavaScript's UTF-16
-    if (block.lastKey[objectId] === undefined || block.lastKey[objectId] < op[keyStrIdx]) {
-      block.lastKey[objectId] = op[keyStrIdx]
+    if (block.lastObjectCtr === op[objCtrIdx] && block.lastObjectActor === op[objActorIdx] &&
+        (block.lastKey === undefined || block.lastKey < op[keyStrIdx])) {
+      block.lastKey = op[keyStrIdx]
     }
   } else {
     // List element
@@ -435,12 +437,25 @@ function addBlockOperation(block, op, objectId, actorIds, isChangeOp) {
     const elemIdCtr = op[insertIdx] ? op[idCtrIdx] : op[keyCtrIdx]
     bloomFilterAdd(block.bloom, elemIdActor, elemIdCtr)
 
+    // Set lastVisible on the assumption that this is the last op in the block; if there are further
+    // ops after this one in the block, lastVisible will be overwritten again later.
     if (op[succNumIdx] === 0 || isChangeOp) {
       if (block.firstVisibleActor === undefined) block.firstVisibleActor = elemIdActor
       if (block.firstVisibleCtr === undefined) block.firstVisibleCtr = elemIdCtr
       block.lastVisibleActor = elemIdActor
       block.lastVisibleCtr = elemIdCtr
     }
+  }
+
+  // Keep track of the largest objectId contained within a block
+  if (block.lastObjectCtr === undefined ||
+      op[objActorIdx] !== null && op[objCtrIdx] !== null &&
+      (block.lastObjectCtr === null || block.lastObjectCtr < op[objCtrIdx] ||
+       (block.lastObjectCtr === op[objCtrIdx] && actorIds[block.lastObjectActor] < actorIds[op[objActorIdx]]))) {
+    block.lastObjectActor = op[objActorIdx]
+    block.lastObjectCtr = op[objCtrIdx]
+    block.lastKey = (op[keyStrIdx] !== null ? op[keyStrIdx] : undefined)
+    block.numVisible = 0
   }
 }
 
@@ -969,7 +984,9 @@ function updatePatchProperty(patches, newBlock, objectId, op, docState, propStat
     if (oldSuccNum === 0 && !isWholeDoc && propState[elemId].action === 'insert') {
       propState[elemId].action = 'update'
       convertInsertToUpdate(patch.edits, listIndex, elemId)
-      if (newBlock) newBlock.numVisible[objectId] -= 1
+      if (newBlock && newBlock.lastObjectActor === op[objActorIdx] && newBlock.lastObjectCtr === op[objCtrIdx]) {
+        newBlock.numVisible -= 1
+      }
     }
 
     if (patchValue) {
@@ -980,9 +997,8 @@ function updatePatchProperty(patches, newBlock, objectId, op, docState, propStat
       if (!propState[elemId].action && (oldSuccNum === undefined || isWholeDoc)) {
         propState[elemId].action = 'insert'
         appendEdit(patch.edits, {action: 'insert', index: listIndex, elemId, opId: patchKey, value: patchValue})
-        if (newBlock) {
-          if (newBlock.numVisible[objectId] === undefined) newBlock.numVisible[objectId] = 0
-          newBlock.numVisible[objectId] += 1
+        if (newBlock && newBlock.lastObjectActor === op[objActorIdx] && newBlock.lastObjectCtr === op[objCtrIdx]) {
+          newBlock.numVisible += 1
         }
 
       // If the property has a value and it's not an insert, then it must be an update.
@@ -993,7 +1009,9 @@ function updatePatchProperty(patches, newBlock, objectId, op, docState, propStat
         if (lastEdit.count > 1) lastEdit.count -= 1; else patch.edits.pop()
         propState[elemId].action = 'update'
         appendUpdate(patch.edits, listIndex, elemId, patchKey, patchValue, true)
-        if (newBlock) newBlock.numVisible[objectId] += 1
+        if (newBlock && newBlock.lastObjectActor === op[objActorIdx] && newBlock.lastObjectCtr === op[objCtrIdx]) {
+          newBlock.numVisible += 1
+        }
 
       } else {
         // A 'normal' update
@@ -1005,7 +1023,9 @@ function updatePatchProperty(patches, newBlock, objectId, op, docState, propStat
       // If the property used to have a non-overwritten/non-deleted value, but no longer, it's a remove
       propState[elemId].action = 'remove'
       appendEdit(patch.edits, {action: 'remove', index: listIndex, count: 1})
-      if (newBlock) newBlock.numVisible[objectId] -= 1
+      if (newBlock && newBlock.lastObjectActor === op[objActorIdx] && newBlock.lastObjectCtr === op[objCtrIdx]) {
+        newBlock.numVisible -= 1
+      }
     }
 
   } else if (patchValue || !isWholeDoc) {
@@ -1207,7 +1227,7 @@ function mergeDocChangeOps(patches, newBlock, outCols, changeState, docState, li
 
     if (takeDocOp) {
       appendOperation(outCols, docState.blocks[blockIndex].columns, docOp)
-      addBlockOperation(newBlock, docOp, objectId, docState.actorIds, false)
+      addBlockOperation(newBlock, docOp, docState.actorIds, false)
 
       if (docOp[insertIdx] && elemVisible) {
         elemVisible = false
@@ -1232,9 +1252,9 @@ function mergeDocChangeOps(patches, newBlock, outCols, changeState, docState, li
             throw new RangeError(`no matching operation for pred: ${op[predCtrIdx][j]}@${docState.actorIds[op[predActorIdx][j]]}`)
           }
         }
-        updatePatchProperty(patches, newBlock, objectId, op, docState, propState, listIndex)
         appendOperation(outCols, changeCols[i], op)
-        addBlockOperation(newBlock, op, objectId, docState.actorIds, true)
+        addBlockOperation(newBlock, op, docState.actorIds, true)
+        updatePatchProperty(patches, newBlock, objectId, op, docState, propState, listIndex)
 
         if (op[insertIdx]) {
           elemVisible = false
@@ -1260,9 +1280,7 @@ function mergeDocChangeOps(patches, newBlock, outCols, changeState, docState, li
   if (docOp) {
     appendOperation(outCols, docState.blocks[blockIndex].columns, docOp)
     newBlock.numOps++
-    if (docOp[objActorIdx] === objActor && docOp[objCtrIdx] === objCtr) {
-      addBlockOperation(newBlock, docOp, objectId, docState.actorIds, false)
-    }
+    addBlockOperation(newBlock, docOp, docState.actorIds, false)
   }
   return {docOpsConsumed, blockIndex}
 }
@@ -1284,7 +1302,8 @@ function applyOps(patches, changeState, docState) {
   const objActor = objActorNum === null ? null : docState.actorIds[objActorNum]
   const keyActor = keyActorNum === null ? null : docState.actorIds[keyActorNum]
   const ops = {
-    objActor, objCtr, keyActor, keyCtr, keyStr, idActor: docState.actorIds[idActorNum], idCtr, insert,
+    objActor, objActorNum, objCtr, keyActor, keyActorNum, keyCtr, keyStr,
+    idActor: docState.actorIds[idActorNum], idCtr, insert,
     objId: objActor === null ? '_root' : `${objCtr}@${objActor}`
   }
 
@@ -1297,9 +1316,9 @@ function applyOps(patches, changeState, docState) {
   const newBlock = {
     columns: undefined,
     bloom: new Uint8Array(block.bloom),
-    lastKey: copyObject(block.lastKey),
-    numVisible: copyObject(block.numVisible),
     numOps: skipCount,
+    lastKey: block.lastKey,
+    numVisible: block.numVisible,
     lastObjectActor: block.lastObjectActor,
     lastObjectCtr: block.lastObjectCtr,
     firstVisibleActor: resetFirstVisible ? undefined : block.firstVisibleActor,
@@ -1457,6 +1476,8 @@ function setupPatches(patches, objectIds, docState) {
             const seekPos = {
               objActor: obj.actorId,  objCtr: obj.counter,
               keyActor: elem.actorId, keyCtr: elem.counter,
+              objActorNum: docState.actorIds.indexOf(obj.actorId),
+              keyActorNum: docState.actorIds.indexOf(elem.actorId),
               keyStr:   null,         insert: false,
               objId:    objectId
             }
@@ -1729,9 +1750,9 @@ class BackendDoc {
       this.blocks = [{
         columns: makeDecoders([], DOC_OPS_COLUMNS),
         bloom: new Uint8Array(BLOOM_FILTER_SIZE),
-        lastKey: {},
-        numVisible: {},
         numOps: 0,
+        lastKey: undefined,
+        numVisible: undefined,
         lastObjectActor: undefined,
         lastObjectCtr: undefined,
         firstVisibleActor: undefined,

--- a/test/new_backend_test.js
+++ b/test/new_backend_test.js
@@ -66,10 +66,10 @@ describe('BackendDoc applying changes', () => {
       succActor: [0x7f, 0],
       succCtr:   [0x7f, 3]
     })
-    assert.deepStrictEqual(backend.blocks[0].lastKey, {_root: 'y'})
+    assert.strictEqual(backend.blocks[0].lastKey, 'y')
     assert.strictEqual(backend.blocks[0].numOps, 3)
-    assert.strictEqual(backend.blocks[0].lastObjectActor, undefined)
-    assert.strictEqual(backend.blocks[0].lastObjectCtr, undefined)
+    assert.strictEqual(backend.blocks[0].lastObjectActor, null)
+    assert.strictEqual(backend.blocks[0].lastObjectCtr, null)
   })
 
   it('should overwrite root object properties (2)', () => {
@@ -113,10 +113,10 @@ describe('BackendDoc applying changes', () => {
       succActor: [0x7f, 0],
       succCtr:   [0x7f, 3]
     })
-    assert.deepStrictEqual(backend.blocks[0].lastKey, {_root: 'z'})
+    assert.strictEqual(backend.blocks[0].lastKey, 'z')
     assert.strictEqual(backend.blocks[0].numOps, 4)
-    assert.strictEqual(backend.blocks[0].lastObjectActor, undefined)
-    assert.strictEqual(backend.blocks[0].lastObjectCtr, undefined)
+    assert.strictEqual(backend.blocks[0].lastObjectActor, null)
+    assert.strictEqual(backend.blocks[0].lastObjectCtr, null)
   })
 
   it('should allow concurrent overwrites of the same value', () => {
@@ -197,8 +197,10 @@ describe('BackendDoc applying changes', () => {
       succActor: [0x7d, 0, 1, 2], // 0, 1, 2
       succCtr:   [0x7f, 2, 2, 0] // 2, 2, 2
     })
-    assert.deepStrictEqual(backend1.blocks[0].lastKey, {_root: 'x'})
-    assert.deepStrictEqual(backend1.blocks[0].numOps, 4)
+    assert.strictEqual(backend1.blocks[0].lastKey, 'x')
+    assert.strictEqual(backend1.blocks[0].numOps, 4)
+    assert.strictEqual(backend1.blocks[0].lastObjectActor, null)
+    assert.strictEqual(backend1.blocks[0].lastObjectCtr, null)
     // The two backends are not identical because actors appear in a different order
     checkColumns(backend2.blocks[0], {
       objActor: [],
@@ -216,7 +218,7 @@ describe('BackendDoc applying changes', () => {
       succActor: [0x7d, 0, 2, 1], // 0, 2, 1 <-- different from backend1
       succCtr:   [0x7f, 2, 2, 0] // 2, 2, 2
     })
-    assert.deepStrictEqual(backend2.blocks[0].lastKey, {_root: 'x'})
+    assert.strictEqual(backend2.blocks[0].lastKey, 'x')
     assert.strictEqual(backend2.blocks[0].numOps, 4)
   })
 
@@ -267,7 +269,7 @@ describe('BackendDoc applying changes', () => {
       succActor: [2, 0],
       succCtr:   [0x7e, 2, 0] // 2, 2
     })
-    assert.deepStrictEqual(backend.blocks[0].lastKey, {_root: 'x'})
+    assert.strictEqual(backend.blocks[0].lastKey, 'x')
     assert.strictEqual(backend.blocks[0].numOps, 3)
   })
 
@@ -347,7 +349,7 @@ describe('BackendDoc applying changes', () => {
       succActor: [0x7f, 0],
       succCtr:   [0x7f, 5]
     })
-    assert.deepStrictEqual(backend.blocks[0].lastKey, {_root: 'map', [`1@${actor}`]: 'z'})
+    assert.strictEqual(backend.blocks[0].lastKey, 'z')
     assert.strictEqual(backend.blocks[0].numOps, 5)
     assert.strictEqual(backend.blocks[0].lastObjectActor, 0)
     assert.strictEqual(backend.blocks[0].lastObjectCtr, 1)
@@ -405,7 +407,7 @@ describe('BackendDoc applying changes', () => {
       succActor: [0x7f, 0],
       succCtr:   [0x7f, 5]
     })
-    assert.deepStrictEqual(backend.blocks[0].lastKey, {_root: 'a', [`1@${actor}`]: 'b', [`2@${actor}`]: 'c', [`3@${actor}`]: 'd'})
+    assert.strictEqual(backend.blocks[0].lastKey, 'd')
     assert.strictEqual(backend.blocks[0].numOps, 5)
     assert.strictEqual(backend.blocks[0].lastObjectActor, 0)
     assert.strictEqual(backend.blocks[0].lastObjectCtr, 3)
@@ -442,9 +444,9 @@ describe('BackendDoc applying changes', () => {
       succActor: [],
       succCtr:   []
     })
-    assert.deepStrictEqual(backend.blocks[0].lastKey, {_root: 'text'})
-    assert.deepStrictEqual(backend.blocks[0].numVisible, {[`1@${actor}`]: 1})
     assert.strictEqual(backend.blocks[0].numOps, 2)
+    assert.strictEqual(backend.blocks[0].lastKey, undefined)
+    assert.strictEqual(backend.blocks[0].numVisible, 1)
     assert.strictEqual(backend.blocks[0].lastObjectActor, 0)
     assert.strictEqual(backend.blocks[0].lastObjectCtr, 1)
     assert.strictEqual(backend.blocks[0].firstVisibleActor, 0)
@@ -499,9 +501,11 @@ describe('BackendDoc applying changes', () => {
       succActor: [],
       succCtr:   []
     })
-    assert.deepStrictEqual(backend.blocks[0].lastKey, {_root: 'text'})
-    assert.deepStrictEqual(backend.blocks[0].numVisible, {[`1@${actor}`]: 4})
     assert.strictEqual(backend.blocks[0].numOps, 5)
+    assert.strictEqual(backend.blocks[0].lastKey, undefined)
+    assert.strictEqual(backend.blocks[0].numVisible, 4)
+    assert.strictEqual(backend.blocks[0].lastObjectActor, 0)
+    assert.strictEqual(backend.blocks[0].lastObjectCtr, 1)
     assert.strictEqual(backend.blocks[0].firstVisibleActor, 0)
     assert.strictEqual(backend.blocks[0].firstVisibleCtr, 2)
     assert.strictEqual(backend.blocks[0].lastVisibleActor, 0)
@@ -589,9 +593,11 @@ describe('BackendDoc applying changes', () => {
       succActor: [],
       succCtr:   []
     })
-    assert.deepStrictEqual(backend.blocks[0].lastKey, {_root: 'text'})
-    assert.deepStrictEqual(backend.blocks[0].numVisible, {[`1@${actor}`]: 4})
     assert.strictEqual(backend.blocks[0].numOps, 5)
+    assert.strictEqual(backend.blocks[0].lastKey, undefined)
+    assert.strictEqual(backend.blocks[0].numVisible, 4)
+    assert.strictEqual(backend.blocks[0].lastObjectActor, 0)
+    assert.strictEqual(backend.blocks[0].lastObjectCtr, 1)
     assert.strictEqual(backend.blocks[0].firstVisibleActor, 0)
     assert.strictEqual(backend.blocks[0].firstVisibleCtr, 2)
     assert.strictEqual(backend.blocks[0].lastVisibleActor, 0)
@@ -638,9 +644,10 @@ describe('BackendDoc applying changes', () => {
       succActor: [0x7f, 0],
       succCtr:   [0x7f, 3]
     })
-    assert.deepStrictEqual(backend.blocks[0].lastKey, {_root: 'text'})
-    assert.deepStrictEqual(backend.blocks[0].numVisible, {[`1@${actor}`]: 0})
     assert.strictEqual(backend.blocks[0].numOps, 2)
+    assert.strictEqual(backend.blocks[0].numVisible, 0)
+    assert.strictEqual(backend.blocks[0].lastObjectActor, 0)
+    assert.strictEqual(backend.blocks[0].lastObjectCtr, 1)
     assert.strictEqual(backend.blocks[0].firstVisibleActor, undefined)
     assert.strictEqual(backend.blocks[0].firstVisibleCtr, undefined)
     assert.strictEqual(backend.blocks[0].lastVisibleActor, undefined)
@@ -690,9 +697,10 @@ describe('BackendDoc applying changes', () => {
       succActor: [0x7f, 0],
       succCtr:   [0x7f, 5]
     })
-    assert.deepStrictEqual(backend.blocks[0].lastKey, {_root: 'text'})
-    assert.deepStrictEqual(backend.blocks[0].numVisible, {[`1@${actor}`]: 2})
     assert.strictEqual(backend.blocks[0].numOps, 4)
+    assert.strictEqual(backend.blocks[0].numVisible, 2)
+    assert.strictEqual(backend.blocks[0].lastObjectActor, 0)
+    assert.strictEqual(backend.blocks[0].lastObjectCtr, 1)
     assert.strictEqual(backend.blocks[0].firstVisibleActor, 0)
     assert.strictEqual(backend.blocks[0].firstVisibleCtr, 2)
     assert.strictEqual(backend.blocks[0].lastVisibleActor, 0)
@@ -792,9 +800,10 @@ describe('BackendDoc applying changes', () => {
         succActor: [],
         succCtr:   []
       })
-      assert.deepStrictEqual(backend.blocks[0].lastKey, {_root: 'text'})
-      assert.deepStrictEqual(backend.blocks[0].numVisible, {[`1@${actor1}`]: 3})
       assert.strictEqual(backend.blocks[0].numOps, 4)
+      assert.strictEqual(backend.blocks[0].numVisible, 3)
+      assert.strictEqual(backend.blocks[0].lastObjectActor, 0)
+      assert.strictEqual(backend.blocks[0].lastObjectCtr, 1)
       assert.strictEqual(backend.blocks[0].firstVisibleActor, 0)
       assert.strictEqual(backend.blocks[0].firstVisibleCtr, 2)
       assert.strictEqual(backend.blocks[0].lastVisibleActor, 0)
@@ -881,9 +890,10 @@ describe('BackendDoc applying changes', () => {
         succActor: [],
         succCtr:   []
       })
-      assert.deepStrictEqual(backend.blocks[0].lastKey, {_root: 'text'})
-      assert.deepStrictEqual(backend.blocks[0].numVisible, {[`1@${actor1}`]: 4})
       assert.strictEqual(backend.blocks[0].numOps, 5)
+      assert.strictEqual(backend.blocks[0].numVisible, 4)
+      assert.strictEqual(backend.blocks[0].lastObjectActor, 0)
+      assert.strictEqual(backend.blocks[0].lastObjectCtr, 1)
       // firstVisible is incorrect -- it should strictly be (1,3) rather than (0,2) -- but that
       // doesn't matter since in any case it'll be different from the previous block's lastVisible
       assert.strictEqual(backend.blocks[0].firstVisibleActor, 0)
@@ -945,9 +955,10 @@ describe('BackendDoc applying changes', () => {
       succActor: [2, 0],
       succCtr:   [0x7e, 5, 1] // 5, 6
     })
-    assert.deepStrictEqual(backend.blocks[0].lastKey, {_root: 'text'})
-    assert.deepStrictEqual(backend.blocks[0].numVisible, {[`1@${actor}`]: 3})
     assert.strictEqual(backend.blocks[0].numOps, 6)
+    assert.strictEqual(backend.blocks[0].numVisible, 3)
+    assert.strictEqual(backend.blocks[0].lastObjectActor, 0)
+    assert.strictEqual(backend.blocks[0].lastObjectCtr, 1)
     assert.strictEqual(backend.blocks[0].firstVisibleActor, 0)
     assert.strictEqual(backend.blocks[0].firstVisibleCtr, 2)
     assert.strictEqual(backend.blocks[0].lastVisibleActor, 0)
@@ -993,9 +1004,10 @@ describe('BackendDoc applying changes', () => {
       succActor: [2, 0],
       succCtr:   [0x7e, 6, 0x7f] // 6, 5
     })
-    assert.deepStrictEqual(backend.blocks[0].lastKey, {_root: 'text'})
-    assert.deepStrictEqual(backend.blocks[0].numVisible, {[`1@${actor}`]: 3})
     assert.strictEqual(backend.blocks[0].numOps, 6)
+    assert.strictEqual(backend.blocks[0].numVisible, 3)
+    assert.strictEqual(backend.blocks[0].lastObjectActor, 0)
+    assert.strictEqual(backend.blocks[0].lastObjectCtr, 1)
     assert.strictEqual(backend.blocks[0].firstVisibleActor, 0)
     assert.strictEqual(backend.blocks[0].firstVisibleCtr, 2)
     assert.strictEqual(backend.blocks[0].lastVisibleActor, 0)
@@ -1054,13 +1066,79 @@ describe('BackendDoc applying changes', () => {
       succActor: [],
       succCtr:   []
     })
-    assert.deepStrictEqual(backend.blocks[0].lastKey, {_root: 'list', [`3@${actor}`]: 'x'})
-    assert.deepStrictEqual(backend.blocks[0].numVisible, {[`1@${actor}`]: 2})
     assert.strictEqual(backend.blocks[0].numOps, 4)
+    assert.strictEqual(backend.blocks[0].lastKey, 'x')
+    assert.strictEqual(backend.blocks[0].numVisible, 0)
+    assert.strictEqual(backend.blocks[0].lastObjectActor, 0)
+    assert.strictEqual(backend.blocks[0].lastObjectCtr, 3)
     assert.strictEqual(backend.blocks[0].firstVisibleActor, 0)
     assert.strictEqual(backend.blocks[0].firstVisibleCtr, 2)
     assert.strictEqual(backend.blocks[0].lastVisibleActor, undefined)
     assert.strictEqual(backend.blocks[0].lastVisibleCtr, undefined)
+  })
+
+  it('should handle multiple list objects', () => {
+    const actor = uuid()
+    const change1 = {actor, seq: 1, startOp: 1, time: 0, deps: [], ops: [
+      {action: 'makeList', obj: '_root',      key: 'list1',         insert: false,           pred: []},
+      {action: 'set',      obj: `1@${actor}`, elemId: '_head',      insert: true, datatype: 'uint', value: 1, pred: []},
+      {action: 'makeList', obj: '_root',      key: 'list2',         insert: false,           pred: []},
+      {action: 'set',      obj: `3@${actor}`, elemId: '_head',      insert: true, datatype: 'uint', value: 2, pred: []}
+    ]}
+    const change2 = {actor, seq: 2, startOp: 5, time: 0, deps: [hash(change1)], ops: [
+      {action: 'set',      obj: `1@${actor}`, elemId: `2@${actor}`, insert: true, datatype: 'uint', value: 3, pred: []}
+    ]}
+    const backend = new BackendDoc()
+    assert.deepStrictEqual(backend.applyChanges([encodeChange(change1)]), {
+      maxOp: 4, clock: {[actor]: 1}, deps: [hash(change1)], pendingChanges: 0,
+      diffs: {objectId: '_root', type: 'map', props: {
+        list1: {[`1@${actor}`]: {objectId: `1@${actor}`, type: 'list', edits: [
+          {action: 'insert', index: 0, elemId: `2@${actor}`, opId: `2@${actor}`, value: {
+            type: 'value', value: 1, datatype: 'uint'
+          }}
+        ]}},
+        list2: {[`3@${actor}`]: {objectId: `3@${actor}`, type: 'list', edits: [
+          {action: 'insert', index: 0, elemId: `4@${actor}`, opId: `4@${actor}`, value: {
+            type: 'value', value: 2, datatype: 'uint'
+          }}
+        ]}}
+      }}
+    })
+    assert.deepStrictEqual(backend.applyChanges([encodeChange(change2)]), {
+      maxOp: 5, clock: {[actor]: 2}, deps: [hash(change2)], pendingChanges: 0,
+      diffs: {objectId: '_root', type: 'map', props: {
+        list1: {[`1@${actor}`]: {objectId: `1@${actor}`, type: 'list', edits: [
+          {action: 'insert', index: 1, elemId: `5@${actor}`, opId: `5@${actor}`, value: {
+            type: 'value', value: 3, datatype: 'uint'
+          }}
+        ]}}
+      }}
+    })
+    checkColumns(backend.blocks[0], {
+      objActor: [0, 2, 3, 0],
+      objCtr:   [0, 2, 2, 1, 0x7f, 3], // null, null, 1, 1, 3
+      keyActor: [0, 3, 0x7f, 0, 0, 1], // null, null, null, 0, null
+      keyCtr:   [0, 2, 0x7d, 0, 2, 0x7e], // null, null, 0, 2, 0
+      keyStr:   [0x7e, 5, 0x6c, 0x69, 0x73, 0x74, 0x31, 5, 0x6c, 0x69, 0x73, 0x74, 0x32, 0, 3], // 'list1', 'list2', null, null, null
+      idActor:  [5, 0],
+      idCtr:    [0x7b, 1, 2, 0x7f, 3, 0x7f], // 1, 3, 2, 5, 4
+      insert:   [2, 3], // false, false, true, true, true
+      action:   [2, 2, 3, 1], // 2x makeList, 3x set
+      valLen:   [2, 0, 3, 0x13], // 2x null, 3x uint
+      valRaw:   [1, 3, 2],
+      succNum:  [5, 0],
+      succActor: [],
+      succCtr:   []
+    })
+    assert.strictEqual(backend.blocks[0].numOps, 5)
+    assert.strictEqual(backend.blocks[0].lastKey, undefined)
+    assert.strictEqual(backend.blocks[0].numVisible, 1)
+    assert.strictEqual(backend.blocks[0].lastObjectActor, 0)
+    assert.strictEqual(backend.blocks[0].lastObjectCtr, 3)
+    assert.strictEqual(backend.blocks[0].firstVisibleActor, 0)
+    assert.strictEqual(backend.blocks[0].firstVisibleCtr, 2)
+    assert.strictEqual(backend.blocks[0].lastVisibleActor, 0)
+    assert.strictEqual(backend.blocks[0].lastVisibleCtr, 4)
   })
 
   it('should handle a counter inside a map', () => {
@@ -1109,8 +1187,10 @@ describe('BackendDoc applying changes', () => {
       succActor: [2, 0],
       succCtr:   [0x7e, 2, 1] // 2, 3
     })
-    assert.deepStrictEqual(backend.blocks[0].lastKey, {_root: 'counter'})
+    assert.strictEqual(backend.blocks[0].lastKey, 'counter')
     assert.strictEqual(backend.blocks[0].numOps, 3)
+    assert.strictEqual(backend.blocks[0].lastObjectActor, null)
+    assert.strictEqual(backend.blocks[0].lastObjectCtr, null)
   })
 
   it('should handle a counter inside a list element', () => {
@@ -1159,9 +1239,11 @@ describe('BackendDoc applying changes', () => {
       succActor: [0x7f, 0],
       succCtr:   [0x7f, 3]
     })
-    assert.deepStrictEqual(backend.blocks[0].lastKey, {_root: 'list'})
-    assert.deepStrictEqual(backend.blocks[0].numVisible, {[`1@${actor}`]: 1})
     assert.strictEqual(backend.blocks[0].numOps, 3)
+    assert.strictEqual(backend.blocks[0].lastKey, undefined)
+    assert.strictEqual(backend.blocks[0].numVisible, 1)
+    assert.strictEqual(backend.blocks[0].lastObjectActor, 0)
+    assert.strictEqual(backend.blocks[0].lastObjectCtr, 1)
     assert.strictEqual(backend.blocks[0].firstVisibleActor, 0)
     assert.strictEqual(backend.blocks[0].firstVisibleCtr, 2)
     assert.strictEqual(backend.blocks[0].lastVisibleActor, 0)
@@ -1191,8 +1273,10 @@ describe('BackendDoc applying changes', () => {
       maxOp: 3, clock: {[actor]: 3}, deps: [hash(change3)], pendingChanges: 0,
       diffs: {objectId: '_root', type: 'map', props: {counter: {}}}
     })
-    assert.deepStrictEqual(backend.blocks[0].lastKey, {_root: 'counter'})
+    assert.strictEqual(backend.blocks[0].lastKey, 'counter')
     assert.strictEqual(backend.blocks[0].numOps, 2)
+    assert.strictEqual(backend.blocks[0].lastObjectActor, null)
+    assert.strictEqual(backend.blocks[0].lastObjectCtr, null)
   })
 
   it('should handle conflicts inside list elements', () => {
@@ -1270,9 +1354,11 @@ describe('BackendDoc applying changes', () => {
         succActor: [0x7e, 0, 1],
         succCtr:   [0x7e, 3, 0] // 3, 3
       })
-      assert.deepStrictEqual(backend.blocks[0].lastKey, {_root: 'list'})
-      assert.deepStrictEqual(backend.blocks[0].numVisible, {[`1@${actor1}`]: 1})
       assert.strictEqual(backend.blocks[0].numOps, 4)
+      assert.strictEqual(backend.blocks[0].lastKey, undefined)
+      assert.strictEqual(backend.blocks[0].numVisible, 1)
+      assert.strictEqual(backend.blocks[0].lastObjectActor, 0)
+      assert.strictEqual(backend.blocks[0].lastObjectCtr, 1)
       assert.strictEqual(backend.blocks[0].firstVisibleActor, 0)
       assert.strictEqual(backend.blocks[0].firstVisibleCtr, 2)
       assert.strictEqual(backend.blocks[0].lastVisibleActor, 0)
@@ -1325,9 +1411,11 @@ describe('BackendDoc applying changes', () => {
       succActor: [2, 0],
       succCtr:   [0x7e, 4, 1] // 4, 5
     })
-    assert.deepStrictEqual(backend.blocks[0].lastKey, {_root: 'text'})
-    assert.deepStrictEqual(backend.blocks[0].numVisible, {[`1@${actor}`]: 2})
     assert.strictEqual(backend.blocks[0].numOps, 5)
+    assert.strictEqual(backend.blocks[0].lastKey, undefined)
+    assert.strictEqual(backend.blocks[0].numVisible, 2)
+    assert.strictEqual(backend.blocks[0].lastObjectActor, 0)
+    assert.strictEqual(backend.blocks[0].lastObjectCtr, 1)
     assert.strictEqual(backend.blocks[0].firstVisibleActor, 0)
     assert.strictEqual(backend.blocks[0].firstVisibleCtr, 2)
     assert.strictEqual(backend.blocks[0].lastVisibleActor, 0)
@@ -1372,9 +1460,11 @@ describe('BackendDoc applying changes', () => {
       succActor: [2, 0],
       succCtr:   [0x7e, 4, 1] // 4, 5
     })
-    assert.deepStrictEqual(backend.blocks[0].lastKey, {_root: 'text'})
-    assert.deepStrictEqual(backend.blocks[0].numVisible, {[`1@${actor}`]: 2})
     assert.strictEqual(backend.blocks[0].numOps, 5)
+    assert.strictEqual(backend.blocks[0].lastKey, undefined)
+    assert.strictEqual(backend.blocks[0].numVisible, 2)
+    assert.strictEqual(backend.blocks[0].lastObjectActor, 0)
+    assert.strictEqual(backend.blocks[0].lastObjectCtr, 1)
     assert.strictEqual(backend.blocks[0].firstVisibleActor, 0)
     assert.strictEqual(backend.blocks[0].firstVisibleCtr, 2)
     assert.strictEqual(backend.blocks[0].lastVisibleActor, 0)
@@ -1441,9 +1531,11 @@ describe('BackendDoc applying changes', () => {
       succActor: [2, 1, 0x7f, 0], // actor2, actor2, actor1
       succCtr:   [0x7f, 3, 2, 1] // 3, 4, 5
     })
-    assert.deepStrictEqual(backend.blocks[0].lastKey, {_root: 'text'})
-    assert.deepStrictEqual(backend.blocks[0].numVisible, {[`1@${actor1}`]: 3})
     assert.strictEqual(backend.blocks[0].numOps, 7)
+    assert.strictEqual(backend.blocks[0].lastKey, undefined)
+    assert.strictEqual(backend.blocks[0].numVisible, 3)
+    assert.strictEqual(backend.blocks[0].lastObjectActor, 0)
+    assert.strictEqual(backend.blocks[0].lastObjectCtr, 1)
     // firstVisible is incorrect -- it should strictly be (0,3) rather than (0,2) -- but that
     // doesn't matter since in any case it'll be different from the previous block's lastVisible
     assert.strictEqual(backend.blocks[0].firstVisibleActor, 0)
@@ -1498,9 +1590,11 @@ describe('BackendDoc applying changes', () => {
       succActor: [0x7d, 0, 1, 0], // actor1, actor2, actor1
       succCtr:   [0x7d, 3, 0, 1] // 3, 3, 4
     })
-    assert.deepStrictEqual(backend.blocks[0].lastKey, {_root: 'text'})
-    assert.deepStrictEqual(backend.blocks[0].numVisible, {[`1@${actor1}`]: 1})
     assert.strictEqual(backend.blocks[0].numOps, 5)
+    assert.strictEqual(backend.blocks[0].lastKey, undefined)
+    assert.strictEqual(backend.blocks[0].numVisible, 1)
+    assert.strictEqual(backend.blocks[0].lastObjectActor, 0)
+    assert.strictEqual(backend.blocks[0].lastObjectCtr, 1)
     assert.strictEqual(backend.blocks[0].firstVisibleActor, 0)
     assert.strictEqual(backend.blocks[0].firstVisibleCtr, 2)
     assert.strictEqual(backend.blocks[0].lastVisibleActor, 0)
@@ -1545,9 +1639,11 @@ describe('BackendDoc applying changes', () => {
       succActor: [2, 0],
       succCtr:   [0x7e, 4, 1] // 4, 5
     })
-    assert.deepStrictEqual(backend.blocks[0].lastKey, {_root: 'text'})
-    assert.deepStrictEqual(backend.blocks[0].numVisible, {[`1@${actor}`]: 1})
     assert.strictEqual(backend.blocks[0].numOps, 4)
+    assert.strictEqual(backend.blocks[0].lastKey, undefined)
+    assert.strictEqual(backend.blocks[0].numVisible, 1)
+    assert.strictEqual(backend.blocks[0].lastObjectActor, 0)
+    assert.strictEqual(backend.blocks[0].lastObjectCtr, 1)
     assert.strictEqual(backend.blocks[0].firstVisibleActor, 0)
     assert.strictEqual(backend.blocks[0].firstVisibleCtr, 3)
     assert.strictEqual(backend.blocks[0].lastVisibleActor, 0)
@@ -1625,9 +1721,11 @@ describe('BackendDoc applying changes', () => {
         succActor: [0x7e, 0, 1], // 0, 1
         succCtr:   [0x7e, 3, 0] // 3, 3
       })
-      assert.deepStrictEqual(backend.blocks[0].lastKey, {_root: 'list'})
-      assert.deepStrictEqual(backend.blocks[0].numVisible, {[`1@${actor1}`]: 1})
       assert.strictEqual(backend.blocks[0].numOps, 3)
+      assert.strictEqual(backend.blocks[0].lastKey, undefined)
+      assert.strictEqual(backend.blocks[0].numVisible, 1)
+      assert.strictEqual(backend.blocks[0].lastObjectActor, 0)
+      assert.strictEqual(backend.blocks[0].lastObjectCtr, 1)
       assert.strictEqual(backend.blocks[0].firstVisibleActor, 0)
       assert.strictEqual(backend.blocks[0].firstVisibleCtr, 2)
       assert.strictEqual(backend.blocks[0].lastVisibleActor, 0)
@@ -1691,7 +1789,7 @@ describe('BackendDoc applying changes', () => {
       succActor: [0x7f, 0],
       succCtr:   [0x7f, 3]
     })
-    assert.deepStrictEqual(backend.blocks[0].lastKey, {_root: 'map', [`1@${actor1}`]: 'x', [`1@${actor2}`]: 'y'})
+    assert.strictEqual(backend.blocks[0].lastKey, 'y')
     assert.strictEqual(backend.blocks[0].numOps, 5)
     assert.strictEqual(backend.blocks[0].lastObjectActor, 1)
     assert.strictEqual(backend.blocks[0].lastObjectCtr, 1)
@@ -1750,8 +1848,10 @@ describe('BackendDoc applying changes', () => {
       succActor: [0x7f, 0],
       succCtr:   [0x7f, 3]
     })
-    assert.deepStrictEqual(backend.blocks[0].lastKey, {_root: 'x', [`1@${actor1}`]: 'y'})
+    assert.strictEqual(backend.blocks[0].lastKey, 'y')
     assert.strictEqual(backend.blocks[0].numOps, 4)
+    assert.strictEqual(backend.blocks[0].lastObjectActor, 0)
+    assert.strictEqual(backend.blocks[0].lastObjectCtr, 1)
   })
 
   it('should allow changes containing unknown columns, actions, and datatypes', () => {
@@ -1798,8 +1898,10 @@ describe('BackendDoc applying changes', () => {
       241:      [2, 0],
       243:      [2, 1]
     })
-    assert.deepStrictEqual(backend.blocks[0].lastKey, {_root: 'x'})
+    assert.strictEqual(backend.blocks[0].lastKey, 'x')
     assert.strictEqual(backend.blocks[0].numOps, 1)
+    assert.strictEqual(backend.blocks[0].lastObjectActor, null)
+    assert.strictEqual(backend.blocks[0].lastObjectCtr, null)
   })
 
   it('should split a long insertion into multiple blocks', () => {


### PR DESCRIPTION
This PR fixes a bug reported by taronish (via Slack). If a document contained a text object with enough operations to split it across two blocks, and then a root object operation was performed with a higher key than any existing key on the root object, then that operation would be inserted at the beginning of the second block, not after the existing root object operations as it should. Further down the line this would cause exceptions like "RangeError: could not find list element with ID" or "RangeError: no matching operation for pred" even though the operations were valid.

I fixed it by correcting the block skipping logic in `seekToOp`. Incidentally, the fix was closely related to a simplification of the block metadata that I wanted to do anyway, so I did that simplification at the same time.