### PR TITLE
wasm/js: Run patchCallback in JS, not in webassembly

### DIFF
--- a/javascript/src/stable.ts
+++ b/javascript/src/stable.ts
@@ -350,7 +350,18 @@ function progressDocument<T>(
   }
   const state = _state(doc)
   const nextState = { ...state, heads: undefined }
-  const nextDoc = state.handle.applyPatches(doc, nextState, callback)
+  let nextDoc
+  if (callback != null) {
+    let headsBefore = state.heads
+    let { value, patches } = state.handle.applyAndReturnPatches(doc, nextState)
+    if (patches.length > 0) {
+      let before = view(doc, headsBefore || [])
+      callback(patches, { before, after: value })
+    }
+    nextDoc = value
+  } else {
+    nextDoc = state.handle.applyPatches(doc, nextState)
+  }
   state.heads = heads
   return nextDoc
 }

--- a/javascript/src/types.ts
+++ b/javascript/src/types.ts
@@ -4,7 +4,7 @@ export { Counter } from "./counter"
 export { Int, Uint, Float64 } from "./numbers"
 
 import { Counter } from "./counter"
-import type { Patch, PatchInfo, MarkRange } from "@automerge/automerge-wasm"
+import type { Patch, MarkRange } from "@automerge/automerge-wasm"
 export type { Patch, Mark, MarkRange } from "@automerge/automerge-wasm"
 
 export type AutomergeValue =
@@ -33,6 +33,11 @@ export type MarkValue = string | number | null | boolean | Date | Uint8Array
  * modify the value use {@link change}
  */
 export type Doc<T> = { readonly [P in keyof T]: T[P] }
+
+export type PatchInfo<T> = {
+  before: Doc<T>
+  after: Doc<T>
+}
 
 /**
  * Callback which is called by various methods in this library to notify the

--- a/javascript/test/legacy_tests.ts
+++ b/javascript/test/legacy_tests.ts
@@ -340,7 +340,12 @@ describe("Automerge", () => {
         const s2 = Automerge.change(
           s1,
           {
-            patchCallback: (patches, info) => callbacks.push({ patches, info }),
+            patchCallback: (patches, info) =>
+              callbacks.push({
+                patches,
+                before: info.before,
+                after: info.after,
+              }),
           },
           doc => {
             doc.birds = ["Goldfinch"]
@@ -362,8 +367,8 @@ describe("Automerge", () => {
           path: ["birds", 0, 0],
           value: "Goldfinch",
         })
-        assert.strictEqual(callbacks[0].info.before, s1)
-        assert.strictEqual(callbacks[0].info.after, s2)
+        assert.deepStrictEqual(callbacks[0].before, s1)
+        assert.deepStrictEqual(callbacks[0].after, s2)
       })
 
       it("should call a patchCallback set up on document initialisation", () => {
@@ -373,7 +378,8 @@ describe("Automerge", () => {
           after: Automerge.Doc<any>
         }> = []
         s1 = Automerge.init({
-          patchCallback: (patches, info) => callbacks.push({ patches, info }),
+          patchCallback: (patches, info) =>
+            callbacks.push({ patches, before: info.before, after: info.after }),
         })
         const s2 = Automerge.change(s1, doc => (doc.bird = "Goldfinch"))
         assert.strictEqual(callbacks.length, 1)
@@ -387,8 +393,8 @@ describe("Automerge", () => {
           path: ["bird", 0],
           value: "Goldfinch",
         })
-        assert.strictEqual(callbacks[0].info.before, s1)
-        assert.strictEqual(callbacks[0].info.after, s2)
+        assert.deepStrictEqual(callbacks[0].before, s1)
+        assert.deepStrictEqual(callbacks[0].after, s2)
       })
     })
 
@@ -1783,14 +1789,18 @@ describe("Automerge", () => {
         Automerge.init<any>(),
         doc => (doc.birds = ["Goldfinch"])
       )
-      const callbacks: Array<any> = []
+      const callbacks: Array<{
+        patch: Automerge.Patch[]
+        before: Automerge.Doc<any>
+        after: Automerge.Doc<any>
+      }> = []
       const before = Automerge.init()
       const [after] = Automerge.applyChanges(
         before,
         Automerge.getAllChanges(s1),
         {
           patchCallback(patch, info) {
-            callbacks.push({ patch, info })
+            callbacks.push({ patch, before: info.before, after: info.after })
           },
         }
       )
@@ -1810,8 +1820,8 @@ describe("Automerge", () => {
         path: ["birds", 0, 0],
         value: "Goldfinch",
       })
-      assert.strictEqual(callbacks[0].info.before, before)
-      assert.strictEqual(callbacks[0].info.after, after)
+      assert.deepStrictEqual(callbacks[0].before, before)
+      assert.deepStrictEqual(callbacks[0].after, after)
     })
 
     it("should merge multiple applied changes into one patch", () => {

--- a/javascript/test/marks.ts
+++ b/javascript/test/marks.ts
@@ -6,11 +6,11 @@ describe("Automerge", () => {
   describe("marks", () => {
     it("should allow marks that can be seen in patches", () => {
       let value = "bold"
-      let callbacks = []
-      let doc1 = Automerge.init({
+      let callbacks: Automerge.Patch[][] = []
+      let doc1 = Automerge.init<{ x: string }>({
         patchCallback: (patches, info) => callbacks.push(patches),
       })
-      doc1 = Automerge.change(doc1, d => {
+      doc1 = Automerge.change<{ x: string }>(doc1, d => {
         d.x = "the quick fox jumps over the lazy dog"
       })
       doc1 = Automerge.change(doc1, d => {

--- a/javascript/test/patches.ts
+++ b/javascript/test/patches.ts
@@ -1,0 +1,24 @@
+import * as assert from "assert"
+import { unstable as Automerge } from "../src"
+
+describe("patches", () => {
+  it("should provide access to before and after states", () => {
+    const doc = Automerge.init<{ count: number }>()
+    const headsBefore = Automerge.getHeads(doc)
+    let headsAfter
+
+    const newDoc = Automerge.change(
+      doc,
+      {
+        patchCallback: (_, patchInfo) => {
+          assert.deepEqual(Automerge.getHeads(patchInfo.before), headsBefore)
+          headsAfter = Automerge.getHeads(patchInfo.after) // => error: recursive use of an object detected which would lead to unsafe aliasing in rust
+        },
+      },
+      doc => {
+        doc.count = 1
+      }
+    )
+    assert.deepEqual(headsAfter, Automerge.getHeads(newDoc))
+  })
+})

--- a/rust/automerge-wasm/index.d.ts
+++ b/rust/automerge-wasm/index.d.ts
@@ -253,14 +253,8 @@ export class Automerge {
   dump(): void;
 
   // experimental api can go here
-  applyPatches<Doc>(obj: Doc, meta?: unknown, callback?: (patch: Array<Patch>, info: PatchInfo<Doc>) => void): Doc;
-}
-
-export interface PatchInfo<T> {
-  before: T,
-  after: T,
-  from: Heads,
-  to: Heads,
+  applyPatches<Doc>(obj: Doc, meta?: unknown): Doc;
+  applyAndReturnPatches<Doc>(obj: Doc, meta?: unknown): {value: Doc, patches: Patch[]};
 }
 
 export interface JsSyncState {

--- a/rust/automerge-wasm/test/test.ts
+++ b/rust/automerge-wasm/test/test.ts
@@ -1939,40 +1939,6 @@ describe('Automerge', () => {
       assert.deepEqual(mat.text, "ab011ij")
     })
 
-    it('propogates exceptions thrown in patch callback', () => {
-      const doc = create(true)
-      doc.enablePatches(true)
-      let mat : any = doc.materialize("/")
-      doc.putObject("/", "text", "abcdefghij")
-      assert.throws(() => {
-        doc.applyPatches(mat, {}, (patches, info) => {
-          throw new RangeError("hello world")
-        })
-      }, /RangeError: hello world/)
-    })
-
-    it('patch callback has correct patch info', () => {
-      const doc = create(true)
-      let mat : any = doc.materialize("/")
-      doc.putObject("/", "text", "abcdefghij")
-
-      let before = doc.materialize("/")
-      let from = doc.getHeads()
-
-      doc.enablePatches(true)
-      doc.splice("/text", 2, 2, "00")
-
-      let after = doc.materialize("/")
-      let to = doc.getHeads()
-
-      doc.applyPatches(mat, {}, (patches, info) => {
-        assert.deepEqual(info.before, before);
-        assert.deepEqual(info.after, after);
-        assert.deepEqual(info.from, from);
-        assert.deepEqual(info.to, to);
-      })
-    })
-
     it('can handle utf16 text', () => {
       const doc = create(true)
       doc.enablePatches(true)


### PR DESCRIPTION
This fixes #593. Passing the pointer to the current document into the callback from the webassmebly side is basically never going to be safe because we end up with multiple borrows of the doc. Even if we were to not pass the doc pointer into the callback, the user could do something unsafe by calling another method on a reference to the document retained elsewhere. Instead, we run the callback in JS, so we don't have to worry about re-entrant borrows of the document.