### PR TITLE
automerge-c: Prevent "incompatible pointer type" warnings in mark tests

### DIFF
--- a/rust/automerge-c/src/doc/mark.rs
+++ b/rust/automerge-c/src/doc/mark.rs
@@ -76,6 +76,9 @@ impl TryFrom<&AMmarkExpand> for ExpandMark {
     }
 }
 
+/// \struct AMmark
+/// \installed_headerfile
+/// \brief An association of out-of-bound information with a sequence.
 pub struct AMmark<'a>(Mark<'a>);
 
 impl<'a> AMmark<'a> {

--- a/rust/automerge-c/test/mark_tests.c
+++ b/rust/automerge-c/test/mark_tests.c
@@ -46,7 +46,7 @@ static void test_AMmark_round_trip(void** state) {
         AMstackItems(stack_ptr, AMmarks(doc_state->doc, obj_id, NULL), cmocka_cb, AMexpect(AM_VAL_TYPE_MARK));
 
     assert_int_equal(2, AMitemsSize(&marks));
-    AMmark* mark;
+    AMmark const* mark;
 
     assert_true(AMitemToMark(AMitemsNext(&marks, 1), &mark));
     assert_int_equal(0, AMmarkStart(mark));
@@ -100,7 +100,7 @@ static void test_AMmark_unicode_indexing(void** state) {
     AMitems marks =
         AMstackItems(stack_ptr, AMmarks(doc_state->doc, obj_id, NULL), cmocka_cb, AMexpect(AM_VAL_TYPE_MARK));
 
-    AMmark* mark;
+    AMmark const* mark;
     assert_int_equal(1, AMitemsSize(&marks));
     assert_true(AMitemToMark(AMitemsNext(&marks, 1), &mark));
 


### PR DESCRIPTION
These changes prevent warning messages like the following when compiling with GCC:
```
In file included from .../automerge/rust/automerge-c/test/mark_tests.c:11:
.../automerge/rust/automerge-c/test/mark_tests.c: In function ‘test_AMmark_round_trip’:
.../automerge/rust/automerge-c/test/mark_tests.c:51:54: warning: passing argument 2 of ‘AMitemToMark’ from incompatible pointer type [-Wincompatible-pointer-types]
   51 |     assert_true(AMitemToMark(AMitemsNext(&marks, 1), &mark));
      |                                                      ^~~~~
      |                                                      |
      |                                                      AMmark **
In file included from .../automerge/rust/automerge-c/test/mark_tests.c:14:
.../automerge/rust/automerge-c/rust/automerge-c/build/include/automerge-c/automerge.h:2664:68: note: expected ‘const struct AMmark **’ but argument is of type ‘AMmark **’
 2664 | bool AMitemToMark(const struct AMitem *item, const struct AMmark **value);
      |                                              ~~~~~~~~~~~~~~~~~~~~~~^~~~~
.../automerge/rust/automerge-c/test/mark_tests.c:55:54: warning: passing argument 2 of ‘AMitemToMark’ from incompatible pointer type [-Wincompatible-pointer-types]
   55 |     assert_true(AMitemToMark(AMitemsNext(&marks, 1), &mark));
      |                                                      ^~~~~
      |                                                      |
      |                                                      AMmark **
.../automerge/rust/automerge-c/rust/automerge-c/build/include/automerge-c/automerge.h:2664:68: note: expected ‘const struct AMmark **’ but argument is of type ‘AMmark **’
 2664 | bool AMitemToMark(const struct AMitem *item, const struct AMmark **value);
      |                                              ~~~~~~~~~~~~~~~~~~~~~~^~~~~
.../automerge/rust/automerge-c/test/mark_tests.c: In function ‘test_AMmark_unicode_indexing’:
.../automerge/rust/automerge-c/test/mark_tests.c:105:54: warning: passing argument 2 of ‘AMitemToMark’ from incompatible pointer type [-Wincompatible-pointer-types]
  105 |     assert_true(AMitemToMark(AMitemsNext(&marks, 1), &mark));
      |                                                      ^~~~~
      |                                                      |
      |                                                      AMmark **
.../automerge/rust/automerge-c/rust/automerge-c/build/include/automerge-c/automerge.h:2664:68: note: expected ‘const struct AMmark **’ but argument is of type ‘AMmark **’
 2664 | bool AMitemToMark(const struct AMitem *item, const struct AMmark **value);
      |                                              ~~~~~~~~~~~~~~~~~~~~~~^~~~~
```