### PR TITLE
rework marks & patches

### DIFF
--- a/javascript/test/marks.ts
+++ b/javascript/test/marks.ts
@@ -58,12 +58,10 @@ describe("Automerge", () => {
       doc2 = Automerge.loadIncremental(doc2, Automerge.save(doc1))
 
       assert.deepStrictEqual(callbacks[0][2], {
-        action: "mark",
-        path: ["x"],
-        marks: [
-          { name: "font-weight", start: 5, end: 7, value },
-          { name: "font-weight", start: 9, end: 10, value },
-        ],
+        action: "splice",
+        path: ["x", 5],
+        value: "ui",
+        marks: { "font-weight": "bold" },
       })
 
       assert.deepStrictEqual(Automerge.marks(doc2, "x"), [

--- a/rust/automerge-wasm/PATCH.md
+++ b/rust/automerge-wasm/PATCH.md
@@ -1,0 +1,189 @@
+
+## Automerge Patchs
+
+### Path
+
+All patches have a path.  This path describes the set of properties that need to be traversed to reach the intended target.
+
+For instances.  If a document looked like this
+
+```js
+{
+  animals: [
+      {  name: "Lion",
+         genus: "Panthera",
+      },
+      {  name: "Chimpanzee",
+         genus: "Panthera",
+      }
+  ]
+}
+```
+
+And a patch came to change the genus of Chimpanzee to "Pan" it would look like this.
+
+```js
+{
+  action: "put",
+  path: [ "animals", 1, "genus" ],
+  value: "Pan",
+}
+```
+
+### Values
+
+Patch values can be
+
+```ts
+type PatchValue = string | number | boolean | null | Date | Uint8Array | {} | []
+```
+
+These stand in for the different scalar types in Automerge plus an empty object or an empty list.
+
+### Put
+
+Changing a single key in a map or index in a list.  This never changes the length of a list.
+
+```ts
+type PutPatch = {
+  action: 'put'
+  path: Prop[],
+  value: PatchValue,
+  conflict?: boolean
+}
+
+let patch : PutPatch = {
+  action: "put",
+  path: [ "config", "enabled" ],
+  value: true,
+  conflict: true, // optional
+}
+```
+
+The conflict field indicates that another conflict value is present which can be queried via an api call.
+If the field is missing, it's assumed to be false.
+
+### Insert
+
+Inserts one or more values into a list.  This increases the length of the list by the given amount.
+
+```ts
+type InsertPatch = {
+  action: 'insert'
+  path: Prop[],
+  values: PatchValue[],
+  conflicts?: boolean[]
+}
+
+let patch : InsertPatch = {
+  action: "insert",
+  path: [ "emoji", 3 ],
+  values: [ "😍", "🔥", "🎆" ],
+  conflicts: [ false, true, false ] // optional
+}
+```
+
+If the `conflicts` field is missing, it's assumed to be all false.
+
+### Delete
+
+Delete patches remove a key from a map or one or more elements from a list or text object.
+
+```js
+
+type DelPatch = {
+  action: 'del'
+  path: Prop[],
+  length?: number,
+}
+
+let patch : DelPatch = {
+  action: "del",
+  path: [ "items", 3 ],
+  length: 10, // optional
+}
+```
+
+The length field is present only on sequences and when there is a run of consecutive deletes.
+
+### Inc
+
+Increment a number by 'value`
+
+```ts
+type IncPatch = {
+  action: 'inc'
+  path: Prop[],
+  value: number
+}
+
+let patch : IncPatch = {
+  action: "inc",
+  path: [ "config", "logins" ],
+  value: 1
+}
+```
+
+### Splice
+
+Splice a string into a text object
+
+```ts
+type SpliceTextPatch = {
+  action: 'splice'
+  path: Prop[],
+  value: string,
+}
+
+let patch : SpliceTextPatch = {
+  action: "inc",
+  path: [ "text", 123 ],
+  value: "and so it was done"
+}
+```
+
+### Conflict
+
+Signals that a field has become conflicted but its value has not changed.
+
+```ts
+type ConflictPatch = {
+  action: 'conflict'
+  path: Prop[],
+}
+
+let patch : ConflictPatch = {
+  action: 'conflict',
+  path: [ "keys", 11 ]
+}
+``
+
+### Mark
+
+One or more marks have been added to the document.  The start and end position, mark name and mark value are included.  A value of `null` means the mark has been removed.
+
+```ts
+type Mark = {
+  name: string,
+  value: Value,
+  start: number,
+  end: number,
+}
+
+type MarkPatch = {
+  action: 'mark'
+  path: Prop[],
+  marks: Mark[]
+}
+
+let patch : MarkPatch = {
+  action: 'mark',
+  path: [ "keys", 11 ]
+  marks: [
+     { name: 'font-weight', value: 'bold', start: 0, end: 5 },
+     { name: 'color', value: 'blue', start: 8, end: 11 },
+  ]
+}
+```
+
+

--- a/rust/automerge-wasm/PATCH.md
+++ b/rust/automerge-wasm/PATCH.md
@@ -68,10 +68,16 @@ If the field is missing, it's assumed to be false.
 Inserts one or more values into a list.  This increases the length of the list by the given amount.
 
 ```ts
+
+interface MarkSet  {
+  [name : string]: Value;
+}
+
 type InsertPatch = {
   action: 'insert'
   path: Prop[],
   values: PatchValue[],
+  marks?: MarkSet,
   conflicts?: boolean[]
 }
 
@@ -80,10 +86,11 @@ let patch : InsertPatch = {
   path: [ "emoji", 3 ],
   values: [ "😍", "🔥", "🎆" ],
   conflicts: [ false, true, false ] // optional
+  marks: { size: 24 },
 }
 ```
 
-If the `conflicts` field is missing, it's assumed to be all false.
+If the `conflicts` field is missing, it's assumed to be all false. `marks` will be missing if there are none.
 
 ### Delete
 
@@ -133,14 +140,18 @@ type SpliceTextPatch = {
   action: 'splice'
   path: Prop[],
   value: string,
+  marks?: MarkSet,
 }
 
 let patch : SpliceTextPatch = {
   action: "inc",
   path: [ "text", 123 ],
   value: "and so it was done"
+  marks: { bold: true },
 }
 ```
+
+The 'marks` field will be missing if there are none.
 
 ### Conflict
 

--- a/rust/automerge-wasm/index.d.ts
+++ b/rust/automerge-wasm/index.d.ts
@@ -104,6 +104,10 @@ export type PutPatch = {
   conflict?: boolean
 }
 
+export interface MarkSet  {
+  [name : string]: Value;
+}
+
 export type MarkPatch = {
   action: 'mark'
   path: Prop[],
@@ -140,12 +144,14 @@ export type SpliceTextPatch = {
   action: 'splice'
   path: Prop[],
   value: string,
+  marks?: MarkSet,
 }
 
 export type InsertPatch = {
   action: 'insert'
   path: Prop[],
   values: PatchValue[],
+  marks?: MarkSet,
   conflicts?: boolean[]
 }
 

--- a/rust/automerge-wasm/index.d.ts
+++ b/rust/automerge-wasm/index.d.ts
@@ -94,13 +94,14 @@ export type Op = {
   pred: string[],
 }
 
-export type Patch =  PutPatch | DelPatch | SpliceTextPatch | IncPatch | InsertPatch | MarkPatch | UnmarkPatch;
+export type PatchValue = string | number | boolean | null | Date | Uint8Array | {} | []
+export type Patch =  PutPatch | DelPatch | SpliceTextPatch | IncPatch | InsertPatch | MarkPatch | UnmarkPatch | ConflictPatch;
 
 export type PutPatch = {
   action: 'put'
   path: Prop[],
-  value: Value
-  conflict: boolean
+  value: PatchValue,
+  conflict?: boolean
 }
 
 export type MarkPatch = {
@@ -144,7 +145,13 @@ export type SpliceTextPatch = {
 export type InsertPatch = {
   action: 'insert'
   path: Prop[],
-  values: Value[],
+  values: PatchValue[],
+  conflicts?: boolean[]
+}
+
+export type ConflictPatch = {
+  action: 'conflict'
+  path: Prop[],
 }
 
 export type Mark = {

--- a/rust/automerge-wasm/test/marks.ts
+++ b/rust/automerge-wasm/test/marks.ts
@@ -618,5 +618,21 @@ describe('Automerge', () => {
         { action: 'del', length: 29, path: [ 'text', 0 ] }
       ]);
     })
+
+    it('peritext marks', () => {
+      let doc1 : Automerge = create({ actor: "aabbcc" })
+
+      let text = doc1.putObject("_root", "text", "The Peritext editor")
+      doc1.mark(text, { start: 4, end: 12, expand: 'none' }, "link", true);
+      doc1.mark(text, { start: 8, end: 12, expand: 'both' }, "bold", true);
+      doc1.splice(text, 3, 10, "")
+      doc1.splice(text, 3, 0, "!")
+
+      let textval = doc1.text(text);
+      let marks = doc1.marks(text);
+
+      assert.deepEqual(doc1.text(text), "The!editor")
+      assert.deepEqual(doc1.marks(text), [])
+    })
   })
 })

--- a/rust/automerge-wasm/test/marks.ts
+++ b/rust/automerge-wasm/test/marks.ts
@@ -619,7 +619,7 @@ describe('Automerge', () => {
       ]);
     })
 
-    it('peritext marks', () => {
+    it('fully deleted marks will not attach to new text', () => {
       let doc1 : Automerge = create({ actor: "aabbcc" })
 
       let text = doc1.putObject("_root", "text", "The Peritext editor")

--- a/rust/automerge-wasm/test/test.ts
+++ b/rust/automerge-wasm/test/test.ts
@@ -623,10 +623,10 @@ describe('Automerge', () => {
       assert.deepEqual(doc4.getAll('_root', 'bird'), [['str', 'Greenfinch', '1@aaaa'], ['str', 'Goldfinch', '1@bbbb']])
       assert.deepEqual(doc3.diffIncremental(), [
         { action: 'put', path: ['bird'], value: 'Greenfinch' },
-        { action: 'put', path: ['bird'], value: 'Goldfinch' },
+        { action: 'put', path: ['bird'], conflict: true, value: 'Goldfinch' },
       ])
       assert.deepEqual(doc4.diffIncremental(), [
-        { action: 'put', path: ['bird'], value: 'Goldfinch' },
+        { action: 'put', path: ['bird'], conflict: true, value: 'Goldfinch' },
       ])
     })
 
@@ -655,13 +655,13 @@ describe('Automerge', () => {
         ['str', 'Greenfinch', '1@aaaa'], ['str', 'Chaffinch', '1@bbbb'], ['str', 'Goldfinch', '1@cccc']
       ])
       assert.deepEqual(doc1.diffIncremental(), [
-        { action: 'put', path: ['bird'], value: 'Chaffinch' },
-        { action: 'put', path: ['bird'], value: 'Goldfinch' }
+        { action: 'put', path: ['bird'], conflict: true, value: 'Chaffinch' },
+        { action: 'put', path: ['bird'], conflict: true, value: 'Goldfinch' }
       ])
       assert.deepEqual(doc2.diffIncremental(), [
-        { action: 'put', path: ['bird'], value: 'Goldfinch' },
+        { action: 'put', path: ['bird'], conflict: true, value: 'Goldfinch' },
       ])
-      assert.deepEqual(doc3.diffIncremental(), [ ])
+      assert.deepEqual(doc3.diffIncremental(), [ { action: "conflict", path: ['bird'] } ])
     })
 
     it('should allow a conflict to be resolved', () => {
@@ -677,7 +677,7 @@ describe('Automerge', () => {
       assert.deepEqual(doc3.getAll('_root', 'bird'), [['str', 'Goldfinch', '2@aaaa']])
       assert.deepEqual(doc3.diffIncremental(), [
         { action: 'put', path: ['bird'], value: 'Greenfinch' },
-        { action: 'put', path: ['bird'], value: 'Chaffinch' },
+        { action: 'put', path: ['bird'], value: 'Chaffinch', conflict: true },
         { action: 'put', path: ['bird'], value: 'Goldfinch' }
       ])
     })
@@ -723,10 +723,10 @@ describe('Automerge', () => {
       assert.deepEqual(doc4.getAll('1@aaaa', 0), [['str', 'Song Thrush', '4@aaaa'], ['str', 'Redwing', '4@bbbb']])
       assert.deepEqual(doc3.diffIncremental(), [
         { action: 'put', path: ['birds',0], value: 'Song Thrush' },
-        { action: 'put', path: ['birds',0], value: 'Redwing' }
+        { action: 'put', path: ['birds',0], value: 'Redwing', conflict: true }
       ])
       assert.deepEqual(doc4.diffIncremental(), [
-        { action: 'put', path: ['birds',0], value: 'Redwing' },
+        { action: 'put', path: ['birds',0], value: 'Redwing', conflict: true },
       ])
     })
 
@@ -753,11 +753,11 @@ describe('Automerge', () => {
         { action: 'del', path: ['birds',0], },
         { action: 'put', path: ['birds',1], value: 'Song Thrush' },
         { action: 'insert', path: ['birds',0], values: ['Ring-necked parakeet'] },
-        { action: 'put', path: ['birds',2], value: 'Redwing' }
+        { action: 'put', path: ['birds',2], value: 'Redwing', conflict: true }
       ])
       assert.deepEqual(doc4.diffIncremental(), [
         { action: 'put', path: ['birds',0], value: 'Ring-necked parakeet' },
-        { action: 'put', path: ['birds',2], value: 'Redwing' },
+        { action: 'put', path: ['birds',2], value: 'Redwing', conflict: true },
       ])
     })
 
@@ -774,7 +774,7 @@ describe('Automerge', () => {
       assert.deepEqual(doc3.getAll('_root', 'bird'), [['str', 'Robin', '1@aaaa'], ['str', 'Wren', '1@bbbb']])
       assert.deepEqual(doc3.diffIncremental(), [
         { action: 'put', path: ['bird'], value: 'Robin' },
-        { action: 'put', path: ['bird'], value: 'Wren' }
+        { action: 'put', path: ['bird'], value: 'Wren', conflict: true }
       ])
       doc3.loadIncremental(change3)
       assert.deepEqual(doc3.getWithType('_root', 'bird'), ['str', 'Robin'])
@@ -801,11 +801,11 @@ describe('Automerge', () => {
       doc2.loadIncremental(change1)
       assert.deepEqual(doc1.getAll('_root', 'birds'), [['list', '1@aaaa'], ['map', '1@bbbb']])
       assert.deepEqual(doc1.diffIncremental(), [
-        { action: 'put', path: ['birds'], value: {} },
+        { action: 'put', path: ['birds'], value: {}, conflict: true },
         { action: 'put', path: ['birds', 'Sparrowhawk'], value: 1 }
       ])
       assert.deepEqual(doc2.getAll('_root', 'birds'), [['list', '1@aaaa'], ['map', '1@bbbb']])
-      assert.deepEqual(doc2.diffIncremental(), [])
+      assert.deepEqual(doc2.diffIncremental(), [{ action: "conflict", path: ["birds"] }])
     })
 
     it('should support date objects', () => {

--- a/rust/automerge/examples/watch.rs
+++ b/rust/automerge/examples/watch.rs
@@ -85,6 +85,12 @@ fn get_changes(_doc: &Automerge, patches: Vec<Patch>) {
             PatchAction::Mark { marks } => {
                 println!("mark {:?} in obj {:?}, object path {:?}", marks, obj, path,)
             }
+            PatchAction::Conflict { prop } => {
+                println!(
+                    "conflict on {:?} in obj {:?}, object path {:?}",
+                    prop, obj, path,
+                )
+            }
         }
     }
 }

--- a/rust/automerge/src/automerge/current_state.rs
+++ b/rust/automerge/src/automerge/current_state.rs
@@ -19,12 +19,9 @@ struct TextSpan {
 
 #[derive(Debug, Default)]
 struct TextState<'a> {
-    //text: String,
     len: usize,
-    //mark: Option<MarkData>,
     spans: Vec<TextSpan>,
     marks: MarkStateMachine<'a>,
-    //finished: Vec<Mark<'a>>,
 }
 
 impl<'a> TextState<'a> {
@@ -179,7 +176,6 @@ fn log_list_patches<'a, I: Iterator<Item = &'a Op>>(
             let conflict = val_enum > 0;
             patch_log.insert(*obj, index, value.clone().into(), opid, conflict, marks);
         });
-    //patch_log.mark(*obj, &finished);
 }
 
 fn log_map_key_patches<'a, I: Iterator<Item = &'a Op>>(

--- a/rust/automerge/src/automerge/current_state.rs
+++ b/rust/automerge/src/automerge/current_state.rs
@@ -3,7 +3,7 @@ use std::borrow::Cow;
 use itertools::Itertools;
 
 use crate::{
-    marks::{MarkSet, MarkStateMachine},
+    marks::{MarkSetBldr, MarkStateMachine},
     patches::{PatchLog, TextRepresentation},
     types::{Key, ListEncoding, ObjId, Op, OpId},
     Automerge, ObjType, OpType, Value,
@@ -13,7 +13,7 @@ use crate::{
 struct TextSpan {
     text: String,
     start: usize,
-    marks: Option<MarkSet>,
+    marks: Option<MarkSetBldr>,
 }
 
 #[derive(Debug, Default)]

--- a/rust/automerge/src/automerge/current_state.rs
+++ b/rust/automerge/src/automerge/current_state.rs
@@ -1,9 +1,10 @@
 use std::borrow::Cow;
+use std::rc::Rc;
 
 use itertools::Itertools;
 
 use crate::{
-    marks::{MarkSetBldr, MarkStateMachine},
+    marks::{MarkSet, MarkStateMachine},
     patches::{PatchLog, TextRepresentation},
     types::{Key, ListEncoding, ObjId, Op, OpId},
     Automerge, ObjType, OpType, Value,
@@ -13,7 +14,7 @@ use crate::{
 struct TextSpan {
     text: String,
     start: usize,
-    marks: Option<MarkSetBldr>,
+    marks: Option<Rc<MarkSet>>,
 }
 
 #[derive(Debug, Default)]

--- a/rust/automerge/src/automerge/diff.rs
+++ b/rust/automerge/src/automerge/diff.rs
@@ -268,12 +268,6 @@ fn get_inc(before: &Winner<'_>, after: &Winner<'_>) -> Option<i64> {
     None
 }
 
-// this implementation of MarkDiff creates two sets of marks - before and then after
-// and then compares them to generate a diff
-// this has a O(n2) performance vs the number of marks which isn't ideal
-// im confident theres a single pass solution to this that is O(n) but I will
-// leave it to a future person to figure out how to implement that :)
-
 #[derive(Debug, Clone)]
 struct MarkDiff<'a> {
     doc: &'a Automerge,

--- a/rust/automerge/src/automerge/diff.rs
+++ b/rust/automerge/src/automerge/diff.rs
@@ -6,7 +6,7 @@ use crate::patches::TextRepresentation;
 use crate::{
     exid::ExId,
     iter::{Keys, ListRange, MapRange, Values},
-    marks::{Mark, MarkSet, MarkStateMachine},
+    marks::{Mark, MarkSetBldr, MarkStateMachine},
     patches::PatchLog,
     types::{Clock, ListEncoding, ObjId, Op, Prop, ScalarValue},
     value::Value,
@@ -94,16 +94,16 @@ fn resolve<'a>(
 
 #[derive(Debug, Clone)]
 enum Patch<'a> {
-    New(Winner<'a>, Option<MarkSet>),
+    New(Winner<'a>, Option<MarkSetBldr>),
     Old {
         before: Winner<'a>,
         after: Winner<'a>,
-        marks: Option<MarkSet>,
+        marks: Option<MarkSetBldr>,
     },
     Update {
         before: Winner<'a>,
         after: Winner<'a>,
-        marks: Option<MarkSet>,
+        marks: Option<MarkSetBldr>,
     },
     Delete(Winner<'a>),
 }
@@ -289,7 +289,7 @@ impl<'a> MarkDiff<'a> {
         }
     }
 
-    fn current(&self) -> Option<MarkSet> {
+    fn current(&self) -> Option<MarkSetBldr> {
         // do this without all the cloning - cache the result
         let b = self.before.current().cloned().unwrap_or_default();
         let a = self.after.current().cloned().unwrap_or_default();

--- a/rust/automerge/src/automerge/diff.rs
+++ b/rust/automerge/src/automerge/diff.rs
@@ -1,6 +1,4 @@
 use itertools::Itertools;
-use std::borrow::Cow;
-use std::collections::BTreeMap;
 use std::ops::Deref;
 use std::ops::RangeBounds;
 
@@ -8,9 +6,9 @@ use crate::patches::TextRepresentation;
 use crate::{
     exid::ExId,
     iter::{Keys, ListRange, MapRange, Values},
-    marks::{Mark, MarkStateMachine},
+    marks::{Mark, MarkSet, MarkStateMachine},
     patches::PatchLog,
-    types::{Clock, ListEncoding, MarkData, ObjId, Op, Prop, ScalarValue},
+    types::{Clock, ListEncoding, ObjId, Op, Prop, ScalarValue},
     value::Value,
     Automerge, AutomergeError, ChangeHash, Cursor, ObjType, OpType, ReadDoc,
 };
@@ -35,6 +33,7 @@ fn process<'a, T: Iterator<Item = &'a Op>>(
     ops: T,
     before: &'a Clock,
     after: &'a Clock,
+    diff: &mut MarkDiff<'a>,
 ) -> Option<Patch<'a>> {
     let mut before_op = None;
     let mut after_op = None;
@@ -51,7 +50,7 @@ fn process<'a, T: Iterator<Item = &'a Op>>(
             push_top(&mut after_op, op, predates_before, after);
         }
     }
-    resolve(before_op, after_op)
+    resolve(before_op, after_op, diff)
 }
 
 fn push_top<'a>(top: &mut Option<Winner<'a>>, op: &'a Op, cross_visible: bool, clock: &'a Clock) {
@@ -68,68 +67,70 @@ fn push_top<'a>(top: &mut Option<Winner<'a>>, op: &'a Op, cross_visible: bool, c
     }
 }
 
-fn resolve<'a>(before: Option<Winner<'a>>, after: Option<Winner<'a>>) -> Option<Patch<'a>> {
+fn resolve<'a>(
+    before: Option<Winner<'a>>,
+    after: Option<Winner<'a>>,
+    diff: &mut MarkDiff<'a>,
+) -> Option<Patch<'a>> {
     match (before, after) {
-        (None, Some(after)) if after.is_mark() => Some(Patch::Mark(after, MarkType::Add)),
-        (None, Some(after)) => Some(Patch::New(after)),
-        (Some(before), None) if before.is_mark() => Some(Patch::Mark(before, MarkType::Del)),
+        (None, Some(after)) if after.is_mark() => diff.process_after(after.op),
+        (None, Some(after)) => Some(Patch::New(after, diff.after.current().cloned())),
+        (Some(before), None) if before.is_mark() => diff.process_before(before.op),
         (Some(before), None) => Some(Patch::Delete(before)),
-        (Some(_), Some(after)) if after.is_mark() => Some(Patch::Mark(after, MarkType::Old)),
-        (Some(before), Some(after)) if before.op.id == after.op.id => {
-            Some(Patch::Old { before, after })
-        }
-        (Some(before), Some(after)) if before.op.id != after.op.id => {
-            Some(Patch::Update { before, after })
-        }
+        (Some(_), Some(after)) if after.is_mark() => diff.process(after.op),
+        (Some(before), Some(after)) if before.op.id == after.op.id => Some(Patch::Old {
+            before,
+            after,
+            marks: diff.current(),
+        }),
+        (Some(before), Some(after)) if before.op.id != after.op.id => Some(Patch::Update {
+            before,
+            after,
+            marks: diff.after.current().cloned(),
+        }),
         _ => None,
     }
 }
 
-#[derive(Debug, Copy, Clone)]
-enum MarkType {
-    Add,
-    Old,
-    Del,
-}
-
 #[derive(Debug, Clone)]
 enum Patch<'a> {
-    New(Winner<'a>),
+    New(Winner<'a>, Option<MarkSet>),
     Old {
         before: Winner<'a>,
         after: Winner<'a>,
+        marks: Option<MarkSet>,
     },
     Update {
         before: Winner<'a>,
         after: Winner<'a>,
+        marks: Option<MarkSet>,
     },
     Delete(Winner<'a>),
-    Mark(Winner<'a>, MarkType),
 }
 
 impl<'a> Patch<'a> {
     fn op(&'a self) -> &'a Op {
         match self {
-            Patch::New(op) => op,
+            Patch::New(op, _) => op,
             Patch::Update { after, .. } => after,
             Patch::Old { after, .. } => after,
             Patch::Delete(op) => op,
-            Patch::Mark(op, _) => op,
         }
     }
 }
 
 pub(crate) fn log_diff(doc: &Automerge, before: &Clock, after: &Clock, patch_log: &mut PatchLog) {
     for (obj, typ, ops) in doc.ops().iter_objs() {
+        let mut diff = MarkDiff::new(doc);
         let ops_by_key = ops.group_by(|o| o.elemid_or_key());
         let diffs = ops_by_key
             .into_iter()
-            .filter_map(|(_key, key_ops)| process(key_ops, before, after));
+            .filter_map(|(_key, key_ops)| process(key_ops, before, after, &mut diff));
 
         if typ == ObjType::Text && matches!(patch_log.text_rep(), TextRepresentation::String) {
-            log_text_diff(doc, patch_log, obj, diffs)
+            log_text_diff(patch_log, obj, diffs)
         } else if typ.is_sequence() {
-            log_list_diff(doc, patch_log, obj, diffs);
+            log_list_diff(patch_log, obj, diffs);
         } else {
             log_map_diff(doc, patch_log, obj, diffs);
         }
@@ -137,23 +138,17 @@ pub(crate) fn log_diff(doc: &Automerge, before: &Clock, after: &Clock, patch_log
 }
 
 fn log_list_diff<'a, I: Iterator<Item = Patch<'a>>>(
-    doc: &Automerge,
     patch_log: &mut PatchLog,
     obj: &ObjId,
     patches: I,
 ) {
-    let mut marks = MarkDiff::default();
     patches.fold(0, |index, patch| match patch {
-        Patch::Mark(op, mark_type) => {
-            marks.process(index, mark_type, op.op, doc);
-            index
-        }
-        Patch::New(op) => {
+        Patch::New(op, marks) => {
             let value = op.value_at(Some(op.clock)).into();
-            patch_log.insert(*obj, index, value, op.id, op.conflict);
+            patch_log.insert(*obj, index, value, op.id, op.conflict, marks);
             index + 1
         }
-        Patch::Update { before, after } => {
+        Patch::Update { before, after, .. } => {
             let conflict = !before.conflict && after.conflict;
             if after.cross_visible {
                 let value = after.value_at(Some(after.clock)).into();
@@ -164,12 +159,19 @@ fn log_list_diff<'a, I: Iterator<Item = Patch<'a>>>(
             }
             index + 1
         }
-        Patch::Old { before, after } => {
+        Patch::Old {
+            before,
+            after,
+            marks,
+        } => {
             if !before.conflict && after.conflict {
                 patch_log.flag_conflict_seq(*obj, index);
             }
             if let Some(n) = get_inc(&before, &after) {
                 patch_log.increment_seq(*obj, index, n, after.id);
+            }
+            if let Some(marks) = &marks {
+                patch_log.mark(*obj, index, 1, marks)
             }
             index + 1
         }
@@ -178,42 +180,40 @@ fn log_list_diff<'a, I: Iterator<Item = Patch<'a>>>(
             index
         }
     });
-    if let Some(m) = marks.finish() {
-        patch_log.mark(*obj, &m);
-    }
 }
 
 fn log_text_diff<'a, I: Iterator<Item = Patch<'a>>>(
-    doc: &Automerge,
     patch_log: &mut PatchLog,
     obj: &ObjId,
     patches: I,
 ) {
-    let mut marks = MarkDiff::default();
     let encoding = ListEncoding::Text;
     patches.fold(0, |index, patch| match &patch {
-        Patch::Mark(op, mark_type) => {
-            marks.process(index, *mark_type, op.op, doc);
-            index
-        }
-        Patch::New(op) => {
-            patch_log.splice(*obj, index, op.to_str());
+        Patch::New(op, marks) => {
+            patch_log.splice(*obj, index, op.to_str(), marks.clone());
             index + op.width(encoding)
         }
-        Patch::Update { before, after } => {
+        Patch::Update {
+            before,
+            after,
+            marks,
+        } => {
             patch_log.delete_seq(*obj, index, before.width(encoding));
-            patch_log.splice(*obj, index, after.to_str());
+            patch_log.splice(*obj, index, after.to_str(), marks.clone());
             index + after.width(encoding)
         }
-        Patch::Old { after, .. } => index + after.width(encoding),
+        Patch::Old { after, marks, .. } => {
+            let len = after.width(encoding);
+            if let Some(marks) = marks {
+                patch_log.mark(*obj, index, len, marks)
+            }
+            index + len
+        }
         Patch::Delete(before) => {
             patch_log.delete_seq(*obj, index, before.width(encoding));
             index
         }
     });
-    if let Some(m) = marks.finish() {
-        patch_log.mark(*obj, &m);
-    }
 }
 
 fn log_map_diff<'a, I: Iterator<Item = Patch<'a>>>(
@@ -225,11 +225,11 @@ fn log_map_diff<'a, I: Iterator<Item = Patch<'a>>>(
     diffs
         .filter_map(|patch| Some((get_prop(doc, patch.op())?, patch)))
         .for_each(|(key, patch)| match patch {
-            Patch::New(op) => {
+            Patch::New(op, _) => {
                 let value = op.value_at(Some(op.clock)).into();
                 patch_log.put_map(*obj, key, value, op.id, op.conflict, false)
             }
-            Patch::Update { before, after } => {
+            Patch::Update { before, after, .. } => {
                 let conflict = !before.conflict && after.conflict;
                 if after.cross_visible {
                     let value = after.value_at(Some(after.clock)).into();
@@ -239,7 +239,7 @@ fn log_map_diff<'a, I: Iterator<Item = Patch<'a>>>(
                     patch_log.put_map(*obj, key, value, after.id, conflict, false)
                 }
             }
-            Patch::Old { before, after } => {
+            Patch::Old { before, after, .. } => {
                 if !before.conflict && after.conflict {
                     patch_log.flag_conflict_map(*obj, key);
                 }
@@ -248,7 +248,6 @@ fn log_map_diff<'a, I: Iterator<Item = Patch<'a>>>(
                 }
             }
             Patch::Delete(_) => patch_log.delete_map(*obj, key),
-            Patch::Mark(_, _) => {}
         });
 }
 
@@ -274,171 +273,48 @@ fn get_inc(before: &Winner<'_>, after: &Winner<'_>) -> Option<i64> {
 // im confident theres a single pass solution to this that is O(n) but I will
 // leave it to a future person to figure out how to implement that :)
 
-#[derive(Default, Debug, Clone, PartialEq)]
+#[derive(Debug, Clone)]
 struct MarkDiff<'a> {
+    doc: &'a Automerge,
     before: MarkStateMachine<'a>,
     after: MarkStateMachine<'a>,
-    before_marks: Vec<Mark<'a>>,
-    after_marks: Vec<Mark<'a>>,
 }
 
 impl<'a> MarkDiff<'a> {
-    fn process(&mut self, index: usize, mark_type: MarkType, op: &'a Op, doc: &'a Automerge) {
-        match mark_type {
-            MarkType::Add => self.add(index, op, doc),
-            MarkType::Old => self.before(index, op, doc),
-            MarkType::Del => self.del(index, op, doc),
+    fn new(doc: &'a Automerge) -> Self {
+        MarkDiff {
+            doc,
+            before: MarkStateMachine::default(),
+            after: MarkStateMachine::default(),
         }
     }
 
-    fn add(&mut self, index: usize, op: &'a Op, doc: &'a Automerge) {
-        let mark = match &op.action {
-            OpType::MarkBegin(_, data) => self.after.mark_begin(op.id, index, data, doc),
-            OpType::MarkEnd(_) => self.after.mark_end(op.id, index, doc),
-            _ => None,
-        };
-        if let Some(m) = mark {
-            self.after_marks.push(m);
-        }
-    }
-
-    fn before(&mut self, index: usize, op: &'a Op, doc: &'a Automerge) {
-        let marks = match &op.action {
-            OpType::MarkBegin(_, data) => (
-                self.before.mark_begin(op.id, index, data, doc),
-                self.after.mark_begin(op.id, index, data, doc),
-            ),
-            OpType::MarkEnd(_) => (
-                self.before.mark_end(op.id, index, doc),
-                self.after.mark_end(op.id, index, doc),
-            ),
-            _ => (None, None),
-        };
-        match marks {
-            (Some(before), Some(after)) if before != after => {
-                self.after_marks.push(after);
-                self.before_marks.push(before)
-            }
-            (Some(before), None) => self.before_marks.push(before),
-            (None, Some(after)) => self.after_marks.push(after),
-            _ => {}
-        }
-    }
-
-    fn del(&mut self, index: usize, op: &'a Op, doc: &'a Automerge) {
-        let mark = match &op.action {
-            OpType::MarkBegin(_, data) => self.before.mark_begin(op.id, index, data, doc),
-            OpType::MarkEnd(_) => self.before.mark_end(op.id, index, doc),
-            _ => None,
-        };
-        if let Some(m) = mark {
-            self.before_marks.push(m);
-        }
-    }
-
-    fn finish(&mut self) -> Option<Vec<Mark<'a>>> {
-        let mut f = BTreeMap::new();
-        'after_marks: for after in &mut self.after_marks {
-            for before in &mut self.before_marks {
-                if after.start > before.end {
-                    continue; // 'after_marks; // too far - next mark
-                }
-                if after.data.name != before.data.name || before.start >= before.end {
-                    continue;
-                }
-                if after.end >= before.start {
-                    // before       ------------*
-                    // after   ----------------*
-                    mark(&mut f, after.start, before.start, after);
-                    if after.end > before.start {
-                        after.start = std::cmp::max(after.start, before.start);
-                    } else {
-                        continue 'after_marks;
-                    }
-                }
-                if after.start >= before.start {
-                    // before ------------*
-                    // after    ---------*
-                    if after.start > before.start {
-                        before.start = std::cmp::min(before.start, after.start);
-                        unmark(&mut f, before.start, after.start, before);
-                    }
-                    if after.end > before.end {
-                        if after.data.value != before.data.value {
-                            mark(&mut f, after.start, before.end, after);
-                        }
-                        after.start = before.end;
-                        before.start = before.end;
-                        continue;
-                    } else {
-                        if after.data.value != before.data.value {
-                            mark(&mut f, after.start, after.end, after);
-                        }
-                        before.start = after.end;
-                        continue 'after_marks;
-                    }
-                }
-            }
-            // mark after
-            mark(&mut f, after.start, after.end, after);
-        }
-        for before in &self.before_marks {
-            if before.start != before.end {
-                unmark(&mut f, before.start, before.end, before);
-            }
-        }
-        if !f.is_empty() {
-            Some(f.into_values().flat_map(|v| v.into_iter()).collect())
+    fn current(&self) -> Option<MarkSet> {
+        // do this without all the cloning - cache the result
+        let b = self.before.current().cloned().unwrap_or_default();
+        let a = self.after.current().cloned().unwrap_or_default();
+        if a != b {
+            let result = b.diff(&a);
+            Some(result)
         } else {
             None
         }
     }
-}
 
-fn unmark<'a>(
-    finished: &mut BTreeMap<String, Vec<Mark<'a>>>,
-    start: usize,
-    end: usize,
-    from: &Mark<'a>,
-) {
-    let f_vec = finished.entry(from.data.name.to_string()).or_default();
-    if start < end {
-        if let Some(last) = f_vec.last_mut() {
-            if last.data.name == from.data.name && last.data.value.is_null() && last.end == start {
-                last.end = end;
-                return;
-            }
-        }
-        f_vec.push(Mark {
-            start,
-            end,
-            data: Cow::Owned(MarkData {
-                name: from.data.name.clone(),
-                value: ScalarValue::Null,
-            }),
-        });
+    fn process(&mut self, op: &'a Op) -> Option<Patch<'static>> {
+        self.before.process(op, &self.doc.ops.m);
+        self.after.process(op, &self.doc.ops.m);
+        None
     }
-}
 
-fn mark<'a>(
-    finished: &mut BTreeMap<String, Vec<Mark<'a>>>,
-    start: usize,
-    end: usize,
-    from: &Mark<'a>,
-) {
-    let f_vec = finished.entry(from.data.name.to_string()).or_default();
-    if start < end {
-        if let Some(last) = f_vec.last_mut() {
-            if last.data == from.data && last.end == start {
-                last.end = end;
-                return;
-            }
-        }
-        f_vec.push(Mark {
-            start,
-            end,
-            data: from.data.clone(),
-        });
+    fn process_before(&mut self, op: &'a Op) -> Option<Patch<'static>> {
+        self.before.process(op, &self.doc.ops.m);
+        None
+    }
+
+    fn process_after(&mut self, op: &'a Op) -> Option<Patch<'static>> {
+        self.after.process(op, &self.doc.ops.m);
+        None
     }
 }
 
@@ -641,13 +517,13 @@ mod tests {
         },
         Insert {
             values: Vec<Value<'static>>,
-            conflict: bool,
         },
         DelMap,
         DelSeq,
         Increment(i64),
         SpliceText(String),
         Mark(Vec<ObservedMark>),
+        Conflict(Prop),
     }
 
     #[derive(Debug, Clone, PartialEq)]
@@ -702,18 +578,13 @@ mod tests {
                     action: ObservedAction::Increment(value),
                     path: ex_path_and(path, prop),
                 },
-                PatchAction::Insert {
-                    index,
-                    values,
-                    conflict,
-                } => ObservedPatch {
+                PatchAction::Insert { index, values, .. } => ObservedPatch {
                     action: ObservedAction::Insert {
-                        values: values.into_iter().map(|(v, _)| v.clone()).collect(),
-                        conflict,
+                        values: values.into_iter().map(|(v, _, _)| v.clone()).collect(),
                     },
                     path: ex_path_and(path, index),
                 },
-                PatchAction::SpliceText { index, value } => ObservedPatch {
+                PatchAction::SpliceText { index, value, .. } => ObservedPatch {
                     action: ObservedAction::SpliceText(value.make_string()),
                     path: ex_path_and(path, index),
                 },
@@ -732,6 +603,10 @@ mod tests {
                             })
                             .collect(),
                     ),
+                    path: format!("/{}", path.clone().join("/")),
+                },
+                PatchAction::Conflict { prop } => ObservedPatch {
+                    action: ObservedAction::Conflict(prop),
                     path: format!("/{}", path.clone().join("/")),
                 },
             }
@@ -1033,14 +908,12 @@ mod tests {
                     path: "/list/0".into(),
                     action: ObservedAction::Insert {
                         values: vec![25.into()],
-                        conflict: false
                     },
                 },
                 ObservedPatch {
                     path: "/list/2".into(),
                     action: ObservedAction::Insert {
                         values: vec![35.into()],
-                        conflict: false
                     },
                 },
             ]
@@ -1068,7 +941,6 @@ mod tests {
                 path: "/list/1".into(),
                 action: ObservedAction::Insert {
                     values: vec![28.into(), 27.into(), 26.into(), 25.into(),],
-                    conflict: false,
                 }
             },]
         );
@@ -1117,7 +989,6 @@ mod tests {
                     path: "/list/2".into(),
                     action: ObservedAction::Insert {
                         values: vec![36.into()],
-                        conflict: false
                     },
                 },
             ]
@@ -1297,7 +1168,6 @@ mod tests {
                 path: "/list/4".into(),
                 action: ObservedAction::Insert {
                     values: vec![ScalarValue::Str("Z".into()).into()],
-                    conflict: false,
                 },
             })
             .as_ref()
@@ -1311,7 +1181,6 @@ mod tests {
                 path: "/list/3".into(),
                 action: ObservedAction::Insert {
                     values: vec![ScalarValue::Str("C".into()).into()],
-                    conflict: false,
                 }
             })
             .as_ref()

--- a/rust/automerge/src/hydrate/list.rs
+++ b/rust/automerge/src/hydrate/list.rs
@@ -31,14 +31,10 @@ impl List {
                     ListValue::new(value.0.into(), conflict);
                 Ok(())
             }
-            PatchAction::Insert {
-                index,
-                values,
-                conflict,
-            } => {
+            PatchAction::Insert { index, values, .. } => {
                 for (n, value) in values.into_iter().enumerate() {
                     self.0
-                        .insert(index + n, ListValue::new(value.0.clone().into(), conflict));
+                        .insert(index + n, ListValue::new(value.0.clone().into(), value.2));
                 }
                 Ok(())
             }

--- a/rust/automerge/src/hydrate/text.rs
+++ b/rust/automerge/src/hydrate/text.rs
@@ -13,7 +13,7 @@ pub struct Text {
 impl Text {
     pub(crate) fn apply(&mut self, patch: PatchAction) -> Result<(), HydrateError> {
         match patch {
-            PatchAction::SpliceText { index, value } => {
+            PatchAction::SpliceText { index, value, .. } => {
                 self.value.splice_text_value(index, &value);
                 Ok(())
             }

--- a/rust/automerge/src/iter/list_range.rs
+++ b/rust/automerge/src/iter/list_range.rs
@@ -2,6 +2,7 @@ use std::fmt;
 use std::ops::RangeBounds;
 
 use crate::exid::ExId;
+use crate::marks::MarkSet;
 use crate::op_set::OpSet;
 use crate::types::Clock;
 use crate::types::ListEncoding;
@@ -72,6 +73,7 @@ impl<'a, R: RangeBounds<usize>> Iterator for ListRange<'a, R> {
                         value,
                         id,
                         conflict,
+                        marks: None, // TODO
                     });
                 }
             }
@@ -86,4 +88,5 @@ pub struct ListRangeItem<'a> {
     pub value: Value<'a>,
     pub id: ExId,
     pub conflict: bool,
+    pub marks: Option<MarkSet>,
 }

--- a/rust/automerge/src/iter/list_range.rs
+++ b/rust/automerge/src/iter/list_range.rs
@@ -1,8 +1,9 @@
 use std::fmt;
 use std::ops::RangeBounds;
+use std::rc::Rc;
 
 use crate::exid::ExId;
-use crate::marks::{MarkSet, MarkSetBldr};
+use crate::marks::MarkSet;
 use crate::op_set::OpSet;
 use crate::types::Clock;
 use crate::types::ListEncoding;
@@ -61,6 +62,7 @@ impl<'a, R: RangeBounds<usize>> Iterator for ListRange<'a, R> {
     type Item = ListRangeItem<'a>;
 
     fn next(&mut self) -> Option<Self::Item> {
+        log!("ListRange next");
         self.iter.as_mut().and_then(|inner| {
             for TopOp {
                 op,
@@ -68,6 +70,7 @@ impl<'a, R: RangeBounds<usize>> Iterator for ListRange<'a, R> {
                 marks,
             } in inner.iter.by_ref()
             {
+                log!("TOP OP: {:?}", op);
                 let index = inner.state;
                 inner.state += op.width(inner.encoding);
                 let value = op.value_at(inner.clock.as_ref());
@@ -93,7 +96,7 @@ pub struct ListRangeItem<'a> {
     pub value: Value<'a>,
     pub id: ExId,
     pub conflict: bool,
-    pub(crate) marks: Option<MarkSetBldr>,
+    pub(crate) marks: Option<Rc<MarkSet>>,
 }
 
 impl<'a> ListRangeItem<'a> {

--- a/rust/automerge/src/iter/list_range.rs
+++ b/rust/automerge/src/iter/list_range.rs
@@ -62,7 +62,6 @@ impl<'a, R: RangeBounds<usize>> Iterator for ListRange<'a, R> {
     type Item = ListRangeItem<'a>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        log!("ListRange next");
         self.iter.as_mut().and_then(|inner| {
             for TopOp {
                 op,
@@ -70,7 +69,6 @@ impl<'a, R: RangeBounds<usize>> Iterator for ListRange<'a, R> {
                 marks,
             } in inner.iter.by_ref()
             {
-                log!("TOP OP: {:?}", op);
                 let index = inner.state;
                 inner.state += op.width(inner.encoding);
                 let value = op.value_at(inner.clock.as_ref());

--- a/rust/automerge/src/marks.rs
+++ b/rust/automerge/src/marks.rs
@@ -85,50 +85,20 @@ impl MarkAccumulator {
     }
 }
 
-/*
-#[derive(Debug, Clone, PartialEq, Default)]
-pub(crate) struct MarkSetBldr {
-    pub(crate) marks: Rc<MarkSet>,
-}
-*/
-
-/*
-impl std::ops::Deref for MarkSetBldr {
-    type Target = MarkSet;
-
-    fn deref(&self) -> &Self::Target {
-        &self.marks
-    }
-}
-*/
-
 #[derive(Debug, Clone, PartialEq, Default)]
 pub struct MarkSet {
     marks: BTreeMap<SmolStr, ScalarValue>,
 }
 
 impl MarkSet {
-    pub fn iter(&self) -> MarkSetIterator<'_> {
-        MarkSetIterator {
-            iter: self.marks.iter(),
-        }
+    pub fn iter(&self) -> impl Iterator<Item = (&str, &ScalarValue)> {
+        self.marks
+            .iter()
+            .map(|(name, value)| (name.as_str(), value))
     }
 
     fn inner(&self) -> &BTreeMap<SmolStr, ScalarValue> {
         &self.marks
-    }
-}
-
-#[derive(Debug)]
-pub struct MarkSetIterator<'a> {
-    iter: std::collections::btree_map::Iter<'a, SmolStr, ScalarValue>,
-}
-
-impl<'a> Iterator for MarkSetIterator<'a> {
-    type Item = (&'a str, &'a ScalarValue);
-
-    fn next(&mut self) -> Option<Self::Item> {
-        self.iter.next().map(|(name, value)| (name.as_str(), value))
     }
 }
 

--- a/rust/automerge/src/op_set.rs
+++ b/rust/automerge/src/op_set.rs
@@ -140,7 +140,7 @@ impl OpSetInternal {
     pub(crate) fn top_ops<'a>(&'a self, obj: &ObjId, clock: Option<Clock>) -> TopOps<'a> {
         self.trees
             .get(obj)
-            .map(|tree| tree.internal.top_ops(clock))
+            .map(|tree| tree.internal.top_ops(clock, &self.m))
             .unwrap_or_default()
     }
 

--- a/rust/automerge/src/op_tree.rs
+++ b/rust/automerge/src/op_tree.rs
@@ -1,4 +1,5 @@
 use crate::iter::TopOps;
+use crate::marks::MarkSet;
 pub(crate) use crate::op_set::OpSetMetadata;
 use crate::patches::PatchLog;
 use crate::{
@@ -85,6 +86,7 @@ pub(crate) struct FoundOpWithPatchLog<'a> {
     pub(crate) succ: Vec<usize>,
     pub(crate) pos: usize,
     pub(crate) index: usize,
+    pub(crate) marks: Option<MarkSet>,
 }
 
 impl<'a> FoundOpWithPatchLog<'a> {
@@ -102,12 +104,24 @@ impl<'a> FoundOpWithPatchLog<'a> {
                         &obj.id,
                         query::SeekMark::new(op.id.prev(), self.pos, obj.encoding),
                     );
-                    patch_log.mark(obj.id, &q.marks);
+                    for mark in q.marks {
+                        let index = mark.start;
+                        let len = mark.len();
+                        let marks = mark.into_mark_set();
+                        patch_log.mark(obj.id, index, len, &marks);
+                    }
                 }
             } else if obj.typ == ObjType::Text {
-                patch_log.splice(obj.id, self.index, op.to_str());
+                patch_log.splice(obj.id, self.index, op.to_str(), self.marks.clone());
             } else {
-                patch_log.insert(obj.id, self.index, op.value().into(), op.id, false);
+                patch_log.insert(
+                    obj.id,
+                    self.index,
+                    op.value().into(),
+                    op.id,
+                    false,
+                    self.marks.clone(),
+                );
             }
             return;
         }
@@ -154,7 +168,7 @@ impl<'a> FoundOpWithPatchLog<'a> {
                 && self.before.is_none()
                 && self.after.is_none()
             {
-                patch_log.insert(obj.id, self.index, op.value().into(), op.id, conflict);
+                patch_log.insert(obj.id, self.index, op.value().into(), op.id, conflict, None);
             } else if self.after.is_some() {
                 if self.before.is_none() {
                     patch_log.flag_conflict(obj.id, &key);
@@ -225,6 +239,7 @@ impl OpTreeInternal {
         op: &'a Op,
         mut pos: usize,
         index: usize,
+        marks: Option<MarkSet>,
     ) -> FoundOpWithPatchLog<'a> {
         let mut iter = self.iter();
         let mut found = None;
@@ -272,6 +287,7 @@ impl OpTreeInternal {
             succ,
             pos,
             index,
+            marks,
         }
     }
 
@@ -317,10 +333,11 @@ impl OpTreeInternal {
             let query = self.search(query::OpIdSearch::op(op, encoding), meta);
             let pos = query.pos();
             let index = query.index();
-            self.found_op_with_patch_log(meta, op, pos, index)
+            let marks = query.marks(meta);
+            self.found_op_with_patch_log(meta, op, pos, index, marks)
         } else {
             let pos = self.binary_search_by(|o| meta.key_cmp(&o.key, &op.key));
-            self.found_op_with_patch_log(meta, op, pos, 0)
+            self.found_op_with_patch_log(meta, op, pos, 0, None)
         }
     }
 
@@ -341,7 +358,7 @@ impl OpTreeInternal {
 
     pub(crate) fn seek_ops_by_prop<'a>(
         &'a self,
-        meta: &OpSetMetadata,
+        meta: &'a OpSetMetadata,
         prop: Prop,
         encoding: ListEncoding,
         clock: Option<&Clock>,
@@ -385,7 +402,7 @@ impl OpTreeInternal {
         left
     }
 
-    pub(crate) fn search<'a, 'b: 'a, Q>(&'b self, mut query: Q, m: &OpSetMetadata) -> Q
+    pub(crate) fn search<'a, 'b: 'a, Q>(&'b self, mut query: Q, m: &'a OpSetMetadata) -> Q
     where
         Q: TreeQuery<'a>,
     {

--- a/rust/automerge/src/op_tree.rs
+++ b/rust/automerge/src/op_tree.rs
@@ -1,5 +1,5 @@
 use crate::iter::TopOps;
-use crate::marks::MarkSetBldr;
+use crate::marks::MarkSet;
 pub(crate) use crate::op_set::OpSetMetadata;
 use crate::patches::PatchLog;
 use crate::{
@@ -12,6 +12,7 @@ use crate::{
     ObjType, OpType,
 };
 use std::cmp::Ordering;
+use std::rc::Rc;
 use std::{fmt::Debug, mem};
 
 mod iter;
@@ -86,7 +87,7 @@ pub(crate) struct FoundOpWithPatchLog<'a> {
     pub(crate) succ: Vec<usize>,
     pub(crate) pos: usize,
     pub(crate) index: usize,
-    pub(crate) marks: Option<MarkSetBldr>,
+    pub(crate) marks: Option<Rc<MarkSet>>,
 }
 
 impl<'a> FoundOpWithPatchLog<'a> {
@@ -107,7 +108,7 @@ impl<'a> FoundOpWithPatchLog<'a> {
                     for mark in q.marks {
                         let index = mark.start;
                         let len = mark.len();
-                        let marks = mark.into_mark_set_bldr();
+                        let marks = mark.into_mark_set();
                         patch_log.mark(obj.id, index, len, &marks);
                     }
                 }
@@ -243,7 +244,7 @@ impl OpTreeInternal {
         op: &'a Op,
         mut pos: usize,
         index: usize,
-        marks: Option<MarkSetBldr>,
+        marks: Option<Rc<MarkSet>>,
     ) -> FoundOpWithPatchLog<'a> {
         let mut iter = self.iter();
         let mut found = None;

--- a/rust/automerge/src/op_tree/node.rs
+++ b/rust/automerge/src/op_tree/node.rs
@@ -48,7 +48,7 @@ impl OpTreeNode {
     pub(crate) fn search<'a, 'b: 'a, Q>(
         &'b self,
         query: &mut Q,
-        m: &OpSetMetadata,
+        m: &'a OpSetMetadata,
         ops: &'a [Op],
     ) -> bool
     where

--- a/rust/automerge/src/patches/patch.rs
+++ b/rust/automerge/src/patches/patch.rs
@@ -1,4 +1,7 @@
-use crate::{marks::Mark, ObjId, Prop, Value};
+use crate::{
+    marks::{Mark, MarkSet},
+    ObjId, Prop, Value,
+};
 use core::fmt::Debug;
 use std::fmt;
 
@@ -49,14 +52,15 @@ pub enum PatchAction {
         index: usize,
         /// The values that were inserted, in order that they appear. As with [`Self::PutMap`] and
         /// [`Self::PutSeq`] the object ID is only meaningful for `Value::Obj` values
-        values: SequenceTree<(Value<'static>, ObjId)>,
-        conflict: bool,
+        values: SequenceTree<(Value<'static>, ObjId, bool)>,
+        marks: Option<MarkSet>,
     },
     /// Some text was spliced into a text object
     SpliceText {
         index: usize,
         /// The text that was inserted
         value: TextValue,
+        marks: Option<MarkSet>,
     },
     /// A counter was incremented
     Increment {
@@ -64,6 +68,11 @@ pub enum PatchAction {
         prop: Prop,
         /// The amount incremented, may be negative
         value: i64,
+    },
+    /// A new conflict has appeared
+    Conflict {
+        /// The conflicted property
+        prop: Prop,
     },
     /// A key was deleted from a map
     DeleteMap { key: String },

--- a/rust/automerge/src/patches/patch.rs
+++ b/rust/automerge/src/patches/patch.rs
@@ -53,6 +53,7 @@ pub enum PatchAction {
         /// The values that were inserted, in order that they appear. As with [`Self::PutMap`] and
         /// [`Self::PutSeq`] the object ID is only meaningful for `Value::Obj` values
         values: SequenceTree<(Value<'static>, ObjId, bool)>,
+        /// All marks currently active for these values
         marks: Option<MarkSet>,
     },
     /// Some text was spliced into a text object
@@ -60,6 +61,7 @@ pub enum PatchAction {
         index: usize,
         /// The text that was inserted
         value: TextValue,
+        /// All marks currently active for this span of text
         marks: Option<MarkSet>,
     },
     /// A counter was incremented
@@ -78,7 +80,7 @@ pub enum PatchAction {
     DeleteMap { key: String },
     /// One or more indices were removed from a sequence
     DeleteSeq { index: usize, length: usize },
-    /// Some marks within a text object were modified
+    /// Some marks within a text object were added or removed
     Mark { marks: Vec<Mark<'static>> },
 }
 

--- a/rust/automerge/src/patches/patch_builder.rs
+++ b/rust/automerge/src/patches/patch_builder.rs
@@ -1,6 +1,7 @@
 use core::fmt::Debug;
+use std::rc::Rc;
 
-use crate::marks::MarkSetBldr;
+use crate::marks::MarkSet;
 use crate::{ObjId, Prop, ReadDoc, Value};
 
 use super::{Patch, PatchAction};
@@ -9,7 +10,7 @@ use crate::{marks::Mark, sequence_tree::SequenceTree};
 #[derive(Debug, Clone, Default)]
 pub(crate) struct PatchBuilder {
     patches: Vec<Patch>,
-    last_mark_set: Option<MarkSetBldr>, // keep this around for a quick pointer equality test
+    last_mark_set: Option<Rc<MarkSet>>, // keep this around for a quick pointer equality test
 }
 
 impl PatchBuilder {
@@ -38,7 +39,7 @@ impl PatchBuilder {
         index: usize,
         tagged_value: (Value<'_>, ObjId),
         conflict: bool,
-        marks: Option<MarkSetBldr>,
+        marks: Option<Rc<MarkSet>>,
     ) {
         let value = (tagged_value.0.to_owned(), tagged_value.1, conflict);
         if let Some(PatchAction::Insert {
@@ -77,7 +78,7 @@ impl PatchBuilder {
         obj: ObjId,
         index: usize,
         value: &str,
-        marks: Option<MarkSetBldr>,
+        marks: Option<Rc<MarkSet>>,
     ) {
         if let Some(PatchAction::SpliceText {
             index: tail_index,

--- a/rust/automerge/src/patches/patch_log.rs
+++ b/rust/automerge/src/patches/patch_log.rs
@@ -2,7 +2,7 @@ use crate::automerge::diff::ReadDocAt;
 use crate::exid::ExId;
 use crate::hydrate::Value;
 use crate::iter::{ListRangeItem, MapRangeItem};
-use crate::marks::Mark;
+use crate::marks::{MarkAccumulator, MarkSet};
 use crate::types::{ObjId, ObjType, OpId, Prop};
 use crate::{Automerge, ChangeHash, Patch, ReadDoc};
 use std::collections::BTreeSet;
@@ -38,7 +38,7 @@ use super::{PatchBuilder, TextRepresentation};
 /// // sync message was received, to the state after.
 /// let patches = doc.make_patches(&mut patch_log);
 /// ```
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug)]
 pub struct PatchLog {
     events: Vec<(ObjId, Event)>,
     expose: HashSet<OpId>,
@@ -47,7 +47,7 @@ pub struct PatchLog {
     pub(crate) heads: Option<Vec<ChangeHash>>,
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug)]
 pub(crate) enum Event {
     PutMap {
         key: String,
@@ -71,12 +71,14 @@ pub(crate) enum Event {
     Splice {
         index: usize,
         text: String,
+        marks: Option<MarkSet>,
     },
     Insert {
         index: usize,
         value: Value,
         id: OpId,
         conflict: bool,
+        marks: Option<MarkSet>,
     },
     IncrementMap {
         key: String,
@@ -95,7 +97,7 @@ pub(crate) enum Event {
         index: usize,
     },
     Mark {
-        mark: Vec<Mark<'static>>,
+        marks: MarkAccumulator,
     },
 }
 
@@ -264,23 +266,25 @@ impl PatchLog {
         ))
     }
 
-    pub(crate) fn splice(&mut self, obj: ObjId, index: usize, text: &str) {
+    pub(crate) fn splice(&mut self, obj: ObjId, index: usize, text: &str, marks: Option<MarkSet>) {
         self.events.push((
             obj,
             Event::Splice {
                 index,
                 text: text.to_string(),
+                marks,
             },
         ))
     }
 
-    pub(crate) fn mark(&mut self, obj: ObjId, marks: &[Mark<'_>]) {
-        self.events.push((
-            obj,
-            Event::Mark {
-                mark: marks.iter().map(|m| m.clone().into_owned()).collect(),
-            },
-        ))
+    pub(crate) fn mark(&mut self, obj: ObjId, index: usize, len: usize, marks: &MarkSet) {
+        if let Some((_, Event::Mark { marks: tail_marks })) = self.events.last_mut() {
+            tail_marks.add(index, len, marks);
+            return;
+        }
+        let mut acc = MarkAccumulator::default();
+        acc.add(index, len, marks);
+        self.events.push((obj, Event::Mark { marks: acc }))
     }
 
     pub(crate) fn insert(
@@ -290,6 +294,7 @@ impl PatchLog {
         value: Value,
         id: OpId,
         conflict: bool,
+        marks: Option<MarkSet>,
     ) {
         self.events.push((
             obj,
@@ -298,6 +303,7 @@ impl PatchLog {
                 value,
                 id,
                 conflict,
+                marks,
             },
         ))
     }
@@ -372,9 +378,17 @@ impl PatchLog {
                     value,
                     id,
                     conflict,
+                    marks,
                 } => {
                     let opid = doc.id_to_exid(*id);
-                    patch_builder.insert(read_doc, exid, *index, (value.into(), opid), *conflict);
+                    patch_builder.insert(
+                        read_doc,
+                        exid,
+                        *index,
+                        (value.into(), opid),
+                        *conflict,
+                        marks.clone(),
+                    );
                 }
                 Event::DeleteSeq { index, num } => {
                     patch_builder.delete_seq(read_doc, exid, *index, *num);
@@ -386,11 +400,11 @@ impl PatchLog {
                 Event::FlagConflictSeq { index } => {
                     patch_builder.flag_conflict(read_doc, exid, index.into());
                 }
-                Event::Splice { index, text } => {
-                    patch_builder.splice_text(read_doc, exid, *index, text);
+                Event::Splice { index, text, marks } => {
+                    patch_builder.splice_text(read_doc, exid, *index, text, marks.clone());
                 }
-                Event::Mark { mark } => {
-                    patch_builder.mark(read_doc, exid, mark.clone().into_iter())
+                Event::Mark { marks } => {
+                    patch_builder.mark(read_doc, exid, marks.clone().into_iter())
                 }
             }
         }
@@ -496,7 +510,8 @@ impl ExposeQueue {
         match doc.ops().object_type(&id)? {
             ObjType::Text if matches!(text_rep, TextRepresentation::String) => {
                 let text = read_doc.text(&exid).ok()?;
-                patch_builder.splice_text(read_doc, exid, 0, &text);
+                // TODO - need read_doc, text_spans()
+                patch_builder.splice_text(read_doc, exid, 0, &text, None);
             }
             ObjType::List | ObjType::Text => {
                 for ListRangeItem {
@@ -504,12 +519,20 @@ impl ExposeQueue {
                     value,
                     id,
                     conflict,
+                    marks,
                 } in read_doc.list_range(&exid, ..)
                 {
                     if value.is_object() {
                         self.insert(id.clone());
                     }
-                    patch_builder.insert(read_doc, exid.clone(), index, (value, id), conflict);
+                    patch_builder.insert(
+                        read_doc,
+                        exid.clone(),
+                        index,
+                        (value, id),
+                        conflict,
+                        marks,
+                    );
                 }
             }
             ObjType::Map | ObjType::Table => {

--- a/rust/automerge/src/patches/patch_log.rs
+++ b/rust/automerge/src/patches/patch_log.rs
@@ -2,11 +2,12 @@ use crate::automerge::diff::ReadDocAt;
 use crate::exid::ExId;
 use crate::hydrate::Value;
 use crate::iter::{ListRangeItem, MapRangeItem};
-use crate::marks::{MarkAccumulator, MarkSetBldr};
+use crate::marks::{MarkAccumulator, MarkSet};
 use crate::types::{ObjId, ObjType, OpId, Prop};
 use crate::{Automerge, ChangeHash, Patch, ReadDoc};
 use std::collections::BTreeSet;
 use std::collections::HashSet;
+use std::rc::Rc;
 
 use super::{PatchBuilder, TextRepresentation};
 
@@ -71,14 +72,14 @@ pub(crate) enum Event {
     Splice {
         index: usize,
         text: String,
-        marks: Option<MarkSetBldr>,
+        marks: Option<Rc<MarkSet>>,
     },
     Insert {
         index: usize,
         value: Value,
         id: OpId,
         conflict: bool,
-        marks: Option<MarkSetBldr>,
+        marks: Option<Rc<MarkSet>>,
     },
     IncrementMap {
         key: String,
@@ -271,7 +272,7 @@ impl PatchLog {
         obj: ObjId,
         index: usize,
         text: &str,
-        marks: Option<MarkSetBldr>,
+        marks: Option<Rc<MarkSet>>,
     ) {
         self.events.push((
             obj,
@@ -283,7 +284,7 @@ impl PatchLog {
         ))
     }
 
-    pub(crate) fn mark(&mut self, obj: ObjId, index: usize, len: usize, marks: &MarkSetBldr) {
+    pub(crate) fn mark(&mut self, obj: ObjId, index: usize, len: usize, marks: &Rc<MarkSet>) {
         if let Some((_, Event::Mark { marks: tail_marks })) = self.events.last_mut() {
             tail_marks.add(index, len, marks);
             return;
@@ -300,7 +301,7 @@ impl PatchLog {
         value: Value,
         id: OpId,
         conflict: bool,
-        marks: Option<MarkSetBldr>,
+        marks: Option<Rc<MarkSet>>,
     ) {
         self.events.push((
             obj,

--- a/rust/automerge/src/patches/patch_log.rs
+++ b/rust/automerge/src/patches/patch_log.rs
@@ -2,7 +2,7 @@ use crate::automerge::diff::ReadDocAt;
 use crate::exid::ExId;
 use crate::hydrate::Value;
 use crate::iter::{ListRangeItem, MapRangeItem};
-use crate::marks::{MarkAccumulator, MarkSet};
+use crate::marks::{MarkAccumulator, MarkSetBldr};
 use crate::types::{ObjId, ObjType, OpId, Prop};
 use crate::{Automerge, ChangeHash, Patch, ReadDoc};
 use std::collections::BTreeSet;
@@ -71,14 +71,14 @@ pub(crate) enum Event {
     Splice {
         index: usize,
         text: String,
-        marks: Option<MarkSet>,
+        marks: Option<MarkSetBldr>,
     },
     Insert {
         index: usize,
         value: Value,
         id: OpId,
         conflict: bool,
-        marks: Option<MarkSet>,
+        marks: Option<MarkSetBldr>,
     },
     IncrementMap {
         key: String,
@@ -266,7 +266,13 @@ impl PatchLog {
         ))
     }
 
-    pub(crate) fn splice(&mut self, obj: ObjId, index: usize, text: &str, marks: Option<MarkSet>) {
+    pub(crate) fn splice(
+        &mut self,
+        obj: ObjId,
+        index: usize,
+        text: &str,
+        marks: Option<MarkSetBldr>,
+    ) {
         self.events.push((
             obj,
             Event::Splice {
@@ -277,7 +283,7 @@ impl PatchLog {
         ))
     }
 
-    pub(crate) fn mark(&mut self, obj: ObjId, index: usize, len: usize, marks: &MarkSet) {
+    pub(crate) fn mark(&mut self, obj: ObjId, index: usize, len: usize, marks: &MarkSetBldr) {
         if let Some((_, Event::Mark { marks: tail_marks })) = self.events.last_mut() {
             tail_marks.add(index, len, marks);
             return;
@@ -294,7 +300,7 @@ impl PatchLog {
         value: Value,
         id: OpId,
         conflict: bool,
-        marks: Option<MarkSet>,
+        marks: Option<MarkSetBldr>,
     ) {
         self.events.push((
             obj,

--- a/rust/automerge/src/query/insert.rs
+++ b/rust/automerge/src/query/insert.rs
@@ -3,16 +3,41 @@ use crate::marks::MarkSet;
 use crate::marks::MarkStateMachine;
 use crate::op_tree::OpTreeNode;
 use crate::query::{ListState, MarkMap, OpSetMetadata, OpTree, QueryResult, TreeQuery};
-use crate::types::{Clock, Key, ListEncoding, Op, HEAD};
+use crate::types::{Clock, Key, ListEncoding, Op, OpId, OpType, HEAD};
 use std::fmt::Debug;
 
 #[derive(Debug, Clone, PartialEq)]
 pub(crate) struct InsertNth<'a> {
     idx: ListState,
-    valid: Option<usize>,
     clock: Option<Clock>,
-    last_valid_insert: Option<Key>,
+    last_visible_key: Option<Key>,
+    candidates: Vec<Loc>,
     marks: MarkMap<'a>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+struct Loc {
+    key: Key,
+    pos: usize,
+    id: Option<OpId>,
+}
+
+impl Loc {
+    fn new(pos: usize, key: Key) -> Self {
+        Loc { key, pos, id: None }
+    }
+
+    fn mark(pos: usize, key: Key, id: OpId) -> Self {
+        Loc {
+            key,
+            pos,
+            id: Some(id),
+        }
+    }
+
+    fn matches(&self, op: &Op) -> bool {
+        self.id == Some(op.id.prev())
+    }
 }
 
 impl<'a> InsertNth<'a> {
@@ -21,16 +46,16 @@ impl<'a> InsertNth<'a> {
         if target == 0 {
             InsertNth {
                 idx,
-                valid: Some(0),
-                last_valid_insert: Some(Key::Seq(HEAD)),
+                last_visible_key: None,
+                candidates: vec![Loc::new(0, Key::Seq(HEAD))],
                 clock,
                 marks: Default::default(),
             }
         } else {
             InsertNth {
                 idx,
-                valid: None,
-                last_valid_insert: None,
+                last_visible_key: None,
+                candidates: vec![],
                 clock,
                 marks: Default::default(),
             }
@@ -46,12 +71,50 @@ impl<'a> InsertNth<'a> {
     }
 
     pub(crate) fn pos(&self) -> usize {
-        self.valid.unwrap_or(self.idx.pos())
+        self.candidates
+            .last()
+            .map(|loc| loc.pos)
+            .unwrap_or(self.idx.pos())
     }
 
     pub(crate) fn key(&self) -> Result<Key, AutomergeError> {
-        self.last_valid_insert
+        self.candidates
+            .last()
+            .map(|loc| loc.key)
+            .or(self.last_visible_key)
             .ok_or(AutomergeError::InvalidIndex(self.idx.target()))
+    }
+
+    fn identify_valid_insertion_spot(&mut self, op: &'a Op, key: &Key) {
+        if !self.idx.done() {
+            return;
+        }
+
+        // first insert we see after idx.done()
+        if op.insert && self.candidates.is_empty() && self.last_visible_key.is_some() {
+            if let Some(key) = self.last_visible_key {
+                self.candidates.push(Loc::new(self.idx.pos(), key))
+            }
+        }
+
+        // sticky marks
+        if !self.candidates.is_empty() {
+            // if we find a begin/end pair - ignore them
+            if let OpType::MarkEnd(_) = &op.action {
+                if let Some(pos) = self.candidates.iter().position(|loc| loc.matches(op)) {
+                    // mark points between begin and end are invalid
+                    self.candidates.truncate(pos);
+                    return;
+                }
+            }
+            if matches!(
+                op.action,
+                OpType::MarkBegin(true, _) | OpType::MarkEnd(false)
+            ) {
+                self.candidates
+                    .push(Loc::mark(self.idx.pos() + 1, *key, op.id));
+            }
+        }
     }
 }
 
@@ -63,8 +126,7 @@ impl<'a> TreeQuery<'a> for InsertNth<'a> {
     fn can_shortcut_search(&mut self, tree: &'a OpTree) -> bool {
         if let Some(last) = &tree.last_insert {
             if last.index + last.width == self.idx.target() {
-                self.valid = Some(last.pos + 1);
-                self.last_valid_insert = Some(last.key);
+                self.candidates.push(Loc::new(last.pos + 1, last.key));
                 return true;
             }
         }
@@ -80,26 +142,18 @@ impl<'a> TreeQuery<'a> for InsertNth<'a> {
         }
     }
 
-    fn query_element(&mut self, element: &'a Op) -> QueryResult {
-        self.marks.process(element);
-        let key = element.elemid_or_key();
-        let visible = element.visible_at(self.clock.as_ref());
-        // an insert after we're done - could be a valid insert point
-        if element.insert && self.valid.is_none() && self.idx.done() {
-            self.valid = Some(self.idx.pos());
-        }
-        // sticky marks
-        if self.valid.is_some() && element.valid_mark_anchor() {
-            self.last_valid_insert = Some(key);
-            self.valid = None;
-        }
+    fn query_element(&mut self, op: &'a Op) -> QueryResult {
+        self.marks.process(op);
+        let key = op.elemid_or_key();
+        let visible = op.visible_at(self.clock.as_ref());
+        self.identify_valid_insertion_spot(op, &key);
         if visible {
-            if self.valid.is_some() {
+            if !self.candidates.is_empty() {
                 return QueryResult::Finish;
             }
-            self.last_valid_insert = Some(key);
+            self.last_visible_key = Some(key);
         }
-        self.idx.process_op(element, key, visible);
+        self.idx.process_op(op, key, visible);
         QueryResult::Next
     }
 }

--- a/rust/automerge/src/query/insert.rs
+++ b/rust/automerge/src/query/insert.rs
@@ -1,10 +1,11 @@
 use crate::error::AutomergeError;
-use crate::marks::MarkSetBldr;
+use crate::marks::MarkSet;
 use crate::marks::MarkStateMachine;
 use crate::op_tree::OpTreeNode;
 use crate::query::{ListState, MarkMap, OpSetMetadata, OpTree, QueryResult, TreeQuery};
 use crate::types::{Clock, Key, ListEncoding, Op, OpId, OpType, HEAD};
 use std::fmt::Debug;
+use std::rc::Rc;
 
 #[derive(Debug, Clone, PartialEq)]
 pub(crate) struct InsertNth<'a> {
@@ -62,7 +63,7 @@ impl<'a> InsertNth<'a> {
         }
     }
 
-    pub(crate) fn marks(&self, m: &OpSetMetadata) -> Option<MarkSetBldr> {
+    pub(crate) fn marks(&self, m: &OpSetMetadata) -> Option<Rc<MarkSet>> {
         let mut marks = MarkStateMachine::default();
         for (id, mark_data) in self.marks.iter() {
             marks.mark_begin(*id, mark_data, m);

--- a/rust/automerge/src/query/insert.rs
+++ b/rust/automerge/src/query/insert.rs
@@ -1,5 +1,5 @@
 use crate::error::AutomergeError;
-use crate::marks::MarkSet;
+use crate::marks::MarkSetBldr;
 use crate::marks::MarkStateMachine;
 use crate::op_tree::OpTreeNode;
 use crate::query::{ListState, MarkMap, OpSetMetadata, OpTree, QueryResult, TreeQuery};
@@ -62,7 +62,7 @@ impl<'a> InsertNth<'a> {
         }
     }
 
-    pub(crate) fn marks(&self, m: &OpSetMetadata) -> Option<MarkSet> {
+    pub(crate) fn marks(&self, m: &OpSetMetadata) -> Option<MarkSetBldr> {
         let mut marks = MarkStateMachine::default();
         for (id, mark_data) in self.marks.iter() {
             marks.mark_begin(*id, mark_data, m);

--- a/rust/automerge/src/query/insert.rs
+++ b/rust/automerge/src/query/insert.rs
@@ -1,18 +1,21 @@
 use crate::error::AutomergeError;
+use crate::marks::MarkSet;
+use crate::marks::MarkStateMachine;
 use crate::op_tree::OpTreeNode;
-use crate::query::{ListState, OpTree, QueryResult, TreeQuery};
+use crate::query::{ListState, MarkMap, OpSetMetadata, OpTree, QueryResult, TreeQuery};
 use crate::types::{Clock, Key, ListEncoding, Op, HEAD};
 use std::fmt::Debug;
 
 #[derive(Debug, Clone, PartialEq)]
-pub(crate) struct InsertNth {
+pub(crate) struct InsertNth<'a> {
     idx: ListState,
     valid: Option<usize>,
     clock: Option<Clock>,
     last_valid_insert: Option<Key>,
+    marks: MarkMap<'a>,
 }
 
-impl InsertNth {
+impl<'a> InsertNth<'a> {
     pub(crate) fn new(target: usize, encoding: ListEncoding, clock: Option<Clock>) -> Self {
         let idx = ListState::new(encoding, target);
         if target == 0 {
@@ -21,6 +24,7 @@ impl InsertNth {
                 valid: Some(0),
                 last_valid_insert: Some(Key::Seq(HEAD)),
                 clock,
+                marks: Default::default(),
             }
         } else {
             InsertNth {
@@ -28,8 +32,17 @@ impl InsertNth {
                 valid: None,
                 last_valid_insert: None,
                 clock,
+                marks: Default::default(),
             }
         }
+    }
+
+    pub(crate) fn marks(&self, m: &OpSetMetadata) -> Option<MarkSet> {
+        let mut marks = MarkStateMachine::default();
+        for (id, mark_data) in self.marks.iter() {
+            marks.mark_begin(*id, mark_data, m);
+        }
+        marks.current().cloned()
     }
 
     pub(crate) fn pos(&self) -> usize {
@@ -42,7 +55,7 @@ impl InsertNth {
     }
 }
 
-impl<'a> TreeQuery<'a> for InsertNth {
+impl<'a> TreeQuery<'a> for InsertNth<'a> {
     fn equiv(&mut self, other: &Self) -> bool {
         self.pos() == other.pos() && self.key() == other.key()
     }
@@ -58,16 +71,17 @@ impl<'a> TreeQuery<'a> for InsertNth {
         false
     }
 
-    fn query_node(&mut self, child: &OpTreeNode, ops: &[Op]) -> QueryResult {
+    fn query_node(&mut self, child: &'a OpTreeNode, ops: &'a [Op]) -> QueryResult {
         self.idx.check_if_node_is_clean(child);
         if self.clock.is_none() {
-            self.idx.process_node(child, ops)
+            self.idx.process_node(child, ops, Some(&mut self.marks))
         } else {
             QueryResult::Descend
         }
     }
 
-    fn query_element(&mut self, element: &Op) -> QueryResult {
+    fn query_element(&mut self, element: &'a Op) -> QueryResult {
+        self.marks.process(element);
         let key = element.elemid_or_key();
         let visible = element.visible_at(self.clock.as_ref());
         // an insert after we're done - could be a valid insert point

--- a/rust/automerge/src/query/list_state.rs
+++ b/rust/automerge/src/query/list_state.rs
@@ -4,25 +4,10 @@ use crate::query::QueryResult;
 use crate::types::{Key, ListEncoding, Op, OpId, OpType};
 use fxhash::FxBuildHasher;
 use std::collections::HashMap;
-use std::ops::{Deref, DerefMut};
 
 #[derive(Debug, Clone, Default, PartialEq)]
 pub(crate) struct MarkMap<'a> {
     map: HashMap<OpId, &'a MarkData, FxBuildHasher>,
-}
-
-impl<'a> Deref for MarkMap<'a> {
-    type Target = HashMap<OpId, &'a MarkData, FxBuildHasher>;
-
-    fn deref(&self) -> &Self::Target {
-        &self.map
-    }
-}
-
-impl<'a> DerefMut for MarkMap<'a> {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.map
-    }
 }
 
 impl<'a> MarkMap<'a> {
@@ -36,6 +21,18 @@ impl<'a> MarkMap<'a> {
             }
             _ => {}
         }
+    }
+
+    pub(crate) fn iter(&self) -> impl Iterator<Item = (&OpId, &&MarkData)> {
+        self.map.iter()
+    }
+
+    pub(crate) fn insert(&mut self, op: OpId, data: &'a MarkData) {
+        self.map.insert(op, data);
+    }
+
+    pub(crate) fn remove(&mut self, op: &OpId) {
+        self.map.remove(op);
     }
 }
 

--- a/rust/automerge/src/query/list_state.rs
+++ b/rust/automerge/src/query/list_state.rs
@@ -1,6 +1,43 @@
+use crate::marks::MarkData;
 use crate::op_tree::{LastInsert, OpTreeNode};
 use crate::query::QueryResult;
-use crate::types::{Key, ListEncoding, Op};
+use crate::types::{Key, ListEncoding, Op, OpId, OpType};
+use fxhash::FxBuildHasher;
+use std::collections::HashMap;
+use std::ops::{Deref, DerefMut};
+
+#[derive(Debug, Clone, Default, PartialEq)]
+pub(crate) struct MarkMap<'a> {
+    map: HashMap<OpId, &'a MarkData, FxBuildHasher>,
+}
+
+impl<'a> Deref for MarkMap<'a> {
+    type Target = HashMap<OpId, &'a MarkData, FxBuildHasher>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.map
+    }
+}
+
+impl<'a> DerefMut for MarkMap<'a> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.map
+    }
+}
+
+impl<'a> MarkMap<'a> {
+    pub(crate) fn process(&mut self, op: &'a Op) {
+        match &op.action {
+            OpType::MarkBegin(_, data) => {
+                self.map.insert(op.id, data);
+            }
+            OpType::MarkEnd(_) => {
+                self.map.remove(&op.id.prev());
+            }
+            _ => {}
+        }
+    }
+}
 
 #[derive(Debug, Clone, PartialEq)]
 pub(crate) struct ListState {
@@ -41,12 +78,17 @@ impl ListState {
         self.never_seen_puts &= node.index.has_never_seen_puts();
     }
 
-    pub(crate) fn process_node(&mut self, node: &OpTreeNode, ops: &[Op]) -> QueryResult {
+    pub(crate) fn process_node<'a>(
+        &mut self,
+        node: &'a OpTreeNode,
+        ops: &[Op],
+        marks: Option<&mut MarkMap<'a>>,
+    ) -> QueryResult {
         if self.encoding == ListEncoding::List {
-            self.process_list_node(node, ops)
+            self.process_list_node(node, ops, marks)
         } else if self.never_seen_puts {
             // text node is clean - use the indexes
-            self.process_text_node(node)
+            self.process_text_node(node, marks)
         } else {
             // text nodes are intended to only be interacted with splice()
             // meaning all ops are inserts or deleted inserts
@@ -57,17 +99,38 @@ impl ListState {
         }
     }
 
-    fn process_text_node(&mut self, node: &OpTreeNode) -> QueryResult {
+    fn process_marks<'a>(&mut self, node: &'a OpTreeNode, marks: Option<&mut MarkMap<'a>>) {
+        if let Some(marks) = marks {
+            for (id, data) in node.index.mark_begin.iter() {
+                marks.insert(*id, data);
+            }
+            for id in node.index.mark_end.iter() {
+                marks.remove(id);
+            }
+        }
+    }
+
+    fn process_text_node<'a>(
+        &mut self,
+        node: &'a OpTreeNode,
+        marks: Option<&mut MarkMap<'a>>,
+    ) -> QueryResult {
         let num_vis = node.index.visible_len(self.encoding);
         if self.index + num_vis >= self.target {
             return QueryResult::Descend;
         }
         self.index += num_vis;
         self.pos += node.len();
+        self.process_marks(node, marks);
         QueryResult::Next
     }
 
-    fn process_list_node(&mut self, node: &OpTreeNode, ops: &[Op]) -> QueryResult {
+    fn process_list_node<'a>(
+        &mut self,
+        node: &'a OpTreeNode,
+        ops: &[Op],
+        marks: Option<&mut MarkMap<'a>>,
+    ) -> QueryResult {
         let mut num_vis = node.index.visible.len();
         if let Some(last_seen) = self.last_seen {
             // the elemid `last_seen` is counted in this node's index
@@ -99,6 +162,7 @@ impl ListState {
         } else if self.last_seen.is_some() && Some(last_elemid) != self.last_seen {
             self.last_seen = None;
         }
+        self.process_marks(node, marks);
         QueryResult::Next
     }
 

--- a/rust/automerge/src/query/nth.rs
+++ b/rust/automerge/src/query/nth.rs
@@ -72,7 +72,7 @@ impl<'a> TreeQuery<'a> for Nth<'a> {
     fn query_node(&mut self, child: &OpTreeNode, ops: &[Op]) -> QueryResult {
         self.idx.check_if_node_is_clean(child);
         if self.clock.is_none() {
-            self.idx.process_node(child, ops)
+            self.idx.process_node(child, ops, None)
         } else {
             QueryResult::Descend
         }

--- a/rust/automerge/src/query/opid.rs
+++ b/rust/automerge/src/query/opid.rs
@@ -1,10 +1,11 @@
-use crate::marks::{MarkSetBldr, MarkStateMachine};
+use crate::marks::{MarkSet, MarkStateMachine};
 use crate::op_tree::OpTreeNode;
 use crate::query::OpSetMetadata;
 use crate::query::{ListState, MarkMap, QueryResult, TreeQuery};
 use crate::types::Clock;
 use crate::types::{ListEncoding, Op, OpId};
 use std::cmp::Ordering;
+use std::rc::Rc;
 
 /// Search for an OpId in a tree.  /// Returns the index of the operation in the tree.
 #[derive(Debug, Clone, PartialEq)]
@@ -71,7 +72,7 @@ impl<'a> OpIdSearch<'a> {
         }
     }
 
-    pub(crate) fn marks(&self, m: &OpSetMetadata) -> Option<MarkSetBldr> {
+    pub(crate) fn marks(&self, m: &OpSetMetadata) -> Option<Rc<MarkSet>> {
         let mut marks = MarkStateMachine::default();
         for (id, mark_data) in self.marks.iter() {
             marks.mark_begin(*id, mark_data, m);

--- a/rust/automerge/src/query/opid.rs
+++ b/rust/automerge/src/query/opid.rs
@@ -1,4 +1,4 @@
-use crate::marks::{MarkSet, MarkStateMachine};
+use crate::marks::{MarkSetBldr, MarkStateMachine};
 use crate::op_tree::OpTreeNode;
 use crate::query::OpSetMetadata;
 use crate::query::{ListState, MarkMap, QueryResult, TreeQuery};
@@ -71,7 +71,7 @@ impl<'a> OpIdSearch<'a> {
         }
     }
 
-    pub(crate) fn marks(&self, m: &OpSetMetadata) -> Option<MarkSet> {
+    pub(crate) fn marks(&self, m: &OpSetMetadata) -> Option<MarkSetBldr> {
         let mut marks = MarkStateMachine::default();
         for (id, mark_data) in self.marks.iter() {
             marks.mark_begin(*id, mark_data, m);

--- a/rust/automerge/src/query/seek_mark.rs
+++ b/rust/automerge/src/query/seek_mark.rs
@@ -19,6 +19,8 @@ pub(crate) struct SeekMark<'a> {
     pub(crate) marks: Vec<Mark<'a>>,
 }
 
+// should be able to use MarkStateMachine here now - FIXME
+
 impl<'a> SeekMark<'a> {
     pub(crate) fn new(id: OpId, end: usize, encoding: ListEncoding) -> Self {
         SeekMark {

--- a/rust/automerge/src/transaction/inner.rs
+++ b/rust/automerge/src/transaction/inner.rs
@@ -1,7 +1,8 @@
 use std::num::NonZeroU64;
+use std::rc::Rc;
 
 use crate::exid::ExId;
-use crate::marks::{ExpandMark, Mark, MarkSetBldr};
+use crate::marks::{ExpandMark, Mark, MarkSet};
 use crate::patches::{PatchLog, TextRepresentation};
 use crate::query::{self, OpIdSearch};
 use crate::storage::Change as StoredChange;
@@ -707,7 +708,7 @@ impl TransactionInner {
             OpType::MarkEnd(expand.after()),
         )?;
         if patch_log.is_active() {
-            patch_log.mark(obj.id, mark.start, mark.len(), &mark.into_mark_set_bldr());
+            patch_log.mark(obj.id, mark.start, mark.len(), &mark.into_mark_set());
         }
         Ok(())
     }
@@ -734,7 +735,7 @@ impl TransactionInner {
         obj: ObjId,
         prop: Prop,
         op: Op,
-        marks: Option<MarkSetBldr>,
+        marks: Option<Rc<MarkSet>>,
     ) {
         // TODO - id_to_exid should be a noop if not used - change type to Into<ExId>?
         if patch_log.is_active() {

--- a/rust/automerge/src/transaction/inner.rs
+++ b/rust/automerge/src/transaction/inner.rs
@@ -1,7 +1,7 @@
 use std::num::NonZeroU64;
 
 use crate::exid::ExId;
-use crate::marks::{ExpandMark, Mark, MarkSet};
+use crate::marks::{ExpandMark, Mark, MarkSetBldr};
 use crate::patches::{PatchLog, TextRepresentation};
 use crate::query::{self, OpIdSearch};
 use crate::storage::Change as StoredChange;
@@ -707,7 +707,7 @@ impl TransactionInner {
             OpType::MarkEnd(expand.after()),
         )?;
         if patch_log.is_active() {
-            patch_log.mark(obj.id, mark.start, mark.len(), &mark.into_mark_set());
+            patch_log.mark(obj.id, mark.start, mark.len(), &mark.into_mark_set_bldr());
         }
         Ok(())
     }
@@ -734,7 +734,7 @@ impl TransactionInner {
         obj: ObjId,
         prop: Prop,
         op: Op,
-        marks: Option<MarkSet>,
+        marks: Option<MarkSetBldr>,
     ) {
         // TODO - id_to_exid should be a noop if not used - change type to Into<ExId>?
         if patch_log.is_active() {

--- a/rust/automerge/src/transaction/manual_transaction.rs
+++ b/rust/automerge/src/transaction/manual_transaction.rs
@@ -192,7 +192,6 @@ impl<'a> ReadDoc for Transaction<'a> {
     }
 
     fn text<O: AsRef<ExId>>(&self, obj: O) -> Result<String, AutomergeError> {
-        log!("text + scope {:?}", self.get_scope(None));
         self.doc.text_for(obj.as_ref(), self.get_scope(None))
     }
 

--- a/rust/automerge/src/types.rs
+++ b/rust/automerge/src/types.rs
@@ -767,14 +767,6 @@ impl Op {
         self.action.is_mark()
     }
 
-    pub(crate) fn valid_mark_anchor(&self) -> bool {
-        self.succ.is_empty()
-            && matches!(
-                &self.action,
-                OpType::MarkBegin(true, _) | OpType::MarkEnd(false)
-            )
-    }
-
     pub(crate) fn is_noop(&self, action: &OpType) -> bool {
         matches!((&self.action, action), (OpType::Put(n), OpType::Put(m)) if n == m)
     }

--- a/rust/automerge/src/types.rs
+++ b/rust/automerge/src/types.rs
@@ -455,7 +455,14 @@ pub enum Prop {
 }
 
 impl Prop {
-    pub(crate) fn to_index(&self) -> Option<usize> {
+    pub fn as_str(&self) -> Option<&str> {
+        match self {
+            Prop::Map(s) => Some(s),
+            Prop::Seq(_) => None,
+        }
+    }
+
+    pub fn as_index(&self) -> Option<usize> {
         match self {
             Prop::Map(_) => None,
             Prop::Seq(n) => Some(*n),

--- a/rust/automerge/tests/test.rs
+++ b/rust/automerge/tests/test.rs
@@ -1618,6 +1618,7 @@ fn regression_insert_opid() {
         seq_tree.push((
             Value::Scalar(std::borrow::Cow::Owned(ScalarValue::Null)),
             ObjId::Id(2 * (i + 1) as u64, doc.get_actor().clone(), 0),
+            false,
         ));
         expected_patches.push(Patch {
             obj: ObjId::Id(1, doc.get_actor().clone(), 0),
@@ -1625,7 +1626,7 @@ fn regression_insert_opid() {
             action: PatchAction::Insert {
                 index: i,
                 values: seq_tree,
-                conflict: false,
+                marks: None,
             },
         });
         expected_patches.push(Patch {
@@ -1708,19 +1709,10 @@ fn marks() {
 
     let marks = tx.marks(&text_id).unwrap();
 
-    // should empty marks be returned?
-    // probably not in this case (where they can never grow)
-    // but not sure how to detect that case reliably.
-    assert_eq!(marks.len(), 2);
-    assert_eq!(marks[0].start, 0);
-    assert_eq!(marks[0].end, 0);
+    assert_eq!(marks[0].start, 9);
+    assert_eq!(marks[0].end, 14);
     assert_eq!(marks[0].name(), "bold");
     assert_eq!(marks[0].value(), &ScalarValue::from(true));
-
-    assert_eq!(marks[1].start, 9);
-    assert_eq!(marks[1].end, 14);
-    assert_eq!(marks[1].name(), "bold");
-    assert_eq!(marks[1].value(), &ScalarValue::from(true));
 }
 
 #[test]

--- a/rust/automerge/tests/test.rs
+++ b/rust/automerge/tests/test.rs
@@ -1825,6 +1825,25 @@ fn can_isolate() -> Result<(), AutomergeError> {
     Ok(())
 }
 
+#[test]
+fn inserting_text_near_deleted_marks() {
+    let mut doc = Automerge::new();
+    let mut tx = doc.transaction();
+    let text_id = tx.put_object(&ROOT, "text", ObjType::Text).unwrap();
+    tx.splice_text(&text_id, 0, 0, "hello world").unwrap();
+    let mark = Mark::new("bold".to_string(), true, 2, 8);
+    tx.mark(&text_id, mark, ExpandMark::After).unwrap();
+    let mark = Mark::new("link".to_string(), true, 3, 6);
+    tx.mark(&text_id, mark, ExpandMark::None).unwrap();
+
+    tx.splice_text(&text_id, 1, 10, "").unwrap(); // 'h'
+    dbg!(tx.text(&text_id).unwrap(), tx.marks(&text_id).unwrap());
+    tx.splice_text(&text_id, 0, 0, "a").unwrap(); // 'ah'
+    dbg!(tx.text(&text_id).unwrap(), tx.marks(&text_id).unwrap());
+    tx.splice_text(&text_id, 2, 0, "a").unwrap(); // 'ah<bold>a</bold>'
+    dbg!(tx.text(&text_id).unwrap(), tx.marks(&text_id).unwrap());
+}
+
 /*
 #[test]
 fn conflicting_unicode_text_with_different_widths() -> Result<(), AutomergeError> {


### PR DESCRIPTION
Done:

* rework how patches and marks interact
* inserts & splice patches now contain all current marks
* wrote a [PATCH.md](https://github.com/automerge/automerge/blob/patch_marks/rust/automerge-wasm/PATCH.md)
* patch marks are not more predictable (sort by `name`, `start`)
* expose conflict information in JS patches (#539)
* several bugs around marks (empty marks) are gone (#609)
* fixed an issue where deleted marks would reappear (#604)

Todo:

* ~~LOTS of code has changed - need more tests to make sure all new code paths are covered~~
* ~~performance tests - this should have negligible impact on mark-less code but need to confirm~~
* ~~several FIXME's need to be resolved~~

