### PR TITLE
Update type declaration for `change` function for consistency

### DIFF
--- a/@types/automerge/index.d.ts
+++ b/@types/automerge/index.d.ts
@@ -47,8 +47,8 @@ declare module 'automerge' {
 
   function merge<T>(localdoc: Doc<T>, remotedoc: Doc<T>): Doc<T>
 
-  function change<D, T = Proxy<D>>(doc: D, options: ChangeOptions<T>, callback: ChangeFn<T>): D
-  function change<D, T = Proxy<D>>(doc: D, callback: ChangeFn<T>): D
+  function change<T>(doc: Doc<T>, options: ChangeOptions<T>, callback: ChangeFn<T>): Doc<T>
+  function change<T>(doc: Doc<T>, callback: ChangeFn<T>): Doc<T>
   function emptyChange<D extends Doc<any>>(doc: D, options?: ChangeOptions<D>): D
   function applyChanges<T>(doc: Doc<T>, changes: BinaryChange[]): [Doc<T>, Patch]
   function equals<T>(val1: T, val2: T): boolean
@@ -127,8 +127,8 @@ declare module 'automerge' {
 
   namespace Frontend {
     function applyPatch<T>(doc: Doc<T>, patch: Patch, backendState?: BackendState): Doc<T>
-    function change<D, T = Proxy<D>>(doc: D, message: string | undefined, callback: ChangeFn<T>): [D, Change]
-    function change<D, T = Proxy<D>>(doc: D, callback: ChangeFn<T>): [D, Change]
+    function change<T>(doc: Doc<T>, message: string | undefined, callback: ChangeFn<T>): [Doc<T>, Change]
+    function change<T>(doc: Doc<T>, callback: ChangeFn<T>): [Doc<T>, Change]
     function emptyChange<T>(doc: Doc<T>, message?: string): [Doc<T>, Change]
     function from<T>(initialState: T | Doc<T>, options?: InitOptions<T>): [Doc<T>, Change]
     function getActorId<T>(doc: Doc<T>): string


### PR DESCRIPTION
See https://github.com/automerge/automerge.github.io/issues/16 for a description of the issue.

Make the change function work like the other type declarations (like
applyChanges, applyPatch, etc.) where the user just specifies
the plain type `T` as a type param and the function returns
a `Doc<T>` (which is shorthand for a `FreezeObject<T>`).

For consistency it looks like the same change could also be applied to `getHistory` and maybe `emptyChange` (but I haven't used those yet, so not sure).  Then that `Proxy<T>` type could potentially be removed.  I think what it's trying to convey can be conveyed better in other ways.