### PR TITLE
Add `PatchInfo` and `PatchSource` types to exports

### DIFF
--- a/javascript/src/low_level.ts
+++ b/javascript/src/low_level.ts
@@ -3,7 +3,6 @@ import {
   Automerge,
   type Change,
   type DecodedChange,
-  type Actor,
   SyncState,
   type SyncMessage,
   type JsSyncState,

--- a/javascript/src/proxies.ts
+++ b/javascript/src/proxies.ts
@@ -1,11 +1,6 @@
 /* eslint-disable  @typescript-eslint/no-explicit-any */
 import { Text } from "./text"
-import {
-  Automerge,
-  type Heads,
-  type ObjID,
-  type Prop,
-} from "@automerge/automerge-wasm"
+import { Automerge, type ObjID, type Prop } from "@automerge/automerge-wasm"
 
 import type { AutomergeValue, ScalarValue, MapValue, ListValue } from "./types"
 import {

--- a/javascript/src/stable.ts
+++ b/javascript/src/stable.ts
@@ -22,6 +22,8 @@ export {
   type Patch,
   type PatchCallback,
   type ScalarValue,
+  type PatchInfo,
+  type PatchSource,
 } from "./types"
 
 import { Text } from "./text"

--- a/javascript/src/types.ts
+++ b/javascript/src/types.ts
@@ -4,7 +4,7 @@ export { Counter } from "./counter"
 export { Int, Uint, Float64 } from "./numbers"
 
 import { Counter } from "./counter"
-import type { Cursor, Patch, MarkRange } from "@automerge/automerge-wasm"
+import type { Patch } from "@automerge/automerge-wasm"
 export type { Cursor, Patch, Mark, MarkRange } from "@automerge/automerge-wasm"
 
 export type AutomergeValue =

--- a/javascript/src/unstable.ts
+++ b/javascript/src/unstable.ts
@@ -49,6 +49,8 @@ export {
   type MarkValue,
   type AutomergeValue,
   type ScalarValue,
+  type PatchSource,
+  type PatchInfo,
 } from "./unstable_types"
 
 import type { Cursor, Mark, MarkRange, MarkValue } from "./unstable_types"

--- a/javascript/src/unstable_types.ts
+++ b/javascript/src/unstable_types.ts
@@ -12,6 +12,8 @@ export {
   type MarkRange,
   type MarkValue,
   type Cursor,
+  type PatchInfo,
+  type PatchSource,
 } from "./types"
 
 import { RawString } from "./raw_string"


### PR DESCRIPTION
This will be of specific use to `automerge-repo`.

This also tidies up a few unused imports