### PR TITLE
js: Transpile ESM to CommonJS

### DIFF
--- a/javascript/package.json
+++ b/javascript/package.json
@@ -14,24 +14,25 @@
     "package.json",
     "dist/index.d.ts",
     "dist/cjs/**/*.js",
+    "dist/cjs/**/*.cjs",
     "dist/mjs/**/*.js",
     "dist/*.d.ts"
   ],
   "type": "module",
   "types": "./dist/index.d.ts",
   "module": "./dist/mjs/index.js",
-  "main": "./dist/cjs/index.js",
+  "main": "./dist/cjs/index.cjs",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/mjs/index.js",
-      "require": "./dist/cjs/index.js",
+      "require": "./dist/cjs/index.cjs",
       "default": "./dist/mjs/index.js"
     },
     "./next": {
       "types": "./dist/next.d.ts",
       "import": "./dist/mjs/next.js",
-      "require": "./dist/cjs/next.js",
+      "require": "./dist/cjs/next.cjs",
       "default": "./dist/mjs/next.js"
     }
   },
@@ -40,7 +41,7 @@
     "lint": "eslint src",
     "check-fmt": "prettier -c .prettierrc --check",
     "fmt": "prettier -c .prettierrc -w",
-    "build": "tsc -p config/mjs.json && tsc -p config/cjs.json && tsc -p config/declonly.json --emitDeclarationOnly",
+    "build": "tsc -p config/mjs.json && node ./scripts/transpile-cjs.mjs && tsc -p config/declonly.json --emitDeclarationOnly",
     "test": "ts-mocha --loader=ts-node/esm --experimental-specifier-resolution=node --type-check test/*.ts",
     "deno:build": "denoify && node ./scripts/deno-prefixer.mjs",
     "deno:test": "deno test ./deno-tests/deno.ts --allow-read --allow-net",
@@ -54,6 +55,7 @@
     "@typescript-eslint/eslint-plugin": "^5.46.0",
     "@typescript-eslint/parser": "^5.46.0",
     "denoify": "1.4.5",
+    "esbuild": "^0.19.2",
     "eslint": "^8.29.0",
     "fast-sha256": "^1.3.0",
     "mocha": "^10.2.0",

--- a/javascript/scripts/transpile-cjs.mjs
+++ b/javascript/scripts/transpile-cjs.mjs
@@ -1,0 +1,23 @@
+import { build } from "esbuild"
+import { fileURLToPath } from "url"
+import { dirname } from "path"
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = dirname(__filename)
+
+const projectDir = `${__dirname}/..`
+const distDir = `${projectDir}/dist`
+const inDir = `${distDir}/mjs`
+const outDir = `${distDir}/cjs`
+
+await build({
+  absWorkingDir: distDir,
+  entryPoints: [`${inDir}/*.js`],
+  outdir: outDir,
+  bundle: true,
+  packages: "external",
+  format: "cjs",
+  target: "node14",
+  platform: "node",
+  outExtension: { ".js": ".cjs" },
+})


### PR DESCRIPTION
Problem: Previously, in 5f43505bc88d8789b9279c88505280559cb83443 I modified the typescript config to output commonjs modules for commonjs consumers. However, the module format being correct doesn't actually fix things because when loading the module the loader (well, node at least) notices that the package the cjs output is in has `"type": "module"` and so attempts to load the JS as ESM modules and chokes.

Solution: Output the js files in `dist/cjs` with a `*.cjs` suffix. This lets node know that these files are definitely absolutely commonJS modules and please load them as commonjs modules, thank you. Unfortunately `tsc` won't do this for us as it requires not just renaming the output files, but also rewriting the import paths in the transformed files to havea a `*.cjs` suffix and typescript has a design principle of never rewriting imports. This means that we instead use `esbuild` to transform the ESM output to CJS.