### PR TITLE
remove limitation that merge requires different actors

### DIFF
--- a/README.md
+++ b/README.md
@@ -413,8 +413,7 @@ and it is the essence of what Automerge is all about.
 
 `Automerge.merge(doc1, doc2)` is a related function that is useful for testing. It looks for any
 changes that appear in `doc2` but not in `doc1`, and applies them to `doc1`, returning an updated
-version of `doc1`. This function requires that `doc1` and `doc2` have different actor IDs (that is,
-they originated from different calls to `Automerge.init()`). See the [Usage](#usage) section above
+version of `doc1`. See the [Usage](#usage) section above
 for an example using `Automerge.merge()`.
 
 ### Conflicting changes

--- a/src/automerge.js
+++ b/src/automerge.js
@@ -61,9 +61,6 @@ function save(doc) {
 function merge(localDoc, remoteDoc) {
   const localState = Frontend.getBackendState(localDoc, 'merge')
   const remoteState = Frontend.getBackendState(remoteDoc, 'merge', 'second')
-  if (Frontend.getActorId(localDoc) === Frontend.getActorId(remoteDoc)) {
-    throw new RangeError('Cannot merge an actor with itself')
-  }
   const changes = backend.getChangesAdded(localState, remoteState)
   const [updatedDoc] = applyChanges(localDoc, changes)
   return updatedDoc


### PR DESCRIPTION
When I chatted with @ept he mentioned that the restriction is artificial and was put there to stop people accidentally misusing the API. Unfortunately it is a limitation for certain use-cases.

My use-case: I'm having an end-to-end encrypted protocol where `save` is leveraged to create Snapshots of the current document that are stored remotely. Now if a client has a

- local version
- fetches the latest snapshot to apply it

You can't merge the documents together. I also can imaging architectures that leverage `save` to place document into different storages and need to merge them.

Of course this already is an advanced use-case and could be worked around directly leveraging `applyChanges`. 

Let me know if you think the restriction is important enough or it's fine to remove.

_Note_: `yarn test` is passing