### PR TITLE
js: Return heads of new changes from changeAt

### DIFF
--- a/javascript/test/basic_test.ts
+++ b/javascript/test/basic_test.ts
@@ -656,7 +656,7 @@ describe("Automerge", () => {
       let heads1 = Automerge.getHeads(doc1)
       let doc2 = Automerge.clone(doc1, { patchCallback })
       doc2 = Automerge.change(doc2, d => (d.a = "b"))
-      doc2 = Automerge.changeAt(doc2, heads1, d => (d.b = "c"))
+      doc2 = Automerge.changeAt(doc2, heads1, d => (d.b = "c")).newDoc
       doc1 = Automerge.merge(doc1, doc2)
       doc2 = Automerge.change(doc2, d => (d.x = "y"))
       doc1 = Automerge.loadIncremental(doc1, Automerge.saveIncremental(doc2))

--- a/javascript/test/change_at.ts
+++ b/javascript/test/change_at.ts
@@ -15,7 +15,7 @@ describe("Automerge", () => {
         assert.deepEqual(d.text, "aaabbbccc")
         Automerge.splice(d, ["text"], 2, 3, "XXX")
         assert.deepEqual(d.text, "aaXXXbccc")
-      })
+      }).newDoc
       assert.deepEqual(doc1.text, "aaXXXBBBccc")
     })
 
@@ -38,10 +38,38 @@ describe("Automerge", () => {
 
       // now make an empty changeAt
       // eslint-disable-next-line @typescript-eslint/no-empty-function
-      doc1 = Automerge.changeAt(doc1, headsBeforeFork, _d => {})
+      doc1 = Automerge.changeAt(doc1, headsBeforeFork, _d => {}).newDoc
 
       // We didn't do anything, heads shouldn't have changed
       assert.equal(Automerge.getHeads(doc1).length, 2)
+    })
+
+    it("should return the heads of the change document from changeAt", () => {
+      let doc1 = Automerge.init<{ text: string; [key: string]: string }>()
+      doc1 = Automerge.change(doc1, d => (d.text = "aaabbbccc"))
+
+      // Create a fork
+      let doc2 = Automerge.clone(doc1)
+      doc2 = Automerge.change(doc2, d => (d.doc2 = "doc2"))
+      const headsOnFork = Automerge.getHeads(doc2)
+
+      doc1 = Automerge.change(doc1, d => (d.doc1 = "doc1"))
+      const doc1Heads = Automerge.getHeads(doc1)
+
+      // Merge the fork back in
+      doc1 = Automerge.merge(doc1, doc2)
+
+      // We now have a forked history, we want to changeAt on the first head
+      const { newDoc, newHeads } = Automerge.changeAt(doc1, doc1Heads, d => {
+        d.text = "changed"
+      })
+      doc1 = newDoc
+
+      // The heads of the document should now be the heads returned from changeAt,
+      // plus the heads of the unchanged fork
+      const expectedHeads = new Set([...headsOnFork, ...newHeads!])
+      const actualHeads = new Set(Automerge.getHeads(doc1))
+      assert.deepEqual(actualHeads, expectedHeads)
     })
   })
 })


### PR DESCRIPTION
`changeAt` is useful because it allows the user to choose when they synchronize state with the document by saving the heads of the last sync point and then applying changes since that last sync point using `changeAt`. This only goes one way however, to go in the other direction the user needs to be able to obtain the diff from the now applied changes to the state of the document including any other concurrent changes. To enable this modify `changeAt` to return a `{newDoc: Doc<T>, newHeads: Heads | null}` instead of just `Doc<T>`. The returned `newHeads` is the hash of the transaction created by the change callback and can be used as the `before` argument to `diff` to obtain a diff from the result of the changeAt call to the state of the document including concurrent changes.