### PR TITLE
Fix encoding of document containing an empty change

### DIFF
--- a/backend/new.js
+++ b/backend/new.js
@@ -684,6 +684,11 @@ function readNextChangeOp(docState, changeState) {
     changeState.columns = makeDecoders(change.columns, CHANGE_COLUMNS)
     changeState.opCtr = change.startOp
 
+    // If it's an empty change (no ops), set its maxOp here since it won't be set below
+    if (changeState.columns[actionIdx].decoder.done) {
+      change.maxOp = change.startOp - 1
+    }
+
     // Update docState based on the information in the change
     updateBlockColumns(docState, changeState.columns)
     const {actorIds, actorTable} = getActorTable(docState.actorIds, change)

--- a/test/test.js
+++ b/test/test.js
@@ -341,6 +341,18 @@ describe('Automerge', () => {
         assert.deepStrictEqual(emptyChange.deps, [history[0].change.hash, history[1].change.hash].sort())
         assert.deepStrictEqual(emptyChange.ops, [])
       })
+
+      it('should encode and decode correctly', () => {
+        s1 = Automerge.emptyChange(s1)
+        s1 = Automerge.change(s1, doc => doc.z = 1)
+        s1 = Automerge.change(s1, doc => doc.z = 1000)
+        const changes = Automerge.getAllChanges(Automerge.load(Automerge.save(s1)))
+        ;[s2] = Automerge.applyChanges(Automerge.init(), changes)
+        const heads1 = Automerge.Backend.getHeads(Automerge.Frontend.getBackendState(s1))
+        const heads2 = Automerge.Backend.getHeads(Automerge.Frontend.getBackendState(s2))
+        assert.deepStrictEqual(heads1, heads2)
+        assert.deepStrictEqual(s1, s2)
+      })
     })
 
     describe('root object', () => {


### PR DESCRIPTION
The new backend did not compute the maxOp property of a change that had no operations, which would cause an exception later when a subsequent change, or the whole document, was encoded. This fixes the issue. Thanks to @jrakow for reporting it.

Fixes #456