### PR TITLE
rust: Make Automerge::load_incremental_log_patches public

### DIFF
--- a/rust/automerge/src/automerge.rs
+++ b/rust/automerge/src/automerge.rs
@@ -618,7 +618,7 @@ impl Automerge {
 
     /// Like [`Self::load_incremental`] but log the changes to the current state of the document to
     /// [`PatchLog`]
-    pub(crate) fn load_incremental_log_patches(
+    pub fn load_incremental_log_patches(
         &mut self,
         data: &[u8],
         patch_log: &mut PatchLog,


### PR DESCRIPTION
This method was inadvertantly `pub(crate)`. Make it public to allow a complete implementation of `AutoCommit` like things in userspace.