### PR TITLE
Public clock API

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "flake-utils": {
       "locked": {
-        "lastModified": 1667395993,
-        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
+        "lastModified": 1676283394,
+        "narHash": "sha256-XX2f9c3iySLCw54rJ/CZs+ZK6IQy7GXNY4nSOyu2QG4=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
+        "rev": "3db36a8b464d0c4532ba1c7dda728f4576d6d073",
         "type": "github"
       },
       "original": {
@@ -32,11 +32,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1669542132,
-        "narHash": "sha256-DRlg++NJAwPh8io3ExBJdNW7Djs3plVI5jgYQ+iXAZQ=",
+        "lastModified": 1678111249,
+        "narHash": "sha256-ZTIbK7vthZwti5XeLZE+twkb4l44q01q2XoLMmmJe94=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "a115bb9bd56831941be3776c8a94005867f316a7",
+        "rev": "a028e2873d7fcf44e66b784b4ba061824315537f",
         "type": "github"
       },
       "original": {
@@ -75,11 +75,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1669775522,
-        "narHash": "sha256-6xxGArBqssX38DdHpDoPcPvB/e79uXyQBwpBcaO/BwY=",
+        "lastModified": 1678156469,
+        "narHash": "sha256-DyUmhPPS2B+01BsQ3AwLrcA+m6PHfyUeShiLbmQxCf4=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "3158e47f6b85a288d12948aeb9a048e0ed4434d6",
+        "rev": "423b16bef17c9e8e9ea515e502c0c5d0f8e51f4a",
         "type": "github"
       },
       "original": {

--- a/rust/automerge/src/autocommit.rs
+++ b/rust/automerge/src/autocommit.rs
@@ -1,5 +1,6 @@
 use std::ops::RangeBounds;
 
+use crate::clock::ExClock;
 use crate::exid::ExId;
 use crate::op_observer::{BranchableObserver, OpObserver};
 use crate::sync::SyncDoc;
@@ -253,6 +254,16 @@ impl<Obs: Observation> AutoCommitWithObs<Obs> {
     pub fn get_last_local_change(&mut self) -> Option<&Change> {
         self.ensure_transaction_closed();
         self.doc.get_last_local_change()
+    }
+
+    /// Get the vector clock for the given heads.
+    pub fn clock_for_heads(&self, heads: &[ChangeHash]) -> ExClock {
+        self.doc.clock_for_heads(heads)
+    }
+
+    /// Get the heads hashes for the given vector clock.
+    pub fn heads_for_clock(&self, clock: &ExClock) -> Result<Vec<ChangeHash>, AutomergeError> {
+        self.doc.heads_for_clock(clock)
     }
 
     pub fn get_changes(

--- a/rust/automerge/src/error.rs
+++ b/rust/automerge/src/error.rs
@@ -54,6 +54,8 @@ pub enum AutomergeError {
     NonChangeCompressed,
     #[error("id was not an object id")]
     NotAnObject,
+    #[error("this clock refers to the future")]
+    FutureClock,
 }
 
 impl PartialEq for AutomergeError {

--- a/rust/automerge/src/lib.rs
+++ b/rust/automerge/src/lib.rs
@@ -245,7 +245,7 @@ mod automerge;
 mod autoserde;
 mod change;
 mod change_graph;
-mod clock;
+pub mod clock;
 mod columnar;
 mod convert;
 mod error;


### PR DESCRIPTION
For one of my projects I've found a need to work with vector clocks from automerge heads primarily because the heads can't be compared to indicate which is newer. This PR adds a conversion from heads to a clock and vice-versa, as well as some methods on the public vector clock that enable users to interact with it and create their own for testing.