### PR TITLE
Fix path parameter for Cursor API

### DIFF
--- a/javascript/src/unstable.ts
+++ b/javascript/src/unstable.ts
@@ -273,7 +273,7 @@ export function splice<T>(
 
 export function getCursor<T>(
   doc: Doc<T>,
-  prop: stable.Prop,
+  path: stable.Prop[],
   index: number
 ): Cursor {
   const state = _state(doc, false)
@@ -281,7 +281,10 @@ export function getCursor<T>(
   if (!objectId) {
     throw new RangeError("invalid object for getCursor")
   }
-  const value = `${objectId}/${prop}`
+
+  path.unshift(objectId)
+  const value = path.join("/")
+
   try {
     return state.handle.getCursor(value, index)
   } catch (e) {
@@ -291,7 +294,7 @@ export function getCursor<T>(
 
 export function getCursorPosition<T>(
   doc: Doc<T>,
-  prop: stable.Prop,
+  path: stable.Prop[],
   cursor: Cursor
 ): number {
   const state = _state(doc, false)
@@ -299,7 +302,10 @@ export function getCursorPosition<T>(
   if (!objectId) {
     throw new RangeError("invalid object for getCursorPosition")
   }
-  const value = `${objectId}/${prop}`
+
+  path.unshift(objectId)
+  const value = path.join("/")
+
   try {
     return state.handle.getCursorPosition(value, cursor)
   } catch (e) {

--- a/javascript/test/basic_test.ts
+++ b/javascript/test/basic_test.ts
@@ -573,7 +573,7 @@ describe("Automerge", () => {
       let doc = Automerge.from({
         value: "The sly fox jumped over the lazy dog",
       })
-      let cursor = Automerge.getCursor(doc, "value", 19)
+      let cursor = Automerge.getCursor(doc, ["value"], 19)
       doc = Automerge.change(doc, d => {
         Automerge.splice(d, ["value"], 0, 3, "Has the")
       })
@@ -585,7 +585,7 @@ describe("Automerge", () => {
         doc.value,
         "Has the sly fox jumped right over the lazy dog"
       )
-      let index = Automerge.getCursorPosition(doc, "value", cursor)
+      let index = Automerge.getCursorPosition(doc, ["value"], cursor)
     })
   })
 })


### PR DESCRIPTION
Apologies for not spotting this in the original PR. Cursor path parameter updated to match that of `splice` etc 