### PR TITLE
Declaration specifies more operations than supported

### DIFF
--- a/@types/automerge/index.d.ts
+++ b/@types/automerge/index.d.ts
@@ -86,10 +86,13 @@ declare module 'automerge' {
     deleteAt?(index: number, numDelete?: number): List<T>
   }
 
-  class Text extends List<string> {
+  class Text { //extends List<string> {
     constructor(text?: string | string[])
     get(index: number): string
     toSpans<T>(): (string | T)[]
+    insertAt?(index: number, ...args: T[]): List<T>
+    deleteAt?(index: number, numDelete?: number): List<T>
+    // supported Array<string> functions
   }
 
   // Note that until https://github.com/Microsoft/TypeScript/issues/2361 is addressed, we


### PR DESCRIPTION
The declaration files specifies support for ALL operations specified in nodejs' Array declaration file. In fact, not all are actually supported, for instance `array.push(element)` is not. At https://github.com/automerge/automerge/blob/ad5104200c5bb0e6525f30a90d100eee26fa927b/frontend/text.js#L167 we have all the supported operations. (Spoiler alert: push is not there 🙁)