### PR TITLE
JS: don't materialize on view

### DIFF
--- a/javascript/src/stable.ts
+++ b/javascript/src/stable.ts
@@ -394,8 +394,7 @@ function progressDocument<T>(
       nextState
     )
     if (patches.length > 0) {
-      const before = view(doc, headsBefore || [])
-      callback(patches, { before, after: value })
+      callback(patches, { before: doc, after: value })
     }
     nextDoc = value
   } else {

--- a/javascript/src/stable.ts
+++ b/javascript/src/stable.ts
@@ -10,6 +10,7 @@ import {
   type Doc,
   type PatchCallback,
   type Patch,
+  type PatchSource,
 } from "./types"
 export {
   type AutomergeValue,
@@ -378,7 +379,7 @@ export function changeAt<T>(
 
 function progressDocument<T>(
   doc: Doc<T>,
-  source: string,
+  source: PatchSource,
   heads: Heads | null,
   callback?: PatchCallback<T>
 ): Doc<T> {
@@ -407,7 +408,7 @@ function progressDocument<T>(
 
 function _change<T>(
   doc: Doc<T>,
-  source: string,
+  source: PatchSource,
   options: ChangeOptions<T>,
   callback: ChangeFn<T>,
   scope?: Heads
@@ -492,7 +493,7 @@ export function emptyChange<T>(
 
   const heads = state.handle.getHeads()
   state.handle.emptyChange(options.message, options.time)
-  return progressDocument(doc, "local", heads)
+  return progressDocument(doc, "emptyChange", heads)
 }
 
 /**
@@ -953,7 +954,7 @@ export function receiveSyncMessage<T>(
   return [
     progressDocument(
       doc,
-      "sync",
+      "receiveSyncMessage",
       heads,
       opts.patchCallback || state.patchCallback
     ),

--- a/javascript/src/types.ts
+++ b/javascript/src/types.ts
@@ -37,6 +37,7 @@ export type Doc<T> = { readonly [P in keyof T]: T[P] }
 export type PatchInfo<T> = {
   before: Doc<T>
   after: Doc<T>
+  source: string
 }
 
 /**

--- a/javascript/src/types.ts
+++ b/javascript/src/types.ts
@@ -34,10 +34,19 @@ export type MarkValue = string | number | null | boolean | Date | Uint8Array
  */
 export type Doc<T> = { readonly [P in keyof T]: T[P] }
 
+export type PatchSource =
+  | "from"
+  | "emptyChange"
+  | "change"
+  | "changeAt"
+  | "merge"
+  | "loadIncremental"
+  | "applyChanges"
+  | "receiveSyncMessage"
 export type PatchInfo<T> = {
   before: Doc<T>
   after: Doc<T>
-  source: string
+  source: PatchSource
 }
 
 /**

--- a/javascript/src/unstable.ts
+++ b/javascript/src/unstable.ts
@@ -79,6 +79,7 @@ export {
   changeAt,
   emptyChange,
   loadIncremental,
+  saveIncremental,
   save,
   merge,
   getActorId,


### PR DESCRIPTION
There was an unnecessary call to `view()` that would call an expensive `materialize()` that was not needed.  Removing for performance reasons.