### PR TITLE
js: integrate isolated doc in changeAt on empty change

### DIFF
--- a/javascript/src/stable.ts
+++ b/javascript/src/stable.ts
@@ -390,7 +390,6 @@ function progressDocument<T>(
   const nextState = { ...state, heads: undefined }
   let nextDoc
   if (callback != null) {
-    const headsBefore = state.heads
     const { value, patches } = state.handle.applyAndReturnPatches(
       doc,
       nextState
@@ -440,6 +439,9 @@ function _change<T>(
     callback(root)
     if (state.handle.pendingOps() === 0) {
       state.heads = undefined
+      if (scope != null) {
+        state.handle.integrate()
+      }
       return doc
     } else {
       state.handle.commit(options.message, options.time)

--- a/javascript/test/change_at.ts
+++ b/javascript/test/change_at.ts
@@ -6,7 +6,7 @@ describe("Automerge", () => {
     it("should be able to change a doc at a prior state", () => {
       let doc1 = Automerge.init<{ text: string }>()
       doc1 = Automerge.change(doc1, d => (d.text = "aaabbbccc"))
-      let heads1 = Automerge.getHeads(doc1)
+      const heads1 = Automerge.getHeads(doc1)
       doc1 = Automerge.change(doc1, d => {
         Automerge.splice(d, ["text"], 3, 3, "BBB")
       })
@@ -17,6 +17,31 @@ describe("Automerge", () => {
         assert.deepEqual(d.text, "aaXXXbccc")
       })
       assert.deepEqual(doc1.text, "aaXXXBBBccc")
+    })
+
+    it.only("should leave multiple heads intact on empty changes", () => {
+      let doc1 = Automerge.init<{ text: string; [key: string]: string }>()
+      doc1 = Automerge.change(doc1, d => (d.text = "aaabbbccc"))
+      const headsBeforeFork = Automerge.getHeads(doc1)
+
+      // Create a fork
+      let doc2 = Automerge.clone(doc1)
+      doc2 = Automerge.change(doc2, d => (d.doc2 = "doc2"))
+
+      doc1 = Automerge.change(doc1, d => (d.doc1 = "doc1"))
+
+      // Merge the fork back in
+      doc1 = Automerge.merge(doc1, doc2)
+
+      // We have a forked history
+      assert.equal(Automerge.getHeads(doc1).length, 2)
+
+      // now make an empty changeAt
+      // eslint-disable-next-line @typescript-eslint/no-empty-function
+      doc1 = Automerge.changeAt(doc1, headsBeforeFork, _d => {})
+
+      // We didn't do anything, heads shouldn't have changed
+      assert.equal(Automerge.getHeads(doc1).length, 2)
     })
   })
 })


### PR DESCRIPTION
Context: The `changeAt` function "isolates" the document at some heads and then executes a change callback on the isolated document. This allows the user to run a change callback as if it were operating on the document as at the given heads, rather than whatever the "current" state is. Once the change callback is complete `changeAt` calls `automerge_wasm::Automerge::integrate` to move the document back to the current heads of the document (those that were active before the call to `changeAt`).

Problem: The logic for calling `integrate` - which is in `_change` - when the callback was complete did not handle the case where the callback made no changes at all. This left the document pointing at the isolated heads even after the `changeAt` call was complete.

Solution: Modify the `_change` logic to call `integrate` even in the case of empty changes.