### PR TITLE
rust: Make AutoCommit Send again

### DIFF
--- a/rust/automerge/src/autocommit.rs
+++ b/rust/automerge/src/autocommit.rs
@@ -927,3 +927,14 @@ impl<'a> SyncDoc for SyncWrapper<'a> {
             .receive_sync_message_log_patches(sync_state, message, patch_log)
     }
 }
+
+#[cfg(test)]
+mod tests {
+
+    fn is_send<S: Send>() {}
+
+    #[test]
+    fn test_autocommit_is_send() {
+        is_send::<super::AutoCommit>();
+    }
+}

--- a/rust/automerge/src/automerge/current_state.rs
+++ b/rust/automerge/src/automerge/current_state.rs
@@ -1,5 +1,5 @@
 use std::borrow::Cow;
-use std::rc::Rc;
+use std::sync::Arc;
 
 use itertools::Itertools;
 
@@ -14,7 +14,7 @@ use crate::{
 struct TextSpan {
     text: String,
     start: usize,
-    marks: Option<Rc<MarkSet>>,
+    marks: Option<Arc<MarkSet>>,
 }
 
 #[derive(Debug, Default)]

--- a/rust/automerge/src/automerge/diff.rs
+++ b/rust/automerge/src/automerge/diff.rs
@@ -1,7 +1,7 @@
 use itertools::Itertools;
 use std::ops::Deref;
 use std::ops::RangeBounds;
-use std::rc::Rc;
+use std::sync::Arc;
 
 use crate::patches::TextRepresentation;
 use crate::{
@@ -95,16 +95,16 @@ fn resolve<'a>(
 
 #[derive(Debug, Clone)]
 enum Patch<'a> {
-    New(Winner<'a>, Option<Rc<MarkSet>>),
+    New(Winner<'a>, Option<Arc<MarkSet>>),
     Old {
         before: Winner<'a>,
         after: Winner<'a>,
-        marks: Option<Rc<MarkSet>>,
+        marks: Option<Arc<MarkSet>>,
     },
     Update {
         before: Winner<'a>,
         after: Winner<'a>,
-        marks: Option<Rc<MarkSet>>,
+        marks: Option<Arc<MarkSet>>,
     },
     Delete(Winner<'a>),
 }
@@ -284,13 +284,13 @@ impl<'a> MarkDiff<'a> {
         }
     }
 
-    fn current(&self) -> Option<Rc<MarkSet>> {
+    fn current(&self) -> Option<Arc<MarkSet>> {
         // do this without all the cloning - cache the result
         let b = self.before.current().cloned().unwrap_or_default();
         let a = self.after.current().cloned().unwrap_or_default();
         if a != b {
             let result = b.diff(&a);
-            Some(Rc::new(result))
+            Some(Arc::new(result))
         } else {
             None
         }

--- a/rust/automerge/src/iter/list_range.rs
+++ b/rust/automerge/src/iter/list_range.rs
@@ -1,6 +1,6 @@
 use std::fmt;
 use std::ops::RangeBounds;
-use std::rc::Rc;
+use std::sync::Arc;
 
 use crate::exid::ExId;
 use crate::marks::MarkSet;
@@ -94,7 +94,7 @@ pub struct ListRangeItem<'a> {
     pub value: Value<'a>,
     pub id: ExId,
     pub conflict: bool,
-    pub(crate) marks: Option<Rc<MarkSet>>,
+    pub(crate) marks: Option<Arc<MarkSet>>,
 }
 
 impl<'a> ListRangeItem<'a> {

--- a/rust/automerge/src/iter/top_ops.rs
+++ b/rust/automerge/src/iter/top_ops.rs
@@ -2,7 +2,7 @@ use crate::marks::{MarkSet, MarkStateMachine};
 use crate::op_tree::OpSetMetadata;
 use crate::op_tree::OpTreeIter;
 use crate::types::{Clock, Key, Op};
-use std::rc::Rc;
+use std::sync::Arc;
 
 #[derive(Default)]
 pub(crate) struct TopOps<'a> {
@@ -12,7 +12,7 @@ pub(crate) struct TopOps<'a> {
     num_ops: usize,
     clock: Option<Clock>,
     key: Option<Key>,
-    last_op: Option<(usize, &'a Op, Option<Rc<MarkSet>>)>,
+    last_op: Option<(usize, &'a Op, Option<Arc<MarkSet>>)>,
     marks: MarkStateMachine<'a>,
     meta: Option<&'a OpSetMetadata>,
 }
@@ -21,7 +21,7 @@ pub(crate) struct TopOps<'a> {
 pub(crate) struct TopOp<'a> {
     pub(crate) op: &'a Op,
     pub(crate) conflict: bool,
-    pub(crate) marks: Option<Rc<MarkSet>>,
+    pub(crate) marks: Option<Arc<MarkSet>>,
 }
 
 impl<'a> TopOps<'a> {

--- a/rust/automerge/src/op_tree.rs
+++ b/rust/automerge/src/op_tree.rs
@@ -12,7 +12,7 @@ use crate::{
     ObjType, OpType,
 };
 use std::cmp::Ordering;
-use std::rc::Rc;
+use std::sync::Arc;
 use std::{fmt::Debug, mem};
 
 mod iter;
@@ -87,7 +87,7 @@ pub(crate) struct FoundOpWithPatchLog<'a> {
     pub(crate) succ: Vec<usize>,
     pub(crate) pos: usize,
     pub(crate) index: usize,
-    pub(crate) marks: Option<Rc<MarkSet>>,
+    pub(crate) marks: Option<Arc<MarkSet>>,
 }
 
 impl<'a> FoundOpWithPatchLog<'a> {
@@ -244,7 +244,7 @@ impl OpTreeInternal {
         op: &'a Op,
         mut pos: usize,
         index: usize,
-        marks: Option<Rc<MarkSet>>,
+        marks: Option<Arc<MarkSet>>,
     ) -> FoundOpWithPatchLog<'a> {
         let mut iter = self.iter();
         let mut found = None;

--- a/rust/automerge/src/patches/patch_builder.rs
+++ b/rust/automerge/src/patches/patch_builder.rs
@@ -1,5 +1,5 @@
 use core::fmt::Debug;
-use std::rc::Rc;
+use std::sync::Arc;
 
 use crate::marks::MarkSet;
 use crate::{ObjId, Prop, ReadDoc, Value};
@@ -10,7 +10,7 @@ use crate::{marks::Mark, sequence_tree::SequenceTree};
 #[derive(Debug, Clone, Default)]
 pub(crate) struct PatchBuilder {
     patches: Vec<Patch>,
-    last_mark_set: Option<Rc<MarkSet>>, // keep this around for a quick pointer equality test
+    last_mark_set: Option<Arc<MarkSet>>, // keep this around for a quick pointer equality test
 }
 
 impl PatchBuilder {
@@ -39,7 +39,7 @@ impl PatchBuilder {
         index: usize,
         tagged_value: (Value<'_>, ObjId),
         conflict: bool,
-        marks: Option<Rc<MarkSet>>,
+        marks: Option<Arc<MarkSet>>,
     ) {
         let value = (tagged_value.0.to_owned(), tagged_value.1, conflict);
         if let Some(PatchAction::Insert {
@@ -78,7 +78,7 @@ impl PatchBuilder {
         obj: ObjId,
         index: usize,
         value: &str,
-        marks: Option<Rc<MarkSet>>,
+        marks: Option<Arc<MarkSet>>,
     ) {
         if let Some(PatchAction::SpliceText {
             index: tail_index,

--- a/rust/automerge/src/patches/patch_log.rs
+++ b/rust/automerge/src/patches/patch_log.rs
@@ -7,7 +7,7 @@ use crate::types::{ObjId, ObjType, OpId, Prop};
 use crate::{Automerge, ChangeHash, Patch, ReadDoc};
 use std::collections::BTreeSet;
 use std::collections::HashSet;
-use std::rc::Rc;
+use std::sync::Arc;
 
 use super::{PatchBuilder, TextRepresentation};
 
@@ -72,14 +72,14 @@ pub(crate) enum Event {
     Splice {
         index: usize,
         text: String,
-        marks: Option<Rc<MarkSet>>,
+        marks: Option<Arc<MarkSet>>,
     },
     Insert {
         index: usize,
         value: Value,
         id: OpId,
         conflict: bool,
-        marks: Option<Rc<MarkSet>>,
+        marks: Option<Arc<MarkSet>>,
     },
     IncrementMap {
         key: String,
@@ -272,7 +272,7 @@ impl PatchLog {
         obj: ObjId,
         index: usize,
         text: &str,
-        marks: Option<Rc<MarkSet>>,
+        marks: Option<Arc<MarkSet>>,
     ) {
         self.events.push((
             obj,
@@ -284,7 +284,7 @@ impl PatchLog {
         ))
     }
 
-    pub(crate) fn mark(&mut self, obj: ObjId, index: usize, len: usize, marks: &Rc<MarkSet>) {
+    pub(crate) fn mark(&mut self, obj: ObjId, index: usize, len: usize, marks: &Arc<MarkSet>) {
         if let Some((_, Event::Mark { marks: tail_marks })) = self.events.last_mut() {
             tail_marks.add(index, len, marks);
             return;
@@ -301,7 +301,7 @@ impl PatchLog {
         value: Value,
         id: OpId,
         conflict: bool,
-        marks: Option<Rc<MarkSet>>,
+        marks: Option<Arc<MarkSet>>,
     ) {
         self.events.push((
             obj,

--- a/rust/automerge/src/query/insert.rs
+++ b/rust/automerge/src/query/insert.rs
@@ -5,7 +5,7 @@ use crate::op_tree::OpTreeNode;
 use crate::query::{ListState, MarkMap, OpSetMetadata, OpTree, QueryResult, TreeQuery};
 use crate::types::{Clock, Key, ListEncoding, Op, OpId, OpType, HEAD};
 use std::fmt::Debug;
-use std::rc::Rc;
+use std::sync::Arc;
 
 #[derive(Debug, Clone, PartialEq)]
 pub(crate) struct InsertNth<'a> {
@@ -63,7 +63,7 @@ impl<'a> InsertNth<'a> {
         }
     }
 
-    pub(crate) fn marks(&self, m: &OpSetMetadata) -> Option<Rc<MarkSet>> {
+    pub(crate) fn marks(&self, m: &OpSetMetadata) -> Option<Arc<MarkSet>> {
         let mut marks = MarkStateMachine::default();
         for (id, mark_data) in self.marks.iter() {
             marks.mark_begin(*id, mark_data, m);

--- a/rust/automerge/src/query/opid.rs
+++ b/rust/automerge/src/query/opid.rs
@@ -5,7 +5,7 @@ use crate::query::{ListState, MarkMap, QueryResult, TreeQuery};
 use crate::types::Clock;
 use crate::types::{ListEncoding, Op, OpId};
 use std::cmp::Ordering;
-use std::rc::Rc;
+use std::sync::Arc;
 
 /// Search for an OpId in a tree.  /// Returns the index of the operation in the tree.
 #[derive(Debug, Clone, PartialEq)]
@@ -72,7 +72,7 @@ impl<'a> OpIdSearch<'a> {
         }
     }
 
-    pub(crate) fn marks(&self, m: &OpSetMetadata) -> Option<Rc<MarkSet>> {
+    pub(crate) fn marks(&self, m: &OpSetMetadata) -> Option<Arc<MarkSet>> {
         let mut marks = MarkStateMachine::default();
         for (id, mark_data) in self.marks.iter() {
             marks.mark_begin(*id, mark_data, m);

--- a/rust/automerge/src/transaction/inner.rs
+++ b/rust/automerge/src/transaction/inner.rs
@@ -1,5 +1,5 @@
 use std::num::NonZeroU64;
-use std::rc::Rc;
+use std::sync::Arc;
 
 use crate::exid::ExId;
 use crate::marks::{ExpandMark, Mark, MarkSet};
@@ -761,7 +761,7 @@ impl TransactionInner {
         obj: ObjId,
         prop: Prop,
         op: Op,
-        marks: Option<Rc<MarkSet>>,
+        marks: Option<Arc<MarkSet>>,
     ) {
         // TODO - id_to_exid should be a noop if not used - change type to Into<ExId>?
         if patch_log.is_active() {


### PR DESCRIPTION
We use an `Rc` internally when generating patches. This inadvertantly made `AutoCommit` `!Send`. Swap `Rc` for `Arc` to make `AutoCommit` `Send` again, add a test to make sure this remains the case.

Fixes #681 