### PR TITLE
automerge-c: External build support

### DIFF
--- a/rust/automerge-c/CMakeLists.txt
+++ b/rust/automerge-c/CMakeLists.txt
@@ -4,37 +4,46 @@ project(automerge-c VERSION 0.2.1
                     LANGUAGES C
                     DESCRIPTION "C bindings for the Automerge Rust library.")
 
-set(LIBRARY_NAME "automerge")
-
-set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
-
-option(BUILD_SHARED_LIBS "Enable the choice of a shared or static library.")
-
-option(UTF32_INDEXING "Enable UTF-32 indexing.")
-
 include(CTest)
 
 include(CMakePackageConfigHelpers)
 
 include(GNUInstallDirs)
 
-set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
+list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake")
+
+set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
+
+set(DEFAULT_LIBRARY_NAME "automerge")
+
+set(LIBRARY_NAME "${DEFAULT_LIBRARY_NAME}" CACHE STRING "The library's name.")
+
+set(DEFAULT_BINDINGS_NAME "${DEFAULT_LIBRARY_NAME}_core")
+
+set(BINDINGS_NAME "${DEFAULT_BINDINGS_NAME}" CACHE STRING "The bindings' name.")
+
+set(LIBRARY_PREFIX "${CMAKE_STATIC_LIBRARY_PREFIX}" CACHE STRING "An output library's prefix.")
+
+set(LIBRARY_SUFFIX "${CMAKE_STATIC_LIBRARY_SUFFIX}" CACHE STRING "An output library's suffix.")
+
+option(BUILD_SHARED_LIBS "Enable the choice of a shared or static library.")
+
+option(UTF32_INDEXING "Enable UTF-32 indexing.")
 
 string(MAKE_C_IDENTIFIER ${PROJECT_NAME} SYMBOL_PREFIX)
 
 string(TOUPPER ${SYMBOL_PREFIX} SYMBOL_PREFIX)
 
-set(CARGO_TARGET_DIR "${CMAKE_BINARY_DIR}/Cargo/target")
+set(CARGO_TARGET_DIR "${PROJECT_BINARY_DIR}/Cargo/target")
 
-set(CBINDGEN_INCLUDEDIR "${CMAKE_BINARY_DIR}/${CMAKE_INSTALL_INCLUDEDIR}")
+set(CBINDGEN_INCLUDEDIR "${PROJECT_BINARY_DIR}/${CMAKE_INSTALL_INCLUDEDIR}")
 
 set(CBINDGEN_TARGET_DIR "${CBINDGEN_INCLUDEDIR}/${PROJECT_NAME}")
 
-find_program (
-    CARGO_CMD
-    "cargo"
-    PATHS "$ENV{CARGO_HOME}/bin"
-    DOC "The Cargo command"
+find_program (CARGO_CMD
+              "cargo"
+              PATHS "$ENV{CARGO_HOME}/bin"
+              DOC "The Rust package manager"
 )
 
 if(NOT CARGO_CMD)
@@ -43,12 +52,22 @@ if(NOT CARGO_CMD)
                         "environment variable to its path.")
 endif()
 
-string(TOLOWER "${CMAKE_BUILD_TYPE}" BUILD_TYPE_LOWER)
+find_program(RUSTC_CMD
+             "rustc"
+             PATHS "$ENV{CARGO_HOME}/bin"
+             DOC "The Rust compiler"
+)
+
+if(NOT RUSTC_CMD)
+    message(FATAL_ERROR "Rustc (Rust compiler) not found! "
+                        "Please install it and/or set the CARGO_HOME "
+                        "environment variable to its path.")
+endif()
 
 # In order to build with -Z build-std, we need to pass target explicitly.
 # https://doc.rust-lang.org/cargo/reference/unstable.html#build-std
 execute_process (
-    COMMAND rustc -vV
+    COMMAND ${RUSTC_CMD} -vV
     OUTPUT_VARIABLE RUSTC_VERSION
     OUTPUT_STRIP_TRAILING_WHITESPACE
 )
@@ -57,10 +76,12 @@ string(REGEX REPLACE ".*host: ([^ \n]*).*" "\\1"
     ${RUSTC_VERSION}
 )
 
-if(BUILD_TYPE_LOWER STREQUAL debug)
-    set(CARGO_BUILD_TYPE "debug")
+set(CARGO_FLAGS --target=${CARGO_TARGET})
 
-    set(CARGO_FLAG --target=${CARGO_TARGET})
+set(RUSTFLAGS "")
+
+if(CMAKE_BUILD_TYPE MATCHES Debug)
+    set(CARGO_BUILD_TYPE "debug")
 else()
     set(CARGO_BUILD_TYPE "release")
 
@@ -68,9 +89,9 @@ else()
         set(RUSTUP_TOOLCHAIN nightly)
     endif()
 
-    set(RUSTFLAGS -C\ panic=abort)
+    set(RUSTFLAGS "${RUSTFLAGS} -C panic=abort")
 
-    set(CARGO_FLAG -Z build-std=std,panic_abort --release --target=${CARGO_TARGET})
+    set(CARGO_FLAGS -Z build-std=std,panic_abort --release ${CARGO_FLAGS})
 endif()
 
 if(UTF32_INDEXING)
@@ -83,11 +104,9 @@ endif()
 
 set(CARGO_BINARY_DIR "${CARGO_TARGET_DIR}/${CARGO_TARGET}/${CARGO_BUILD_TYPE}")
 
-set(BINDINGS_NAME "${LIBRARY_NAME}_core")
-
 configure_file(
-    ${CMAKE_MODULE_PATH}/Cargo.toml.in
-    ${CMAKE_SOURCE_DIR}/Cargo.toml
+    ${PROJECT_SOURCE_DIR}/cmake/Cargo.toml.in
+    ${PROJECT_SOURCE_DIR}/Cargo.toml
     @ONLY
     NEWLINE_STYLE LF
 )
@@ -95,8 +114,8 @@ configure_file(
 set(INCLUDE_GUARD_PREFIX "${SYMBOL_PREFIX}")
 
 configure_file(
-    ${CMAKE_MODULE_PATH}/cbindgen.toml.in
-    ${CMAKE_SOURCE_DIR}/cbindgen.toml
+    ${PROJECT_SOURCE_DIR}/cmake/cbindgen.toml.in
+    ${PROJECT_SOURCE_DIR}/cbindgen.toml
     @ONLY
     NEWLINE_STYLE LF
 )
@@ -112,17 +131,16 @@ add_custom_command(
     OUTPUT
         ${CARGO_OUTPUT}
     COMMAND
-        # \note cbindgen won't regenerate its output header file after it's been removed but it will after its
-        #       configuration file has been updated.
-        ${CMAKE_COMMAND} -DCONDITION=NOT_EXISTS -P ${CMAKE_SOURCE_DIR}/cmake/file-touch.cmake -- ${CBINDGEN_TARGET_DIR}/${LIBRARY_NAME}.h ${CMAKE_SOURCE_DIR}/cbindgen.toml
+        # Force cbindgen to regenerate the header file by updating its configuration file; removing the header won't.
+        ${CMAKE_COMMAND} -DCONDITION=NOT_EXISTS -P ${PROJECT_SOURCE_DIR}/cmake/file-touch.cmake -- ${CBINDGEN_TARGET_DIR}/${LIBRARY_NAME}.h ${PROJECT_SOURCE_DIR}/cbindgen.toml
     COMMAND
-        ${CMAKE_COMMAND} -E env CARGO_TARGET_DIR=${CARGO_TARGET_DIR} CBINDGEN_TARGET_DIR=${CBINDGEN_TARGET_DIR} RUSTUP_TOOLCHAIN=${RUSTUP_TOOLCHAIN} RUSTFLAGS=${RUSTFLAGS} ${CARGO_CMD} build ${CARGO_FLAG} ${CARGO_FEATURES}
+        ${CMAKE_COMMAND} -E env CARGO_TARGET_DIR=${CARGO_TARGET_DIR} CBINDGEN_TARGET_DIR=${CBINDGEN_TARGET_DIR} RUSTUP_TOOLCHAIN=${RUSTUP_TOOLCHAIN} RUSTFLAGS=${RUSTFLAGS} ${CARGO_CMD} build ${CARGO_FLAGS} ${CARGO_FEATURES}
     COMMAND
         # Compensate for cbindgen's translation of consecutive uppercase letters to "ScreamingSnakeCase".
-        ${CMAKE_COMMAND} -DMATCH_REGEX=A_M\([^_]+\)_ -DREPLACE_EXPR=AM_\\1_ -P ${CMAKE_SOURCE_DIR}/cmake/file-regex-replace.cmake -- ${CBINDGEN_TARGET_DIR}/${LIBRARY_NAME}.h
+        ${CMAKE_COMMAND} -DMATCH_REGEX=A_M\([^_]+\)_ -DREPLACE_EXPR=AM_\\1_ -P ${PROJECT_SOURCE_DIR}/cmake/file-regex-replace.cmake -- ${CBINDGEN_TARGET_DIR}/${LIBRARY_NAME}.h
     COMMAND
-        # Compensate for cbindgen ignoring `std:mem::size_of<usize>()` calls.
-        ${CMAKE_COMMAND} -DMATCH_REGEX=USIZE_ -DREPLACE_EXPR=\+${CMAKE_SIZEOF_VOID_P} -P ${CMAKE_SOURCE_DIR}/cmake/file-regex-replace.cmake -- ${CBINDGEN_TARGET_DIR}/${LIBRARY_NAME}.h
+        # Compensate for cbindgen ignoring `std::mem::size_of<usize>()` calls.
+        ${CMAKE_COMMAND} -DMATCH_REGEX=USIZE_ -DREPLACE_EXPR=\+${CMAKE_SIZEOF_VOID_P} -P ${PROJECT_SOURCE_DIR}/cmake/file-regex-replace.cmake -- ${CBINDGEN_TARGET_DIR}/${LIBRARY_NAME}.h
     MAIN_DEPENDENCY
         src/lib.rs
     DEPENDS
@@ -143,11 +161,11 @@ add_custom_command(
         src/sync/have.rs
         src/sync/message.rs
         src/sync/state.rs
-        ${CMAKE_SOURCE_DIR}/build.rs
-        ${CMAKE_MODULE_PATH}/Cargo.toml.in
-        ${CMAKE_MODULE_PATH}/cbindgen.toml.in
+        ${PROJECT_SOURCE_DIR}/build.rs
+        ${PROJECT_SOURCE_DIR}/cmake/Cargo.toml.in
+        ${PROJECT_SOURCE_DIR}/cmake/cbindgen.toml.in
     WORKING_DIRECTORY
-        ${CMAKE_SOURCE_DIR}
+        ${PROJECT_SOURCE_DIR}
     COMMENT
         "Producing the bindings' artifacts with Cargo..."
     VERBATIM
@@ -156,6 +174,26 @@ add_custom_command(
 add_custom_target(${BINDINGS_NAME}_artifacts ALL
     DEPENDS ${CARGO_OUTPUT}
 )
+
+# Enable an external build tool to find the bindings in the root of the
+# out-of-source build directory when it has overridden an aspect of its name.
+if(NOT (("${LIBRARY_PREFIX}" STREQUAL "${CMAKE_STATIC_LIBRARY_PREFIX}") AND
+        ("${BINDINGS_NAME}" STREQUAL "${DEFAULT_BINDINGS_NAME}") AND
+        ("${LIBRARY_SUFFIX}" STREQUAL "${CMAKE_STATIC_LIBRARY_SUFFIX}")))
+    add_custom_command(
+        TARGET ${BINDINGS_NAME}_artifacts
+        POST_BUILD
+        COMMAND
+            ${CMAKE_COMMAND} -E echo "Copying \"${CARGO_BINARY_DIR}/${CMAKE_STATIC_LIBRARY_PREFIX}${BINDINGS_NAME}${CMAKE_STATIC_LIBRARY_SUFFIX}\" to \"${PROJECT_BINARY_DIR}/${LIBRARY_PREFIX}${BINDINGS_NAME}${LIBRARY_SUFFIX}\"..."
+        COMMAND
+            ${CMAKE_COMMAND} -E copy ${CARGO_BINARY_DIR}/${CMAKE_STATIC_LIBRARY_PREFIX}${BINDINGS_NAME}${CMAKE_STATIC_LIBRARY_SUFFIX} ${PROJECT_BINARY_DIR}/${LIBRARY_PREFIX}${BINDINGS_NAME}${LIBRARY_SUFFIX}
+        WORKING_DIRECTORY
+            ${PROJECT_SOURCE_DIR}
+        COMMENT
+            "Aliasing the bindings for the external build tool..."
+        VERBATIM
+    )
+endif()
 
 add_library(${BINDINGS_NAME} STATIC IMPORTED GLOBAL)
 
@@ -187,15 +225,15 @@ set(UTILS_SUBDIR "utils")
 add_custom_command(
     OUTPUT
         ${CBINDGEN_TARGET_DIR}/${UTILS_SUBDIR}/enum_string.h
-        ${CMAKE_BINARY_DIR}/src/${UTILS_SUBDIR}/enum_string.c
+        ${PROJECT_BINARY_DIR}/src/${UTILS_SUBDIR}/enum_string.c
     COMMAND
-        ${CMAKE_COMMAND} -DPROJECT_NAME=${PROJECT_NAME} -DLIBRARY_NAME=${LIBRARY_NAME} -DSUBDIR=${UTILS_SUBDIR} -P ${CMAKE_SOURCE_DIR}/cmake/enum-string-functions-gen.cmake -- ${CBINDGEN_TARGET_DIR}/${LIBRARY_NAME}.h ${CBINDGEN_TARGET_DIR}/${UTILS_SUBDIR}/enum_string.h ${CMAKE_BINARY_DIR}/src/${UTILS_SUBDIR}/enum_string.c
+        ${CMAKE_COMMAND} -DPROJECT_NAME=${PROJECT_NAME} -DLIBRARY_NAME=${LIBRARY_NAME} -DSUBDIR=${UTILS_SUBDIR} -P ${PROJECT_SOURCE_DIR}/cmake/enum-string-functions-gen.cmake -- ${CBINDGEN_TARGET_DIR}/${LIBRARY_NAME}.h ${CBINDGEN_TARGET_DIR}/${UTILS_SUBDIR}/enum_string.h ${PROJECT_BINARY_DIR}/src/${UTILS_SUBDIR}/enum_string.c
     MAIN_DEPENDENCY
         ${CBINDGEN_TARGET_DIR}/${LIBRARY_NAME}.h
     DEPENDS
-        ${CMAKE_SOURCE_DIR}/cmake/enum-string-functions-gen.cmake
+        ${PROJECT_SOURCE_DIR}/cmake/enum-string-functions-gen.cmake
     WORKING_DIRECTORY
-        ${CMAKE_SOURCE_DIR}
+        ${PROJECT_SOURCE_DIR}
     COMMENT
         "Generating the enum string functions with CMake..."
     VERBATIM
@@ -203,7 +241,7 @@ add_custom_command(
 
 add_custom_target(${LIBRARY_NAME}_utilities
     DEPENDS ${CBINDGEN_TARGET_DIR}/${UTILS_SUBDIR}/enum_string.h
-            ${CMAKE_BINARY_DIR}/src/${UTILS_SUBDIR}/enum_string.c
+            ${PROJECT_BINARY_DIR}/src/${UTILS_SUBDIR}/enum_string.c
 )
 
 add_library(${LIBRARY_NAME})
@@ -233,11 +271,31 @@ target_link_libraries(${LIBRARY_NAME}
 #       contain a non-existent path so its build-time include directory
 #       must be specified for all of its dependent targets instead.
 target_include_directories(${LIBRARY_NAME}
-    PUBLIC "$<BUILD_INTERFACE:${CBINDGEN_INCLUDEDIR};${CMAKE_SOURCE_DIR}/${CMAKE_INSTALL_INCLUDEDIR}>"
+    PUBLIC "$<BUILD_INTERFACE:${CBINDGEN_INCLUDEDIR};${PROJECT_SOURCE_DIR}/${CMAKE_INSTALL_INCLUDEDIR}>"
            "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>"
 )
 
 add_dependencies(${LIBRARY_NAME} ${BINDINGS_NAME}_artifacts)
+
+# Enable an external build tool to find the library in the root of the
+# out-of-source build directory when it has overridden an aspect of its name.
+if(NOT (("${LIBRARY_PREFIX}" STREQUAL "${CMAKE_STATIC_LIBRARY_PREFIX}") AND
+        ("${LIBRARY_NAME}" STREQUAL "${DEFAULT_LIBRARY_NAME}") AND
+        ("${LIBRARY_SUFFIX}" STREQUAL "${CMAKE_STATIC_LIBRARY_SUFFIX}")))
+    add_custom_command(
+        TARGET ${LIBRARY_NAME}
+        POST_BUILD
+        COMMAND
+            ${CMAKE_COMMAND} -E echo "Copying \"${CMAKE_STATIC_LIBRARY_PREFIX}${LIBRARY_NAME}${CMAKE_STATIC_LIBRARY_SUFFIX}\" to \"${PROJECT_BINARY_DIR}/${LIBRARY_PREFIX}${LIBRARY_NAME}${LIBRARY_SUFFIX}\"..."
+        COMMAND
+            ${CMAKE_COMMAND} -E copy ${PROJECT_BINARY_DIR}/${CMAKE_STATIC_LIBRARY_PREFIX}${LIBRARY_NAME}${CMAKE_STATIC_LIBRARY_SUFFIX} ${PROJECT_BINARY_DIR}/${LIBRARY_PREFIX}${LIBRARY_NAME}${LIBRARY_SUFFIX}
+        WORKING_DIRECTORY
+            ${PROJECT_SOURCE_DIR}
+        COMMENT
+            "Aliasing the library for the external build tool..."
+        VERBATIM
+    )
+endif()
 
 # Generate the configuration header.
 math(EXPR INTEGER_PROJECT_VERSION_MAJOR "${PROJECT_VERSION_MAJOR} * 100000")
@@ -251,7 +309,7 @@ math(EXPR INTEGER_PROJECT_VERSION "${INTEGER_PROJECT_VERSION_MAJOR} + \
                                    ${INTEGER_PROJECT_VERSION_PATCH}")
 
 configure_file(
-    ${CMAKE_MODULE_PATH}/config.h.in
+    ${PROJECT_SOURCE_DIR}/cmake/config.h.in
     ${CBINDGEN_TARGET_DIR}/config.h
     @ONLY
     NEWLINE_STYLE LF
@@ -263,19 +321,19 @@ target_sources(${LIBRARY_NAME}
         src/${UTILS_SUBDIR}/stack_callback_data.c
         src/${UTILS_SUBDIR}/stack.c
         src/${UTILS_SUBDIR}/string.c
-        ${CMAKE_BINARY_DIR}/src/${UTILS_SUBDIR}/enum_string.c
+        ${PROJECT_BINARY_DIR}/src/${UTILS_SUBDIR}/enum_string.c
     PUBLIC
         FILE_SET api TYPE HEADERS
             BASE_DIRS
                 ${CBINDGEN_INCLUDEDIR}
-                ${CMAKE_SOURCE_DIR}/${CMAKE_INSTALL_INCLUDEDIR}
+                ${CMAKE_INSTALL_INCLUDEDIR}
             FILES
                 ${CBINDGEN_TARGET_DIR}/${LIBRARY_NAME}.h
                 ${CBINDGEN_TARGET_DIR}/${UTILS_SUBDIR}/enum_string.h
-                ${CMAKE_SOURCE_DIR}/${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}/${UTILS_SUBDIR}/result.h
-                ${CMAKE_SOURCE_DIR}/${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}/${UTILS_SUBDIR}/stack_callback_data.h
-                ${CMAKE_SOURCE_DIR}/${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}/${UTILS_SUBDIR}/stack.h
-                ${CMAKE_SOURCE_DIR}/${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}/${UTILS_SUBDIR}/string.h
+                ${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}/${UTILS_SUBDIR}/result.h
+                ${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}/${UTILS_SUBDIR}/stack_callback_data.h
+                ${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}/${UTILS_SUBDIR}/stack.h
+                ${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}/${UTILS_SUBDIR}/string.h
     INTERFACE
         FILE_SET config TYPE HEADERS
             BASE_DIRS
@@ -312,3 +370,4 @@ endif()
 add_subdirectory(docs)
 
 add_subdirectory(examples EXCLUDE_FROM_ALL)
+


### PR DESCRIPTION
@orionz and @alexjg, these changes enable an external build tool—like SCons—to delegate the building of the automerge-c library to CMake instead of requiring its CMake build configuration to be translated into the external build tool's native configuration.