### PR TITLE
explicitly expose Lamport ordering in a test

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -764,6 +764,17 @@ describe('Automerge', () => {
         }, /Cannot create a reference to an existing document object/)
       })
 
+      it('concurrent edits insert in reverse actorid order if counters equal', () => {
+        s1 = Automerge.init('aaaa')
+        s2 = Automerge.init('bbbb')
+        s1 = Automerge.change(s1, doc => doc.list = [])
+        s2 = Automerge.merge(s2, s1)
+        s1 = Automerge.change(s1, doc => doc.list.splice(0, 0, "2@aaaa"))
+        s2 = Automerge.change(s2, doc => doc.list.splice(0, 0, "2@bbbb"))
+        s2 = Automerge.merge(s2, s1)
+        assert.deepStrictEqual(s2.list, ["2@bbbb", "2@aaaa"])
+      })
+
       it('concurrent edits insert in reverse counter order if different', () => {
         s1 = Automerge.init('aaaa')
         s2 = Automerge.init('bbbb')
@@ -774,16 +785,6 @@ describe('Automerge', () => {
         s2 = Automerge.change(s2, doc => doc.list.splice(0, 0, "3@bbbb"))
         s2 = Automerge.merge(s2, s1)
         assert.deepStrictEqual(s2.list, ["3@bbbb", "2@aaaa"])
-      })
-
-      it('should treat out-by-one assignment as insertion', () => {
-        s1 = Automerge.change(s1, doc => doc.japaneseFood = ['udon'])
-        s1 = Automerge.change(s1, doc => doc.japaneseFood[1] = 'sushi')
-        assert.deepStrictEqual(s1.japaneseFood, ['udon', 'sushi'])
-        assert.strictEqual(s1.japaneseFood[0], 'udon')
-        assert.strictEqual(s1.japaneseFood[1], 'sushi')
-        assert.strictEqual(s1.japaneseFood[2], undefined)
-        assert.strictEqual(s1.japaneseFood.length, 2)
       })
     })
 


### PR DESCRIPTION
Had a bug in the rust version with lamport ordering being wrong - none of the tests caught it - here are a few that would have caught this sooner.