### PR TITLE
Dont build clocks when making whole-document patches

### DIFF
--- a/rust/automerge/src/autocommit.rs
+++ b/rust/automerge/src/autocommit.rs
@@ -180,7 +180,10 @@ impl AutoCommit {
             self.patch_log.make_patches(&self.doc)
         } else if before.is_empty() && after == heads {
             let mut patch_log = PatchLog::active(self.patch_log.text_rep());
-            patch_log.heads = Some(after.to_vec());
+            // This if statement is only active if the current heads are the same as `after`
+            // so we don't need to tell the patch log to target a specific heads and consequently
+            // it wll be able to generate patches very fast as it doesn't need to make any clocks
+            patch_log.heads = None;
             current_state::log_current_state_patches(&self.doc, &mut patch_log);
             patch_log.make_patches(&self.doc)
         } else {


### PR DESCRIPTION
Context: `Automerge::diff` allows you to generate patches from any set of heads to any other set of heads in the document. In the general case this requires constructing a set of clocks for each set of heads to determine which ops should be visible in the set of patches. However, `Automerge::diff` also has some logic to check for cases where we can skip building clocks in order to generate the patches faster.

Problem: The logic to skip building clocks was incorrectly failing to skip generating clocks in the case when the `before` heads were empty and the `after` heads were the heads of the document (i.e. when generating a patch for the whole current state of the document).

Solution: Set the `PatchLog::heads` clock to `None` in the case of a full history patch to skip clock generation.

fixes #652 