### PR TITLE
conflict ordering bug in `doc.get*()`

### DIFF
--- a/javascript/test/basic_test.ts
+++ b/javascript/test/basic_test.ts
@@ -303,6 +303,46 @@ describe("Automerge", () => {
     })
   })
 
+  describe("merge", () => {
+    it("it should handle conflicts the same in merges as with loads", () => {
+      let doc1 = Automerge.from({ sub: { x: 0, y: 0 } })
+      let doc2 = Automerge.clone(doc1)
+      let doc3 = Automerge.clone(doc1)
+      let doc4 = Automerge.clone(doc1)
+
+      // same counter - different actors
+      doc1 = Automerge.change(doc1, d => (d.sub.x = 1))
+      doc2 = Automerge.change(doc2, d => (d.sub.x = 2))
+      doc3 = Automerge.change(doc3, d => (d.sub.x = 3))
+      doc4 = Automerge.change(doc4, d => (d.sub.x = 4))
+
+      // differrent counter and different actors
+      doc1 = Automerge.change(doc1, d => (d.sub.y = 1))
+
+      doc2 = Automerge.change(doc2, d => (d.sub.y = 2))
+      doc2 = Automerge.change(doc2, d => (d.sub.y = 3))
+
+      doc3 = Automerge.change(doc3, d => (d.sub.y = 4))
+      doc3 = Automerge.change(doc3, d => (d.sub.y = 5))
+      doc3 = Automerge.change(doc3, d => (d.sub.y = 6))
+
+      doc4 = Automerge.change(doc4, d => (d.sub.y = 7))
+      doc4 = Automerge.change(doc4, d => (d.sub.y = 8))
+      doc4 = Automerge.change(doc4, d => (d.sub.y = 9))
+      doc4 = Automerge.change(doc4, d => (d.sub.y = 10))
+
+      let docM = Automerge.init()
+      docM = Automerge.merge(docM, doc1)
+      docM = Automerge.merge(docM, doc2)
+      docM = Automerge.merge(docM, doc3)
+      docM = Automerge.merge(docM, doc4)
+
+      let docL = Automerge.load(Automerge.save(docM))
+
+      assert.deepEqual(docM.sub.x, docL.sub.x)
+    })
+  })
+
   describe("clone", () => {
     it("should not copy the patchcallback", () => {
       const patches: Automerge.Patch[][] = []

--- a/rust/automerge/src/automerge.rs
+++ b/rust/automerge/src/automerge.rs
@@ -1432,7 +1432,7 @@ impl ReadDoc for Automerge {
         prop: P,
     ) -> Result<Vec<(Value<'_>, ExId)>, AutomergeError> {
         let obj = self.exid_to_obj(obj.as_ref())?.0;
-        let mut result = match prop.into() {
+        Ok(match prop.into() {
             Prop::Map(p) => {
                 let prop = self.ops.m.props.lookup(&p);
                 if let Some(p) = prop {
@@ -1458,9 +1458,7 @@ impl ReadDoc for Automerge {
                     .map(|o| (o.value(), self.id_to_exid(o.id)))
                     .collect()
             }
-        };
-        result.sort_by(|a, b| b.1.cmp(&a.1));
-        Ok(result)
+        })
     }
 
     fn get_all_at<O: AsRef<ExId>, P: Into<Prop>>(

--- a/rust/automerge/src/exid.rs
+++ b/rust/automerge/src/exid.rs
@@ -2,7 +2,6 @@ use crate::storage::parse;
 use crate::ActorId;
 use serde::Serialize;
 use serde::Serializer;
-use std::cmp::{Ord, Ordering};
 use std::fmt;
 use std::hash::{Hash, Hasher};
 
@@ -149,24 +148,6 @@ impl Hash for ExId {
                 actor.hash(state);
             }
         }
-    }
-}
-
-impl Ord for ExId {
-    fn cmp(&self, other: &Self) -> Ordering {
-        match (self, other) {
-            (ExId::Root, ExId::Root) => Ordering::Equal,
-            (ExId::Root, _) => Ordering::Less,
-            (_, ExId::Root) => Ordering::Greater,
-            (ExId::Id(c1, a1, _), ExId::Id(c2, a2, _)) if c1 == c2 => a2.cmp(a1),
-            (ExId::Id(c1, _, _), ExId::Id(c2, _, _)) => c1.cmp(c2),
-        }
-    }
-}
-
-impl PartialOrd for ExId {
-    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        Some(self.cmp(other))
     }
 }
 


### PR DESCRIPTION
Found a bug where `doc.get[_all]()` would return results in the wrong order when a conflict existed.  This would lead to the wrong conflict being materialized on document load in the javascript client.