### PR TITLE
Fix proxy iterators

### DIFF
--- a/javascript/src/proxies.ts
+++ b/javascript/src/proxies.ts
@@ -783,15 +783,18 @@ function listMethods<T extends Target>(target: T) {
     },
 
     entries() {
-      const i = 0
-      const iterator = {
+      let i = 0
+      const iterator: IterableIterator<[number, ValueType<T>]> = {
         next: () => {
           const value = valueAt(target, i)
           if (value === undefined) {
             return { value: undefined, done: true }
           } else {
-            return { value: [i, value], done: false }
+            return { value: [i++, value], done: false }
           }
+        },
+        [Symbol.iterator]() {
+          return this
         },
       }
       return iterator
@@ -800,29 +803,33 @@ function listMethods<T extends Target>(target: T) {
     keys() {
       let i = 0
       const len = context.length(objectId, heads)
-      const iterator = {
+      const iterator: IterableIterator<number> = {
         next: () => {
-          let value: undefined | number = undefined
           if (i < len) {
-            value = i
-            i++
+            return { value: i++, done: false }
           }
-          return { value, done: true }
+          return { value: undefined, done: true }
+        },
+        [Symbol.iterator]() {
+          return this
         },
       }
       return iterator
     },
 
     values() {
-      const i = 0
-      const iterator = {
+      let i = 0
+      const iterator: IterableIterator<ValueType<T>> = {
         next: () => {
-          const value = valueAt(target, i)
+          const value = valueAt(target, i++)
           if (value === undefined) {
             return { value: undefined, done: true }
           } else {
             return { value, done: false }
           }
+        },
+        [Symbol.iterator]() {
+          return this
         },
       }
       return iterator

--- a/javascript/test/proxies.ts
+++ b/javascript/test/proxies.ts
@@ -1,0 +1,53 @@
+import * as assert from "assert"
+import { beforeEach } from "mocha"
+import { type Doc, from, change } from "../src"
+
+type DocType = {
+  list: string[]
+}
+
+describe("Proxy Tests", () => {
+  describe("Iterators", () => {
+    let doc: Doc<DocType>
+    beforeEach(() => {
+      doc = from({ list: ["a", "b", "c"] })
+    })
+
+    it("Lists should return iterable entries", () => {
+      change(doc, d => {
+        let count = 0
+
+        for (const [index, value] of d.list.entries()) {
+          assert.equal(value, d.list[index])
+          count++
+        }
+
+        assert.equal(count, 3)
+      })
+    })
+
+    it("Lists should return iterable values", () => {
+      change(doc, d => {
+        let count = 0
+
+        for (const value of d.list.values()) {
+          assert.equal(value, d.list[count++])
+        }
+
+        assert.equal(count, 3)
+      })
+    })
+
+    it("Lists should return iterable keys", () => {
+      change(doc, d => {
+        let count = 3
+
+        for (const index of d.list.keys()) {
+          assert.equal(index + count--, 3)
+        }
+
+        assert.equal(count, 0)
+      })
+    })
+  })
+})


### PR DESCRIPTION
The list proxy methods `keys`, `values` and `entries` don't currently return the correct values or a valid `Iterable`. This PR should fix both.