### PR TITLE
isolate/integrate/changeAt

### DIFF
--- a/javascript/src/constants.ts
+++ b/javascript/src/constants.ts
@@ -4,6 +4,7 @@ export const STATE = Symbol.for("_am_meta") // symbol used to hide application m
 export const TRACE = Symbol.for("_am_trace") // used for debugging
 export const OBJECT_ID = Symbol.for("_am_objectId") // symbol used to hide the object id on automerge objects
 export const IS_PROXY = Symbol.for("_am_isProxy") // symbol used to test if the document is a proxy object
+export const CLEAR_CACHE = Symbol.for("_am_clearCache") // symbol used to tell a proxy object to clear its cache
 
 export const UINT = Symbol.for("_am_uint")
 export const INT = Symbol.for("_am_int")

--- a/javascript/src/internal_state.ts
+++ b/javascript/src/internal_state.ts
@@ -1,6 +1,6 @@
 import { type ObjID, type Heads, Automerge } from "@automerge/automerge-wasm"
 
-import { STATE, OBJECT_ID, TRACE, IS_PROXY } from "./constants"
+import { STATE, OBJECT_ID, CLEAR_CACHE, TRACE, IS_PROXY } from "./constants"
 
 import type { Doc, PatchCallback } from "./types"
 
@@ -25,6 +25,10 @@ export function _state<T>(doc: Doc<T>, checkroot = true): InternalState<T> {
     throw new RangeError("must be the document root")
   }
   return state
+}
+
+export function _clear_cache<T>(doc: Doc<T>): void {
+  Reflect.set(doc, CLEAR_CACHE, true)
 }
 
 export function _trace<T>(doc: Doc<T>): string | undefined {

--- a/javascript/src/proxies.ts
+++ b/javascript/src/proxies.ts
@@ -19,6 +19,7 @@ import {
   TRACE,
   IS_PROXY,
   OBJECT_ID,
+  CLEAR_CACHE,
   COUNTER,
   INT,
   UINT,
@@ -241,6 +242,9 @@ const MapHandler = {
     }
     if (key === TRACE) {
       target.trace = val
+      return true
+    }
+    if (key === CLEAR_CACHE) {
       return true
     }
     const [value, datatype] = import_value(val, textV2)

--- a/javascript/src/unstable.ts
+++ b/javascript/src/unstable.ts
@@ -74,6 +74,7 @@ export {
   free,
   getHeads,
   change,
+  changeAt,
   emptyChange,
   loadIncremental,
   save,
@@ -117,7 +118,7 @@ export { RawString } from "./raw_string"
 /** @hidden */
 export const getBackend = stable.getBackend
 
-import { _is_proxy, _state, _obj } from "./internal_state"
+import { _is_proxy, _state, _obj, _clear_cache } from "./internal_state"
 
 /**
  * Create a new automerge document
@@ -236,6 +237,7 @@ export function splice<T>(
   if (!objectId) {
     throw new RangeError("invalid object for splice")
   }
+  _clear_cache(doc)
   const value = `${objectId}/${prop}`
   try {
     return state.handle.splice(value, index, del, newText)

--- a/javascript/test/change_at.ts
+++ b/javascript/test/change_at.ts
@@ -1,0 +1,24 @@
+import * as assert from "assert"
+import { unstable as Automerge } from "../src"
+import * as WASM from "@automerge/automerge-wasm"
+import { mismatched_heads } from "./helpers"
+
+describe("Automerge", () => {
+  describe("changeAt", () => {
+    it("should be able to change a doc at a prior state", () => {
+      let doc1 = Automerge.init()
+      doc1 = Automerge.change(doc1, d => (d.text = "aaabbbccc"))
+      let heads1 = Automerge.getHeads(doc1)
+      doc1 = Automerge.change(doc1, d => {
+        Automerge.splice(d, "text", 3, 3, "BBB")
+      })
+      assert.deepEqual(doc1.text, "aaaBBBccc")
+      doc1 = Automerge.changeAt(doc1, heads1, d => {
+        assert.deepEqual(d.text, "aaabbbccc")
+        Automerge.splice(d, "text", 2, 3, "XXX")
+        assert.deepEqual(d.text, "aaXXXbccc")
+      })
+      assert.deepEqual(doc1.text, "aaXXXBBBccc")
+    })
+  })
+})

--- a/javascript/test/text_v1.ts
+++ b/javascript/test/text_v1.ts
@@ -280,7 +280,6 @@ describe("Automerge.Text", () => {
     assert.strictEqual(s1.text.toString(), "🐦")
 
     // this tests the wasm::materialize path
-    Automerge.dump(s1)
     s2 = Automerge.load(Automerge.save(s1))
     assert.strictEqual(s2.text.toString(), "🐦")
 

--- a/rust/automerge-wasm/index.d.ts
+++ b/rust/automerge-wasm/index.d.ts
@@ -199,6 +199,10 @@ export class Automerge {
 
   diff(before: Heads, after: Heads): Patch[];
 
+  // isolate
+  isolate(heads: Heads): void;
+  integrate(): void;
+
   // returns a single value - if there is a conflict return the winner
   get(obj: ObjID, prop: Prop, heads?: Heads): Value | undefined;
   getWithType(obj: ObjID, prop: Prop, heads?: Heads): FullValue | null;

--- a/rust/automerge-wasm/src/lib.rs
+++ b/rust/automerge-wasm/src/lib.rs
@@ -642,6 +642,16 @@ impl Automerge {
         Ok(interop::JsPatches(patches).try_into()?)
     }
 
+    pub fn isolate(&mut self, heads: Array) -> Result<(), error::Isolate> {
+        let heads = get_heads(Some(heads))?.unwrap();
+        self.doc.isolate(&heads);
+        Ok(())
+    }
+
+    pub fn integrate(&mut self) {
+        self.doc.integrate()
+    }
+
     pub fn length(&self, obj: JsValue, heads: Option<Array>) -> Result<f64, error::Get> {
         let (obj, _) = self.import(obj)?;
         if let Some(heads) = get_heads(heads)? {
@@ -1201,6 +1211,18 @@ pub mod error {
 
     impl From<Diff> for JsValue {
         fn from(e: Diff) -> Self {
+            JsValue::from(e.to_string())
+        }
+    }
+
+    #[derive(Debug, thiserror::Error)]
+    pub enum Isolate {
+        #[error("bad heads: {0}")]
+        Heads(#[from] interop::error::BadChangeHashes),
+    }
+
+    impl From<Isolate> for JsValue {
+        fn from(e: Isolate) -> Self {
             JsValue::from(e.to_string())
         }
     }

--- a/rust/automerge-wasm/test/isolate.ts
+++ b/rust/automerge-wasm/test/isolate.ts
@@ -1,0 +1,52 @@
+
+import { describe, it } from 'mocha';
+//@ts-ignore
+import assert from 'assert'
+//@ts-ignore
+import { create } from '..'
+
+
+let util = require('util')
+
+describe('Automerge', () => {
+  describe('isolate', () => {
+    it('it should be able to isolate', ()=> {
+        // setup a simple text object
+        let doc1 = create();
+        doc1.putObject("/", "text", "aaabbbccc");
+        assert.deepStrictEqual(doc1.text("/text"), "aaabbbccc");
+
+        // record the init state
+        let heads1 = doc1.getHeads();
+
+        // make a change
+        doc1.splice("/text", 3, 3, "BBB");
+        assert.deepStrictEqual(doc1.text("/text"), "aaaBBBccc");
+
+        // but then isolate to the orig state
+        doc1.isolate(heads1)
+        assert.deepStrictEqual(doc1.text("/text"), "aaabbbccc");
+
+        // make a change in isolation
+        doc1.splice("/text", 3, 3, "ZZZ");
+        assert.deepStrictEqual(doc1.text("/text"), "aaaZZZccc");
+
+        // fork off the doc and make changes
+        let doc2 = doc1.fork();
+        doc2.splice("/text",0,0,"000");
+        assert.deepStrictEqual(doc2.text("/text"), "000aaaZZZBBBccc");
+
+        // merging in outside changes will not show until you integrate
+        doc1.merge(doc2)
+        assert.deepStrictEqual(doc1.text("/text"), "aaaZZZccc");
+
+        // yet more changes in isolation
+        doc1.splice("/text", 7, 2, "CC");
+        assert.deepStrictEqual(doc1.text("/text"), "aaaZZZcCC");
+
+        doc1.integrate()
+        /// Now we can see all the changes we couldnt before
+        assert.deepStrictEqual(doc1.text("/text"), "000aaaZZZBBBcCC");
+    })
+  })
+})

--- a/rust/automerge/src/clock.rs
+++ b/rust/automerge/src/clock.rs
@@ -58,6 +58,16 @@ impl Clock {
             .or_insert(data);
     }
 
+    pub(crate) fn isolate(&mut self, actor_index: usize) {
+        self.include(
+            actor_index,
+            ClockData {
+                max_op: u64::MAX,
+                seq: u64::MAX,
+            },
+        )
+    }
+
     pub(crate) fn covers(&self, id: &OpId) -> bool {
         if let Some(data) = self.0.get(&id.actor()) {
             data.max_op >= id.counter()

--- a/rust/automerge/src/patches/patch_log.rs
+++ b/rust/automerge/src/patches/patch_log.rs
@@ -129,6 +129,10 @@ impl PatchLog {
         Self::new(false, text_rep)
     }
 
+    pub fn null() -> Self {
+        Self::new(false, TextRepresentation::default())
+    }
+
     /// Create a new [`PatchLog`] which does record changes.
     ///
     /// See also: [`PatchLog::new`] for a more detailed explanation.


### PR DESCRIPTION
Ok.  I added some new functionality to Automerge and it comes in three flavors.  First:

```rust
    let mut doc = Automerge::new();
    ...
    let tx = doc.transaction_at(PatchLog::null(), heads);
```
This creates a transaction object that instead of operating at `HEAD` it operates at given heads.  The ReadDoc interface will return state that began at head.   The change will have deps equal to the heads passed in.  Etc... 

Making this work required several changes.

The big one is creating new ActorId's for each level of concurrency.  This is handled in the `fn isolate_actor()`. I did this by prepending some bytes to the primary actor id based on the level of actor id concurrency.  This is obviously inefficient, and could be incorporated in a future version of the binary format, but as for right now will usually mean 1 or 2 extra actor id's in the save file.

Next, I created a new internal read-doc like api that always takes a `clock: Option<Clock>`.  This was needed because now ManualTransaction and AutoCommit might or might not be passing a clock with each call.  As the base and `_at` versions of all the functions were basically the same since the op_set rewrite this was very easy.

Lastly. I modified the `InsertNth` query and `inner_splice` function to also operate correctly if not working on HEAD.   They were written with the assumption that they were they had to change.

Once this was done I went after `AutoCommit`.  It gets two new functions.  `doc.isolate(heads)` and `doc.integrate()`.  One locks autocommit into a chain of transactions `at(heads)` that when complete chain into a new transaction based on the previous one.  This means that non local changes will no longer be seen.  When `integrate` is called the document reverts to HEAD.  The biggest change needed for this was having the PatchLog follow the scope of the document.  This required adding some code to each place that takes in non-local changes, but also to `patch_to()` the new heads when either an `isolate()` or `integrate()` is called.

This really made me feel the power and flexibility of the diff code as all I needed to add was 

```rust
    fn patch_to(&mut self, after: &[ChangeHash]) {
        // we may be isolated so we dont use self.doc.get_heads()
        let before = self.get_heads();
        if before.as_slice() != after {
            let before_clock = self.doc.clock_at(&before);
            let after_clock = self.doc.clock_at(after);
            diff::log_diff(&self.doc, &before_clock, &after_clock, &mut self.patch_log);
        }
    }
```

Finally I added `doc = Automerge.changeAt(doc, heads, (d) => { ... }` to the JavaScript library.  All that was needed was called `handle.isolate(heads)` before running the change function and running `handle.integrate()` afterwards.

This is brand new and does some crazy new things.  Need good feedback for sure.



