### PR TITLE
restore ability to sort ObjId

### DIFF
--- a/rust/automerge/src/automerge.rs
+++ b/rust/automerge/src/automerge.rs
@@ -1432,7 +1432,7 @@ impl ReadDoc for Automerge {
         prop: P,
     ) -> Result<Vec<(Value<'_>, ExId)>, AutomergeError> {
         let obj = self.exid_to_obj(obj.as_ref())?.0;
-        Ok(match prop.into() {
+        let values = match prop.into() {
             Prop::Map(p) => {
                 let prop = self.ops.m.props.lookup(&p);
                 if let Some(p) = prop {
@@ -1458,7 +1458,13 @@ impl ReadDoc for Automerge {
                     .map(|o| (o.value(), self.id_to_exid(o.id)))
                     .collect()
             }
-        })
+        };
+        // this is a test to make sure opid and exid are always sorting the same way
+        assert_eq!(
+            values.iter().map(|v| &v.1).collect::<Vec<_>>(),
+            values.iter().map(|v| &v.1).sorted().collect::<Vec<_>>()
+        );
+        Ok(values)
     }
 
     fn get_all_at<O: AsRef<ExId>, P: Into<Prop>>(
@@ -1470,7 +1476,7 @@ impl ReadDoc for Automerge {
         let prop = prop.into();
         let obj = self.exid_to_obj(obj.as_ref())?.0;
         let clock = self.clock_at(heads);
-        let result = match prop {
+        let values = match prop {
             Prop::Map(p) => {
                 let prop = self.ops.m.props.lookup(&p);
                 if let Some(p) = prop {
@@ -1497,7 +1503,12 @@ impl ReadDoc for Automerge {
                     .collect()
             }
         };
-        Ok(result)
+        // this is a test to make sure opid and exid are always sorting the same way
+        assert_eq!(
+            values.iter().map(|v| &v.1).collect::<Vec<_>>(),
+            values.iter().map(|v| &v.1).sorted().collect::<Vec<_>>()
+        );
+        Ok(values)
     }
 
     fn get_missing_deps(&self, heads: &[ChangeHash]) -> Vec<ChangeHash> {

--- a/rust/automerge/src/exid.rs
+++ b/rust/automerge/src/exid.rs
@@ -2,6 +2,7 @@ use crate::storage::parse;
 use crate::ActorId;
 use serde::Serialize;
 use serde::Serializer;
+use std::cmp::{Ord, Ordering};
 use std::fmt;
 use std::hash::{Hash, Hasher};
 
@@ -163,6 +164,24 @@ impl Serialize for ExId {
 impl AsRef<ExId> for ExId {
     fn as_ref(&self) -> &ExId {
         self
+    }
+}
+
+impl Ord for ExId {
+    fn cmp(&self, other: &Self) -> Ordering {
+        match (self, other) {
+            (ExId::Root, ExId::Root) => Ordering::Equal,
+            (ExId::Root, _) => Ordering::Less,
+            (_, ExId::Root) => Ordering::Greater,
+            (ExId::Id(c1, a1, _), ExId::Id(c2, a2, _)) if c1 == c2 => a1.cmp(a2),
+            (ExId::Id(c1, _, _), ExId::Id(c2, _, _)) => c1.cmp(c2),
+        }
+    }
+}
+
+impl PartialOrd for ExId {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
     }
 }
 


### PR DESCRIPTION
A bug was found in the ExId(ObjId) Cmp implementation.  I did not believe it was needed outside the project so I removed the need for it internally and removed the bad implementation.  Turns out someone wanted it.  I've restored it bug free.  My primary concern here is that instead of a proper unit test I added an `assert_eq!()` macro to `get_all[_at]()` and to show that all results do not change order when sorted.  Looking for feedback if this is sufficient to test the code. 