### PR TITLE
automerge-c: Fix issue #738

### DIFF
--- a/rust/automerge-c/examples/quickstart.c
+++ b/rust/automerge-c/examples/quickstart.c
@@ -53,7 +53,7 @@ int main(int argc, char** argv) {
     AMitems changes = AMstackItems(&stack, AMgetChanges(doc1, NULL), abort_cb, AMexpect(AM_VAL_TYPE_CHANGE));
     AMitem* item = NULL;
     while ((item = AMitemsNext(&changes, 1)) != NULL) {
-        AMchange const* change;
+        AMchange* change;
         AMitemToChange(item, &change);
         AMitems const heads = AMstackItems(&stack, AMitemFromChangeHash(AMchangeHash(change)), abort_cb,
                                            AMexpect(AM_VAL_TYPE_CHANGE_HASH));
@@ -79,14 +79,15 @@ static bool abort_cb(AMstack** stack, void* data) {
 
     char const* suffix = NULL;
     if (!stack) {
-        suffix = "Stack*";
+        suffix = "stack*";
     } else if (!*stack) {
-        suffix = "Stack";
+        suffix = "stack";
     } else if (!(*stack)->result) {
-        suffix = "";
+        suffix = "result";
     }
     if (suffix) {
-        fprintf(stderr, "Null `AMresult%s*`.\n", suffix);
+        fprintf(stderr, "Null `AM%s*`.\n", suffix);
+        free(data);
         AMstackFree(stack);
         exit(EXIT_FAILURE);
         return false;
@@ -108,6 +109,7 @@ static bool abort_cb(AMstack** stack, void* data) {
         char* const c_msg = AMstrdup(AMresultError((*stack)->result), NULL);
         fprintf(stderr, "%s; %s.\n", buffer, c_msg);
         free(c_msg);
+        free(data);
         AMstackFree(stack);
         exit(EXIT_FAILURE);
         return false;
@@ -118,7 +120,7 @@ static bool abort_cb(AMstack** stack, void* data) {
         if (tag != sc_data->bitmask) {
             fprintf(stderr, "Unexpected tag `%s` (%d) instead of `%s` at %s:%d.\n", AMvalTypeToString(tag), tag,
                     AMvalTypeToString(sc_data->bitmask), sc_data->file, sc_data->line);
-            free(sc_data);
+            free(data);
             AMstackFree(stack);
             exit(EXIT_FAILURE);
             return false;

--- a/rust/automerge-c/test/cmocka_utils.c
+++ b/rust/automerge-c/test/cmocka_utils.c
@@ -72,6 +72,7 @@ bool cmocka_cb(AMstack** stack, void* data) {
     assert_non_null_where((*stack)->result, sc_data->file, sc_data->line);
     if (AMresultStatus((*stack)->result) != AM_STATUS_OK) {
         fail_msg_view_where("%s", AMresultError((*stack)->result), sc_data->file, sc_data->line);
+        free(data);
         return false;
     }
     /* Test that the types of all item values are members of the mask. */
@@ -81,8 +82,10 @@ bool cmocka_cb(AMstack** stack, void* data) {
         AMvalType const tag = AMitemValType(item);
         if (!(tag & sc_data->bitmask)) {
             fail_msg_where("Unexpected value type `%s`.", AMvalTypeToString(tag), sc_data->file, sc_data->line);
+            free(data);
             return false;
         }
     }
+    free(data);
     return true;
 }

--- a/rust/automerge-c/test/ported_wasm/basic_tests.c
+++ b/rust/automerge-c/test/ported_wasm/basic_tests.c
@@ -1126,7 +1126,7 @@ static void test_should_be_able_to_fetch_changes_by_hash(void** state) {
        null")  */
     AMbyteSpan change_hash1;
     assert_true(AMitemToChangeHash(AMitemsNext(&head1, 1), &change_hash1));
-    AMchange const* change1;
+    AMchange* change1;
     assert_true(AMitemToChange(AMstackItem(stack_ptr, AMgetChangeByHash(doc1, change_hash1.src, change_hash1.count),
                                            cmocka_cb, AMexpect(AM_VAL_TYPE_CHANGE)),
                                &change1));


### PR DESCRIPTION
* Changed `abort_cb()` to always free the  memory allocated for its `data` argument.
* Changed `cmocka_cb()` to always free the  memory allocated for its `data` argument.
* Prevented MSVC warning C4090 in `test_should_be_able_to_fetch_changes_by_hash()`.