### PR TITLE
Export list of change sources as array as well as type

### DIFF
--- a/javascript/src/next.ts
+++ b/javascript/src/next.ts
@@ -49,6 +49,7 @@ export {
   type AutomergeValue,
   type ScalarValue,
   type PatchSource,
+  PatchSources,
   type PatchInfo,
 } from "./next_types.js"
 

--- a/javascript/src/next_types.ts
+++ b/javascript/src/next_types.ts
@@ -14,6 +14,7 @@ export {
   type Cursor,
   type PatchInfo,
   type PatchSource,
+  PatchSources,
 } from "./types.js"
 
 import { RawString } from "./raw_string.js"

--- a/javascript/src/stable.ts
+++ b/javascript/src/stable.ts
@@ -24,6 +24,7 @@ export {
   type ScalarValue,
   type PatchInfo,
   type PatchSource,
+  PatchSources,
 } from "./types.js"
 
 import { Text } from "./text.js"

--- a/javascript/src/types.ts
+++ b/javascript/src/types.ts
@@ -34,15 +34,19 @@ export type MarkValue = string | number | null | boolean | Date | Uint8Array
  */
 export type Doc<T> = { readonly [P in keyof T]: T[P] }
 
-export type PatchSource =
-  | "from"
-  | "emptyChange"
-  | "change"
-  | "changeAt"
-  | "merge"
-  | "loadIncremental"
-  | "applyChanges"
-  | "receiveSyncMessage"
+export const PatchSources = [
+  "from",
+  "emptyChange",
+  "change",
+  "changeAt",
+  "merge",
+  "loadIncremental",
+  "applyChanges",
+  "receiveSyncMessage",
+] as const
+
+export type PatchSource = (typeof PatchSources)[number]
+
 export type PatchInfo<T> = {
   before: Doc<T>
   after: Doc<T>


### PR DESCRIPTION
PatchSources are currently defined as a type, but it is also useful to be able to check that a source is valid at runtime. This PR keeps the type the same, but also exports the list of sources as an array.