### PR TITLE
allow referencing existing objects when part of the conflict set

### DIFF
--- a/frontend/context.js
+++ b/frontend/context.js
@@ -229,7 +229,14 @@ class Context {
    */
   createNestedObjects(obj, key, value, insert, pred, elemId) {
     if (value[OBJECT_ID]) {
-      throw new RangeError('Cannot create a reference to an existing document object')
+      const object = this.updated[obj] || this.cache[obj]
+      const conflicts = object && object[CONFLICTS][key]
+      const valueInConflicts = conflicts && Object.values(conflicts)
+        .some(v => v && v[OBJECT_ID] === value[OBJECT_ID])
+
+      if (!valueInConflicts) {
+        throw new RangeError('Cannot create a reference to an existing document object')
+      }
     }
     const objectId = this.nextOpId()
 

--- a/test/test.js
+++ b/test/test.js
@@ -547,6 +547,20 @@ describe('Automerge', () => {
         }, /Cannot create a reference to an existing document object/)
       })
 
+      it('should allow allow referencing an existing object that is part of the conflict set', () => {
+        s2 = Automerge.clone(s1)
+        s1 = Automerge.change(s1, doc => doc.object = { id: 'a' })
+        s2 = Automerge.change(s2, doc => doc.object = { id: 'b' })
+
+        const result = Automerge.merge(s1, s2)
+        const conflicts = Automerge.getConflicts(result, 'object')
+
+        // Should not throw "Cannot create a reference to an existing document object"
+        Automerge.change(result, doc => {
+          doc.object = Object.values(conflicts)[0]
+        })
+      })
+
       it('should handle deletion of properties within a map', () => {
         s1 = Automerge.change(s1, 'set style', doc => {
           doc.textStyle = {typeface: 'Optima', bold: false, fontSize: 12}
@@ -771,6 +785,20 @@ describe('Automerge', () => {
         assert.throws(() => {
           Automerge.change(s1, doc => { doc.x = []; doc.y = doc.x })
         }, /Cannot create a reference to an existing document object/)
+      })
+
+      it('should allow referencing an existing list that is part of the conflict set', () => {
+        s2 = Automerge.clone(s1)
+        s1 = Automerge.change(s1, doc => doc.list = ['a'])
+        s2 = Automerge.change(s2, doc => doc.list = ['b'])
+
+        const result = Automerge.merge(s1, s2)
+        const conflicts = Automerge.getConflicts(result, 'list')
+
+        // Should not throw "Cannot create a reference to an existing document object"
+        Automerge.change(result, doc => {
+          doc.list = Object.values(conflicts)[0]
+        })
       })
 
       it('concurrent edits insert in reverse actorid order if counters equal', () => {


### PR DESCRIPTION
Issue https://github.com/automerge/automerge-rs/issues/526 demonstrated that it was not possible to resolve a conflict by choosing one of the conflicting objects or arrays. The following change allows setting a nested object to be an existing object reference so long as the referenced object id is currently listed as one of the conflicts for the key.