### PR TITLE
Feat: return unobserve function to observe (Observable class)

### DIFF
--- a/frontend/observable.js
+++ b/frontend/observable.js
@@ -8,6 +8,9 @@ const { OBJECT_ID, CONFLICTS } = require('./constants')
  */
 class Observable {
   constructor() {
+    /**
+     * @type {Object<string, Array<Function>>}
+     */
     this.observers = {} // map from objectId to array of observers for that object
   }
 
@@ -102,12 +105,18 @@ class Observable {
    * the object, the new state of the object, a boolean that is true if the
    * change is the result of calling `Automerge.change()` locally, and the array
    * of binary changes applied to the document.
+   * @returns {Function} - unsubscribe function, It works like removeEventListener
    */
   observe(object, callback) {
     const objectId = object[OBJECT_ID]
     if (!objectId) throw new TypeError('The observed object must be part of an Automerge document')
     if (!this.observers[objectId]) this.observers[objectId] = []
     this.observers[objectId].push(callback)
+    return () => {
+      this.observers[objectId] = this.observers[objectId].filter(
+        (observeFn) => observeFn !== callback
+      )
+    }
   }
 }
 

--- a/test/observable_test.js
+++ b/test/observable_test.js
@@ -161,4 +161,17 @@ describe('Automerge.Observable', () => {
     assert.strictEqual(called1, true)
     assert.strictEqual(called2, true)
   })
+
+  it("can unobserve spcific variable's changes", () => {
+    const observable = new Automerge.Observable()
+    let doc = Automerge.init({observable})
+    let called1 = false
+    let called2 = false
+    const unobserveCalled1 = observable.observe(doc, () => { called1 = true })
+    observable.observe(doc, () => { called2 = true })
+    unobserveCalled1()
+    Automerge.change(doc, doc => doc.foo = 'bar')
+    assert.strictEqual(called1, false)
+    assert.strictEqual(called2, true)
+  });
 })


### PR DESCRIPTION
If developer don't want to observe, or watch specific value's changes. They can do it, but they cannot remove callback function in observers.

This feature allows developers to eliminate functions they directly register as callbacks whenever they want.