### PR TITLE
Cache the op.width() value 

### DIFF
--- a/rust/automerge/src/automerge.rs
+++ b/rust/automerge/src/automerge.rs
@@ -20,7 +20,7 @@ use crate::transaction::{
 };
 use crate::types::{
     ActorId, ChangeHash, Clock, ElemId, Export, Exportable, Key, MarkData, ObjId, ObjMeta, Op,
-    OpId, OpType, Value,
+    OpArgs, OpId, OpType, Value,
 };
 use crate::{hydrate, ScalarValue};
 use crate::{AutomergeError, Change, Cursor, ObjType, Prop, ReadDoc};
@@ -895,7 +895,7 @@ impl Automerge {
                 let pred = self.ops.m.sorted_opids(pred);
                 (
                     obj,
-                    Op {
+                    Op::new(OpArgs {
                         id,
                         action: OpType::from_action_and_value(
                             c.action,
@@ -907,7 +907,7 @@ impl Automerge {
                         succ: Default::default(),
                         pred,
                         insert: c.insert,
-                    },
+                    }),
                 )
             })
             .collect()

--- a/rust/automerge/src/change_graph.rs
+++ b/rust/automerge/src/change_graph.rs
@@ -197,7 +197,7 @@ mod tests {
         clock::ClockData,
         op_tree::OpSetMetadata,
         storage::{change::ChangeBuilder, convert::op_as_actor_id},
-        types::{Key, ObjId, Op, OpId, OpIds},
+        types::{Key, ObjId, Op, OpArgs, OpId, OpIds},
         ActorId,
     };
 
@@ -300,13 +300,15 @@ mod tests {
 
             let actor_idx = self.index(actor);
             let ops = (0..num_new_ops)
-                .map(|opnum| Op {
-                    id: OpId::new(start_op + opnum as u64, actor_idx),
-                    action: crate::OpType::Put("value".into()),
-                    key: Key::Map(key),
-                    succ: OpIds::empty(),
-                    pred: OpIds::empty(),
-                    insert: false,
+                .map(|opnum| {
+                    Op::new(OpArgs {
+                        id: OpId::new(start_op + opnum as u64, actor_idx),
+                        action: crate::OpType::Put("value".into()),
+                        key: Key::Map(key),
+                        succ: OpIds::empty(),
+                        pred: OpIds::empty(),
+                        insert: false,
+                    })
                 })
                 .collect::<Vec<_>>();
 

--- a/rust/automerge/src/op_set.rs
+++ b/rust/automerge/src/op_set.rs
@@ -480,7 +480,7 @@ pub(crate) mod tests {
     use crate::{
         op_set::OpSet,
         op_tree::B,
-        types::{Key, ObjId, ObjMeta, Op, OpId},
+        types::{Key, ObjId, ObjMeta, Op, OpArgs, OpId},
         ActorId, ScalarValue,
     };
 
@@ -552,21 +552,21 @@ pub(crate) mod tests {
                         .sorted_opids(vec![OpId::new(counter, actor)].into_iter())
                 };
 
-                let op = Op {
+                let op = Op::new(OpArgs {
                     id: OpId::new(counter, actor),
                     action: crate::OpType::Put(ScalarValue::Str(val.into())),
                     key: Key::Map(key),
                     succ,
                     pred,
                     insert: false,
-                };
+                });
                 set.insert(counter as usize, &ObjId::root(), op);
                 counter += 1;
             }
         }
 
         // Now try and create an op which inserts at the next index of 'a'
-        let new_op = Op {
+        let new_op = Op::new(OpArgs {
             id: OpId::new(counter, actor),
             action: crate::OpType::Put(ScalarValue::Str("test".into())),
             key: Key::Map(a),
@@ -575,7 +575,7 @@ pub(crate) mod tests {
                 .m
                 .sorted_opids(std::iter::once(OpId::new(B as u64 - 1, actor))),
             insert: false,
-        };
+        });
         (set, new_op)
     }
 

--- a/rust/automerge/src/op_tree.rs
+++ b/rust/automerge/src/op_tree.rs
@@ -565,20 +565,20 @@ pub(crate) struct FoundOpId<'a> {
 
 #[cfg(test)]
 mod tests {
-    use crate::types::{Op, OpId, OpType};
+    use crate::types::{Op, OpArgs, OpId, OpType};
 
     use super::*;
 
     fn op() -> Op {
         let zero = OpId::new(0, 0);
-        Op {
+        Op::new(OpArgs {
             id: zero,
             action: OpType::Put(0.into()),
             key: zero.into(),
             succ: Default::default(),
             pred: Default::default(),
             insert: false,
-        }
+        })
     }
 
     #[test]

--- a/rust/automerge/src/op_tree/iter.rs
+++ b/rust/automerge/src/op_tree/iter.rs
@@ -217,7 +217,7 @@ impl<'a> Iterator for Inner<'a> {
 #[cfg(test)]
 mod tests {
     use super::super::OpTreeInternal;
-    use crate::types::{Key, Op, OpId, OpType, ScalarValue};
+    use crate::types::{Key, Op, OpArgs, OpId, OpType, ScalarValue};
     use proptest::prelude::*;
 
     #[derive(Clone)]
@@ -266,14 +266,14 @@ mod tests {
     }
 
     fn op(counter: u64) -> Op {
-        Op {
+        Op::new(OpArgs {
             action: OpType::Put(ScalarValue::Uint(counter)),
             id: OpId::new(counter, 0),
             key: Key::Map(0),
             succ: Default::default(),
             pred: Default::default(),
             insert: false,
-        }
+        })
     }
 
     /// A model for a property based test of the OpTreeIter. We generate a set of actions, each

--- a/rust/automerge/src/storage/load/reconstruct_document.rs
+++ b/rust/automerge/src/storage/load/reconstruct_document.rs
@@ -7,7 +7,7 @@ use crate::{
     columnar::Key as DocOpKey,
     op_tree::OpSetMetadata,
     storage::{change::Verified, Change as StoredChange, DocOp, Document},
-    types::{ChangeHash, ElemId, Key, ObjId, ObjType, Op, OpId, OpIds, OpType},
+    types::{ChangeHash, ElemId, Key, ObjId, ObjType, Op, OpArgs, OpId, OpIds, OpType},
     ScalarValue,
 };
 
@@ -320,14 +320,14 @@ impl LoadingObject {
             })?;
             collector.collect(
                 self.id,
-                Op {
+                Op::new(OpArgs {
                     id: opid,
                     pred: meta.sorted_opids(preds.into_iter()),
                     insert: false,
                     succ: OpIds::empty(),
                     key: *key,
                     action: OpType::Delete,
-                },
+                }),
             )?;
         }
         Ok(LoadedObject {
@@ -351,14 +351,14 @@ fn import_op(m: &mut OpSetMetadata, op: DocOp) -> Result<Op, Error> {
         }
     }
     let action = OpType::from_action_and_value(op.action, op.value, op.mark_name, op.expand);
-    Ok(Op {
+    Ok(Op::new(OpArgs {
         id: check_opid(m, op.id)?,
         action,
         key,
         succ: m.try_sorted_opids(op.succ).ok_or(Error::SuccOutOfOrder)?,
         pred: OpIds::empty(),
         insert: op.insert,
-    })
+    }))
 }
 
 /// We construct the OpSetMetadata directly from the vector of actors which are encoded in the

--- a/rust/automerge/src/transaction/inner.rs
+++ b/rust/automerge/src/transaction/inner.rs
@@ -6,8 +6,8 @@ use crate::marks::{ExpandMark, Mark, MarkSet};
 use crate::patches::{PatchLog, TextRepresentation};
 use crate::query::{self, OpIdSearch};
 use crate::storage::Change as StoredChange;
-use crate::types::{Clock, Key, ListEncoding, ObjId, OpId, OpIds};
-use crate::{op_tree::OpSetMetadata, types::Op, Automerge, Change, ChangeHash, Prop};
+use crate::types::{Clock, Key, ListEncoding, ObjId, Op, OpArgs, OpId, OpIds};
+use crate::{op_tree::OpSetMetadata, Automerge, Change, ChangeHash, Prop};
 use crate::{AutomergeError, ObjType, OpType, ScalarValue};
 
 #[derive(Debug, Clone)]
@@ -257,25 +257,25 @@ impl TransactionInner {
     }
 
     fn next_insert(&mut self, key: Key, value: ScalarValue) -> Op {
-        Op {
+        Op::new(OpArgs {
             id: self.next_id(),
             action: OpType::Put(value),
             key,
             succ: Default::default(),
             pred: Default::default(),
             insert: true,
-        }
+        })
     }
 
     fn next_delete(&mut self, key: Key, pred: OpIds) -> Op {
-        Op {
+        Op::new(OpArgs {
             id: self.next_id(),
             action: OpType::Delete,
             key,
             succ: Default::default(),
             pred,
             insert: false,
-        }
+        })
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -366,14 +366,14 @@ impl TransactionInner {
         let pos = query.pos();
         let key = query.key()?;
 
-        let op = Op {
+        let op = Op::new(OpArgs {
             id,
             action,
             key,
             succ: Default::default(),
             pred: Default::default(),
             insert: true,
-        };
+        });
 
         doc.ops_mut().insert(pos, &obj, op.clone());
 
@@ -435,14 +435,14 @@ impl TransactionInner {
 
         let pred = doc.ops().m.sorted_opids(ops.iter().map(|o| o.id));
 
-        let op = Op {
+        let op = Op::new(OpArgs {
             id,
             action,
             key,
             succ: Default::default(),
             pred,
             insert: false,
-        };
+        });
 
         let pos = query.end_pos;
         self.insert_local_op(doc, patch_log, prop, op, pos, obj, &ops_pos);
@@ -477,14 +477,14 @@ impl TransactionInner {
             return Err(AutomergeError::MissingCounter);
         }
 
-        let op = Op {
+        let op = Op::new(OpArgs {
             id,
             action,
             key,
             succ: Default::default(),
             pred,
             insert: false,
-        };
+        });
 
         let pos = query.pos();
         let ops_pos = query.ops_pos;


### PR DESCRIPTION
op.width() was taking 10% of the slow trace I looked at. Caching the value now.   Have yet to confirm the performance improvements due to network issues but wanted to open the PR.