### PR TITLE
automerge-c: Always store its index in an `AMitem` struct

### DIFF
--- a/rust/automerge-c/CMakeLists.txt
+++ b/rust/automerge-c/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.23 FATAL_ERROR)
 
-project(automerge-c VERSION 0.2.1
+project(automerge-c VERSION 0.2.2
                     LANGUAGES C
                     DESCRIPTION "C bindings for the Automerge Rust library.")
 

--- a/rust/automerge-c/src/doc/list.rs
+++ b/rust/automerge-c/src/doc/list.rs
@@ -90,9 +90,9 @@ pub unsafe extern "C" fn AMlistGet(
     let obj_id = to_obj_id!(obj_id);
     let (pos, _) = adjust!(pos, false, doc.length(obj_id));
     match heads.as_ref() {
-        None => to_result(doc.get(obj_id, pos)),
+        None => to_result((doc.get(obj_id, pos), pos)),
         Some(heads) => match <Vec<am::ChangeHash>>::try_from(heads) {
-            Ok(heads) => to_result(doc.get_at(obj_id, pos, &heads)),
+            Ok(heads) => to_result((doc.get_at(obj_id, pos, &heads), pos)),
             Err(e) => AMresult::error(&e.to_string()).into(),
         },
     }
@@ -458,9 +458,9 @@ pub unsafe extern "C" fn AMlistPutObject(
     let (pos, insert) = adjust!(pos, insert, doc.length(obj_id));
     let obj_type = to_obj_type!(obj_type);
     to_result(if insert {
-        (doc.insert_object(obj_id, pos, obj_type), obj_type)
+        (doc.insert_object(obj_id, pos, obj_type), pos, obj_type)
     } else {
-        (doc.put_object(obj_id, pos, obj_type), obj_type)
+        (doc.put_object(obj_id, pos, obj_type), pos, obj_type)
     })
 }
 

--- a/rust/automerge-c/src/doc/map.rs
+++ b/rust/automerge-c/src/doc/map.rs
@@ -70,9 +70,9 @@ pub unsafe extern "C" fn AMmapGet(
     let obj_id = to_obj_id!(obj_id);
     let key = to_str!(key);
     match heads.as_ref() {
-        None => to_result(doc.get(obj_id, key)),
+        None => to_result((doc.get(obj_id, key), key)),
         Some(heads) => match <Vec<am::ChangeHash>>::try_from(heads) {
-            Ok(heads) => to_result(doc.get_at(obj_id, key, &heads)),
+            Ok(heads) => to_result((doc.get_at(obj_id, key, &heads), key)),
             Err(e) => AMresult::error(&e.to_string()).into(),
         },
     }
@@ -309,7 +309,11 @@ pub unsafe extern "C" fn AMmapPutObject(
     let doc = to_doc_mut!(doc);
     let key = to_str!(key);
     let obj_type = to_obj_type!(obj_type);
-    to_result((doc.put_object(to_obj_id!(obj_id), key, obj_type), obj_type))
+    to_result((
+        doc.put_object(to_obj_id!(obj_id), key, obj_type),
+        key,
+        obj_type,
+    ))
 }
 
 /// \memberof AMdoc


### PR DESCRIPTION
One goal of "C API 2" (PR #530) was for a value's corresponding index (e.g. string key within its parent map object or positive integer position within its parent list object) to be available regardless of how it was retrieved and not just when iterating over its parent object.
Unfortunately, "C API 2" only laid the groundwork for achieving that goal so this PR finally pushes it over the finish line with the following changes:
* Changed `AMlistGet()` to store the returned `AMitem` struct's index within it.
* Changed `AMlistPutObject()` to store the returned `AMitem` struct's index within it.
* Changed `AMmapGet()` to store the returned `AMitem` struct's index within it.
* Changed `AMmapPutObject()` to store the returned `AMitem` struct's index within it.
* Bumped the patch version from `1` to `2` because there are no API changes.