### PR TITLE
Cache the last patch on the document's InternalState

### DIFF
--- a/javascript/src/internal_state.ts
+++ b/javascript/src/internal_state.ts
@@ -8,6 +8,7 @@ export interface InternalState<T> {
   handle: Automerge
   heads: Heads | undefined
   freeze: boolean
+  mostRecentPatch: any // TODO: type this
   patchCallback?: PatchCallback<T>
   textV2: boolean
 }


### PR DESCRIPTION
I don't love this! But here it is, a band-aid for a performance problem.

## How it works

What this does is every time you call progressDocument, that patch is also cached on the new document. (LRU=1) When you make a new call to progressDocument, the patch is replaced. 

To benefit from this, we check in diff if there's a saved patch with exactly those heads and if so, we return them!

This allows you to call diff() with the same arguments a few times in a row and memoize the result.

## What's missing / not great

Well, first I'm not a huge fan of shoving stuff into the InternalState object but... it seems relatively harmless.

The tests all pass but it could probably use a couple of extra tests to stress it. I did test that if I messed up the various inputs that it would fail in expected ways but there's not a test that targets this *specifically*.

I did some analysis of the code to make sure this was the correct intervention and @orionz, there were three calls which take patchCallback but *don't* go through progressDocument. Those are:

 * init & load (which use handle.materialize) and 
 * clone (which uses handle.applyPatches directly).

I think it would be sensible to consolidate those onto progressDocument for consistency but I suspect the approach used in load is cheap and fast and that's why it's preferred. Apologies for not having enough knowledge to make an informed call there. There's no downside to not doing this, particularly, other than initial loads in automerge-repo will not currently register themselves in the cache.

The other change @orionz might hate is that we now always use the applyAndReturnPatches form of apply_patches_impl.

## What we should probably do longer term

I think this whole API could benefit from some adjustment -- Orion and I have talked about exposing the diff_cursors as a primitive users could consume but we could probably do even better than that if we did a bit of thinking. (I find the diff_cursors kind of hard to reason about even as I've been working on this code.

## Who wants this?

@geoffreylitt, rather urgently. It's the difference been usable (40ms typing latency) and unusable (110ms typing latency).

Note that even if we accept this there's still more tuning to do. See the attached image.

![image](https://github.com/automerge/automerge/assets/2880/a1a9d878-b45e-4c85-b611-9018b31e6ce5)
