### PR TITLE
Fix out-of-order change application

### DIFF
--- a/backend/new.js
+++ b/backend/new.js
@@ -1812,6 +1812,9 @@ class BackendDoc {
     while (true) {
       const [applied, enqueued] = applyChanges(patches, queue, docState, objectIds, this.haveHashGraph)
       queue = enqueued
+      for (let i = 0; i < applied.length; i++) {
+        docState.changeIndexByHash[applied[i].hash] = this.changes.length + allApplied.length + i
+      }
       if (applied.length > 0) allApplied = allApplied.concat(applied)
       if (queue.length === 0) break
 

--- a/test/test.js
+++ b/test/test.js
@@ -1368,6 +1368,15 @@ describe('Automerge', () => {
       assert.strictEqual(patch.pendingChanges, 0)
     })
 
+    it('should allow changes to be applied in any order', () => {
+      let s1 = Automerge.change(Automerge.init(), doc => doc.bird = 'Goldfinch')
+      let s2 = Automerge.change(s1, doc => doc.bird = 'Chaffinch')
+      let s3 = Automerge.change(s2, doc => doc.bird = 'Greenfinch')
+      let changes = Automerge.getAllChanges(s3).reverse()
+      let [s4, patch] = Automerge.applyChanges(Automerge.init(), changes)
+      assert.deepStrictEqual(s4, {bird: 'Greenfinch'})
+    })
+
     it('should report missing dependencies with out-of-order applyChanges', () => {
       let s0 = Automerge.init()
       let s1 = Automerge.change(s0, doc => doc.test = ['a'])

--- a/test/test.js
+++ b/test/test.js
@@ -1373,7 +1373,7 @@ describe('Automerge', () => {
       let s2 = Automerge.change(s1, doc => doc.bird = 'Chaffinch')
       let s3 = Automerge.change(s2, doc => doc.bird = 'Greenfinch')
       let changes = Automerge.getAllChanges(s3).reverse()
-      let [s4, patch] = Automerge.applyChanges(Automerge.init(), changes)
+      let [s4] = Automerge.applyChanges(Automerge.init(), changes)
       assert.deepStrictEqual(s4, {bird: 'Greenfinch'})
     })
 


### PR DESCRIPTION
There was a bug that meant that if applyChanges was called with changes in an order that was inconsistent with the dependencies between the changes, only some of the changes would get applied. Other changes would remain in the queue even though they were ready to be applied. This PR fixes the bug.