### PR TITLE
Convert strings to text on load

### DIFF
--- a/javascript/src/next.ts
+++ b/javascript/src/next.ts
@@ -132,6 +132,16 @@ export type InitOptions<T> = {
   unchecked?: boolean
   /** Allow loading a document with missing changes */
   allowMissingChanges?: boolean
+  /** Whether to convert raw string to text objects
+   *
+   * @remarks
+   * This is useful if you have some documents which were created using the older API which represented
+   * text as the `Text` class and you are migrating to the new API where text is just a `string`. In
+   * this case the strings from the old document will appear as `RawString`s in the new document. This
+   * option will convert those `RawString`s to `Text` objects. This conversion is achieved by rewriting
+   * all the old string fields to new text fields
+   **/
+  convertRawStringsToText?: boolean
 }
 
 import { ActorId, Doc } from "./stable.js"

--- a/javascript/src/stable.ts
+++ b/javascript/src/stable.ts
@@ -162,6 +162,8 @@ export type InitOptions<T> = {
   unchecked?: boolean
   /** Allow loading a document with missing changes */
   allowMissingChanges?: boolean
+  /** @hidden */
+  convertRawStringsToText?: boolean
 }
 
 /** @hidden */
@@ -611,11 +613,13 @@ export function load<T>(
   const text_v1 = !(opts.enableTextV2 || false)
   const unchecked = opts.unchecked || false
   const allowMissingDeps = opts.allowMissingChanges || false
+  const convertRawStringsToText = opts.convertRawStringsToText || false
   const handle = ApiHandler.load(data, {
     text_v1,
     actor,
     unchecked,
     allowMissingDeps,
+    convertRawStringsToText,
   })
   handle.enableFreeze(!!opts.freeze)
   handle.registerDatatype("counter", (n: number) => new Counter(n))

--- a/javascript/test/stable_unstable_interop.ts
+++ b/javascript/test/stable_unstable_interop.ts
@@ -93,4 +93,24 @@ describe("old/next interop", () => {
     })
     assert.deepStrictEqual(doc.list, ["abc", "def"])
   })
+
+  it("should allow converting scalar strings from old docs to text in new docs", () => {
+    type DocType = {
+      text: string
+      nested: { text: string }
+      list: [string]
+    }
+    const old_doc = old.from<DocType>({
+      text: "abc",
+      nested: { text: "def" },
+      list: ["ghi"],
+    })
+    const saved = old.save(old_doc)
+    const next_doc = next.load<DocType>(saved, {
+      convertRawStringsToText: true,
+    })
+    assert.deepStrictEqual(next_doc.text, "abc")
+    assert.deepStrictEqual(next_doc.nested.text, "def")
+    assert.deepStrictEqual(next_doc.list[0], "ghi")
+  })
 })

--- a/rust/automerge-wasm/index.d.ts
+++ b/rust/automerge-wasm/index.d.ts
@@ -304,6 +304,7 @@ export type LoadOptions = {
   text_v1?: boolean,
   unchecked?: boolean,
   allowMissingDeps?: boolean,
+  convertRawStringsToText?: boolean,
 }
 
 export type InitOptions = {

--- a/rust/automerge-wasm/src/lib.rs
+++ b/rust/automerge-wasm/src/lib.rs
@@ -984,8 +984,13 @@ pub fn load(data: Uint8Array, options: JsValue) -> Result<Automerge, error::Load
     } else {
         OnPartialLoad::Error
     };
-    let mut doc = am::AutoCommit::load_with(&data, on_partial_load, verification_mode)?
-        .with_text_rep(text_rep.into());
+    let mut doc = am::AutoCommit::load_with_options(
+        &data,
+        am::LoadOptions::new()
+            .on_partial_load(on_partial_load)
+            .verification_mode(verification_mode),
+    )?
+    .with_text_rep(text_rep.into());
     if let Some(s) = actor {
         let actor =
             automerge::ActorId::from(hex::decode(s).map_err(error::BadActorId::from)?.to_vec());

--- a/rust/automerge/src/autocommit.rs
+++ b/rust/automerge/src/autocommit.rs
@@ -9,13 +9,13 @@ use crate::patches::{PatchLog, TextRepresentation};
 use crate::sync::SyncDoc;
 use crate::transaction::{CommitOptions, Transactable};
 use crate::types::Clock;
-use crate::VerificationMode;
 use crate::{hydrate, OnPartialLoad};
 use crate::{sync, ObjType, Parents, Patch, ReadDoc, ScalarValue};
 use crate::{
     transaction::TransactionInner, ActorId, Automerge, AutomergeError, Change, ChangeHash, Cursor,
     Prop, Value,
 };
+use crate::{LoadOptions, VerificationMode};
 
 /// An automerge document that automatically manages transactions.
 ///
@@ -106,17 +106,25 @@ impl AutoCommit {
         })
     }
 
+    #[deprecated(since = "0.5.2", note = "use `load_with_options` instead")]
     pub fn load_with(
         data: &[u8],
         on_error: OnPartialLoad,
         mode: VerificationMode,
     ) -> Result<Self, AutomergeError> {
-        let doc = Automerge::load_with(
+        Self::load_with_options(
             data,
-            on_error,
-            mode,
-            &mut PatchLog::inactive(TextRepresentation::default()),
-        )?;
+            LoadOptions::new()
+                .on_partial_load(on_error)
+                .verification_mode(mode),
+        )
+    }
+
+    pub fn load_with_options(
+        data: &[u8],
+        options: LoadOptions<'_>,
+    ) -> Result<Self, AutomergeError> {
+        let doc = Automerge::load_with_options(data, options)?;
         Ok(Self {
             doc,
             transaction: None,

--- a/rust/automerge/src/automerge/current_state.rs
+++ b/rust/automerge/src/automerge/current_state.rs
@@ -752,11 +752,12 @@ mod tests {
         }
 
         let mut patch_log = PatchLog::active(TextRepresentation::String);
-        let _doc = Automerge::load_with(
+        let _doc = Automerge::load_with_options(
             &fixture("counter_value_is_ok.automerge"),
-            crate::OnPartialLoad::Error,
-            crate::storage::VerificationMode::Check,
-            &mut patch_log,
+            crate::LoadOptions::new()
+                .on_partial_load(crate::OnPartialLoad::Error)
+                .verification_mode(crate::VerificationMode::Check)
+                .patch_log(&mut patch_log),
         )
         .unwrap();
         let p = _doc.make_patches(&mut patch_log);

--- a/rust/automerge/src/lib.rs
+++ b/rust/automerge/src/lib.rs
@@ -289,7 +289,7 @@ mod value;
 #[cfg(feature = "optree-visualisation")]
 mod visualisation;
 
-pub use crate::automerge::{Automerge, LoadOptions, OnPartialLoad, SaveOptions};
+pub use crate::automerge::{Automerge, LoadOptions, OnPartialLoad, SaveOptions, StringMigration};
 pub use autocommit::AutoCommit;
 pub use autoserde::AutoSerde;
 pub use change::{Change, LoadError as LoadChangeError};

--- a/rust/automerge/src/lib.rs
+++ b/rust/automerge/src/lib.rs
@@ -289,7 +289,7 @@ mod value;
 #[cfg(feature = "optree-visualisation")]
 mod visualisation;
 
-pub use crate::automerge::{Automerge, OnPartialLoad, SaveOptions};
+pub use crate::automerge::{Automerge, LoadOptions, OnPartialLoad, SaveOptions};
 pub use autocommit::AutoCommit;
 pub use autoserde::AutoSerde;
 pub use change::{Change, LoadError as LoadChangeError};

--- a/rust/automerge/tests/convert_string_to_text.rs
+++ b/rust/automerge/tests/convert_string_to_text.rs
@@ -1,0 +1,58 @@
+use automerge::{
+    transaction::Transactable, AutoCommit, LoadOptions, ObjType, ReadDoc, StringMigration, Value,
+    ROOT,
+};
+use test_log::test;
+
+#[test]
+fn test_strings_in_maps_are_converted_to_text() {
+    let mut doc = AutoCommit::new();
+    doc.put(ROOT, "somestring", "hello").unwrap();
+    let saved = doc.save();
+
+    let loaded = AutoCommit::load_with_options(
+        &saved,
+        LoadOptions::new().migrate_strings(StringMigration::ConvertToText),
+    )
+    .unwrap();
+
+    let val = loaded.get(ROOT, "somestring").unwrap();
+    let Some((val, obj_id)) = val else {
+        panic!("no value found for key 'somestring'");
+    };
+    let Value::Object(obj) = val else {
+        panic!("expected an object, found {:?}", val);
+    };
+    let ObjType::Text = obj else {
+        panic!("expected a text object, found {:?}", obj);
+    };
+    let text = loaded.text(obj_id).unwrap();
+    assert_eq!(text, "hello");
+}
+
+#[test]
+fn test_strings_in_lists_are_converted_to_text() {
+    let mut doc = AutoCommit::new();
+    let list = doc.put_object(ROOT, "list", ObjType::List).unwrap();
+    doc.insert(&list, 0, "hello").unwrap();
+    let saved = doc.save();
+
+    let loaded = AutoCommit::load_with_options(
+        &saved,
+        LoadOptions::new().migrate_strings(StringMigration::ConvertToText),
+    )
+    .unwrap();
+
+    let val = loaded.get(&list, 0).unwrap();
+    let Some((val, obj_id)) = val else {
+        panic!("no value found for key 'somestring'");
+    };
+    let Value::Object(obj) = val else {
+        panic!("expected an object, found {:?}", val);
+    };
+    let ObjType::Text = obj else {
+        panic!("expected a text object, found {:?}", obj);
+    };
+    let text = loaded.text(obj_id).unwrap();
+    assert_eq!(text, "hello");
+}


### PR DESCRIPTION
Add functionality to convert strings to text on load

Problem: As people transition to the new `next` JavaScript API they need to handle old data which is using scalar strings instead of text sequences. The way this manifests is that data which was a `string` in the old API appears as a `RawString` when loaded using the new API. This means that people have to either write code which handles both `RawString` and `string`, or write code which converts the `RawString` to `string`.

Solution: Offer an option to automatically convert the old strings (which are `ScalarValue::Str` in Rust) to text sequences when loading the document. This is achieved by actually adding a change to the document setting all visible string values to text values with the same contents. This isn't a complete solution because if you are syncing with someone who is still using the old version of the application you will end up flip flopping between the value the new application sees and the value the old application sees. However, having the option is still useful for applications who can coordinate some kind of data migration.
