### PR TITLE
add getCursor/getCursorPosition allow use in js::splice()

### DIFF
--- a/javascript/src/types.ts
+++ b/javascript/src/types.ts
@@ -4,8 +4,8 @@ export { Counter } from "./counter"
 export { Int, Uint, Float64 } from "./numbers"
 
 import { Counter } from "./counter"
-import type { Patch, MarkRange } from "@automerge/automerge-wasm"
-export type { Patch, Mark, MarkRange } from "@automerge/automerge-wasm"
+import type { Cursor, Patch, MarkRange } from "@automerge/automerge-wasm"
+export type { Cursor, Patch, Mark, MarkRange } from "@automerge/automerge-wasm"
 
 export type AutomergeValue =
   | ScalarValue

--- a/javascript/src/unstable.ts
+++ b/javascript/src/unstable.ts
@@ -51,12 +51,13 @@ export {
   type ScalarValue,
 } from "./unstable_types"
 
-import type { Mark, MarkRange, MarkValue } from "./unstable_types"
+import type { Cursor, Mark, MarkRange, MarkValue } from "./unstable_types"
 
 import type { ScalarValue, PatchCallback } from "./stable"
 
 import { type UnstableConflicts as Conflicts } from "./conflicts"
 import { unstableConflictAt } from "./conflicts"
+import type { InternalState } from "./internal_state"
 
 export type {
   PutPatch,
@@ -66,6 +67,7 @@ export type {
   IncPatch,
   SyncMessage,
   Heads,
+  Cursor,
 } from "@automerge/automerge-wasm"
 
 export type { ChangeOptions, ApplyOptions, ChangeFn } from "./stable"
@@ -221,10 +223,26 @@ function importOpts<T>(
   }
 }
 
+function cursorToIndex<T>(
+  state: InternalState<T>,
+  value: string,
+  index: number | Cursor
+): number {
+  if (typeof index == "string") {
+    if (/^[0-9]+@[0-9a-zA-z]+$/.test(index)) {
+      return state.handle.getCursorPosition(value, index)
+    } else {
+      throw new RangeError("index must be a number or cursor")
+    }
+  } else {
+    return index
+  }
+}
+
 export function splice<T>(
   doc: Doc<T>,
   prop: stable.Prop,
-  index: number,
+  index: number | Cursor,
   del: number,
   newText?: string
 ) {
@@ -237,10 +255,47 @@ export function splice<T>(
     throw new RangeError("invalid object for splice")
   }
   const value = `${objectId}/${prop}`
+  index = cursorToIndex(state, value, index)
   try {
     return state.handle.splice(value, index, del, newText)
   } catch (e) {
     throw new RangeError(`Cannot splice: ${e}`)
+  }
+}
+
+export function getCursor<T>(
+  doc: Doc<T>,
+  prop: stable.Prop,
+  index: number
+): Cursor {
+  const state = _state(doc, false)
+  const objectId = _obj(doc)
+  if (!objectId) {
+    throw new RangeError("invalid object for getCursor")
+  }
+  const value = `${objectId}/${prop}`
+  try {
+    return state.handle.getCursor(value, index)
+  } catch (e) {
+    throw new RangeError(`Cannot getCursor: ${e}`)
+  }
+}
+
+export function getCursorPosition<T>(
+  doc: Doc<T>,
+  prop: stable.Prop,
+  cursor: Cursor
+): number {
+  const state = _state(doc, false)
+  const objectId = _obj(doc)
+  if (!objectId) {
+    throw new RangeError("invalid object for getCursorPosition")
+  }
+  const value = `${objectId}/${prop}`
+  try {
+    return state.handle.getCursorPosition(value, cursor)
+  } catch (e) {
+    throw new RangeError(`Cannot getCursorPosition: ${e}`)
   }
 }
 

--- a/javascript/src/unstable_types.ts
+++ b/javascript/src/unstable_types.ts
@@ -11,6 +11,7 @@ export {
   type Mark,
   type MarkRange,
   type MarkValue,
+  type Cursor,
 } from "./types"
 
 import { RawString } from "./raw_string"

--- a/javascript/test/basic_test.ts
+++ b/javascript/test/basic_test.ts
@@ -568,4 +568,24 @@ describe("Automerge", () => {
       ])
     })
   })
+  describe("cursor", () => {
+    it("can use cursors in splice calls", () => {
+      let doc = Automerge.from({
+        value: "The sly fox jumped over the lazy dog",
+      })
+      let cursor = Automerge.getCursor(doc, "value", 19)
+      doc = Automerge.change(doc, d => {
+        Automerge.splice(d, "value", 0, 3, "Has the")
+      })
+      assert.deepEqual(doc.value, "Has the sly fox jumped over the lazy dog")
+      doc = Automerge.change(doc, d => {
+        Automerge.splice(d, "value", cursor, 0, "right ")
+      })
+      assert.deepEqual(
+        doc.value,
+        "Has the sly fox jumped right over the lazy dog"
+      )
+      let index = Automerge.getCursorPosition(doc, "value", cursor)
+    })
+  })
 })

--- a/rust/automerge-wasm/index.d.ts
+++ b/rust/automerge-wasm/index.d.ts
@@ -23,6 +23,8 @@ export type FullValue =
   ["text", ObjID] |
   ["table", ObjID]
 
+export type Cursor = string;
+
 export type FullValueWithId =
   ["str", string, ObjID ] |
   ["int", number, ObjID ] |
@@ -198,6 +200,10 @@ export class Automerge {
   marks(obj: ObjID, heads?: Heads): Mark[];
 
   diff(before: Heads, after: Heads): Patch[];
+
+  // text cursor
+  getCursor(obj: ObjID, index: number, heads?: Heads) : Cursor;
+  getCursorPosition(obj: ObjID, cursor: Cursor, heads?: Heads) : number;
 
   // returns a single value - if there is a conflict return the winner
   get(obj: ObjID, prop: Prop, heads?: Heads): Value | undefined;

--- a/rust/automerge-wasm/test/cursor.ts
+++ b/rust/automerge-wasm/test/cursor.ts
@@ -1,0 +1,44 @@
+import { describe, it } from 'mocha';
+//@ts-ignore
+import assert from 'assert'
+//@ts-ignore
+import { create } from '..'
+
+
+let util = require('util')
+
+describe('Automerge', () => {
+  describe('text cursors', () => {
+    it('it should be able to make a cursor from a position in a text document, then use it', ()=> {
+        let doc1 = create();
+        doc1.putObject("/", "text", "the sly fox jumped over the lazy dog");
+        let heads1 = doc1.getHeads();
+
+        // get a cursor at a position
+        let cursor = doc1.getCursor("/text", 12);
+        let index1 = doc1.getCursorPosition("/text", cursor);
+        assert.deepStrictEqual(index1, 12);
+
+        // modifying the text changes the cursor position
+        doc1.splice("/text",0,3,"Has the");
+        assert.deepStrictEqual(doc1.text("/text"), "Has the sly fox jumped over the lazy dog");
+        let index2 = doc1.getCursorPosition("/text", cursor);
+        assert.deepStrictEqual(index2, 16);
+
+        // get the cursor position at heads
+        let index3 = doc1.getCursorPosition("/text", cursor, heads1);
+        assert.deepStrictEqual(index1, index3);
+ 
+        // get a cursor at heads
+        let cursor2 = doc1.getCursor("/text", 12, heads1);
+        let cursor3 = doc1.getCursor("/text", 16);
+        assert.deepStrictEqual(cursor, cursor2);
+        assert.deepStrictEqual(cursor, cursor3);
+
+        // cursor works at the heads
+        let cursor4 = doc1.getCursor("/text", 0);
+        let index4 = doc1.getCursorPosition("/text", cursor4);
+        assert.deepStrictEqual(index4, 0);
+    })
+  })
+})


### PR DESCRIPTION
We added a cursor api to the rust a while back - exposing it to wasm and js.  Currently only the unstable `Automerge::splice()` can take the cursor as an index, however the  `Automerge::getCursorPosition()` call can be used anywhere else.  Added this because of #603