### PR TITLE
text/v1: return value in slice()

### DIFF
--- a/javascript/src/text.ts
+++ b/javascript/src/text.ts
@@ -215,7 +215,7 @@ export class Text {
   }
 
   slice(start?: number, end?: number) {
-    new Text(this.elems.slice(start, end))
+    return new Text(this.elems.slice(start, end))
   }
 
   some(test: (arg: Value) => boolean): boolean {

--- a/javascript/test/text_v1.ts
+++ b/javascript/test/text_v1.ts
@@ -327,4 +327,8 @@ describe("Automerge.Text", () => {
       text: new Automerge.Text("🇺🇸"),
     })
   })
+
+  it("should support slice", () => {
+    assert.strictEqual(s1.text.slice(0).toString(), s1.text.toString())
+  })
 })


### PR DESCRIPTION
I noticed that `slice()` on text doesn't actually return the value, so the return is always `undefined`.

This PR adds a fix and a test case.