### PR TITLE
Add default export to wasm package.json

### DIFF
--- a/rust/automerge-wasm/package.json
+++ b/rust/automerge-wasm/package.json
@@ -55,6 +55,7 @@
   },
   "exports": {
     "browser": "./bundler/automerge_wasm.js",
+    "default": "./nodejs/automerge_wasm.js",
     "require": "./nodejs/automerge_wasm.js"
   }
 }


### PR DESCRIPTION
While trying to update https://github.com/dmonad/crdt-benchmarks to latest @automerge/automerge-wasm, I have hit `ERR_PACKAGE_PATH_NOT_EXPORTED` error while importing with `import Automerge from '@automerge/automerge-wasm'``.

This PR adds an `default` entry to the exports listed in package.json.