### PR TITLE
smaller automerge c

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,10 +2,10 @@ name: CI
 on:
   push:
     branches:
-    - main
+      - main
   pull_request:
     branches:
-    - main
+      - main
 jobs:
   fmt:
     runs-on: ubuntu-latest
@@ -118,7 +118,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: 1.67.0
+          toolchain: nightly-2023-01-26
           default: true
       - uses: Swatinem/rust-cache@v1
       - name: Install CMocka
@@ -127,6 +127,8 @@ jobs:
         uses: jwlawson/actions-setup-cmake@v1.12
         with:
           cmake-version: latest
+      - name: Install rust-src
+        run: rustup component add rust-src
       - name: Build and test C bindings
         run: ./scripts/ci/cmake-build Release Static
         shell: bash

--- a/README.md
+++ b/README.md
@@ -57,7 +57,6 @@ to figure out how to use it. If you are looking to build rust applications which
 use automerge you may want to look into
 [autosurgeon](https://github.com/alexjg/autosurgeon)
 
-
 ## Repository Organisation
 
 - `./rust` - the rust rust implementation and also the Rust components of
@@ -118,6 +117,10 @@ yarn --cwd ./javascript
 
 # install rust dependencies
 cargo install wasm-bindgen-cli wasm-opt cargo-deny
+
+# get nightly rust to produce optimized automerge-c builds
+rustup toolchain install nightly
+rustup component add rust-src --toolchain nightly
 
 # add wasm target in addition to current architecture
 rustup target add wasm32-unknown-unknown

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -10,13 +10,8 @@ members = [
 resolver = "2"
 
 [profile.release]
-debug = true
 lto = true
-opt-level = 3
+codegen-units = 1
 
 [profile.bench]
 debug = true
-
-[profile.release.package.automerge-wasm]
-debug = false
-opt-level = 3

--- a/rust/automerge-c/CMakeLists.txt
+++ b/rust/automerge-c/CMakeLists.txt
@@ -43,19 +43,37 @@ endif()
 
 string(TOLOWER "${CMAKE_BUILD_TYPE}" BUILD_TYPE_LOWER)
 
+# In order to build with -Z build-std, we need to pass target explicitly.
+# https://doc.rust-lang.org/cargo/reference/unstable.html#build-std
+execute_process (
+    COMMAND rustc -vV
+    OUTPUT_VARIABLE RUSTC_VERSION
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+)
+string(REGEX REPLACE ".*host: ([^ \n]*).*" "\\1"
+    CARGO_TARGET
+    ${RUSTC_VERSION}
+)
+
 if(BUILD_TYPE_LOWER STREQUAL debug)
     set(CARGO_BUILD_TYPE "debug")
 
-    set(CARGO_FLAG "")
+    set(CARGO_FLAG --target=${CARGO_TARGET})
 else()
     set(CARGO_BUILD_TYPE "release")
 
-    set(CARGO_FLAG "--release")
+    if (NOT RUSTC_VERSION MATCHES "nightly")
+        set(RUSTUP_TOOLCHAIN nightly)
+    endif()
+
+    set(RUSTFLAGS -C\ panic=abort)
+
+    set(CARGO_FLAG -Z build-std=std,panic_abort --release --target=${CARGO_TARGET})
 endif()
 
 set(CARGO_FEATURES "")
 
-set(CARGO_BINARY_DIR "${CARGO_TARGET_DIR}/${CARGO_BUILD_TYPE}")
+set(CARGO_BINARY_DIR "${CARGO_TARGET_DIR}/${CARGO_TARGET}/${CARGO_BUILD_TYPE}")
 
 set(BINDINGS_NAME "${LIBRARY_NAME}_core")
 
@@ -90,7 +108,7 @@ add_custom_command(
         #       configuration file has been updated.
         ${CMAKE_COMMAND} -DCONDITION=NOT_EXISTS -P ${CMAKE_SOURCE_DIR}/cmake/file-touch.cmake -- ${CBINDGEN_TARGET_DIR}/${LIBRARY_NAME}.h ${CMAKE_SOURCE_DIR}/cbindgen.toml
     COMMAND
-        ${CMAKE_COMMAND} -E env CARGO_TARGET_DIR=${CARGO_TARGET_DIR} CBINDGEN_TARGET_DIR=${CBINDGEN_TARGET_DIR} ${CARGO_CMD} build ${CARGO_FLAG} ${CARGO_FEATURES}
+        ${CMAKE_COMMAND} -E env CARGO_TARGET_DIR=${CARGO_TARGET_DIR} CBINDGEN_TARGET_DIR=${CBINDGEN_TARGET_DIR} RUSTUP_TOOLCHAIN=${RUSTUP_TOOLCHAIN} RUSTFLAGS=${RUSTFLAGS} ${CARGO_CMD} build ${CARGO_FLAG} ${CARGO_FEATURES}
     COMMAND
         # Compensate for cbindgen's translation of consecutive uppercase letters to "ScreamingSnakeCase".
         ${CMAKE_COMMAND} -DMATCH_REGEX=A_M\([^_]+\)_ -DREPLACE_EXPR=AM_\\1_ -P ${CMAKE_SOURCE_DIR}/cmake/file-regex-replace.cmake -- ${CBINDGEN_TARGET_DIR}/${LIBRARY_NAME}.h

--- a/rust/automerge-c/test/byte_span_tests.c
+++ b/rust/automerge-c/test/byte_span_tests.c
@@ -3,6 +3,7 @@
 #include <stddef.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 
 /* third-party */
 #include <cmocka.h>


### PR DESCRIPTION
Generate significantly smaller automerge-c builds

This cuts the size of libautomerge_core.a from 25Mb to 1.6Mb on macOS
and 53Mb to 2.7Mb on Linux.

As a side-effect of setting codegen-units = 1 for all release builds the
optimized wasm files are also 100kb smaller.
