### PR TITLE
automerge-c: Add an explicit dependency on ntdll for WIN32

### DIFF
--- a/rust/automerge-c/CMakeLists.txt
+++ b/rust/automerge-c/CMakeLists.txt
@@ -219,7 +219,7 @@ find_package(Threads REQUIRED)
 set(LIBRARY_DEPENDENCIES Threads::Threads ${CMAKE_DL_LIBS})
 
 if(WIN32)
-    list(APPEND LIBRARY_DEPENDENCIES Bcrypt userenv ws2_32)
+    list(APPEND LIBRARY_DEPENDENCIES Bcrypt ntdll userenv ws2_32)
 else()
     list(APPEND LIBRARY_DEPENDENCIES m)
 endif()


### PR DESCRIPTION
This change fixes issue #689.