### PR TITLE
automerge-c: Improve build flexibility

### DIFF
--- a/rust/automerge-c/CMakeLists.txt
+++ b/rust/automerge-c/CMakeLists.txt
@@ -18,23 +18,22 @@ include(CMakePackageConfigHelpers)
 
 include(GNUInstallDirs)
 
-set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
+list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake")
 
 string(MAKE_C_IDENTIFIER ${PROJECT_NAME} SYMBOL_PREFIX)
 
 string(TOUPPER ${SYMBOL_PREFIX} SYMBOL_PREFIX)
 
-set(CARGO_TARGET_DIR "${CMAKE_BINARY_DIR}/Cargo/target")
+set(CARGO_TARGET_DIR "${PROJECT_BINARY_DIR}/Cargo/target")
 
-set(CBINDGEN_INCLUDEDIR "${CMAKE_BINARY_DIR}/${CMAKE_INSTALL_INCLUDEDIR}")
+set(CBINDGEN_INCLUDEDIR "${PROJECT_BINARY_DIR}/${CMAKE_INSTALL_INCLUDEDIR}")
 
 set(CBINDGEN_TARGET_DIR "${CBINDGEN_INCLUDEDIR}/${PROJECT_NAME}")
 
-find_program (
-    CARGO_CMD
-    "cargo"
-    PATHS "$ENV{CARGO_HOME}/bin"
-    DOC "The Cargo command"
+find_program (CARGO_CMD
+              "cargo"
+              PATHS "$ENV{CARGO_HOME}/bin"
+              DOC "The Rust package manager"
 )
 
 if(NOT CARGO_CMD)
@@ -43,12 +42,22 @@ if(NOT CARGO_CMD)
                         "environment variable to its path.")
 endif()
 
-string(TOLOWER "${CMAKE_BUILD_TYPE}" BUILD_TYPE_LOWER)
+find_program(RUSTC_CMD
+             "rustc"
+             PATHS "$ENV{CARGO_HOME}/bin"
+             DOC "The Rust compiler"
+)
+
+if(NOT RUSTC_CMD)
+    message(FATAL_ERROR "Rustc (Rust compiler) not found! "
+                        "Please install it and/or set the CARGO_HOME "
+                        "environment variable to its path.")
+endif()
 
 # In order to build with -Z build-std, we need to pass target explicitly.
 # https://doc.rust-lang.org/cargo/reference/unstable.html#build-std
 execute_process (
-    COMMAND rustc -vV
+    COMMAND ${RUSTC_CMD} -vV
     OUTPUT_VARIABLE RUSTC_VERSION
     OUTPUT_STRIP_TRAILING_WHITESPACE
 )
@@ -57,7 +66,11 @@ string(REGEX REPLACE ".*host: ([^ \n]*).*" "\\1"
     ${RUSTC_VERSION}
 )
 
-if(BUILD_TYPE_LOWER STREQUAL debug)
+set(CARGO_FLAGS --target=${CARGO_TARGET})
+
+set(RUSTFLAGS "")
+
+if(CMAKE_BUILD_TYPE MATCHES Debug)
     set(CARGO_BUILD_TYPE "debug")
 
     set(CARGO_FLAG --target=${CARGO_TARGET})
@@ -68,9 +81,9 @@ else()
         set(RUSTUP_TOOLCHAIN nightly)
     endif()
 
-    set(RUSTFLAGS -C\ panic=abort)
+    set(RUSTFLAGS "${RUSTFLAGS} -C panic=abort")
 
-    set(CARGO_FLAG -Z build-std=std,panic_abort --release --target=${CARGO_TARGET})
+    set(CARGO_FLAGS -Z build-std=std,panic_abort --release ${CARGO_FLAGS})
 endif()
 
 if(UTF32_INDEXING)
@@ -86,8 +99,8 @@ set(CARGO_BINARY_DIR "${CARGO_TARGET_DIR}/${CARGO_TARGET}/${CARGO_BUILD_TYPE}")
 set(BINDINGS_NAME "${LIBRARY_NAME}_core")
 
 configure_file(
-    ${CMAKE_MODULE_PATH}/Cargo.toml.in
-    ${CMAKE_SOURCE_DIR}/Cargo.toml
+    ${PROJECT_SOURCE_DIR}/cmake/Cargo.toml.in
+    ${PROJECT_SOURCE_DIR}/Cargo.toml
     @ONLY
     NEWLINE_STYLE LF
 )
@@ -95,8 +108,8 @@ configure_file(
 set(INCLUDE_GUARD_PREFIX "${SYMBOL_PREFIX}")
 
 configure_file(
-    ${CMAKE_MODULE_PATH}/cbindgen.toml.in
-    ${CMAKE_SOURCE_DIR}/cbindgen.toml
+    ${PROJECT_SOURCE_DIR}/cmake/cbindgen.toml.in
+    ${PROJECT_SOURCE_DIR}/cbindgen.toml
     @ONLY
     NEWLINE_STYLE LF
 )
@@ -112,17 +125,16 @@ add_custom_command(
     OUTPUT
         ${CARGO_OUTPUT}
     COMMAND
-        # \note cbindgen won't regenerate its output header file after it's been removed but it will after its
-        #       configuration file has been updated.
-        ${CMAKE_COMMAND} -DCONDITION=NOT_EXISTS -P ${CMAKE_SOURCE_DIR}/cmake/file-touch.cmake -- ${CBINDGEN_TARGET_DIR}/${LIBRARY_NAME}.h ${CMAKE_SOURCE_DIR}/cbindgen.toml
+        # Force cbindgen to regenerate the header file by updating its configuration file; removing the header won't.
+        ${CMAKE_COMMAND} -DCONDITION=NOT_EXISTS -P ${PROJECT_SOURCE_DIR}/cmake/file-touch.cmake -- ${CBINDGEN_TARGET_DIR}/${LIBRARY_NAME}.h ${PROJECT_SOURCE_DIR}/cbindgen.toml
     COMMAND
-        ${CMAKE_COMMAND} -E env CARGO_TARGET_DIR=${CARGO_TARGET_DIR} CBINDGEN_TARGET_DIR=${CBINDGEN_TARGET_DIR} RUSTUP_TOOLCHAIN=${RUSTUP_TOOLCHAIN} RUSTFLAGS=${RUSTFLAGS} ${CARGO_CMD} build ${CARGO_FLAG} ${CARGO_FEATURES}
+        ${CMAKE_COMMAND} -E env CARGO_TARGET_DIR=${CARGO_TARGET_DIR} CBINDGEN_TARGET_DIR=${CBINDGEN_TARGET_DIR} RUSTUP_TOOLCHAIN=${RUSTUP_TOOLCHAIN} RUSTFLAGS=${RUSTFLAGS} ${CARGO_CMD} build ${CARGO_FLAGS} ${CARGO_FEATURES}
     COMMAND
         # Compensate for cbindgen's translation of consecutive uppercase letters to "ScreamingSnakeCase".
-        ${CMAKE_COMMAND} -DMATCH_REGEX=A_M\([^_]+\)_ -DREPLACE_EXPR=AM_\\1_ -P ${CMAKE_SOURCE_DIR}/cmake/file-regex-replace.cmake -- ${CBINDGEN_TARGET_DIR}/${LIBRARY_NAME}.h
+        ${CMAKE_COMMAND} -DMATCH_REGEX=A_M\([^_]+\)_ -DREPLACE_EXPR=AM_\\1_ -P ${PROJECT_SOURCE_DIR}/cmake/file-regex-replace.cmake -- ${CBINDGEN_TARGET_DIR}/${LIBRARY_NAME}.h
     COMMAND
-        # Compensate for cbindgen ignoring `std:mem::size_of<usize>()` calls.
-        ${CMAKE_COMMAND} -DMATCH_REGEX=USIZE_ -DREPLACE_EXPR=\+${CMAKE_SIZEOF_VOID_P} -P ${CMAKE_SOURCE_DIR}/cmake/file-regex-replace.cmake -- ${CBINDGEN_TARGET_DIR}/${LIBRARY_NAME}.h
+        # Compensate for cbindgen ignoring `std::mem::size_of<usize>()` calls.
+        ${CMAKE_COMMAND} -DMATCH_REGEX=USIZE_ -DREPLACE_EXPR=\+${CMAKE_SIZEOF_VOID_P} -P ${PROJECT_SOURCE_DIR}/cmake/file-regex-replace.cmake -- ${CBINDGEN_TARGET_DIR}/${LIBRARY_NAME}.h
     MAIN_DEPENDENCY
         src/lib.rs
     DEPENDS
@@ -143,11 +155,11 @@ add_custom_command(
         src/sync/have.rs
         src/sync/message.rs
         src/sync/state.rs
-        ${CMAKE_SOURCE_DIR}/build.rs
-        ${CMAKE_MODULE_PATH}/Cargo.toml.in
-        ${CMAKE_MODULE_PATH}/cbindgen.toml.in
+        ${PROJECT_SOURCE_DIR}/build.rs
+        ${PROJECT_SOURCE_DIR}/cmake/Cargo.toml.in
+        ${PROJECT_SOURCE_DIR}/cmake/cbindgen.toml.in
     WORKING_DIRECTORY
-        ${CMAKE_SOURCE_DIR}
+        ${PROJECT_SOURCE_DIR}
     COMMENT
         "Producing the bindings' artifacts with Cargo..."
     VERBATIM
@@ -187,15 +199,15 @@ set(UTILS_SUBDIR "utils")
 add_custom_command(
     OUTPUT
         ${CBINDGEN_TARGET_DIR}/${UTILS_SUBDIR}/enum_string.h
-        ${CMAKE_BINARY_DIR}/src/${UTILS_SUBDIR}/enum_string.c
+        ${PROJECT_BINARY_DIR}/src/${UTILS_SUBDIR}/enum_string.c
     COMMAND
-        ${CMAKE_COMMAND} -DPROJECT_NAME=${PROJECT_NAME} -DLIBRARY_NAME=${LIBRARY_NAME} -DSUBDIR=${UTILS_SUBDIR} -P ${CMAKE_SOURCE_DIR}/cmake/enum-string-functions-gen.cmake -- ${CBINDGEN_TARGET_DIR}/${LIBRARY_NAME}.h ${CBINDGEN_TARGET_DIR}/${UTILS_SUBDIR}/enum_string.h ${CMAKE_BINARY_DIR}/src/${UTILS_SUBDIR}/enum_string.c
+        ${CMAKE_COMMAND} -DPROJECT_NAME=${PROJECT_NAME} -DLIBRARY_NAME=${LIBRARY_NAME} -DSUBDIR=${UTILS_SUBDIR} -P ${PROJECT_SOURCE_DIR}/cmake/enum-string-functions-gen.cmake -- ${CBINDGEN_TARGET_DIR}/${LIBRARY_NAME}.h ${CBINDGEN_TARGET_DIR}/${UTILS_SUBDIR}/enum_string.h ${PROJECT_BINARY_DIR}/src/${UTILS_SUBDIR}/enum_string.c
     MAIN_DEPENDENCY
         ${CBINDGEN_TARGET_DIR}/${LIBRARY_NAME}.h
     DEPENDS
-        ${CMAKE_SOURCE_DIR}/cmake/enum-string-functions-gen.cmake
+        ${PROJECT_SOURCE_DIR}/cmake/enum-string-functions-gen.cmake
     WORKING_DIRECTORY
-        ${CMAKE_SOURCE_DIR}
+        ${PROJECT_SOURCE_DIR}
     COMMENT
         "Generating the enum string functions with CMake..."
     VERBATIM
@@ -203,7 +215,7 @@ add_custom_command(
 
 add_custom_target(${LIBRARY_NAME}_utilities
     DEPENDS ${CBINDGEN_TARGET_DIR}/${UTILS_SUBDIR}/enum_string.h
-            ${CMAKE_BINARY_DIR}/src/${UTILS_SUBDIR}/enum_string.c
+            ${PROJECT_BINARY_DIR}/src/${UTILS_SUBDIR}/enum_string.c
 )
 
 add_library(${LIBRARY_NAME})
@@ -224,20 +236,62 @@ else()
     list(APPEND LIBRARY_DEPENDENCIES m)
 endif()
 
-target_link_libraries(${LIBRARY_NAME}
-    PUBLIC ${BINDINGS_NAME}
-           ${LIBRARY_DEPENDENCIES}
-)
+target_link_libraries(${LIBRARY_NAME} PUBLIC ${LIBRARY_DEPENDENCIES})
 
 # \note An imported library's INTERFACE_INCLUDE_DIRECTORIES property can't
 #       contain a non-existent path so its build-time include directory
 #       must be specified for all of its dependent targets instead.
 target_include_directories(${LIBRARY_NAME}
-    PUBLIC "$<BUILD_INTERFACE:${CBINDGEN_INCLUDEDIR};${CMAKE_SOURCE_DIR}/${CMAKE_INSTALL_INCLUDEDIR}>"
+    PUBLIC "$<BUILD_INTERFACE:${CBINDGEN_INCLUDEDIR};${PROJECT_SOURCE_DIR}/${CMAKE_INSTALL_INCLUDEDIR}>"
            "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>"
 )
 
 add_dependencies(${LIBRARY_NAME} ${BINDINGS_NAME}_artifacts)
+
+if(WIN32)
+    find_program(LIB_TOOL "lib" REQUIRED)
+
+    add_custom_command(
+        TARGET ${LIBRARY_NAME}
+        POST_BUILD
+        COMMAND
+            ${CMAKE_COMMAND} -E echo "Merging its dependent libraries into \"$<TARGET_FILE:${LIBRARY_NAME}>\"..."
+        COMMAND
+            ${LIB_TOOL} /OUT:$<TARGET_FILE_NAME:${LIBRARY_NAME}> $<TARGET_FILE_NAME:${LIBRARY_NAME}> $<TARGET_FILE:${BINDINGS_NAME}> ntdll.lib
+        WORKING_DIRECTORY
+            ${PROJECT_BINARY_DIR}
+        COMMENT
+            "Merging the libraries..."
+        VERBATIM
+    )
+else()
+    set(OBJECTS_DIR objects)
+
+    set(BINDINGS_OBJECTS_DIR ${OBJECTS_DIR}/$<TARGET_NAME:${BINDINGS_NAME}>)
+
+    add_custom_command(
+        TARGET "${LIBRARY_NAME}"
+        POST_BUILD
+        COMMAND
+            ${CMAKE_COMMAND} -E echo "Merging its dependent libraries into \"$<TARGET_FILE:${LIBRARY_NAME}>\"..."
+        COMMAND
+            ${CMAKE_COMMAND} -E rm -rf ${OBJECTS_DIR}
+        COMMAND
+            ${CMAKE_COMMAND} -E make_directory ${BINDINGS_OBJECTS_DIR}
+        COMMAND
+            ${CMAKE_COMMAND} -E echo "${CMAKE_AR} -x  --plugin /usr/lib/bfd-plugins/liblto_plugin.so $<TARGET_FILE:${BINDINGS_NAME}>"
+        COMMAND
+            ${CMAKE_COMMAND} -E chdir ${BINDINGS_OBJECTS_DIR} ${CMAKE_AR} -x --plugin /usr/lib/bfd-plugins/liblto_plugin.so $<TARGET_FILE:${BINDINGS_NAME}>
+        COMMAND
+            ${CMAKE_COMMAND} -E echo "${CMAKE_AR} -rs --plugin /usr/lib/bfd-plugins/liblto_plugin.so $<TARGET_FILE_NAME:${LIBRARY_NAME}> ${BINDINGS_OBJECTS_DIR}/*.o"
+        COMMAND
+            ${CMAKE_AR} -rs --plugin /usr/lib/bfd-plugins/liblto_plugin.so $<TARGET_FILE_NAME:${LIBRARY_NAME}> ${BINDINGS_OBJECTS_DIR}/*.o
+        WORKING_DIRECTORY
+            ${PROJECT_BINARY_DIR}
+        COMMENT
+            "Merging the libraries' constituent object files..."
+    )
+endif()
 
 # Generate the configuration header.
 math(EXPR INTEGER_PROJECT_VERSION_MAJOR "${PROJECT_VERSION_MAJOR} * 100000")
@@ -251,7 +305,7 @@ math(EXPR INTEGER_PROJECT_VERSION "${INTEGER_PROJECT_VERSION_MAJOR} + \
                                    ${INTEGER_PROJECT_VERSION_PATCH}")
 
 configure_file(
-    ${CMAKE_MODULE_PATH}/config.h.in
+    ${PROJECT_SOURCE_DIR}/cmake/config.h.in
     ${CBINDGEN_TARGET_DIR}/config.h
     @ONLY
     NEWLINE_STYLE LF
@@ -263,19 +317,19 @@ target_sources(${LIBRARY_NAME}
         src/${UTILS_SUBDIR}/stack_callback_data.c
         src/${UTILS_SUBDIR}/stack.c
         src/${UTILS_SUBDIR}/string.c
-        ${CMAKE_BINARY_DIR}/src/${UTILS_SUBDIR}/enum_string.c
+        ${PROJECT_BINARY_DIR}/src/${UTILS_SUBDIR}/enum_string.c
     PUBLIC
         FILE_SET api TYPE HEADERS
             BASE_DIRS
                 ${CBINDGEN_INCLUDEDIR}
-                ${CMAKE_SOURCE_DIR}/${CMAKE_INSTALL_INCLUDEDIR}
+                ${CMAKE_INSTALL_INCLUDEDIR}
             FILES
                 ${CBINDGEN_TARGET_DIR}/${LIBRARY_NAME}.h
                 ${CBINDGEN_TARGET_DIR}/${UTILS_SUBDIR}/enum_string.h
-                ${CMAKE_SOURCE_DIR}/${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}/${UTILS_SUBDIR}/result.h
-                ${CMAKE_SOURCE_DIR}/${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}/${UTILS_SUBDIR}/stack_callback_data.h
-                ${CMAKE_SOURCE_DIR}/${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}/${UTILS_SUBDIR}/stack.h
-                ${CMAKE_SOURCE_DIR}/${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}/${UTILS_SUBDIR}/string.h
+                ${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}/${UTILS_SUBDIR}/result.h
+                ${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}/${UTILS_SUBDIR}/stack_callback_data.h
+                ${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}/${UTILS_SUBDIR}/stack.h
+                ${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}/${UTILS_SUBDIR}/string.h
     INTERFACE
         FILE_SET config TYPE HEADERS
             BASE_DIRS

--- a/rust/automerge-c/CMakeLists.txt
+++ b/rust/automerge-c/CMakeLists.txt
@@ -4,14 +4,6 @@ project(automerge-c VERSION 0.2.1
                     LANGUAGES C
                     DESCRIPTION "C bindings for the Automerge Rust library.")
 
-set(LIBRARY_NAME "automerge")
-
-set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
-
-option(BUILD_SHARED_LIBS "Enable the choice of a shared or static library.")
-
-option(UTF32_INDEXING "Enable UTF-32 indexing.")
-
 include(CTest)
 
 include(CMakePackageConfigHelpers)
@@ -19,6 +11,24 @@ include(CMakePackageConfigHelpers)
 include(GNUInstallDirs)
 
 list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake")
+
+set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
+
+set(${PROJECT_NAME}-DEFAULT_LIBRARY_NAME "automerge")
+
+set(${PROJECT_NAME}-LIBRARY_NAME "${${PROJECT_NAME}-DEFAULT_LIBRARY_NAME}" CACHE STRING "The library's name.")
+
+set(DEFAULT_BINDINGS_NAME "${${PROJECT_NAME}-DEFAULT_LIBRARY_NAME}_core")
+
+set(BINDINGS_NAME "${DEFAULT_BINDINGS_NAME}" CACHE STRING "The bindings' name.")
+
+set(${PROJECT_NAME}-LIBRARY_PREFIX "${CMAKE_STATIC_LIBRARY_PREFIX}" CACHE STRING "An output library's prefix.")
+
+set(${PROJECT_NAME}-LIBRARY_SUFFIX "${CMAKE_STATIC_LIBRARY_SUFFIX}" CACHE STRING "An output library's suffix.")
+
+option(BUILD_SHARED_LIBS "Enable the choice of a shared or static library.")
+
+option(UTF32_INDEXING "Enable UTF-32 indexing.")
 
 string(MAKE_C_IDENTIFIER ${PROJECT_NAME} SYMBOL_PREFIX)
 
@@ -72,8 +82,6 @@ set(RUSTFLAGS "")
 
 if(CMAKE_BUILD_TYPE MATCHES Debug)
     set(CARGO_BUILD_TYPE "debug")
-
-    set(CARGO_FLAG --target=${CARGO_TARGET})
 else()
     set(CARGO_BUILD_TYPE "release")
 
@@ -96,12 +104,9 @@ endif()
 
 set(CARGO_BINARY_DIR "${CARGO_TARGET_DIR}/${CARGO_TARGET}/${CARGO_BUILD_TYPE}")
 
-set(BINDINGS_NAME "${LIBRARY_NAME}_core")
-
 configure_file(
     ${PROJECT_SOURCE_DIR}/cmake/Cargo.toml.in
     ${PROJECT_SOURCE_DIR}/Cargo.toml
-    @ONLY
     NEWLINE_STYLE LF
 )
 
@@ -115,7 +120,7 @@ configure_file(
 )
 
 set(CARGO_OUTPUT
-    ${CBINDGEN_TARGET_DIR}/${LIBRARY_NAME}.h
+    ${CBINDGEN_TARGET_DIR}/${${PROJECT_NAME}-LIBRARY_NAME}.h
     ${CARGO_BINARY_DIR}/${CMAKE_STATIC_LIBRARY_PREFIX}${BINDINGS_NAME}${CMAKE_STATIC_LIBRARY_SUFFIX}
 )
 
@@ -126,15 +131,15 @@ add_custom_command(
         ${CARGO_OUTPUT}
     COMMAND
         # Force cbindgen to regenerate the header file by updating its configuration file; removing the header won't.
-        ${CMAKE_COMMAND} -DCONDITION=NOT_EXISTS -P ${PROJECT_SOURCE_DIR}/cmake/file-touch.cmake -- ${CBINDGEN_TARGET_DIR}/${LIBRARY_NAME}.h ${PROJECT_SOURCE_DIR}/cbindgen.toml
+        ${CMAKE_COMMAND} -DCONDITION=NOT_EXISTS -P ${PROJECT_SOURCE_DIR}/cmake/file-touch.cmake -- ${CBINDGEN_TARGET_DIR}/${${PROJECT_NAME}-LIBRARY_NAME}.h ${PROJECT_SOURCE_DIR}/cbindgen.toml
     COMMAND
         ${CMAKE_COMMAND} -E env CARGO_TARGET_DIR=${CARGO_TARGET_DIR} CBINDGEN_TARGET_DIR=${CBINDGEN_TARGET_DIR} RUSTUP_TOOLCHAIN=${RUSTUP_TOOLCHAIN} RUSTFLAGS=${RUSTFLAGS} ${CARGO_CMD} build ${CARGO_FLAGS} ${CARGO_FEATURES}
     COMMAND
         # Compensate for cbindgen's translation of consecutive uppercase letters to "ScreamingSnakeCase".
-        ${CMAKE_COMMAND} -DMATCH_REGEX=A_M\([^_]+\)_ -DREPLACE_EXPR=AM_\\1_ -P ${PROJECT_SOURCE_DIR}/cmake/file-regex-replace.cmake -- ${CBINDGEN_TARGET_DIR}/${LIBRARY_NAME}.h
+        ${CMAKE_COMMAND} -DMATCH_REGEX=A_M\([^_]+\)_ -DREPLACE_EXPR=AM_\\1_ -P ${PROJECT_SOURCE_DIR}/cmake/file-regex-replace.cmake -- ${CBINDGEN_TARGET_DIR}/${${PROJECT_NAME}-LIBRARY_NAME}.h
     COMMAND
         # Compensate for cbindgen ignoring `std::mem::size_of<usize>()` calls.
-        ${CMAKE_COMMAND} -DMATCH_REGEX=USIZE_ -DREPLACE_EXPR=\+${CMAKE_SIZEOF_VOID_P} -P ${PROJECT_SOURCE_DIR}/cmake/file-regex-replace.cmake -- ${CBINDGEN_TARGET_DIR}/${LIBRARY_NAME}.h
+        ${CMAKE_COMMAND} -DMATCH_REGEX=USIZE_ -DREPLACE_EXPR=\+${CMAKE_SIZEOF_VOID_P} -P ${PROJECT_SOURCE_DIR}/cmake/file-regex-replace.cmake -- ${CBINDGEN_TARGET_DIR}/${${PROJECT_NAME}-LIBRARY_NAME}.h
     MAIN_DEPENDENCY
         src/lib.rs
     DEPENDS
@@ -169,6 +174,26 @@ add_custom_target(${BINDINGS_NAME}_artifacts ALL
     DEPENDS ${CARGO_OUTPUT}
 )
 
+# Enable an external build tool to find the bindings in the root of the
+# out-of-source build directory when it has overridden an aspect of its name.
+if(NOT (("${${PROJECT_NAME}-LIBRARY_PREFIX}" STREQUAL "${CMAKE_STATIC_LIBRARY_PREFIX}") AND
+        ("${BINDINGS_NAME}" STREQUAL "${DEFAULT_BINDINGS_NAME}") AND
+        ("${${PROJECT_NAME}-LIBRARY_SUFFIX}" STREQUAL "${CMAKE_STATIC_LIBRARY_SUFFIX}")))
+    add_custom_command(
+        TARGET ${BINDINGS_NAME}_artifacts
+        POST_BUILD
+        COMMAND
+            ${CMAKE_COMMAND} -E echo "Copying \"${CARGO_BINARY_DIR}/${CMAKE_STATIC_LIBRARY_PREFIX}${BINDINGS_NAME}${CMAKE_STATIC_LIBRARY_SUFFIX}\" to \"${PROJECT_BINARY_DIR}/${${PROJECT_NAME}-LIBRARY_PREFIX}${BINDINGS_NAME}${${PROJECT_NAME}-LIBRARY_SUFFIX}\"..."
+        COMMAND
+            ${CMAKE_COMMAND} -E copy ${CARGO_BINARY_DIR}/${CMAKE_STATIC_LIBRARY_PREFIX}${BINDINGS_NAME}${CMAKE_STATIC_LIBRARY_SUFFIX} ${PROJECT_BINARY_DIR}/${${PROJECT_NAME}-LIBRARY_PREFIX}${BINDINGS_NAME}${${PROJECT_NAME}-LIBRARY_SUFFIX}
+        WORKING_DIRECTORY
+            ${PROJECT_SOURCE_DIR}
+        COMMENT
+            "Aliasing the bindings for the external build tool..."
+        VERBATIM
+    )
+endif()
+
 add_library(${BINDINGS_NAME} STATIC IMPORTED GLOBAL)
 
 target_include_directories(${BINDINGS_NAME} INTERFACE "${CBINDGEN_INCLUDEDIR}")
@@ -185,7 +210,7 @@ set_target_properties(
         IMPORTED_NO_SONAME "TRUE"
         IMPORTED_SONAME ""
         LINKER_LANGUAGE C
-        PUBLIC_HEADER "${CBINDGEN_TARGET_DIR}/${LIBRARY_NAME}.h"
+        PUBLIC_HEADER "${CBINDGEN_TARGET_DIR}/${${PROJECT_NAME}-LIBRARY_NAME}.h"
         SOVERSION "${PROJECT_VERSION_MAJOR}"
         VERSION "${PROJECT_VERSION}"
         # \note Cargo exports all of the symbols automatically.
@@ -201,9 +226,9 @@ add_custom_command(
         ${CBINDGEN_TARGET_DIR}/${UTILS_SUBDIR}/enum_string.h
         ${PROJECT_BINARY_DIR}/src/${UTILS_SUBDIR}/enum_string.c
     COMMAND
-        ${CMAKE_COMMAND} -DPROJECT_NAME=${PROJECT_NAME} -DLIBRARY_NAME=${LIBRARY_NAME} -DSUBDIR=${UTILS_SUBDIR} -P ${PROJECT_SOURCE_DIR}/cmake/enum-string-functions-gen.cmake -- ${CBINDGEN_TARGET_DIR}/${LIBRARY_NAME}.h ${CBINDGEN_TARGET_DIR}/${UTILS_SUBDIR}/enum_string.h ${PROJECT_BINARY_DIR}/src/${UTILS_SUBDIR}/enum_string.c
+        ${CMAKE_COMMAND} -DPROJECT_NAME=${PROJECT_NAME} -DLIBRARY_NAME=${${PROJECT_NAME}-LIBRARY_NAME} -DSUBDIR=${UTILS_SUBDIR} -P ${PROJECT_SOURCE_DIR}/cmake/enum-string-functions-gen.cmake -- ${CBINDGEN_TARGET_DIR}/${${PROJECT_NAME}-LIBRARY_NAME}.h ${CBINDGEN_TARGET_DIR}/${UTILS_SUBDIR}/enum_string.h ${PROJECT_BINARY_DIR}/src/${UTILS_SUBDIR}/enum_string.c
     MAIN_DEPENDENCY
-        ${CBINDGEN_TARGET_DIR}/${LIBRARY_NAME}.h
+        ${CBINDGEN_TARGET_DIR}/${${PROJECT_NAME}-LIBRARY_NAME}.h
     DEPENDS
         ${PROJECT_SOURCE_DIR}/cmake/enum-string-functions-gen.cmake
     WORKING_DIRECTORY
@@ -213,14 +238,14 @@ add_custom_command(
     VERBATIM
 )
 
-add_custom_target(${LIBRARY_NAME}_utilities
+add_custom_target(${${PROJECT_NAME}-LIBRARY_NAME}_utilities
     DEPENDS ${CBINDGEN_TARGET_DIR}/${UTILS_SUBDIR}/enum_string.h
             ${PROJECT_BINARY_DIR}/src/${UTILS_SUBDIR}/enum_string.c
 )
 
-add_library(${LIBRARY_NAME})
+add_library(${${PROJECT_NAME}-LIBRARY_NAME})
 
-target_compile_features(${LIBRARY_NAME} PRIVATE c_std_99)
+target_compile_features(${${PROJECT_NAME}-LIBRARY_NAME} PRIVATE c_std_99)
 
 set(CMAKE_THREAD_PREFER_PTHREAD TRUE)
 
@@ -236,28 +261,28 @@ else()
     list(APPEND LIBRARY_DEPENDENCIES m)
 endif()
 
-target_link_libraries(${LIBRARY_NAME} PUBLIC ${LIBRARY_DEPENDENCIES})
+target_link_libraries(${${PROJECT_NAME}-LIBRARY_NAME} PUBLIC ${LIBRARY_DEPENDENCIES})
 
 # \note An imported library's INTERFACE_INCLUDE_DIRECTORIES property can't
 #       contain a non-existent path so its build-time include directory
 #       must be specified for all of its dependent targets instead.
-target_include_directories(${LIBRARY_NAME}
+target_include_directories(${${PROJECT_NAME}-LIBRARY_NAME}
     PUBLIC "$<BUILD_INTERFACE:${CBINDGEN_INCLUDEDIR};${PROJECT_SOURCE_DIR}/${CMAKE_INSTALL_INCLUDEDIR}>"
            "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>"
 )
 
-add_dependencies(${LIBRARY_NAME} ${BINDINGS_NAME}_artifacts)
+add_dependencies(${${PROJECT_NAME}-LIBRARY_NAME} ${BINDINGS_NAME}_artifacts)
 
 if(WIN32)
     find_program(LIB_TOOL "lib" REQUIRED)
 
     add_custom_command(
-        TARGET ${LIBRARY_NAME}
+        TARGET ${${PROJECT_NAME}-LIBRARY_NAME}
         POST_BUILD
         COMMAND
-            ${CMAKE_COMMAND} -E echo "Merging its dependent libraries into \"$<TARGET_FILE:${LIBRARY_NAME}>\"..."
+            ${CMAKE_COMMAND} -E echo "Merging its dependent libraries into \"$<TARGET_FILE:${${PROJECT_NAME}-LIBRARY_NAME}>\"..."
         COMMAND
-            ${LIB_TOOL} /OUT:$<TARGET_FILE_NAME:${LIBRARY_NAME}> $<TARGET_FILE_NAME:${LIBRARY_NAME}> $<TARGET_FILE:${BINDINGS_NAME}> ntdll.lib
+            ${LIB_TOOL} /OUT:$<TARGET_FILE_NAME:${${PROJECT_NAME}-LIBRARY_NAME}> $<TARGET_FILE_NAME:${${PROJECT_NAME}-LIBRARY_NAME}> $<TARGET_FILE:${BINDINGS_NAME}> ntdll.lib
         WORKING_DIRECTORY
             ${PROJECT_BINARY_DIR}
         COMMENT
@@ -270,10 +295,10 @@ else()
     set(BINDINGS_OBJECTS_DIR ${OBJECTS_DIR}/$<TARGET_NAME:${BINDINGS_NAME}>)
 
     add_custom_command(
-        TARGET "${LIBRARY_NAME}"
+        TARGET "${${PROJECT_NAME}-LIBRARY_NAME}"
         POST_BUILD
         COMMAND
-            ${CMAKE_COMMAND} -E echo "Merging its dependent libraries into \"$<TARGET_FILE:${LIBRARY_NAME}>\"..."
+            ${CMAKE_COMMAND} -E echo "Merging its dependent libraries into \"$<TARGET_FILE:${${PROJECT_NAME}-LIBRARY_NAME}>\"..."
         COMMAND
             ${CMAKE_COMMAND} -E rm -rf ${OBJECTS_DIR}
         COMMAND
@@ -283,13 +308,33 @@ else()
         COMMAND
             ${CMAKE_COMMAND} -E chdir ${BINDINGS_OBJECTS_DIR} ${CMAKE_AR} -x --plugin /usr/lib/bfd-plugins/liblto_plugin.so $<TARGET_FILE:${BINDINGS_NAME}>
         COMMAND
-            ${CMAKE_COMMAND} -E echo "${CMAKE_AR} -rs --plugin /usr/lib/bfd-plugins/liblto_plugin.so $<TARGET_FILE_NAME:${LIBRARY_NAME}> ${BINDINGS_OBJECTS_DIR}/*.o"
+            ${CMAKE_COMMAND} -E echo "${CMAKE_AR} -rs --plugin /usr/lib/bfd-plugins/liblto_plugin.so $<TARGET_FILE_NAME:${${PROJECT_NAME}-LIBRARY_NAME}> ${BINDINGS_OBJECTS_DIR}/*.o"
         COMMAND
-            ${CMAKE_AR} -rs --plugin /usr/lib/bfd-plugins/liblto_plugin.so $<TARGET_FILE_NAME:${LIBRARY_NAME}> ${BINDINGS_OBJECTS_DIR}/*.o
+            ${CMAKE_AR} -rs --plugin /usr/lib/bfd-plugins/liblto_plugin.so $<TARGET_FILE_NAME:${${PROJECT_NAME}-LIBRARY_NAME}> ${BINDINGS_OBJECTS_DIR}/*.o
         WORKING_DIRECTORY
             ${PROJECT_BINARY_DIR}
         COMMENT
             "Merging the libraries' constituent object files..."
+    )
+endif()
+
+# Enable an external build tool to find the library in the root of the
+# out-of-source build directory when it has overridden an aspect of its name.
+if(NOT (("${${PROJECT_NAME}-LIBRARY_PREFIX}" STREQUAL "${CMAKE_STATIC_LIBRARY_PREFIX}") AND
+        ("${${PROJECT_NAME}-LIBRARY_NAME}" STREQUAL "${${PROJECT_NAME}-DEFAULT_LIBRARY_NAME}") AND
+        ("${${PROJECT_NAME}-LIBRARY_SUFFIX}" STREQUAL "${CMAKE_STATIC_LIBRARY_SUFFIX}")))
+    add_custom_command(
+        TARGET ${${PROJECT_NAME}-LIBRARY_NAME}
+        POST_BUILD
+        COMMAND
+            ${CMAKE_COMMAND} -E echo "Copying \"${CMAKE_STATIC_LIBRARY_PREFIX}${${PROJECT_NAME}-LIBRARY_NAME}${CMAKE_STATIC_LIBRARY_SUFFIX}\" to \"${PROJECT_BINARY_DIR}/${${PROJECT_NAME}-LIBRARY_PREFIX}${${PROJECT_NAME}-LIBRARY_NAME}${${PROJECT_NAME}-LIBRARY_SUFFIX}\"..."
+        COMMAND
+            ${CMAKE_COMMAND} -E copy ${PROJECT_BINARY_DIR}/${CMAKE_STATIC_LIBRARY_PREFIX}${${PROJECT_NAME}-LIBRARY_NAME}${CMAKE_STATIC_LIBRARY_SUFFIX} ${PROJECT_BINARY_DIR}/${${PROJECT_NAME}-LIBRARY_PREFIX}${${PROJECT_NAME}-LIBRARY_NAME}${${PROJECT_NAME}-LIBRARY_SUFFIX}
+        WORKING_DIRECTORY
+            ${PROJECT_SOURCE_DIR}
+        COMMENT
+            "Aliasing the library for the external build tool..."
+        VERBATIM
     )
 endif()
 
@@ -311,7 +356,7 @@ configure_file(
     NEWLINE_STYLE LF
 )
 
-target_sources(${LIBRARY_NAME}
+target_sources(${${PROJECT_NAME}-LIBRARY_NAME}
     PRIVATE
         src/${UTILS_SUBDIR}/result.c
         src/${UTILS_SUBDIR}/stack_callback_data.c
@@ -324,7 +369,7 @@ target_sources(${LIBRARY_NAME}
                 ${CBINDGEN_INCLUDEDIR}
                 ${CMAKE_INSTALL_INCLUDEDIR}
             FILES
-                ${CBINDGEN_TARGET_DIR}/${LIBRARY_NAME}.h
+                ${CBINDGEN_TARGET_DIR}/${${PROJECT_NAME}-LIBRARY_NAME}.h
                 ${CBINDGEN_TARGET_DIR}/${UTILS_SUBDIR}/enum_string.h
                 ${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}/${UTILS_SUBDIR}/result.h
                 ${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}/${UTILS_SUBDIR}/stack_callback_data.h
@@ -339,7 +384,7 @@ target_sources(${LIBRARY_NAME}
 )
 
 install(
-    TARGETS ${LIBRARY_NAME}
+    TARGETS ${${PROJECT_NAME}-LIBRARY_NAME}
     EXPORT ${PROJECT_NAME}-config
     FILE_SET api
     FILE_SET config

--- a/rust/automerge-c/cmake/Cargo.toml.in
+++ b/rust/automerge-c/cmake/Cargo.toml.in
@@ -1,19 +1,19 @@
 [package]
-name = "@PROJECT_NAME@"
-version = "@PROJECT_VERSION@"
+name = "${PROJECT_NAME}"
+version = "${PROJECT_VERSION}"
 authors = ["Orion Henry <orion.henry@gmail.com>", "Jason Kankiewicz <jason.kankiewicz@gmail.com>"]
 edition = "2021"
 license = "MIT"
 rust-version = "1.57.0"
 
 [lib]
-name = "@BINDINGS_NAME@"
+name = "${BINDINGS_NAME}"
 crate-type = ["staticlib"]
 bench = false
 doc = false
 
 [dependencies]
-@LIBRARY_NAME@ = { path = "../@LIBRARY_NAME@" }
+${${PROJECT_NAME}-LIBRARY_NAME} = { path = "../${${PROJECT_NAME}-LIBRARY_NAME}" }
 hex = "^0.4.3"
 libc = "^0.2"
 smol_str = "^0.1.21"

--- a/rust/automerge-c/docs/CMakeLists.txt
+++ b/rust/automerge-c/docs/CMakeLists.txt
@@ -1,7 +1,9 @@
+cmake_minimum_required(VERSION 3.23 FATAL_ERROR)
+
 find_package(Doxygen OPTIONAL_COMPONENTS dot)
 
 if(DOXYGEN_FOUND)
-    set(DOXYGEN_ALIASES "installed_headerfile=\\headerfile ${LIBRARY_NAME}.h <${PROJECT_NAME}/${LIBRARY_NAME}.h>")
+    set(DOXYGEN_ALIASES "installed_headerfile=\\headerfile ${${PROJECT_NAME}-LIBRARY_NAME}.h <${PROJECT_NAME}/${${PROJECT_NAME}-LIBRARY_NAME}.h>")
 
     set(DOXYGEN_GENERATE_LATEX YES)
 
@@ -13,19 +15,19 @@ if(DOXYGEN_FOUND)
 
     set(DOXYGEN_SORT_BRIEF_DOCS YES)
 
-    set(DOXYGEN_USE_MDFILE_AS_MAINPAGE "${CMAKE_SOURCE_DIR}/README.md")
+    set(DOXYGEN_USE_MDFILE_AS_MAINPAGE "${PROJECT_SOURCE_DIR}/README.md")
 
     doxygen_add_docs(
-        ${LIBRARY_NAME}_docs
-        "${CBINDGEN_TARGET_DIR}/${LIBRARY_NAME}.h"
+        ${${PROJECT_NAME}-LIBRARY_NAME}_docs
+        "${CBINDGEN_TARGET_DIR}/${${PROJECT_NAME}-LIBRARY_NAME}.h"
         "${CBINDGEN_TARGET_DIR}/config.h"
         "${CBINDGEN_TARGET_DIR}/${UTILS_SUBDIR}/enum_string.h"
-        "${CMAKE_SOURCE_DIR}/${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}/${UTILS_SUBDIR}/result.h"
-        "${CMAKE_SOURCE_DIR}/${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}/${UTILS_SUBDIR}/stack_callback_data.h"
-        "${CMAKE_SOURCE_DIR}/${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}/${UTILS_SUBDIR}/stack.h"
-        "${CMAKE_SOURCE_DIR}/${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}/${UTILS_SUBDIR}/string.h"
-        "${CMAKE_SOURCE_DIR}/README.md"
-        WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+        "${PROJECT_SOURCE_DIR}/${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}/${UTILS_SUBDIR}/result.h"
+        "${PROJECT_SOURCE_DIR}/${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}/${UTILS_SUBDIR}/stack_callback_data.h"
+        "${PROJECT_SOURCE_DIR}/${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}/${UTILS_SUBDIR}/stack.h"
+        "${PROJECT_SOURCE_DIR}/${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}/${UTILS_SUBDIR}/string.h"
+        "${PROJECT_SOURCE_DIR}/README.md"
+        WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
         COMMENT "Producing documentation with Doxygen..."
     )
 
@@ -33,5 +35,5 @@ if(DOXYGEN_FOUND)
     #       command must instead depend upon a target that either outputs the
     #       file or depends upon it also or it will just output an error message
     #       when it can't be found.
-    add_dependencies(${LIBRARY_NAME}_docs ${BINDINGS_NAME}_artifacts ${LIBRARY_NAME}_utilities)
+    add_dependencies(${${PROJECT_NAME}-LIBRARY_NAME}_docs ${BINDINGS_NAME}_artifacts ${${PROJECT_NAME}-LIBRARY_NAME}_utilities)
 endif()

--- a/rust/automerge-c/examples/CMakeLists.txt
+++ b/rust/automerge-c/examples/CMakeLists.txt
@@ -1,39 +1,41 @@
+cmake_minimum_required(VERSION 3.23 FATAL_ERROR)
+
 add_executable(
-    ${LIBRARY_NAME}_quickstart
+    ${${PROJECT_NAME}-LIBRARY_NAME}_quickstart
         quickstart.c
 )
 
-set_target_properties(${LIBRARY_NAME}_quickstart PROPERTIES LINKER_LANGUAGE C)
+set_target_properties(${${PROJECT_NAME}-LIBRARY_NAME}_quickstart PROPERTIES LINKER_LANGUAGE C)
 
 # \note An imported library's INTERFACE_INCLUDE_DIRECTORIES property can't
 #       contain a non-existent path so its build-time include directory
 #       must be specified for all of its dependent targets instead.
 target_include_directories(
-    ${LIBRARY_NAME}_quickstart
+    ${${PROJECT_NAME}-LIBRARY_NAME}_quickstart
     PRIVATE "$<BUILD_INTERFACE:${CBINDGEN_INCLUDEDIR}>"
 )
 
-target_link_libraries(${LIBRARY_NAME}_quickstart PRIVATE ${LIBRARY_NAME})
+target_link_libraries(${${PROJECT_NAME}-LIBRARY_NAME}_quickstart PRIVATE ${${PROJECT_NAME}-LIBRARY_NAME})
 
-add_dependencies(${LIBRARY_NAME}_quickstart ${BINDINGS_NAME}_artifacts)
+add_dependencies(${${PROJECT_NAME}-LIBRARY_NAME}_quickstart ${BINDINGS_NAME}_artifacts)
 
 if(BUILD_SHARED_LIBS AND WIN32)
     add_custom_command(
-        TARGET ${LIBRARY_NAME}_quickstart
+        TARGET ${${PROJECT_NAME}-LIBRARY_NAME}_quickstart
         POST_BUILD
         COMMAND ${CMAKE_COMMAND} -E copy_if_different
-                ${CARGO_CURRENT_BINARY_DIR}/${CMAKE_SHARED_LIBRARY_PREFIX}${LIBRARY_NAME}${CMAKE_${CMAKE_BUILD_TYPE}_POSTFIX}${CMAKE_SHARED_LIBRARY_SUFFIX}
-                ${CMAKE_BINARY_DIR}
+                ${CARGO_CURRENT_BINARY_DIR}/${CMAKE_SHARED_LIBRARY_PREFIX}${${PROJECT_NAME}-LIBRARY_NAME}${CMAKE_${CMAKE_BUILD_TYPE}_POSTFIX}${CMAKE_SHARED_LIBRARY_SUFFIX}
+                ${CMAKE_CURRENT_BINARY_DIR}
         COMMENT "Copying the DLL built by Cargo into the examples directory..."
         VERBATIM
     )
 endif()
 
 add_custom_command(
-    TARGET ${LIBRARY_NAME}_quickstart
+    TARGET ${${PROJECT_NAME}-LIBRARY_NAME}_quickstart
     POST_BUILD
     COMMAND
-        ${LIBRARY_NAME}_quickstart
+        ${${PROJECT_NAME}-LIBRARY_NAME}_quickstart
     COMMENT
         "Running the example quickstart..."
     VERBATIM

--- a/rust/automerge-c/test/CMakeLists.txt
+++ b/rust/automerge-c/test/CMakeLists.txt
@@ -1,7 +1,9 @@
+cmake_minimum_required(VERSION 3.23 FATAL_ERROR)
+
 find_package(cmocka CONFIG REQUIRED)
 
 add_executable(
-    ${LIBRARY_NAME}_test
+    ${${PROJECT_NAME}-LIBRARY_NAME}_test
         actor_id_tests.c
         base_state.c
         byte_span_tests.c
@@ -21,7 +23,7 @@ add_executable(
         ported_wasm/sync_tests.c
 )
 
-set_target_properties(${LIBRARY_NAME}_test PROPERTIES LINKER_LANGUAGE C)
+set_target_properties(${${PROJECT_NAME}-LIBRARY_NAME}_test PROPERTIES LINKER_LANGUAGE C)
 
 if(WIN32)
     set(CMOCKA "cmocka::cmocka")
@@ -29,24 +31,24 @@ else()
     set(CMOCKA "cmocka")
 endif()
 
-target_link_libraries(${LIBRARY_NAME}_test PRIVATE ${CMOCKA} ${LIBRARY_NAME})
+target_link_libraries(${${PROJECT_NAME}-LIBRARY_NAME}_test PRIVATE ${CMOCKA} ${${PROJECT_NAME}-LIBRARY_NAME})
 
-add_dependencies(${LIBRARY_NAME}_test ${BINDINGS_NAME}_artifacts)
+add_dependencies(${${PROJECT_NAME}-LIBRARY_NAME}_test ${BINDINGS_NAME}_artifacts)
 
 if(BUILD_SHARED_LIBS AND WIN32)
     add_custom_command(
-        TARGET ${LIBRARY_NAME}_test
+        TARGET ${${PROJECT_NAME}-LIBRARY_NAME}_test
         POST_BUILD
-        COMMAND ${CMAKE_COMMAND} -E copy_if_different $<TARGET_FILE:${LIBRARY_NAME}> $<TARGET_FILE_DIR:${LIBRARY_NAME}_test>
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different $<TARGET_FILE:${${PROJECT_NAME}-LIBRARY_NAME}> $<TARGET_FILE_DIR:${${PROJECT_NAME}-LIBRARY_NAME}_test>
         COMMENT "Copying the DLL into the tests directory..."
         VERBATIM
     )
 endif()
 
-add_test(NAME ${LIBRARY_NAME}_test COMMAND ${LIBRARY_NAME}_test)
+add_test(NAME ${${PROJECT_NAME}-LIBRARY_NAME}_test COMMAND ${${PROJECT_NAME}-LIBRARY_NAME}_test)
 
 add_custom_command(
-    TARGET ${LIBRARY_NAME}_test
+    TARGET ${${PROJECT_NAME}-LIBRARY_NAME}_test
     POST_BUILD
     COMMAND
         ${CMAKE_CTEST_COMMAND} --config $<CONFIG> --output-on-failure


### PR DESCRIPTION
While developing a C++ library that depends upon automerge-c, I discovered that its CMake build system wasn't flexible enough and that the following features were required:
* Empower an external build tool to dictate the names of its constituent libraries.
* Enable its CMake project to be built as a subdirectory of a dependent CMake project.
* Incorporate the "automerge_core" (Rust bindings) library into the "automerge" (Rust bindings + utilities) library so that it could furnish all of the symbols.

:information_source: This PR includes the changes for #725 and #774.