### PR TITLE
Fix for `List.splice`

### DIFF
--- a/javascript/src/proxies.ts
+++ b/javascript/src/proxies.ts
@@ -704,7 +704,14 @@ function listMethods<T extends Target>(target: T) {
 
     splice(index: any, del: any, ...vals: any[]) {
       index = parseListIndex(index)
+
+      // if del is undefined, delete until the end of the list
+      if (typeof del !== "number") {
+        del = context.length(objectId) - index
+      }
+
       del = parseListIndex(del)
+
       for (const val of vals) {
         if (val && val[OBJECT_ID]) {
           throw new RangeError(

--- a/javascript/test/proxies.ts
+++ b/javascript/test/proxies.ts
@@ -53,31 +53,35 @@ describe("Proxies", () => {
 
   describe("List splice", () => {
     it("should be able to remove a defined number of list entries", () => {
-      change(doc, d => {
+      doc = change(doc, d => {
         d.list.splice(1, 1)
-        assert.deepEqual(d.list, ["a", "c"])
       })
+
+      assert.deepEqual(doc.list, ["a", "c"])
     })
 
     it("should be able to remove a defined number of list entries and add new ones", () => {
-      change(doc, d => {
+      doc = change(doc, d => {
         d.list.splice(1, 1, "d", "e")
-        assert.deepEqual(d.list, ["a", "d", "e", "c"])
       })
+
+      assert.deepEqual(doc.list, ["a", "d", "e", "c"])
     })
 
     it("should be able to insert new values", () => {
-      change(doc, d => {
+      doc = change(doc, d => {
         d.list.splice(1, 0, "d", "e")
-        assert.deepEqual(d.list, ["a", "d", "e", "b", "c"])
       })
+
+      assert.deepEqual(doc.list, ["a", "d", "e", "b", "c"])
     })
 
     it("should work with only a start parameter", () => {
-      change(doc, d => {
+      doc = change(doc, d => {
         d.list.splice(1)
-        assert.deepEqual(d.list, ["a"])
       })
+
+      assert.deepEqual(doc.list, ["a"])
     })
   })
 })

--- a/javascript/test/proxies.ts
+++ b/javascript/test/proxies.ts
@@ -54,7 +54,8 @@ describe("Proxies", () => {
   describe("List splice", () => {
     it("should be able to remove a defined number of list entries", () => {
       doc = change(doc, d => {
-        d.list.splice(1, 1)
+        const deleted = d.list.splice(1, 1)
+        assert.deepEqual(deleted, ["b"])
       })
 
       assert.deepEqual(doc.list, ["a", "c"])
@@ -62,7 +63,8 @@ describe("Proxies", () => {
 
     it("should be able to remove a defined number of list entries and add new ones", () => {
       doc = change(doc, d => {
-        d.list.splice(1, 1, "d", "e")
+        const deleted = d.list.splice(1, 1, "d", "e")
+        assert.deepEqual(deleted, ["b"])
       })
 
       assert.deepEqual(doc.list, ["a", "d", "e", "c"])
@@ -70,7 +72,8 @@ describe("Proxies", () => {
 
     it("should be able to insert new values", () => {
       doc = change(doc, d => {
-        d.list.splice(1, 0, "d", "e")
+        const deleted = d.list.splice(1, 0, "d", "e")
+        assert.deepEqual(deleted, [])
       })
 
       assert.deepEqual(doc.list, ["a", "d", "e", "b", "c"])
@@ -78,7 +81,8 @@ describe("Proxies", () => {
 
     it("should work with only a start parameter", () => {
       doc = change(doc, d => {
-        d.list.splice(1)
+        const deleted = d.list.splice(1)
+        assert.deepEqual(deleted, ["b", "c"])
       })
 
       assert.deepEqual(doc.list, ["a"])

--- a/javascript/test/proxies.ts
+++ b/javascript/test/proxies.ts
@@ -6,14 +6,14 @@ type DocType = {
   list: string[]
 }
 
-describe("Proxy Tests", () => {
-  describe("Iterators", () => {
-    let doc: Doc<DocType>
-    beforeEach(() => {
-      doc = from({ list: ["a", "b", "c"] })
-    })
+describe("Proxies", () => {
+  let doc: Doc<DocType>
+  beforeEach(() => {
+    doc = from({ list: ["a", "b", "c"] })
+  })
 
-    it("Lists should return iterable entries", () => {
+  describe("List Iterators", () => {
+    it("should return iterable entries", () => {
       change(doc, d => {
         let count = 0
 
@@ -26,7 +26,7 @@ describe("Proxy Tests", () => {
       })
     })
 
-    it("Lists should return iterable values", () => {
+    it("should return iterable values", () => {
       change(doc, d => {
         let count = 0
 
@@ -38,7 +38,7 @@ describe("Proxy Tests", () => {
       })
     })
 
-    it("Lists should return iterable keys", () => {
+    it("should return iterable keys", () => {
       change(doc, d => {
         let count = 3
 
@@ -47,6 +47,36 @@ describe("Proxy Tests", () => {
         }
 
         assert.equal(count, 0)
+      })
+    })
+  })
+
+  describe("List splice", () => {
+    it("should be able to remove a defined number of list entries", () => {
+      change(doc, d => {
+        d.list.splice(1, 1)
+        assert.deepEqual(d.list, ["a", "c"])
+      })
+    })
+
+    it("should be able to remove a defined number of list entries and add new ones", () => {
+      change(doc, d => {
+        d.list.splice(1, 1, "d", "e")
+        assert.deepEqual(d.list, ["a", "d", "e", "c"])
+      })
+    })
+
+    it("should be able to insert new values", () => {
+      change(doc, d => {
+        d.list.splice(1, 0, "d", "e")
+        assert.deepEqual(d.list, ["a", "d", "e", "b", "c"])
+      })
+    })
+
+    it("should work with only a start parameter", () => {
+      change(doc, d => {
+        d.list.splice(1)
+        assert.deepEqual(d.list, ["a"])
       })
     })
   })


### PR DESCRIPTION
`List.splice` seems to not function entirely as per the javascript spec. This is a failing test for now, which I will update with a fix shortly.