### PR TITLE
Update `splice`, `mark` & `unmark` path parameters

### DIFF
--- a/javascript/src/unstable.ts
+++ b/javascript/src/unstable.ts
@@ -226,7 +226,7 @@ function importOpts<T>(
 
 export function splice<T>(
   doc: Doc<T>,
-  prop: stable.Prop,
+  path: stable.Prop[],
   index: number,
   del: number,
   newText?: string
@@ -240,7 +240,10 @@ export function splice<T>(
     throw new RangeError("invalid object for splice")
   }
   _clear_cache(doc)
-  const value = `${objectId}/${prop}`
+
+  path.unshift(objectId)
+  const value = path.join("/")
+
   try {
     return state.handle.splice(value, index, del, newText)
   } catch (e) {
@@ -250,7 +253,7 @@ export function splice<T>(
 
 export function mark<T>(
   doc: Doc<T>,
-  prop: stable.Prop,
+  path: stable.Prop[],
   range: MarkRange,
   name: string,
   value: MarkValue
@@ -263,7 +266,10 @@ export function mark<T>(
   if (!objectId) {
     throw new RangeError("invalid object for mark")
   }
-  const obj = `${objectId}/${prop}`
+
+  path.unshift(objectId)
+  const obj = path.join("/")
+
   try {
     return state.handle.mark(obj, range, name, value)
   } catch (e) {
@@ -273,7 +279,7 @@ export function mark<T>(
 
 export function unmark<T>(
   doc: Doc<T>,
-  prop: stable.Prop,
+  path: stable.Prop[],
   range: MarkRange,
   name: string
 ) {
@@ -285,7 +291,10 @@ export function unmark<T>(
   if (!objectId) {
     throw new RangeError("invalid object for unmark")
   }
-  const obj = `${objectId}/${prop}`
+
+  path.unshift(objectId)
+  const obj = path.join("/")
+
   try {
     return state.handle.unmark(obj, range, name)
   } catch (e) {

--- a/javascript/test/basic_test.ts
+++ b/javascript/test/basic_test.ts
@@ -245,7 +245,7 @@ describe("Automerge", () => {
       let doc1 = Automerge.init<any>()
       let doc2 = Automerge.change(doc1, d => {
         d.list = "hello"
-        Automerge.splice(d, "list", 2, 0, "Z")
+        Automerge.splice(d, ["list"], 2, 0, "Z")
       })
       let changes = Automerge.getChanges(doc1, doc2)
       let docB1 = Automerge.init()
@@ -259,7 +259,7 @@ describe("Automerge", () => {
       let doc2 = Automerge.load<any>(doc1.save())
       assert.throws(() => {
         Automerge.change(doc2, d => {
-          Automerge.splice(d, "text", 1, 0, "Z")
+          Automerge.splice(d, ["text"], 1, 0, "Z")
         })
       }, /Cannot splice/)
     })

--- a/javascript/test/change_at.ts
+++ b/javascript/test/change_at.ts
@@ -10,12 +10,12 @@ describe("Automerge", () => {
       doc1 = Automerge.change(doc1, d => (d.text = "aaabbbccc"))
       let heads1 = Automerge.getHeads(doc1)
       doc1 = Automerge.change(doc1, d => {
-        Automerge.splice(d, "text", 3, 3, "BBB")
+        Automerge.splice(d, ["text"], 3, 3, "BBB")
       })
       assert.deepEqual(doc1.text, "aaaBBBccc")
       doc1 = Automerge.changeAt(doc1, heads1, d => {
         assert.deepEqual(d.text, "aaabbbccc")
-        Automerge.splice(d, "text", 2, 3, "XXX")
+        Automerge.splice(d, ["text"], 2, 3, "XXX")
         assert.deepEqual(d.text, "aaXXXbccc")
       })
       assert.deepEqual(doc1.text, "aaXXXBBBccc")

--- a/javascript/test/legacy_tests.ts
+++ b/javascript/test/legacy_tests.ts
@@ -1741,7 +1741,7 @@ describe("Automerge", () => {
     it("should handle updates to a text object", () => {
       let s1 = Automerge.change(Automerge.init<any>(), doc => (doc.text = "ab"))
       let s2 = Automerge.change(s1, doc =>
-        Automerge.splice(doc, "text", 0, 1, "A")
+        Automerge.splice(doc, ["text"], 0, 1, "A")
       )
       let [s3] = Automerge.applyChanges(
         Automerge.init<any>(),

--- a/javascript/test/marks.ts
+++ b/javascript/test/marks.ts
@@ -16,7 +16,7 @@ describe("Automerge", () => {
       doc1 = Automerge.change(doc1, d => {
         Automerge.mark(
           d,
-          "x",
+          ["x"],
           { start: 5, end: 10, expand: "none" },
           "font-weight",
           value
@@ -24,7 +24,7 @@ describe("Automerge", () => {
       })
 
       doc1 = Automerge.change(doc1, d => {
-        Automerge.unmark(d, "x", { start: 7, end: 9 }, "font-weight")
+        Automerge.unmark(d, ["x"], { start: 7, end: 9 }, "font-weight")
       })
 
       assert.deepStrictEqual(callbacks[1], [

--- a/javascript/test/text_test.ts
+++ b/javascript/test/text_test.ts
@@ -15,7 +15,7 @@ describe("Automerge.Text", () => {
   })
 
   it("should support insertion", () => {
-    s1 = Automerge.change(s1, doc => Automerge.splice(doc, "text", 0, 0, "a"))
+    s1 = Automerge.change(s1, doc => Automerge.splice(doc, ["text"], 0, 0, "a"))
     assert.strictEqual(s1.text.length, 1)
     assert.strictEqual(s1.text[0], "a")
     assert.strictEqual(s1.text, "a")
@@ -23,8 +23,10 @@ describe("Automerge.Text", () => {
   })
 
   it("should support deletion", () => {
-    s1 = Automerge.change(s1, doc => Automerge.splice(doc, "text", 0, 0, "abc"))
-    s1 = Automerge.change(s1, doc => Automerge.splice(doc, "text", 1, 1))
+    s1 = Automerge.change(s1, doc =>
+      Automerge.splice(doc, ["text"], 0, 0, "abc")
+    )
+    s1 = Automerge.change(s1, doc => Automerge.splice(doc, ["text"], 1, 1))
     assert.strictEqual(s1.text.length, 2)
     assert.strictEqual(s1.text[0], "a")
     assert.strictEqual(s1.text[1], "c")
@@ -32,9 +34,11 @@ describe("Automerge.Text", () => {
   })
 
   it("should support implicit and explicit deletion", () => {
-    s1 = Automerge.change(s1, doc => Automerge.splice(doc, "text", 0, 0, "abc"))
-    s1 = Automerge.change(s1, doc => Automerge.splice(doc, "text", 1, 1))
-    s1 = Automerge.change(s1, doc => Automerge.splice(doc, "text", 1, 0))
+    s1 = Automerge.change(s1, doc =>
+      Automerge.splice(doc, ["text"], 0, 0, "abc")
+    )
+    s1 = Automerge.change(s1, doc => Automerge.splice(doc, ["text"], 1, 1))
+    s1 = Automerge.change(s1, doc => Automerge.splice(doc, ["text"], 1, 0))
     assert.strictEqual(s1.text.length, 2)
     assert.strictEqual(s1.text[0], "a")
     assert.strictEqual(s1.text[1], "c")
@@ -42,8 +46,12 @@ describe("Automerge.Text", () => {
   })
 
   it("should handle concurrent insertion", () => {
-    s1 = Automerge.change(s1, doc => Automerge.splice(doc, "text", 0, 0, "abc"))
-    s2 = Automerge.change(s2, doc => Automerge.splice(doc, "text", 0, 0, "xyz"))
+    s1 = Automerge.change(s1, doc =>
+      Automerge.splice(doc, ["text"], 0, 0, "abc")
+    )
+    s2 = Automerge.change(s2, doc =>
+      Automerge.splice(doc, ["text"], 0, 0, "xyz")
+    )
     s1 = Automerge.merge(s1, s2)
     assert.strictEqual(s1.text.length, 6)
     assertEqualsOneOf(s1.text, "abcxyz", "xyzabc")
@@ -52,7 +60,7 @@ describe("Automerge.Text", () => {
   it("should handle text and other ops in the same change", () => {
     s1 = Automerge.change(s1, doc => {
       doc.foo = "bar"
-      Automerge.splice(doc, "text", 0, 0, "a")
+      Automerge.splice(doc, ["text"], 0, 0, "a")
     })
     assert.strictEqual(s1.foo, "bar")
     assert.strictEqual(s1.text, "a")
@@ -60,15 +68,17 @@ describe("Automerge.Text", () => {
   })
 
   it("should serialize to JSON as a simple string", () => {
-    s1 = Automerge.change(s1, doc => Automerge.splice(doc, "text", 0, 0, 'a"b'))
+    s1 = Automerge.change(s1, doc =>
+      Automerge.splice(doc, ["text"], 0, 0, 'a"b')
+    )
     assert.strictEqual(JSON.stringify(s1), '{"text":"a\\"b"}')
   })
 
   it("should allow modification after an object is assigned to a document", () => {
     s1 = Automerge.change(Automerge.init(), doc => {
       doc.text = ""
-      Automerge.splice(doc, "text", 0, 0, "abcd")
-      Automerge.splice(doc, "text", 2, 1)
+      Automerge.splice(doc, ["text"], 0, 0, "abcd")
+      Automerge.splice(doc, ["text"], 2, 1)
       assert.strictEqual(doc.text, "abd")
     })
     assert.strictEqual(s1.text, "abd")
@@ -76,7 +86,7 @@ describe("Automerge.Text", () => {
 
   it("should not allow modification outside of a change callback", () => {
     assert.throws(
-      () => Automerge.splice(s1, "text", 0, 0, "a"),
+      () => Automerge.splice(s1, ["text"], 0, 0, "a"),
       /object cannot be modified outside of a change block/
     )
   })


### PR DESCRIPTION
This PR changes the signatures of some of the `unstable` branch functions to take a `path` as an array of `Prop`s, rather than a string.

Closes #630 