### PR TITLE
Remove regex/tracing-subscriber build error workaround

### DIFF
--- a/rust/automerge/Cargo.toml
+++ b/rust/automerge/Cargo.toml
@@ -47,8 +47,6 @@ test-log = { version = "0.2.10", features=["trace"], default-features = false}
 tracing-subscriber = {version = "0.3.9", features = ["fmt", "env-filter"] }
 automerge-test = { path = "../automerge-test" }
 prettytable = "0.10.0"
-# Workaround for https://github.com/tokio-rs/tracing/issues/2565
-regex = { version = "1.0", features = ["unicode-case", "unicode-perl"] }
 
 [[bench]]
 name = "range"


### PR DESCRIPTION
Now that `tracing-subscriber` has been updated to use the correct feature flags for `regex` we can remove the workaround implemented in 17b29d43ba6f7ba8c4b96862c0fcc53a1d9b8cf1