### PR TITLE
js: Add automerge.diff

### DIFF
--- a/javascript/src/stable.ts
+++ b/javascript/src/stable.ts
@@ -9,6 +9,7 @@ import {
   Counter,
   type Doc,
   type PatchCallback,
+  type Patch,
 } from "./types"
 export {
   type AutomergeValue,
@@ -785,6 +786,16 @@ export function getHistory<T>(doc: Doc<T>): State<T>[] {
       return <T>state
     },
   }))
+}
+
+/**
+ * Create a set of patches representing the change from one set of heads to another
+ *
+ * If either of the heads are missing from the document the returned set of patches will be empty
+ */
+export function diff(doc: Doc<any>, before: Heads, after: Heads): Patch[] {
+  const state = _state(doc)
+  return state.handle.diff(before, after)
 }
 
 /** @hidden */

--- a/javascript/src/unstable.ts
+++ b/javascript/src/unstable.ts
@@ -98,6 +98,7 @@ export {
   toJS,
   isAutomerge,
   getObjectId,
+  diff,
 } from "./stable"
 
 export type InitOptions<T> = {

--- a/javascript/test/patches.ts
+++ b/javascript/test/patches.ts
@@ -1,24 +1,49 @@
 import * as assert from "assert"
 import { unstable as Automerge } from "../src"
+import { type List } from "../src"
 
 describe("patches", () => {
-  it("should provide access to before and after states", () => {
-    const doc = Automerge.init<{ count: number }>()
-    const headsBefore = Automerge.getHeads(doc)
-    let headsAfter
+  describe("the patchCallback", () => {
+    it("should provide access to before and after states", () => {
+      const doc = Automerge.init<{ count: number }>()
+      const headsBefore = Automerge.getHeads(doc)
+      let headsAfter
 
-    const newDoc = Automerge.change(
-      doc,
-      {
-        patchCallback: (_, patchInfo) => {
-          assert.deepEqual(Automerge.getHeads(patchInfo.before), headsBefore)
-          headsAfter = Automerge.getHeads(patchInfo.after) // => error: recursive use of an object detected which would lead to unsafe aliasing in rust
+      const newDoc = Automerge.change(
+        doc,
+        {
+          patchCallback: (_, patchInfo) => {
+            assert.deepEqual(Automerge.getHeads(patchInfo.before), headsBefore)
+            headsAfter = Automerge.getHeads(patchInfo.after) // => error: recursive use of an object detected which would lead to unsafe aliasing in rust
+          },
         },
-      },
-      doc => {
-        doc.count = 1
-      }
-    )
-    assert.deepEqual(headsAfter, Automerge.getHeads(newDoc))
+        doc => {
+          doc.count = 1
+        }
+      )
+      assert.deepEqual(headsAfter, Automerge.getHeads(newDoc))
+    })
+  })
+
+  describe("the diff function", () => {
+    it("should return a set of patches", () => {
+      const doc = Automerge.from<{ birds: string[]; fish?: string[] }>({
+        birds: ["goldfinch"],
+      })
+      const before = Automerge.getHeads(doc)
+      const newDoc = Automerge.change(doc, doc => {
+        doc.birds.push("greenfinch")
+        doc.fish = ["cod"] as unknown as List<string>
+      })
+      const after = Automerge.getHeads(newDoc)
+      const patches = Automerge.diff(newDoc, before, after)
+      assert.deepEqual(patches, [
+        { action: "put", path: ["fish"], value: [] },
+        { action: "insert", path: ["birds", 1], values: [""] },
+        { action: "splice", path: ["birds", 1, 0], value: "greenfinch" },
+        { action: "insert", path: ["fish", 0], values: [""] },
+        { action: "splice", path: ["fish", 0, 0], value: "cod" },
+      ])
+    })
   })
 })


### PR DESCRIPTION
Frequently it is useful to get a set of patches which take you from one set of heads in a document to another. Add automerge.diff to achieve this.