### PR TITLE
Allow negative `del` for splice (Fixes #603)

### DIFF
--- a/javascript/src/unstable.ts
+++ b/javascript/src/unstable.ts
@@ -279,11 +279,6 @@ export function splice<T>(
 
   index = cursorToIndex(state, value, index)
 
-  if (del < 0) {
-    index += del
-    del = 0 - del
-  }
-
   try {
     return state.handle.splice(value, index, del, newText)
   } catch (e) {

--- a/javascript/src/unstable.ts
+++ b/javascript/src/unstable.ts
@@ -242,6 +242,21 @@ function cursorToIndex<T>(
   }
 }
 
+/**
+ * Modify a string
+ *
+ * @typeParam T - The type of the value contained in the document
+ * @param doc - The document to modify
+ * @param path - The path to the string to modify
+ * @param index - The position (as a {@link Cursor} or index) to edit.
+ *   If a cursor is used then the edit happens such that the cursor will
+ *   now point to the end of the newText, so you can continue to reuse
+ *   the same cursor for multiple calls to splice.
+ * @param del - The number of code units to delete, a positive number
+ *   deletes N characters after the cursor, a negative number deletes
+ *   N characters before the cursor.
+ * @param newText - The string to insert (if any).
+ */
 export function splice<T>(
   doc: Doc<T>,
   path: stable.Prop[],
@@ -264,6 +279,11 @@ export function splice<T>(
 
   index = cursorToIndex(state, value, index)
 
+  if (del < 0) {
+    index += del
+    del = 0 - del
+  }
+
   try {
     return state.handle.splice(value, index, del, newText)
   } catch (e) {
@@ -271,6 +291,24 @@ export function splice<T>(
   }
 }
 
+/**
+ * Returns a cursor for the given position in a string.
+ *
+ * @remarks
+ * A cursor represents a relative position, "before character X",
+ * rather than an absolute position. As the document is edited, the
+ * cursor remains stable relative to its context, just as you'd expect
+ * from a cursor in a concurrent text editor.
+ *
+ * The string representation is shareable, and so you can use this both
+ * to edit the document yourself (using {@link splice}) or to share multiple
+ * collaborator's current cursor positions over the network.
+ *
+ * @typeParam T - The type of the value contained in the document
+ * @param doc - The document
+ * @param path - The path to the string
+ * @param index - The current index of the position of the cursor
+ */
 export function getCursor<T>(
   doc: Doc<T>,
   path: stable.Prop[],
@@ -292,6 +330,15 @@ export function getCursor<T>(
   }
 }
 
+/**
+ * Returns the current index of the cursor.
+ *
+ * @typeParam T - The type of the value contained in the document
+ *
+ * @param doc - The document
+ * @param path - The path to the string
+ * @param index - The cursor
+ */
 export function getCursorPosition<T>(
   doc: Doc<T>,
   path: stable.Prop[],

--- a/javascript/test/basic_test.ts
+++ b/javascript/test/basic_test.ts
@@ -587,5 +587,44 @@ describe("Automerge", () => {
       )
       let index = Automerge.getCursorPosition(doc, ["value"], cursor)
     })
+
+    it("can use cursors in common text operations", () => {
+      let doc = Automerge.from({
+        value: "The sly fox jumped over the lazy dog",
+      })
+      let doc2 = Automerge.clone(doc)
+
+      let cursor = Automerge.getCursor(doc, ["value"], 8)
+
+      doc = Automerge.change(doc, d => {
+        Automerge.splice(d, ["value"], cursor, 0, "o")
+        Automerge.splice(d, ["value"], cursor, 0, "l")
+        Automerge.splice(d, ["value"], cursor, 0, "e")
+      })
+      doc2 = Automerge.change(doc2, d => {
+        Automerge.splice(d, ["value"], 3, -3, "A")
+      })
+      doc = Automerge.merge(doc, doc2)
+      doc = Automerge.change(doc, d => {
+        Automerge.splice(d, ["value"], cursor, -1, "d")
+        Automerge.splice(d, ["value"], cursor, 0, " ")
+      })
+      assert.deepEqual(doc.value, "A sly old fox jumped over the lazy dog")
+    })
+
+    it("should use javascript string indices", () => {
+      let doc = Automerge.from({
+        value: "🇬🇧🇩🇪",
+      })
+
+      let cursor = Automerge.getCursor(doc, ["value"], doc.value.indexOf("🇩🇪"))
+      doc = Automerge.change(doc, d => {
+        Automerge.splice(d, ["value"], cursor, -2, "")
+        Automerge.splice(d, ["value"], cursor, -2, "")
+        Automerge.splice(d, ["value"], cursor, 0, "🇫🇷")
+      })
+
+      assert.deepEqual(doc.value, "🇫🇷🇩🇪")
+    })
   })
 })

--- a/rust/automerge-c/src/doc.rs
+++ b/rust/automerge-c/src/doc.rs
@@ -836,7 +836,7 @@ pub unsafe extern "C" fn AMsplice(
     let pos = clamp!(pos, len, "pos");
     let del = clamp!(del, len, "del");
     match Vec::<am::ScalarValue>::try_from(&values) {
-        Ok(vals) => to_result(doc.splice(obj_id, pos, del, vals)),
+        Ok(vals) => to_result(doc.splice(obj_id, pos, del as isize, vals)),
         Err(e) => AMresult::error(&e.to_string()).into(),
     }
 }
@@ -876,7 +876,7 @@ pub unsafe extern "C" fn AMspliceText(
     let len = doc.length(obj_id);
     let pos = clamp!(pos, len, "pos");
     let del = clamp!(del, len, "del");
-    to_result(doc.splice_text(obj_id, pos, del, to_str!(text)))
+    to_result(doc.splice_text(obj_id, pos, del as isize, to_str!(text)))
 }
 
 /// \memberof AMdoc

--- a/rust/automerge-wasm/src/lib.rs
+++ b/rust/automerge-wasm/src/lib.rs
@@ -217,7 +217,7 @@ impl Automerge {
     ) -> Result<(), error::Splice> {
         let (obj, obj_type) = self.import(obj)?;
         let start = start as usize;
-        let delete_count = delete_count as usize;
+        let delete_count = delete_count as isize;
         let vals = if let Some(t) = text.as_string() {
             if obj_type == am::ObjType::Text && self.text_rep == TextRepresentation::String {
                 self.doc.splice_text(&obj, start, delete_count, &t)?;

--- a/rust/automerge/src/autocommit.rs
+++ b/rust/automerge/src/autocommit.rs
@@ -818,7 +818,7 @@ impl Transactable for AutoCommit {
         &mut self,
         obj: O,
         pos: usize,
-        del: usize,
+        del: isize,
         vals: V,
     ) -> Result<(), AutomergeError> {
         self.ensure_transaction_open();
@@ -830,7 +830,7 @@ impl Transactable for AutoCommit {
         &mut self,
         obj: O,
         pos: usize,
-        del: usize,
+        del: isize,
         text: &str,
     ) -> Result<(), AutomergeError> {
         self.ensure_transaction_open();

--- a/rust/automerge/src/transaction/manual_transaction.rs
+++ b/rust/automerge/src/transaction/manual_transaction.rs
@@ -369,7 +369,7 @@ impl<'a> Transactable for Transaction<'a> {
         &mut self,
         obj: O,
         pos: usize,
-        del: usize,
+        del: isize,
         vals: V,
     ) -> Result<(), AutomergeError> {
         self.do_tx(|tx, doc, hist| tx.splice(doc, hist, obj.as_ref(), pos, del, vals))
@@ -379,7 +379,7 @@ impl<'a> Transactable for Transaction<'a> {
         &mut self,
         obj: O,
         pos: usize,
-        del: usize,
+        del: isize,
         text: &str,
     ) -> Result<(), AutomergeError> {
         self.do_tx(|tx, doc, hist| tx.splice_text(doc, hist, obj.as_ref(), pos, del, text))

--- a/rust/automerge/src/transaction/transactable.rs
+++ b/rust/automerge/src/transaction/transactable.rs
@@ -72,11 +72,14 @@ pub trait Transactable: ReadDoc {
         prop: P,
     ) -> Result<(), AutomergeError>;
 
+    /// replace a section of a list. If `del` is positive then N values
+    /// are deleted after position `pos` and the new values inserted. If
+    /// it is negative then N values are deleted before position `pos` instead.
     fn splice<O: AsRef<ExId>, V: IntoIterator<Item = ScalarValue>>(
         &mut self,
         obj: O,
         pos: usize,
-        del: usize,
+        del: isize,
         vals: V,
     ) -> Result<(), AutomergeError>;
 
@@ -85,7 +88,7 @@ pub trait Transactable: ReadDoc {
         &mut self,
         obj: O,
         pos: usize,
-        del: usize,
+        del: isize,
         text: &str,
     ) -> Result<(), AutomergeError>;
 

--- a/rust/edit-trace/benches/main.rs
+++ b/rust/edit-trace/benches/main.rs
@@ -2,7 +2,7 @@ use automerge::{transaction::Transactable, AutoCommit, Automerge, ObjType, ROOT}
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
 use std::fs;
 
-fn replay_trace_tx(commands: Vec<(usize, usize, String)>) -> Automerge {
+fn replay_trace_tx(commands: Vec<(usize, isize, String)>) -> Automerge {
     let mut doc = Automerge::new();
     let mut tx = doc.transaction();
     let text = tx.put_object(ROOT, "text", ObjType::Text).unwrap();
@@ -13,7 +13,7 @@ fn replay_trace_tx(commands: Vec<(usize, usize, String)>) -> Automerge {
     doc
 }
 
-fn replay_trace_autotx(commands: Vec<(usize, usize, String)>) -> AutoCommit {
+fn replay_trace_autotx(commands: Vec<(usize, isize, String)>) -> AutoCommit {
     let mut doc = AutoCommit::new();
     let text = doc.put_object(ROOT, "text", ObjType::Text).unwrap();
     for (pos, del, vals) in commands {
@@ -45,7 +45,7 @@ fn bench(c: &mut Criterion) {
     let mut commands = vec![];
     for i in 0..edits.len() {
         let pos: usize = edits[i][0].as_usize().unwrap();
-        let del: usize = edits[i][1].as_usize().unwrap();
+        let del: isize = edits[i][1].as_isize().unwrap();
         let mut vals = String::new();
         for j in 2..edits[i].len() {
             let v = edits[i][j].as_str().unwrap();

--- a/rust/edit-trace/src/main.rs
+++ b/rust/edit-trace/src/main.rs
@@ -9,7 +9,7 @@ fn main() -> Result<(), AutomergeError> {
     let mut commands = vec![];
     for i in 0..edits.len() {
         let pos: usize = edits[i][0].as_usize().unwrap();
-        let del: usize = edits[i][1].as_usize().unwrap();
+        let del: isize = edits[i][1].as_isize().unwrap();
         let mut vals = String::new();
         for j in 2..edits[i].len() {
             let v = edits[i][j].as_str().unwrap();


### PR DESCRIPTION
This allows cursors to be used for common text editing operations
without having to recalculate indices.

Add some documentation and tests while I'm at it.

I think this (coupled with the new API using javascript-native string indices) fully addresses the idea in #603.
