### PR TITLE
Renumber marks columns in change chunks

### DIFF
--- a/rust/automerge/src/storage/change/change_op_columns.rs
+++ b/rust/automerge/src/storage/change/change_op_columns.rs
@@ -32,8 +32,8 @@ const INSERT_COL_ID: ColumnId = ColumnId::new(3);
 const ACTION_COL_ID: ColumnId = ColumnId::new(4);
 const VAL_COL_ID: ColumnId = ColumnId::new(5);
 const PRED_COL_ID: ColumnId = ColumnId::new(7);
-const EXPAND_COL_ID: ColumnId = ColumnId::new(8);
-const MARK_NAME_COL_ID: ColumnId = ColumnId::new(9);
+const EXPAND_COL_ID: ColumnId = ColumnId::new(9);
+const MARK_NAME_COL_ID: ColumnId = ColumnId::new(10);
 
 #[derive(Clone, Debug, PartialEq)]
 pub(crate) struct ChangeOp {


### PR DESCRIPTION
They now match the ids in doc chunks

Fixes #575
