### PR TITLE
Fix regex/tracing-subscriber dependency hell

### DIFF
--- a/rust/automerge/Cargo.toml
+++ b/rust/automerge/Cargo.toml
@@ -47,7 +47,8 @@ test-log = { version = "0.2.10", features=["trace"], default-features = false}
 tracing-subscriber = {version = "0.3.9", features = ["fmt", "env-filter"] }
 automerge-test = { path = "../automerge-test" }
 prettytable = "0.10.0"
-regex = "1.8.0"
+# Workaround for https://github.com/tokio-rs/tracing/issues/2565
+regex = { version = "1.0", features = ["unicode-case", "unicode-perl"] }
 
 [[bench]]
 name = "range"


### PR DESCRIPTION
Due to a series of unfortunate events involving feature resoution and the tracing-subscriber and regex crates, the tracing-subscriber integration in our tests was crashing. This is detailed here: https://github.com/tokio-rs/tracing/issues/2565

For now we work around this by adding a dev dependency on regex which enables the required features. tracing-subscriber will be updated shortly and then we will need to get the updated tracing-subscriber into test-log and then we can relax.