### PR TITLE
Handle splitting string into code points (Fixes #602)

### DIFF
--- a/javascript/src/proxies.ts
+++ b/javascript/src/proxies.ts
@@ -995,6 +995,13 @@ function textMethods(target: Target) {
       const text = context.text(objectId)
       return text.indexOf(o, start)
     },
+    insertAt(index: number, ...values: any[]) {
+      if (values.every(v => typeof v === "string")) {
+        context.splice(objectId, index, 0, values.join(""))
+      } else {
+        listMethods(target).insertAt(index, ...values)
+      }
+    },
   }
   return methods
 }

--- a/javascript/src/text.ts
+++ b/javascript/src/text.ts
@@ -128,7 +128,11 @@ export class Text {
         "object cannot be modified outside of a change block"
       )
     }
-    this.elems.splice(index, 0, ...values)
+    if (values.every(v => typeof v === "string")) {
+      this.elems.splice(index, 0, ...values.join(""))
+    } else {
+      this.elems.splice(index, 0, ...values)
+    }
   }
 
   /**

--- a/javascript/test/text_v1.ts
+++ b/javascript/test/text_v1.ts
@@ -68,7 +68,7 @@ describe("Automerge.Text", () => {
   it("should allow modification before an object is assigned to a document", () => {
     s1 = Automerge.change(Automerge.init(), doc => {
       const text = new Automerge.Text()
-      text.insertAt(0, "a", "b", "c", "d")
+      text.insertAt(0, "abcd")
       text.deleteAt(2)
       doc.text = text
       assert.strictEqual(doc.text.toString(), "abd")
@@ -293,5 +293,31 @@ describe("Automerge.Text", () => {
     let s4 = Automerge.from({ some: "value" })
     s4 = Automerge.merge(s4, s2)
     assert.strictEqual(s4.text.toString(), "🐦")
+  })
+
+  it("should let you insert strings", () => {
+    s1 = Automerge.from({
+      text: new Automerge.Text(""),
+    })
+
+    s1 = Automerge.change(s1, d => {
+      d.text.insertAt(0, "four")
+    })
+
+    assert.strictEqual(s1.text.length, 4)
+  })
+
+  it("should index by unicode code points", () => {
+    s1 = Automerge.from({
+      text: new Automerge.Text(""),
+    })
+
+    s1 = Automerge.change(s1, d => {
+      d.text.insertAt(0, "🇬🇧")
+      d.text.insertAt(2, "four")
+    })
+
+    assert.strictEqual(s1.text.length, 6)
+    assert.strictEqual(s1.text.toString(), "🇬🇧four")
   })
 })


### PR DESCRIPTION
In the next major release of automerge, we'll expose the new text
API; but in the meantime, let's fix this footgun in the existing
implementation.

I decided against adding yet another API (.insertTextAt) because
it seems likely that it'd be deprecated in the next release anyway.
