### PR TITLE
Fix missing marks at end of text

### DIFF
--- a/rust/automerge/src/op_tree.rs
+++ b/rust/automerge/src/op_tree.rs
@@ -105,7 +105,7 @@ impl<'a> FoundOpWithPatchLog<'a> {
                         &obj.id,
                         query::SeekMark::new(op.id.prev(), self.pos, obj.encoding),
                     );
-                    for mark in q.marks {
+                    for mark in q.finish() {
                         let index = mark.start;
                         let len = mark.len();
                         let marks = mark.into_mark_set();

--- a/rust/automerge/tests/test_mark_patches.rs
+++ b/rust/automerge/tests/test_mark_patches.rs
@@ -1,0 +1,39 @@
+use automerge::{
+    marks::{ExpandMark, Mark},
+    transaction::Transactable,
+    ObjType, PatchAction, ROOT,
+};
+use test_log::test;
+
+#[test]
+fn mark_patches_at_end_of_text() {
+    let mut doc1 = automerge::AutoCommit::new();
+    let text = doc1.put_object(ROOT, "text", ObjType::Text).unwrap();
+    doc1.splice_text(&text, 0, 0, "sample").unwrap();
+    let heads_before_mark = doc1.get_heads();
+    let mut doc2 = automerge::AutoCommit::load(&doc1.save()).unwrap();
+
+    doc1.mark(
+        &text,
+        Mark::new("bold".to_string(), true, 5, 6),
+        ExpandMark::After,
+    )
+    .unwrap();
+
+    // Pop the patches
+    doc2.diff_incremental();
+    let changes_after_mark = doc1.save_after(&heads_before_mark);
+    doc2.load_incremental(&changes_after_mark).unwrap();
+
+    let mut patches = doc2.diff_incremental();
+    assert_eq!(patches.len(), 1, "no patches generated");
+    let patch = patches.pop().unwrap();
+    assert_eq!(patch.obj, text);
+    assert_eq!(patch.path, vec![(ROOT, "text".into())]);
+    let PatchAction::Mark { mut marks } = patch.action else {
+        panic!("Expected a mark patch, got {:?}", patch.action);
+    };
+    assert_eq!(marks.len(), 1);
+    let mark = marks.pop().unwrap();
+    assert_eq!(mark.name(), "bold");
+}


### PR DESCRIPTION
Problem: Applying a change which adds a mark to the last character in a text object would not generate a patch for the change in question. The reason this occurs is to do with the fact that  marks are implemented as two consecutive operations, a `MarkBegin` op and a `MarkEnd` op. The logic to determine whether to generate a patch is implemented as a `TreeQuery` (specifically, as `SeekMark`). The `TreeQuery` gets called for every element in the text sequence and scans through looking for the last `MarkBegin` of the same type as the target `MarkEnd`, and then counts indices until the insertion index is encountered. This fails if the insertion index is at the end of the sequence because the `TreeQuery` never gets called.

Solution: Add a `SeekMark::finish` method which checks if the end mark was ever found and if it wasn't assumes that the mark ended at the last index of the sequence.

Fixes #716 