### PR TITLE
Suppress clippy warning in parse.rs + bump toolchain

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: 1.66.0
+          toolchain: 1.67.0
           default: true
           components: rustfmt
       - uses: Swatinem/rust-cache@v1
@@ -28,7 +28,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: 1.66.0
+          toolchain: 1.67.0
           default: true
           components: clippy
       - uses: Swatinem/rust-cache@v1
@@ -42,7 +42,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: 1.66.0
+          toolchain: 1.67.0
           default: true
       - uses: Swatinem/rust-cache@v1
       - name: Build rust docs
@@ -118,7 +118,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: 1.66.0
+          toolchain: 1.67.0
           default: true
       - uses: Swatinem/rust-cache@v1
       - name: Install CMocka
@@ -136,7 +136,7 @@ jobs:
     strategy:
       matrix:
         toolchain:
-          - 1.66.0
+          - 1.67.0
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
@@ -155,7 +155,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: 1.66.0
+          toolchain: 1.67.0
           default: true
       - uses: Swatinem/rust-cache@v1
       - run: ./scripts/ci/build-test
@@ -168,7 +168,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: 1.66.0
+          toolchain: 1.67.0
           default: true
       - uses: Swatinem/rust-cache@v1
       - run: ./scripts/ci/build-test

--- a/rust/automerge/src/storage/parse.rs
+++ b/rust/automerge/src/storage/parse.rs
@@ -308,6 +308,7 @@ impl<'a> Input<'a> {
     }
 
     /// The bytes behind this input - including bytes which have been consumed
+    #[allow(clippy::misnamed_getters)]
     pub(crate) fn bytes(&self) -> &'a [u8] {
         self.original
     }


### PR DESCRIPTION
This clippy warning was causing issues when running `./scripts/ci/run`; one option would be to rename the getter, or to switch up the naming of the fields, but I figured suppressing the clippy warning would be reasonable.

```
error: getter function appears to return the wrong field
   --> automerge/src/storage/parse.rs:311:5
    |
311 | /     pub(crate) fn bytes(&self) -> &'a [u8] {
312 | |         self.original
    | |         ------------- help: consider using: `self.bytes`
313 | |     }
    | |_____^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#misnamed_getters
    = note: `-D clippy::misnamed-getters` implied by `-D warnings`

error: could not compile `automerge` due to previous error
```
