### PR TITLE
Added dummy counter methods

### DIFF
--- a/javascript/src/counter.ts
+++ b/javascript/src/counter.ts
@@ -41,6 +41,30 @@ export class Counter {
   toJSON(): number {
     return this.value
   }
+
+  /**
+   * Increases the value of the counter by `delta`. If `delta` is not given,
+   * increases the value of the counter by 1.
+   *
+   * Will throw an error if used outside of a change callback.
+   */
+  increment(_delta: number): number {
+    throw new Error(
+      "Counters should not be incremented outside of a change callback"
+    )
+  }
+
+  /**
+   * Decreases the value of the counter by `delta`. If `delta` is not given,
+   * decreases the value of the counter by 1.
+   *
+   * Will throw an error if used outside of a change callback.
+   */
+  decrement(_delta: number): number {
+    throw new Error(
+      "Counters should not be decremented outside of a change callback"
+    )
+  }
 }
 
 /**


### PR DESCRIPTION
This adds dummy `increment` and `decrement` methods back in to the `Counter` class.

Method parameters are prefixed with `_` to avoid eslint errors. We could also add `/* eslint-disable @typescript-eslint/no-unused-vars */` to the file if that is preferred.

It can also be added above each method signature, but I am not sure how that effects doc comments being detected properly.

Closes #662 