### PR TITLE
fix: `Nth` query sometimes miscounting

### DIFF
--- a/rust/automerge/src/lib.rs
+++ b/rust/automerge/src/lib.rs
@@ -261,7 +261,7 @@ mod map_range_at;
 pub mod marks;
 pub mod op_observer;
 mod op_set;
-mod op_tree;
+pub mod op_tree;
 mod parents;
 mod query;
 mod read;

--- a/rust/automerge/src/lib.rs
+++ b/rust/automerge/src/lib.rs
@@ -295,6 +295,7 @@ pub use op_observer::{
 };
 pub use parents::{Parent, Parents};
 pub use read::ReadDoc;
+pub use sequence_tree::SequenceTree;
 pub use types::{ActorId, ChangeHash, ObjType, OpType, ParseChangeHashError, Prop, TextEncoding};
 pub use value::{ScalarValue, Value};
 pub use values::Values;

--- a/rust/automerge/src/op_tree.rs
+++ b/rust/automerge/src/op_tree.rs
@@ -16,7 +16,8 @@ mod node;
 
 pub(crate) use iter::OpTreeIter;
 #[allow(unused)]
-pub(crate) use node::{OpTreeNode, B};
+pub(crate) use node::OpTreeNode;
+pub use node::B;
 
 #[derive(Debug, Clone, PartialEq)]
 pub(crate) struct OpTree {

--- a/rust/automerge/src/op_tree/node.rs
+++ b/rust/automerge/src/op_tree/node.rs
@@ -7,7 +7,7 @@ use std::{
 pub(crate) use crate::op_set::OpSetMetadata;
 use crate::query::{ChangeVisibility, Index, QueryResult, TreeQuery};
 use crate::types::Op;
-pub(crate) const B: usize = 16;
+pub const B: usize = 16;
 
 #[derive(Clone, Debug)]
 pub(crate) struct OpTreeNode {

--- a/rust/automerge/src/query/insert.rs
+++ b/rust/automerge/src/query/insert.rs
@@ -97,6 +97,8 @@ impl<'a> TreeQuery<'a> for InsertNth {
             let last_elemid = ops[child.last()].elemid_or_key();
             if child.index.has_visible(&last_elemid) {
                 self.last_seen = Some(last_elemid);
+            } else if self.last_seen.is_some() && Some(last_elemid) != self.last_seen {
+                self.last_seen = None;
             }
             QueryResult::Next
         }

--- a/rust/automerge/src/query/nth.rs
+++ b/rust/automerge/src/query/nth.rs
@@ -97,6 +97,8 @@ impl<'a> TreeQuery<'a> for Nth<'a> {
             let last_elemid = ops[child.last()].elemid_or_key();
             if child.index.has_visible(&last_elemid) {
                 self.last_seen = Some(last_elemid);
+            } else if self.last_seen.is_some() && Some(last_elemid) != self.last_seen {
+                self.last_seen = None;
             }
             QueryResult::Next
         }
@@ -115,7 +117,7 @@ impl<'a> TreeQuery<'a> for Nth<'a> {
             self.last_width = element.width(self.encoding);
             self.seen += self.last_width;
             // we have a new visible element
-            self.last_seen = Some(element.elemid_or_key())
+            self.last_seen = Some(element.elemid_or_key());
         }
         if self.seen > self.target && visible {
             self.ops.push(element);

--- a/rust/automerge/src/sequence_tree.rs
+++ b/rust/automerge/src/sequence_tree.rs
@@ -5,7 +5,7 @@ use std::{
 };
 
 pub(crate) const B: usize = 16;
-pub(crate) type SequenceTree<T> = SequenceTreeInternal<T>;
+pub type SequenceTree<T> = SequenceTreeInternal<T>;
 
 #[derive(Clone, Debug)]
 pub struct SequenceTreeInternal<T> {


### PR DESCRIPTION
This PR fixes a bug in the `Nth` query which led to it not counting the visible element in the parent after skipping a child node.