### PR TITLE
javascript: Allow loading a document with missing changes

### DIFF
--- a/javascript/src/next.ts
+++ b/javascript/src/next.ts
@@ -117,6 +117,8 @@ export type InitOptions<T> = {
   patchCallback?: PatchCallback<T>
   /** @hidden */
   unchecked?: boolean
+  /** Allow loading a document with missing changes */
+  allowMissingChanges?: boolean
 }
 
 import { ActorId, Doc } from "./stable"

--- a/javascript/src/stable.ts
+++ b/javascript/src/stable.ts
@@ -160,6 +160,8 @@ export type InitOptions<T> = {
   enableTextV2?: boolean
   /** @hidden */
   unchecked?: boolean
+  /** Allow loading a document with missing changes */
+  allowMissingChanges?: boolean
 }
 
 /** @hidden */
@@ -608,7 +610,13 @@ export function load<T>(
   const patchCallback = opts.patchCallback
   const text_v1 = !(opts.enableTextV2 || false)
   const unchecked = opts.unchecked || false
-  const handle = ApiHandler.load(data, { text_v1, actor, unchecked })
+  const allowMissingDeps = opts.allowMissingChanges || false
+  const handle = ApiHandler.load(data, {
+    text_v1,
+    actor,
+    unchecked,
+    allowMissingDeps,
+  })
   handle.enableFreeze(!!opts.freeze)
   handle.registerDatatype("counter", (n: number) => new Counter(n))
   const textV2 = opts.enableTextV2 || false

--- a/javascript/test/basic_test.ts
+++ b/javascript/test/basic_test.ts
@@ -1,5 +1,6 @@
 import * as assert from "assert"
 import { next as Automerge } from "../src"
+import * as oldAutomerge from "../src/stable"
 import * as WASM from "@automerge/automerge-wasm"
 import { mismatched_heads } from "./helpers"
 import { PatchSource } from "../src/types"
@@ -304,6 +305,34 @@ describe("Automerge", () => {
       })
       assert.deepEqual(doc.list.indexOf(5), 5)
       assert.deepEqual(doc.text.indexOf("world"), 6)
+    })
+  })
+
+  describe("explicitly allowing missing dependencies when loading", () => {
+    it("should work in unstable", () => {
+      const doc1 = Automerge.init<any>()
+      const doc2 = Automerge.change(doc1, d => {
+        d.list = [1, 2, 3]
+      })
+      const doc3 = Automerge.change(doc2, d => {
+        d.list.push(4)
+      })
+      const changes = Automerge.getChanges(doc2, doc3)
+      assert.equal(changes.length, 1)
+      Automerge.load(changes[0], { allowMissingChanges: true })
+    })
+
+    it("should work in stable", () => {
+      const doc1 = oldAutomerge.init<any>()
+      const doc2 = oldAutomerge.change(doc1, d => {
+        d.list = [1, 2, 3]
+      })
+      const doc3 = oldAutomerge.change(doc2, d => {
+        d.list.push(4)
+      })
+      const changes = oldAutomerge.getChanges(doc2, doc3)
+      assert.equal(changes.length, 1)
+      oldAutomerge.load(changes[0], { allowMissingChanges: true })
     })
   })
 

--- a/rust/automerge-c/Cargo.toml
+++ b/rust/automerge-c/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "automerge-c"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Orion Henry <orion.henry@gmail.com>", "Jason Kankiewicz <jason.kankiewicz@gmail.com>"]
 edition = "2021"
 license = "MIT"

--- a/rust/automerge-wasm/.editorconfig
+++ b/rust/automerge-wasm/.editorconfig
@@ -1,0 +1,3 @@
+[*.{js,ts}]
+indent_style = space
+indent_size = 2

--- a/rust/automerge-wasm/index.d.ts
+++ b/rust/automerge-wasm/index.d.ts
@@ -302,6 +302,7 @@ export type LoadOptions = {
   actor?: Actor,
   text_v1?: boolean,
   unchecked?: boolean,
+  allowMissingDeps?: boolean,
 }
 
 export type InitOptions = {

--- a/rust/automerge-wasm/test/test.ts
+++ b/rust/automerge-wasm/test/test.ts
@@ -469,6 +469,31 @@ describe('Automerge', () => {
     })
   })
 
+  describe("loadIncremental", () => {
+    it("should allow you to load changes with missing deps", () => {
+      const doc1 = create({ actor: "aaaa" })
+      doc1.put("_root", "key", "value") 
+      doc1.saveIncremental()
+      doc1.put("_root", "key", "value2") 
+      const changeWithoutDep = doc1.saveIncremental()
+
+      const doc2 = create({ actor: "bbbb" })
+      doc2.loadIncremental(changeWithoutDep)
+    })
+  })
+
+  describe("load", () => {
+    it("should allow explicitly allowing missing deps", () => {
+      const doc1 = create({ actor: "aaaa" })
+      doc1.put("_root", "key", "value") 
+      doc1.saveIncremental()
+      doc1.put("_root", "key", "value2") 
+      const changeWithoutDep = doc1.saveIncremental()
+
+      load(changeWithoutDep, { allowMissingDeps: true })
+    })
+  })
+
   describe('patch generation', () => {
     it('should include root object key updates', () => {
       const doc1 = create({ actor: 'aaaa' }), doc2 = create({ actor: 'bbbb'})

--- a/rust/automerge/src/automerge.rs
+++ b/rust/automerge/src/automerge.rs
@@ -570,7 +570,8 @@ impl Automerge {
                 am.apply_changes(change.into_iter().chain(c))?;
                 // Only allow missing deps if the first chunk was a document chunk
                 // See https://github.com/automerge/automerge/pull/599#issuecomment-1549667472
-                if !am.queue.is_empty() && !first_chunk_was_doc {
+                if !am.queue.is_empty() && !first_chunk_was_doc && on_error == OnPartialLoad::Error
+                {
                     return Err(AutomergeError::MissingDeps);
                 }
             }

--- a/rust/automerge/src/lib.rs
+++ b/rust/automerge/src/lib.rs
@@ -303,6 +303,7 @@ pub use parents::{Parent, Parents};
 pub use patches::{Patch, PatchAction, PatchLog};
 pub use read::ReadDoc;
 pub use sequence_tree::SequenceTree;
+pub use storage::VerificationMode;
 pub use types::{ActorId, ChangeHash, ObjType, OpType, ParseChangeHashError, Prop};
 pub use value::{ScalarValue, Value};
 

--- a/rust/automerge/src/storage.rs
+++ b/rust/automerge/src/storage.rs
@@ -9,12 +9,12 @@ pub(crate) mod load;
 pub(crate) mod parse;
 pub(crate) mod save;
 
+pub use load::VerificationMode;
 pub(crate) use {
     change::{AsChangeOp, Change, ChangeOp, Compressed, ReadChangeOpError},
     chunk::{CheckSum, Chunk, ChunkType, Header},
     columns::{Columns, MismatchingColumn, RawColumn, RawColumns},
     document::{AsChangeMeta, AsDocOp, ChangeMetadata, CompressConfig, DocOp, Document},
-    load::VerificationMode,
 };
 
 fn shift_range(range: Range<usize>, by: usize) -> Range<usize> {

--- a/rust/automerge/src/storage/load.rs
+++ b/rust/automerge/src/storage/load.rs
@@ -7,8 +7,9 @@ use crate::{
 
 mod change_collector;
 mod reconstruct_document;
+pub use reconstruct_document::VerificationMode;
 pub(crate) use reconstruct_document::{
-    reconstruct_document, DocObserver, LoadedObject, Reconstructed, VerificationMode,
+    reconstruct_document, DocObserver, LoadedObject, Reconstructed,
 };
 
 #[derive(Debug, thiserror::Error)]


### PR DESCRIPTION
The behaviour of `Automerge::load` and all derived APIs has so far been to throw an error if, having finished loading, we find that there are changes which have missing dependencies. This is because it seemed like it would be surprising if you call `load` on a saved file and the document was empty. There are situations however where you know that there may be missing dependencies. Add a flag to `load` to indicate that missing depencies are okay to accomodate this.