### PR TITLE
Allow custom expand on unmark

### DIFF
--- a/javascript/src/unstable.ts
+++ b/javascript/src/unstable.ts
@@ -268,9 +268,8 @@ export function mark<T>(
 export function unmark<T>(
   doc: Doc<T>,
   prop: stable.Prop,
-  name: string,
-  start: number,
-  end: number
+  range: MarkRange,
+  name: string
 ) {
   if (!_is_proxy(doc)) {
     throw new RangeError("object cannot be modified outside of a change block")
@@ -282,7 +281,7 @@ export function unmark<T>(
   }
   const obj = `${objectId}/${prop}`
   try {
-    return state.handle.unmark(obj, name, start, end)
+    return state.handle.unmark(obj, range, name)
   } catch (e) {
     throw new RangeError(`Cannot unmark: ${e}`)
   }

--- a/javascript/test/marks.ts
+++ b/javascript/test/marks.ts
@@ -24,7 +24,7 @@ describe("Automerge", () => {
       })
 
       doc1 = Automerge.change(doc1, d => {
-        Automerge.unmark(d, "x", "font-weight", 7, 9)
+        Automerge.unmark(d, "x", { start: 7, end: 9 }, "font-weight")
       })
 
       assert.deepStrictEqual(callbacks[1], [

--- a/rust/automerge-wasm/index.d.ts
+++ b/rust/automerge-wasm/index.d.ts
@@ -194,7 +194,7 @@ export class Automerge {
 
   // marks
   mark(obj: ObjID, range: MarkRange, name: string, value: Value, datatype?: Datatype): void;
-  unmark(obj: ObjID, name: string, start: number, end: number): void;
+  unmark(obj: ObjID, range: MarkRange, name: string): void;
   marks(obj: ObjID, heads?: Heads): Mark[];
 
   // returns a single value - if there is a conflict return the winner

--- a/rust/automerge-wasm/src/lib.rs
+++ b/rust/automerge-wasm/src/lib.rs
@@ -851,16 +851,10 @@ impl Automerge {
     pub fn unmark(
         &mut self,
         obj: JsValue,
-        key: JsValue,
-        start: f64,
-        end: f64,
-    ) -> Result<(), JsValue> {
-        let (obj, _) = self.import(obj)?;
-        let key = key.as_string().ok_or("key must be a string")?;
-        self.doc
-            .unmark(&obj, &key, start as usize, end as usize)
-            .map_err(to_js_err)?;
-        Ok(())
+        range: JsValue,
+        name: JsValue,
+    ) -> Result<(), error::Mark> {
+        self.mark(obj, range, name, JsValue::NULL, JsValue::from_str("null"))
     }
 
     pub fn marks(&mut self, obj: JsValue, heads: Option<Array>) -> Result<JsValue, JsValue> {

--- a/rust/automerge-wasm/test/marks.ts
+++ b/rust/automerge-wasm/test/marks.ts
@@ -31,7 +31,7 @@ describe('Automerge', () => {
       doc.mark(list, { start: 2, end: 8 }, "bold" , true)
       let marks = doc.marks(list);
       assert.deepStrictEqual(marks, [{ name: 'bold', value: true, start: 2, end: 8 }])
-      doc.unmark(list, 'bold', 4, 6)
+      doc.unmark(list, { start: 4, end: 6, expand: 'none' }, 'bold')
       doc.insert(list, 7, "A")
       doc.insert(list, 3, "A")
       marks = doc.marks(list);
@@ -53,7 +53,7 @@ describe('Automerge', () => {
         { name: 'underline', value: true, start: 3, end: 6 },
         { name: 'bold', value: true, start: 2, end: 8 },
       ])
-      doc.unmark(list, 'bold', 4, 6)
+      doc.unmark(list, { start: 4, end: 6 }, 'bold')
       doc.insert(list, 7, "A")
       doc.insert(list, 3, "A")
       marks = doc.marks(list);
@@ -62,7 +62,7 @@ describe('Automerge', () => {
         { name: 'underline', value: true, start: 4, end: 7 },
         { name: 'bold', value: true, start: 7, end: 10 },
       ])
-      doc.unmark(list, 'bold', 0, 11)
+      doc.unmark(list, { start: 0, end: 11 }, 'bold')
       marks = doc.marks(list);
       assert.deepStrictEqual(marks, [
         { name: 'underline', value: true, start: 4, end: 7 }
@@ -558,7 +558,7 @@ describe('Automerge', () => {
       let heads3 = doc1.getHeads();
       let marks3 = doc1.marks(list);
 
-      doc1.unmark(list, "xxx", 9, 20)
+      doc1.unmark(list, { start: 9, end: 20 }, "xxx")
 
       let heads4 = doc1.getHeads();
       let marks4 = doc1.marks(list);

--- a/rust/automerge/Cargo.toml
+++ b/rust/automerge/Cargo.toml
@@ -47,6 +47,7 @@ test-log = { version = "0.2.10", features=["trace"], default-features = false}
 tracing-subscriber = {version = "0.3.9", features = ["fmt", "env-filter"] }
 automerge-test = { path = "../automerge-test" }
 prettytable = "0.10.0"
+regex = "1.8.0"
 
 [[bench]]
 name = "range"

--- a/rust/automerge/src/autocommit.rs
+++ b/rust/automerge/src/autocommit.rs
@@ -668,6 +668,7 @@ impl<Obs: Observation> Transactable for AutoCommitWithObs<Obs> {
         key: &str,
         start: usize,
         end: usize,
+        expand: ExpandMark,
     ) -> Result<(), AutomergeError> {
         self.ensure_transaction_open();
         let (current, tx) = self.transaction.as_mut().unwrap();
@@ -678,6 +679,7 @@ impl<Obs: Observation> Transactable for AutoCommitWithObs<Obs> {
             key,
             start,
             end,
+            expand,
         )
     }
 

--- a/rust/automerge/src/marks.rs
+++ b/rust/automerge/src/marks.rs
@@ -7,6 +7,13 @@ use crate::value::ScalarValue;
 use crate::Automerge;
 use std::borrow::Cow;
 
+/// Marks let you store out-of-bound information about sequences.
+///
+/// The motivating use-case is rich text editing, see <https://www.inkandswitch.com/peritext/>.
+/// Each position in the sequence can be affected by only one Mark of the same "name".
+/// If multiple collaborators have set marks with the same name but different values
+/// in overlapping ranges, automerge will chose a consistent (but arbitrary) value
+/// when reading marks from the doc.
 #[derive(Debug, Clone, PartialEq)]
 pub struct Mark<'a> {
     pub start: usize,
@@ -168,6 +175,10 @@ impl Display for MarkData {
     }
 }
 
+/// ExpandMark allows you to decide whether new text inserted at the start/end of your
+/// mark should also inherit the mark.
+/// See <https://www.inkandswitch.com/peritext/> for details and
+/// suggestions of which value to use for which operations when building a rich text editor.
 #[derive(PartialEq, Debug, Clone, Copy)]
 pub enum ExpandMark {
     Before,

--- a/rust/automerge/src/op_observer.rs
+++ b/rust/automerge/src/op_observer.rs
@@ -1,4 +1,5 @@
 use crate::exid::ExId;
+
 use crate::marks::Mark;
 use crate::Prop;
 use crate::ReadDoc;

--- a/rust/automerge/src/transaction/inner.rs
+++ b/rust/automerge/src/transaction/inner.rs
@@ -681,6 +681,7 @@ impl TransactionInner {
         Ok(())
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub(crate) fn unmark<Obs: OpObserver>(
         &mut self,
         doc: &mut Automerge,
@@ -689,9 +690,10 @@ impl TransactionInner {
         name: &str,
         start: usize,
         end: usize,
+        expand: ExpandMark,
     ) -> Result<(), AutomergeError> {
         let mark = Mark::new(name.to_string(), ScalarValue::Null, start, end);
-        self.mark(doc, op_observer, ex_obj, mark, ExpandMark::None)
+        self.mark(doc, op_observer, ex_obj, mark, expand)
     }
 
     fn finalize_op<Obs: OpObserver>(

--- a/rust/automerge/src/transaction/manual_transaction.rs
+++ b/rust/automerge/src/transaction/manual_transaction.rs
@@ -358,8 +358,9 @@ impl<'a, Obs: observation::Observation> Transactable for Transaction<'a, Obs> {
         name: &str,
         start: usize,
         end: usize,
+        expand: ExpandMark,
     ) -> Result<(), AutomergeError> {
-        self.do_tx(|tx, doc, obs| tx.unmark(doc, obs, obj.as_ref(), name, start, end))
+        self.do_tx(|tx, doc, obs| tx.unmark(doc, obs, obj.as_ref(), name, start, end, expand))
     }
 
     fn base_heads(&self) -> Vec<ChangeHash> {

--- a/rust/automerge/src/transaction/transactable.rs
+++ b/rust/automerge/src/transaction/transactable.rs
@@ -89,6 +89,7 @@ pub trait Transactable: ReadDoc {
         text: &str,
     ) -> Result<(), AutomergeError>;
 
+    /// Mark a sequence
     fn mark<O: AsRef<ExId>>(
         &mut self,
         obj: O,
@@ -96,12 +97,14 @@ pub trait Transactable: ReadDoc {
         expand: ExpandMark,
     ) -> Result<(), AutomergeError>;
 
+    /// Remove a Mark from a sequence
     fn unmark<O: AsRef<ExId>>(
         &mut self,
         obj: O,
         key: &str,
         start: usize,
         end: usize,
+        expand: ExpandMark,
     ) -> Result<(), AutomergeError>;
 
     /// The heads this transaction will be based on


### PR DESCRIPTION
This lets users have more control over how marks are removed.

Along the way add a bit of documentation to the marks feature

Fixes #577
