### PR TITLE
textv1: Allow multiple codepoint characters when initializing Text

### DIFF
--- a/javascript/src/proxies.ts
+++ b/javascript/src/proxies.ts
@@ -246,9 +246,7 @@ const MapHandler = {
           assertText(value)
           const text = context.putObject(objectId, key, "")
           const proxyText = textProxy(context, text, [...path, key])
-          for (let i = 0; i < value.length; i++) {
-            proxyText[i] = value.get(i)
-          }
+          proxyText.splice(0, 0, ...value)
         }
         break
       }

--- a/javascript/test/text_v1.ts
+++ b/javascript/test/text_v1.ts
@@ -321,4 +321,10 @@ describe("Automerge.Text", () => {
     assert.strictEqual(s1.text.length, 6)
     assert.strictEqual(s1.text.toString(), "🇬🇧four")
   })
+
+  it("should allow initiializing with multiple codepoint characters", () => {
+    s1 = Automerge.from({
+      text: new Automerge.Text("🇺🇸"),
+    })
+  })
 })


### PR DESCRIPTION
Fixes #658 