### PR TITLE
Test and fix for finding a string in a `next` list

### DIFF
--- a/javascript/src/proxies.ts
+++ b/javascript/src/proxies.ts
@@ -609,7 +609,12 @@ function listMethods<T extends Target>(target: T) {
       const length = context.length(objectId)
       for (let i = start; i < length; i++) {
         const value = context.getWithType(objectId, i)
-        if (value && (value[1] === o[OBJECT_ID] || value[1] === o)) {
+        if (
+          value &&
+          (value[1] === o[OBJECT_ID] ||
+            value[1] === o ||
+            valueAt(target, i) === o)
+        ) {
           return i
         }
       }

--- a/javascript/test/proxies.ts
+++ b/javascript/test/proxies.ts
@@ -1,6 +1,6 @@
 import * as assert from "assert"
 import { beforeEach } from "mocha"
-import { type Doc, from, change } from "../src/index.js"
+import { type Doc, from, change, next } from "../src/index.js"
 
 type DocType = {
   list: string[]
@@ -8,8 +8,10 @@ type DocType = {
 
 describe("Proxies", () => {
   let doc: Doc<DocType>
+  let nextDoc: Doc<DocType>
   beforeEach(() => {
     doc = from({ list: ["a", "b", "c"] })
+    nextDoc = next.from({ list: ["a", "b", "c"] })
   })
 
   describe("List Iterators", () => {
@@ -47,6 +49,24 @@ describe("Proxies", () => {
         }
 
         assert.equal(count, 0)
+      })
+    })
+  })
+
+  describe("List indexOf", () => {
+    it("should return the index of a value", () => {
+      change(doc, d => {
+        assert.equal(d.list.indexOf("b"), 1)
+      })
+
+      change(nextDoc, d => {
+        assert.equal(d.list.indexOf("b"), 1)
+      })
+    })
+
+    it("should return -1 if the value is not found", () => {
+      change(doc, d => {
+        assert.equal(d.list.indexOf("d"), -1)
       })
     })
   })


### PR DESCRIPTION
When looking for a string in a list of `next` strings using indexOf, the current logic only matches if we are looking for the exact `String` object, not the string value.

This adds a check for the string value itself too along with a rudimentary test.