### PR TITLE
Decorate skip verify flag on examine command.

### DIFF
--- a/rust/automerge-cli/src/main.rs
+++ b/rust/automerge-cli/src/main.rs
@@ -112,6 +112,9 @@ enum Command {
     /// Read an automerge document and print a JSON representation of the changes in it to stdout
     Examine {
         input_file: Option<PathBuf>,
+
+        /// Whether to verify the head hashes of a compressed document
+        #[clap(long, action = clap::ArgAction::SetFalse)]
         skip_verifying_heads: SkipVerifyFlag,
     },
 


### PR DESCRIPTION
Behavior without this patch is `thread 'main' panicked at 'Found non-required positional argument with a lower index than a required positional argument: "input_file" index Some(1)', /home/issac/.cargo/registry/src/github.com-1ecc6299db9ec823/clap-4.1.11/src/builder/debug_asserts.rs:647:17`

```
automerge/rust/automerge-cli on  main [!] is 📦 v0.1.0 via 🦀 v1.68.0 via ❄️  impure (nix-shell-env) 
❯ git stash
Saved working directory and index state WIP on main: a7f751fa Merge pull request #551 from wjt/patch-1

automerge/rust/automerge-cli on  main [$] is 📦 v0.1.0 via 🦀 v1.68.0 via ❄️  impure (nix-shell-env) 
❯ cargo run -- examine /tmp/database.mismatcheheads.20230322 --skip-verifying-heads
warning: /home/issac/src/automerge/rust/edit-trace/Cargo.toml: unused manifest key: bench.0.debug
   Compiling automerge-cli v0.1.0 (/home/issac/src/automerge/rust/automerge-cli)
    Finished dev [unoptimized + debuginfo] target(s) in 2.55s
     Running `/home/issac/src/automerge/rust/target/debug/automerge examine /tmp/database.mismatcheheads.20230322 --skip-verifying-heads`
thread 'main' panicked at 'Found non-required positional argument with a lower index than a required positional argument: "input_file" index Some(1)', /home/issac/.cargo/registry/src/github.com-1ecc6299db9ec823/clap-4.1.11/src/builder/debug_asserts.rs:647:17
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

automerge/rust/automerge-cli on  main [$] is 📦 v0.1.0 via 🦀 v1.68.0 via ❄️  impure (nix-shell-env) took 2s 
❯ cargo run -- examine /tmp/database.mismatcheheads.20230322                       
warning: /home/issac/src/automerge/rust/edit-trace/Cargo.toml: unused manifest key: bench.0.debug
    Finished dev [unoptimized + debuginfo] target(s) in 0.07s
     Running `/home/issac/src/automerge/rust/target/debug/automerge examine /tmp/database.mismatcheheads.20230322`
thread 'main' panicked at 'Found non-required positional argument with a lower index than a required positional argument: "input_file" index Some(1)', /home/issac/.cargo/registry/src/github.com-1ecc6299db9ec823/clap-4.1.11/src/builder/debug_asserts.rs:647:17
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

automerge/rust/automerge-cli on  main [$] is 📦 v0.1.0 via 🦀 v1.68.0 via ❄️  impure (nix-shell-env) 
❯ git stash pop
On branch main
Your branch is up to date with 'origin/main'.

Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git restore <file>..." to discard changes in working directory)
        modified:   src/main.rs

no changes added to commit (use "git add" and/or "git commit -a")
Dropped refs/stash@{0} (a1952b4e1511d7c43d47e5dab6cff191f99e32fd)

automerge/rust/automerge-cli on  main [!] is 📦 v0.1.0 via 🦀 v1.68.0 via ❄️  impure (nix-shell-env) 
❯ cargo run -- examine /tmp/database.mismatcheheads.20230322
warning: /home/issac/src/automerge/rust/edit-trace/Cargo.toml: unused manifest key: bench.0.debug
   Compiling automerge-cli v0.1.0 (/home/issac/src/automerge/rust/automerge-cli)
    Finished dev [unoptimized + debuginfo] target(s) in 2.37s
     Running `/home/issac/src/automerge/rust/target/debug/automerge examine /tmp/database.mismatcheheads.20230322`
2023-03-22T18:19:22.229862Z ERROR load_with{on_error=Error mode=Check}:reconstruct_document{mode=Check}: automerge::storage::load::reconstruct_document: mismatching heads expected_heads={ChangeHash("d0a79fff5b690d26d670f93fbd0e57264b64566a1adf0f0b996b2e9309e2b37c")} heads={ChangeHash("9c1e9675e4a65067a4083b75b4b0656042d3672171c99b9f80693dfcc5c88853")}
2023-03-22T18:19:22.238424Z ERROR load_with{on_error=Error mode=Check}: automerge::automerge: error=error inflating document chunk ops: mismatching heads
Error: ApplyingInitialChanges { source: Load(InflateDocument(MismatchingHeads(MismatchedHeads { changes: 42549, expected_heads: {ChangeHash("d0a79fff5b690d26d670f93fbd0e57264b64566a1adf0f0b996b2e9309e2b37c")}, derived_heads: {ChangeHash("9c1e9675e4a65067a4083b75b4b0656042d3672171c99b9f80693dfcc5c88853")} }))) }

```