### PR TITLE
js: Run typechecking for tests in CI

### DIFF
--- a/javascript/package.json
+++ b/javascript/package.json
@@ -24,7 +24,7 @@
   "scripts": {
     "lint": "eslint src",
     "build": "tsc -p config/mjs.json && tsc -p config/cjs.json && tsc -p config/declonly.json --emitDeclarationOnly",
-    "test": "ts-mocha test/*.ts",
+    "test": "ts-mocha --type-check test/*.ts",
     "deno:build": "denoify && node ./scripts/deno-prefixer.mjs",
     "deno:test": "deno test ./deno-tests/deno.ts --allow-read --allow-net",
     "watch-docs": "typedoc src/index.ts --watch --readme none"

--- a/javascript/src/unstable.ts
+++ b/javascript/src/unstable.ts
@@ -113,6 +113,8 @@ export type InitOptions<T> = {
   freeze?: boolean
   /** A callback which will be called with the initial patch once the document has finished loading */
   patchCallback?: PatchCallback<T>
+  /** @hidden */
+  unchecked?: boolean
 }
 
 import { ActorId, Doc } from "./stable"

--- a/javascript/test/basic_test.ts
+++ b/javascript/test/basic_test.ts
@@ -284,7 +284,7 @@ describe("Automerge", () => {
       })
       assert.deepEqual(doc5, { list: [2, 1, 9, 10, 3, 11, 12] })
       let doc6 = Automerge.change(doc5, d => {
-        d.list.insertAt(3, 100, 101)
+        Automerge.insertAt(d.list, 3, 100, 101)
       })
       assert.deepEqual(doc6, { list: [2, 1, 9, 100, 101, 10, 3, 11, 12] })
     })
@@ -308,6 +308,7 @@ describe("Automerge", () => {
 
   describe("merge", () => {
     it("it should handle conflicts the same in merges as with loads", () => {
+      type DocShape = { sub: { x: number; y: number } }
       let doc1 = Automerge.from({ sub: { x: 0, y: 0 } })
       let doc2 = Automerge.clone(doc1)
       let doc3 = Automerge.clone(doc1)
@@ -334,13 +335,13 @@ describe("Automerge", () => {
       doc4 = Automerge.change(doc4, d => (d.sub.y = 9))
       doc4 = Automerge.change(doc4, d => (d.sub.y = 10))
 
-      let docM = Automerge.init()
+      let docM = Automerge.init<DocShape>()
       docM = Automerge.merge(docM, doc1)
       docM = Automerge.merge(docM, doc2)
       docM = Automerge.merge(docM, doc3)
       docM = Automerge.merge(docM, doc4)
 
-      let docL = Automerge.load(Automerge.save(docM))
+      let docL = Automerge.load<DocShape>(Automerge.save(docM))
 
       assert.deepEqual(docM.sub.x, docL.sub.x)
     })

--- a/javascript/test/change_at.ts
+++ b/javascript/test/change_at.ts
@@ -1,12 +1,10 @@
 import * as assert from "assert"
 import { unstable as Automerge } from "../src"
-import * as WASM from "@automerge/automerge-wasm"
-import { mismatched_heads } from "./helpers"
 
 describe("Automerge", () => {
   describe("changeAt", () => {
     it("should be able to change a doc at a prior state", () => {
-      let doc1 = Automerge.init()
+      let doc1 = Automerge.init<{ text: string }>()
       doc1 = Automerge.change(doc1, d => (d.text = "aaabbbccc"))
       let heads1 = Automerge.getHeads(doc1)
       doc1 = Automerge.change(doc1, d => {

--- a/javascript/test/patches.ts
+++ b/javascript/test/patches.ts
@@ -40,7 +40,7 @@ describe("patches", () => {
           },
         },
         doc => {
-          doc.list.deleteAt(1)
+          Automerge.deleteAt(doc.list, 1)
         }
       )
       assert.deepEqual(newDoc, { list: ["a", "c"] })

--- a/javascript/test/text_v1.ts
+++ b/javascript/test/text_v1.ts
@@ -284,13 +284,15 @@ describe("Automerge.Text", () => {
     assert.strictEqual(s2.text.toString(), "🐦")
 
     // this tests the observe_init_state path
-    let s3 = Automerge.init()
+    let s3 = Automerge.init<DocType>()
     s3 = Automerge.merge(s3, s2)
     assert.strictEqual(s3.text.toString(), "🐦")
 
     // this tests the diff_incremental path
     let s4 = Automerge.from({ some: "value" })
+    // @ts-ignore
     s4 = Automerge.merge(s4, s2)
+    // @ts-ignore
     assert.strictEqual(s4.text.toString(), "🐦")
   })
 


### PR DESCRIPTION
We weren't running ts-mocha with the --typecheck option, which meant that the tests had accumulated some type errors. Run typechecking for tests in CI so the tests stay clean.