### PR TITLE
adding missing doc comment for updated API

### DIFF
--- a/rust/automerge/src/op_observer.rs
+++ b/rust/automerge/src/op_observer.rs
@@ -17,6 +17,7 @@ pub trait OpObserver {
     /// - `index`: the index the new value has been inserted at.
     /// - `tagged_value`: the value that has been inserted and the id of the operation that did the
     /// insert.
+    /// - `conflict`: whether this put conflicts with other operations.
     fn insert<R: ReadDoc>(
         &mut self,
         doc: &R,


### PR DESCRIPTION
Noted the missing doc comment when hunting down an update issue with automerge-swift API bindings (https://github.com/automerge/automerge-swifter/issues/21)