### PR TITLE
Fix error "RangeError: Invalid length for floating point number: 4"

### DIFF
--- a/@types/automerge/index.d.ts
+++ b/@types/automerge/index.d.ts
@@ -67,6 +67,9 @@ declare module 'automerge' {
   function load<T>(data: BinaryDocument, options?: any): Doc<T>
   function save<T>(doc: Doc<T>): BinaryDocument
 
+  function upgrade(changes: BinaryChange[]): BinaryChange[]
+  function upgrade(data: BinaryDocument): BinaryDocument
+
   function generateSyncMessage<T>(doc: Doc<T>, syncState: SyncState): [SyncState, BinarySyncMessage?]
   function receiveSyncMessage<T>(doc: Doc<T>, syncState: SyncState, message: BinarySyncMessage): [Doc<T>, SyncState, Patch?]
   function initSyncState(): SyncState

--- a/backend/new.js
+++ b/backend/new.js
@@ -1868,7 +1868,7 @@ class BackendDoc {
    * loaded we defer the computation of this hash graph to make loading faster, but if the hash
    * graph is later needed (e.g. for the sync protocol), this function fills it in.
    */
-  computeHashGraph() {
+  computeHashGraph(checkHeads = true) {
     const binaryDoc = this.save()
     this.haveHashGraph = true
     this.changes = []
@@ -1878,7 +1878,7 @@ class BackendDoc {
     this.hashesByActor = {}
     this.clock = {}
 
-    for (let change of decodeChanges([binaryDoc])) {
+    for (let change of decodeChanges([binaryDoc], checkHeads)) {
       const binaryChange = encodeChange(change) // TODO: avoid decoding and re-encoding again
       this.changes.push(binaryChange)
       this.changeIndexByHash[change.hash] = this.changes.length - 1


### PR DESCRIPTION
This PR is for @darrenmce, who reported a problem in ​#449: if an Automerge document was created with a version between v1.0.1-preview.1 and v1.0.1-preview.3, and the document contained floating-point numbers, then that document would no longer be readable in the latest version of Automerge, but instead throw an exception "RangeError: Invalid length for floating point number: 4". This is due to the fact that those Automerge versions sometimes encoded numbers as 32-bit (single precision floats), and in #371 we moved to using only 64-bit (double) floats.

This patch adds a function `Automerge.upgrade(doc)` which takes an old document containing 32-bit floats, and upgrades it to use 64-bit numbers instead. The document can be given either as a Uint8Array (if it's the result of `Automerge.save()`) or an array of Uint8Arrays (if it's the result of `Automerge.getAllChanges()`).

Note: this PR is not intended to be merged into main, because I don't want to add the `Automerge.upgrade` function to the API permanently, and the upgrade is a one-time operation. Anyone who needs to upgrade their document should check out the code on this PR.