### PR TITLE
js: wrap proxy handlers and Automerge.from in try/catch

### DIFF
--- a/javascript/src/error.ts
+++ b/javascript/src/error.ts
@@ -1,0 +1,6 @@
+export class AutomergeError extends Error {
+  constructor(message: unknown) {
+    super(`${message instanceof Error ? message.message : message}`)
+    this.name = "AutomergeError"
+  }
+}

--- a/javascript/src/stable.ts
+++ b/javascript/src/stable.ts
@@ -25,6 +25,7 @@ export {
   type PatchInfo,
   type PatchSource,
 } from "./types"
+export { AutomergeError } from "./error"
 
 import { Text } from "./text"
 export { Text } from "./text"
@@ -144,6 +145,7 @@ export function use(api: API) {
 }
 
 import * as wasm from "@automerge/automerge-wasm"
+import { AutomergeError } from "./error"
 use(wasm)
 
 /**
@@ -295,8 +297,12 @@ export function from<T extends Record<string, unknown>>(
   initialState: T | Doc<T>,
   _opts?: ActorId | InitOptions<T>,
 ): Doc<T> {
-  return _change(init(_opts), "from", {}, d => Object.assign(d, initialState))
-    .newDoc
+  try {
+    return _change(init(_opts), "from", {}, d => Object.assign(d, initialState))
+      .newDoc
+  } catch (err) {
+    throw new AutomergeError(err)
+  }
 }
 
 /**

--- a/javascript/test/error.ts
+++ b/javascript/test/error.ts
@@ -1,0 +1,29 @@
+import * as Automerge from "../src"
+import * as assert from "assert"
+
+describe("Automerge errors", () => {
+  it("proxy handler throws an error, not a string", () => {
+    let error
+    try {
+      Automerge.change(
+        Automerge.from({ d: ["test"] }),
+        doc => (doc.d[2] = "oops")
+      )
+    } catch (err) {
+      error = err
+    }
+
+    assert(error instanceof Error)
+  })
+
+  it("Automerge.from throws an error, not a string", () => {
+    let error
+    try {
+      Automerge.from({ "": "bad key" })
+    } catch (err) {
+      error = err
+    }
+
+    assert(error instanceof Error)
+  })
+})


### PR DESCRIPTION
Addresses #659.

Currently, errors from automerge-wasm are just strings, which don't contain a stacktrace which makes pinpointing errors tedious. This change adds a try/catch around the proxy handler traps to provide a stacktrace to the calling code.

This PR only adds try/catch to `from` and the proxy handlers, since those seemed most likely to be in need of a good stacktrace.