### PR TITLE
add toString() method to RawString object

### DIFF
--- a/javascript/src/proxies.ts
+++ b/javascript/src/proxies.ts
@@ -154,7 +154,7 @@ function import_value(value: any, textV2: boolean): ImportedValue {
       } else if (value instanceof Date) {
         return [value.getTime(), "timestamp"]
       } else if (value instanceof RawString) {
-        return [value.val, "str"]
+        return [value.toString(), "str"]
       } else if (value instanceof Text) {
         return [value, "text"]
       } else if (value instanceof Uint8Array) {

--- a/javascript/src/raw_string.ts
+++ b/javascript/src/raw_string.ts
@@ -3,4 +3,11 @@ export class RawString {
   constructor(val: string) {
     this.val = val
   }
+
+  /**
+   * Returns the content of the RawString object as a simple string
+   */
+  toString(): string {
+    return this.val;
+  }
 }


### PR DESCRIPTION
@orionz , @issackelly This PR adds a `toString()` method to the `RawString` class. This makes it easier to uniformly handle `string` and `RawString` in code, as you can simply call `toString()` on any value of either type and get a string representation of it.