### PR TITLE
Use correct module format for commonjs

### DIFF
--- a/javascript/config/cjs.json
+++ b/javascript/config/cjs.json
@@ -1,4 +1,7 @@
 {
+  "compilerOptions": {
+    "module": "commonjs"
+  },
   "extends": "../tsconfig.json",
   "exclude": [
     "../dist/**/*",


### PR DESCRIPTION
Problem: In the last set of changes we migrated the main tsconfig for @automerge/automerge to ouput ES modules. This tsconfig is included in the tsconfigs used to produce the commonjs output which means that the modules in `dist/cjs` were in fact ES modules and consequently commonjs applications barfed when importing.

Solution: Set `"module": "commonjs"` in `javascript/config/cjs.json` so that we continue to output commonjs modules for commonjs dependents.

Fixes #718 