### PR TITLE
javascript: Expose saveSince

### DIFF
--- a/javascript/src/next.ts
+++ b/javascript/src/next.ts
@@ -107,6 +107,7 @@ export {
   diff,
   insertAt,
   deleteAt,
+  saveSince,
 } from "./stable"
 
 export type InitOptions<T> = {

--- a/javascript/src/stable.ts
+++ b/javascript/src/stable.ts
@@ -1134,6 +1134,12 @@ function isObject(obj: unknown): obj is Record<string, unknown> {
   return typeof obj === "object" && obj !== null
 }
 
+export function saveSince(doc: Doc<unknown>, heads: Heads): Uint8Array {
+  const state = _state(doc)
+  const result = state.handle.saveSince(heads)
+  return result
+}
+
 export type {
   API,
   SyncState,

--- a/javascript/test/basic_test.ts
+++ b/javascript/test/basic_test.ts
@@ -723,4 +723,17 @@ describe("Automerge", () => {
       })
     })
   })
+  describe("saveSince", () => {
+    it("should be the same as saveIncremental since heads of the last saveIncremental", () => {
+      let doc = Automerge.init<any>()
+      doc = Automerge.change(doc, d => (d.a = "b"))
+      Automerge.saveIncremental(doc)
+      const heads = Automerge.getHeads(doc)
+
+      doc = Automerge.change(doc, d => (d.c = "d"))
+      let incremental = Automerge.saveIncremental(doc)
+      let since = Automerge.saveSince(doc, heads)
+      assert.deepEqual(incremental, since)
+    })
+  })
 })

--- a/rust/automerge-wasm/index.d.ts
+++ b/rust/automerge-wasm/index.d.ts
@@ -253,6 +253,7 @@ export class Automerge {
   saveNoCompress(): Uint8Array;
   saveAndVerify(): Uint8Array;
   saveIncremental(): Uint8Array;
+  saveSince(heads: Heads): Uint8Array;
   loadIncremental(data: Uint8Array): number;
 
   // sync over network

--- a/rust/automerge-wasm/src/lib.rs
+++ b/rust/automerge-wasm/src/lib.rs
@@ -680,6 +680,16 @@ impl Automerge {
         Uint8Array::from(bytes.as_slice())
     }
 
+    #[wasm_bindgen(js_name=saveSince)]
+    pub fn save_since(
+        &mut self,
+        heads: Array,
+    ) -> Result<Uint8Array, interop::error::BadChangeHashes> {
+        let heads = get_heads(Some(heads))?.unwrap_or(Vec::new());
+        let bytes = self.doc.save_after(&heads);
+        Ok(Uint8Array::from(bytes.as_slice()))
+    }
+
     #[wasm_bindgen(js_name = saveNoCompress)]
     pub fn save_nocompress(&mut self) -> Uint8Array {
         let bytes = self.doc.save_nocompress();

--- a/rust/automerge-wasm/test/test.ts
+++ b/rust/automerge-wasm/test/test.ts
@@ -273,6 +273,21 @@ describe('Automerge', () => {
       assert.deepEqual(docA.save(), docC.save());
     })
 
+    it("should be able to save since a given heads", () => {
+      const doc = create()
+
+      doc.put("_root", "foo", 1)
+      const heads = doc.getHeads()
+      doc.saveIncremental()
+
+      doc.put("_root", "bar", 2)
+
+      const saveIncremental = doc.saveIncremental()
+      const saveSince = doc.saveSince(heads)
+      assert.deepEqual(saveIncremental, saveSince)
+
+    })
+
     it('should be able to splice text', () => {
       const doc = create()
       const text = doc.putObject("_root", "text", "");

--- a/rust/automerge/src/autocommit.rs
+++ b/rust/automerge/src/autocommit.rs
@@ -403,6 +403,12 @@ impl AutoCommit {
         bytes
     }
 
+    /// Save everything which is not a (transitive) dependency of `heads`
+    pub fn save_after(&mut self, heads: &[ChangeHash]) -> Vec<u8> {
+        self.ensure_transaction_closed();
+        self.doc.save_after(heads)
+    }
+
     pub fn get_missing_deps(&mut self, heads: &[ChangeHash]) -> Vec<ChangeHash> {
         self.ensure_transaction_closed();
         self.doc.get_missing_deps(heads)


### PR DESCRIPTION
In the rust codebase we have a method `Automerge::save_after` which saves the changes since a given set of heads. Expose this as `saveSince` in javascript so that users can implement things like `saveIncremental` in user space.