### PR TITLE
js: check arguments to diff are actually arrays

### DIFF
--- a/javascript/src/stable.ts
+++ b/javascript/src/stable.ts
@@ -946,9 +946,17 @@ export function getHistory<T>(doc: Doc<T>): State<T>[] {
  *
  * If either of the heads are missing from the document the returned set of patches will be empty
  */
-export function diff(doc: Doc<any>, before: Heads, after: Heads): Patch[] {
+export function diff(doc: Doc<unknown>, before: Heads, after: Heads): Patch[] {
+  checkHeads(before, "before")
+  checkHeads(after, "after")
   const state = _state(doc)
   return state.handle.diff(before, after)
+}
+
+function checkHeads(heads: Heads, fieldname: string) {
+  if (!Array.isArray(heads)) {
+    throw new Error(`${fieldname} must be an array`)
+  }
 }
 
 /** @hidden */

--- a/javascript/test/patches.ts
+++ b/javascript/test/patches.ts
@@ -92,5 +92,25 @@ describe("patches", () => {
         { action: "splice", path: ["fish", 0, 0], value: "cod" },
       ])
     })
+
+    it("should throw a nice exception if before or after are not an array", () => {
+      let doc = Automerge.from({ text: "hello world" })
+      const goodBefore = Automerge.getHeads(doc)
+
+      doc = Automerge.change(doc, d => {
+        Automerge.splice(d, ["text"], 0, 0, "hello ")
+      })
+
+      const goodAfter = Automerge.getHeads(doc)
+
+      assert.throws(
+        () => Automerge.diff(doc, null as any, goodAfter),
+        /before must be an array/,
+      )
+      assert.throws(
+        () => Automerge.diff(doc, goodBefore, null as any),
+        /after must be an array/,
+      )
+    })
   })
 })


### PR DESCRIPTION
Problem: the typescript types for diff check that the arguments `before` and `after` are arrays of strings, but if the user ignores those types (or is using javascript) then we don't actually check at runtime that they are valid. These arrays get passed through to the wasm, which can explode messily.

Solution: throw a nice exception in `diff` so that at least the user can find out where they went wrong