### PR TITLE
Add support for cloudflare workers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ perf.*
 build/
 .vim/*
 /target
+.DS_Store

--- a/javascript/e2e/verdaccio.yaml
+++ b/javascript/e2e/verdaccio.yaml
@@ -1,4 +1,5 @@
 storage: "./verdacciodb"
+max_body_size: 100mb
 auth:
   htpasswd:
     file: ./htpasswd

--- a/javascript/package.json
+++ b/javascript/package.json
@@ -35,7 +35,7 @@
     "@types/uuid": "^9.0.0",
     "@typescript-eslint/eslint-plugin": "^5.46.0",
     "@typescript-eslint/parser": "^5.46.0",
-    "denoify": "^1.4.5",
+    "denoify": "1.4.5",
     "eslint": "^8.29.0",
     "fast-sha256": "^1.3.0",
     "mocha": "^10.2.0",
@@ -45,6 +45,9 @@
     "ts-node": "^10.9.1",
     "typedoc": "^0.23.22",
     "typescript": "^4.9.4"
+  },
+  "resolutions": {
+    "denoify/evt": "2.4.18"
   },
   "dependencies": {
     "@automerge/automerge-wasm": "^0.1.26",

--- a/rust/automerge-wasm/.gitignore
+++ b/rust/automerge-wasm/.gitignore
@@ -2,5 +2,6 @@
 /bundler
 /nodejs
 /deno
+/web
 Cargo.lock
 yarn.lock

--- a/rust/automerge-wasm/Cargo.toml
+++ b/rust/automerge-wasm/Cargo.toml
@@ -36,7 +36,7 @@ itertools = "^0.10.3"
 thiserror = "^1.0.16"
 
 [dependencies.wasm-bindgen]
-version = "0.2.84"
+version = "^0.2.85"
 #features = ["std"]
 features = ["serde-serialize", "std"]
 

--- a/rust/automerge-wasm/examples/cloudflare/.gitignore
+++ b/rust/automerge-wasm/examples/cloudflare/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+package-lock.json

--- a/rust/automerge-wasm/examples/cloudflare/package.json
+++ b/rust/automerge-wasm/examples/cloudflare/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "cloudflare",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "start": "wrangler dev --local"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "devDependencies": {
+    "wrangler": "^2.12.2"
+  },
+  "dependencies": {
+    "@automerge/automerge-wasm": "^0.1.26"
+  }
+}

--- a/rust/automerge-wasm/examples/cloudflare/src/index.js
+++ b/rust/automerge-wasm/examples/cloudflare/src/index.js
@@ -1,0 +1,16 @@
+/* eslint-disable no-undef */
+import * as Automerge from "@automerge/automerge-wasm";
+
+export default {
+  async fetch() {
+    const doc = Automerge.create();
+    console.log("doc", doc);
+    const edits = doc.putObject("_root", "edits", "");
+    doc.splice(edits, 0, 0, "the quick fox jumps over the lazy dog");
+    const doc2 = Automerge.load(doc.save());
+    console.log("LOAD", Automerge.load);
+    console.log("DOC", doc.materialize("/"));
+    console.log("DOC2", doc2.materialize("/"));
+    return Response.json(doc.text(edits));
+  },
+};

--- a/rust/automerge-wasm/examples/cloudflare/wrangler.toml
+++ b/rust/automerge-wasm/examples/cloudflare/wrangler.toml
@@ -1,0 +1,3 @@
+name = "cloudflare"
+main = "src/index.js"
+compatibility_date = "2023-03-11"

--- a/rust/automerge-wasm/package.json
+++ b/rust/automerge-wasm/package.json
@@ -21,7 +21,10 @@
     "deno/automerge_wasm_bg.wasm",
     "bundler/automerge_wasm.js",
     "bundler/automerge_wasm_bg.js",
-    "bundler/automerge_wasm_bg.wasm"
+    "bundler/automerge_wasm_bg.wasm",
+    "web/automerge_wasm_bg.wasm",
+    "web/automerge_wasm.js",
+    "web/index.js"
   ],
   "private": false,
   "types": "index.d.ts",
@@ -33,7 +36,7 @@
     "dev": "cross-env PROFILE=dev TARGET_DIR=debug FEATURES='' TARGET=nodejs yarn target",
     "build": "cross-env PROFILE=dev TARGET_DIR=debug FEATURES='' yarn buildall",
     "release": "cross-env PROFILE=release TARGET_DIR=release yarn buildall",
-    "buildall": "cross-env TARGET=nodejs yarn target && cross-env TARGET=bundler yarn target && cross-env TARGET=deno yarn target",
+    "buildall": "cross-env TARGET=nodejs yarn target && cross-env TARGET=bundler yarn target && cross-env TARGET=deno yarn target && TARGET=web yarn target && node -e \"require('fs').cpSync('./src/export-web-wasm.js', './web/index.js')\"",
     "target": "rimraf ./$TARGET && yarn compile && yarn bindgen && yarn opt",
     "compile": "cargo build --target wasm32-unknown-unknown --profile $PROFILE",
     "bindgen": "wasm-bindgen --no-typescript --weak-refs --target $TARGET --out-dir $TARGET ../target/wasm32-unknown-unknown/$TARGET_DIR/automerge_wasm.wasm",
@@ -57,6 +60,7 @@
     "uuid": "^9.0.0"
   },
   "exports": {
+    "workerd": "./web/index.js",
     "browser": "./bundler/automerge_wasm.js",
     "require": "./nodejs/automerge_wasm.js"
   }

--- a/rust/automerge-wasm/src/export-web-wasm.js
+++ b/rust/automerge-wasm/src/export-web-wasm.js
@@ -1,0 +1,6 @@
+// This file is inserted into ./web by the build script
+
+import WASM from "./automerge_wasm_bg.wasm";
+import { initSync } from "./automerge_wasm.js";
+initSync(WASM);
+export * from "./automerge_wasm.js";


### PR DESCRIPTION
Cloudflare Workers uses a slightly different way of importing and using `.wasm` modules ([details](https://blog.cloudflare.com/webassembly-on-cloudflare-workers/)) This adds a new build that leverages `wasm-bindgen`'s `web` target and stitches it together with a entry file.
