### PR TITLE
js: Don't copy patchCallback when cloning

### DIFF
--- a/javascript/src/stable.ts
+++ b/javascript/src/stable.ts
@@ -242,6 +242,7 @@ export function clone<T>(
   // `change` uses the presence of state.heads to determine if we are in a view
   // set it to undefined to indicate that this is a full fat document
   const { heads: _oldHeads, ...stateSansHeads } = state
+  stateSansHeads.patchCallback = opts.patchCallback
   return handle.applyPatches(doc, { ...stateSansHeads, handle })
 }
 

--- a/javascript/test/basic_test.ts
+++ b/javascript/test/basic_test.ts
@@ -303,6 +303,18 @@ describe("Automerge", () => {
     })
   })
 
+  describe("clone", () => {
+    it("should not copy the patchcallback", () => {
+      const patches: Automerge.Patch[][] = []
+      let doc = Automerge.init<{ foo: string | undefined }>({
+        patchCallback: p => patches.push(p),
+      })
+      let doc2 = Automerge.clone(doc)
+      doc2 = Automerge.change(doc2, d => (d.foo = "bar"))
+      assert.deepEqual(patches.length, 0)
+    })
+  })
+
   describe("emptyChange", () => {
     it("should generate a hash", () => {
       let doc = Automerge.init()


### PR DESCRIPTION
The `clone` method which creates a new thread of execution for an automerge document was copying the patch callback from the old document and ignoring the `patchCallback` passed in to the `clone` call. Modify `clone` to use the `patchCallback` passed in and never copy the callback from the original doc.