### PR TITLE
Add commented example of Rollup bundling

### DIFF
--- a/javascript/examples/rollup/.eslintrc.cjs
+++ b/javascript/examples/rollup/.eslintrc.cjs
@@ -1,0 +1,8 @@
+module.exports = {
+  env: {
+    browser: true,
+  },
+  globals: {
+    AutomergeAPI: true,
+  },
+}

--- a/javascript/examples/rollup/.gitignore
+++ b/javascript/examples/rollup/.gitignore
@@ -1,0 +1,8 @@
+yarn.lock
+node_modules
+public/*.wasm
+public/main.js
+public/in-service-worker/*.wasm
+public/in-service-worker/automerge.js
+dist
+*.log

--- a/javascript/examples/rollup/README.md
+++ b/javascript/examples/rollup/README.md
@@ -1,0 +1,30 @@
+# Rollup + Automerge
+
+Example implementation of Automerge bundled with [Rollup](https://rollupjs.org/).
+
+This example illustrates two situations:
+- automerge running inside the page itself
+- automerge running inside a service worker
+
+## Running the example
+
+```bash
+yarn install
+yarn start
+```
+
+## Inside the page
+
+This example is [the homepage](http://localhost:3000).
+
+Check the [`inPageConfig` variable of `rollup.config.js`]() for the commented Rollup's configuration.
+
+## In a service worker
+
+This example is [at `/in-service-worker/`](http://localhost:3000/in-service-worker/).
+
+Check the [`inServiceWorkerConfig` variable of `rollup.config.js`](rollup.config.js/#L8) for the Rollup's configuration.
+
+Running inside a service worker not only affects the bundling, but also how the page and the worker coordinate to wait for the worker to have loaded automerge-wasm. Both the [page script](public/in-service-worker/page.js) and [service worker](public/in-service-worker/service-worker.js) have comments explaining this coordination. 
+
+

--- a/javascript/examples/rollup/package.json
+++ b/javascript/examples/rollup/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "rollup-automerge-example",
+  "version": "0.1.0",
+  "description": "",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "rollup -c",
+    "prestart": "yarn build",
+    "start": "serve public",
+    "test": "node dist/node.js"
+  },
+  "author": "",
+  "devDependencies": {
+    "@automerge/automerge": "2.1.0-alpha.11",
+    "@rollup/plugin-alias": "^5.0.1",
+    "@rollup/plugin-node-resolve": "^15.2.3",
+    "@rollup/plugin-replace": "^5.0.4",
+    "@rollup/plugin-wasm": "^6.2.2",
+    "rollup": "^4.1.4",
+    "rollup-plugin-tla": "^0.0.2",
+    "serve": "^13.0.2"
+  }
+}

--- a/javascript/examples/rollup/public/in-service-worker/index.html
+++ b/javascript/examples/rollup/public/in-service-worker/index.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+	<meta charset="UTF-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<title>Automerge running inside a Service Worker</title>
+</head>
+<body>
+	<h1>Automerge running inside a Service Worker</h1>
+	<label for="counter-value">Counter value:</label>
+	<output id="counter-value" >Service Worker not ready yet!</output>
+	<div>
+	<button data-value="+1">Increment counter</button><button data-value="-1">Decrement counter</button>
+	</div>
+
+	<style>label {font-weight: bold;}</style>
+	<script>
+		/**
+		 * A little debugging help for Firefox, where `console.log` calls
+		 * from inside the service worker don't appear in the page's console
+		 */
+		const channel = new BroadcastChannel('service-worker-log');
+		channel.addEventListener('message', event => {
+			console.log(...event.data)
+		})
+	</script>
+	<script type="module" src="/in-service-worker/page.js"></script>
+</body>
+</html>

--- a/javascript/examples/rollup/public/in-service-worker/page.js
+++ b/javascript/examples/rollup/public/in-service-worker/page.js
@@ -1,0 +1,63 @@
+const registration = await navigator.serviceWorker.register(
+  "/in-service-worker/service-worker.js",
+)
+await navigator.serviceWorker.ready
+// At this point, the service worker is active
+// See https://web.dev/articles/service-worker-lifecycle
+
+// However, active, doesn't mean ready for our purpose.
+// When the browser gets closed, it loses all that was stored in memory
+// Once it relauches, it needs to restore the availability of the Automerge API
+// (and the content of the document used for storing the state if persisted).
+// That's asynchronous so we need to wait for that to have happened before we actually
+// start working with the Service Worker.
+// This is done through a little "isReady", "ready" message handshake
+await new Promise(resolve => {
+  registration.active.postMessage({ action: "isReady" })
+  navigator.serviceWorker.addEventListener("message", handleResponseMessage)
+
+  function handleResponseMessage(event) {
+    if (event.data.action == "ready") {
+      navigator.serviceWorker.removeEventListener(
+        "message",
+        handleResponseMessage,
+      )
+      resolve()
+    }
+  }
+})
+
+// Now the service worker is properly ready
+
+// Ask for the new value, prompting the worker to respond with a `setValue`
+// So it can be displayed on the page
+registration.active.postMessage({
+  action: "getValue",
+})
+
+// ADd the click handler
+document.addEventListener("click", () => {
+  // Only handle clicks on the buttons
+  if (event.target.dataset.value) {
+    registration.active.postMessage({
+      action: "increment",
+      value: parseInt(event.target.dataset.value),
+    })
+  }
+})
+
+// Handle messages coming from the ServiceWorker
+//
+navigator.serviceWorker.addEventListener("message", ({ data }) => {
+  console.log("Message from service worker!", data)
+  const handler = MESSAGE_HANDLERS[data.action]
+  if (handler) {
+    handler(data)
+  }
+})
+
+const MESSAGE_HANDLERS = {
+  setValue({ value }) {
+    document.querySelector("output").value = value
+  },
+}

--- a/javascript/examples/rollup/public/in-service-worker/service-worker.js
+++ b/javascript/examples/rollup/public/in-service-worker/service-worker.js
@@ -1,0 +1,87 @@
+// Firefox is not heavy on forwarding logs from Service Workers
+// to the main window, so instead, we'll use a BroadcastChannel
+// to help debugging. A bit blunt, but that'll do
+const channel = new BroadcastChannel("service-worker-log")
+const originalLog = console.log
+console.log = function (...args) {
+  try {
+    channel.postMessage(args)
+  } catch (error) {
+    // There'll be one point where I'll try to log something
+    // that's not serialisable for `postMessage` so that'll
+    // avoid crashing.
+    originalLog(...args)
+  }
+}
+
+// Import the bundled script for automerge, which will add an `AutomergePromise`
+// allowing to wait for the automerge API once all the event listeners
+// of the service worker have been set up synchronously
+self.importScripts("/in-service-worker/automerge.js")
+
+// Little trickery to have a way to resolve the promise only late
+// With that pattern, we get a reference we can pass to `waitUntil`
+// or use as a way to delay responses to `isReady`, while delaying
+// when the Promise is resolved till the Automerge API has been loaded
+// Thankfully the function passed to the Promise constructor
+// runs synchronously, allowing to register the listeners OK
+const ready = new Promise(markReady => {
+  self.addEventListener("install", event => {
+    console.log("Installing service worker", new Date().toISOString())
+    self.skipWaiting()
+
+    event.waitUntil(ready)
+  })
+
+  self.addEventListener("activate", () => {
+    console.log("Service worker activated")
+  })
+
+  self.addEventListener("message", event => {
+    console.log("Message from page", event)
+    const handler = MESSAGE_HANDLERS[event.data.action]
+    if (handler) {
+      handler(event)
+    }
+  })
+
+  const MESSAGE_HANDLERS = {
+    async isReady(event) {
+      console.log("Checking if server is ready", ready)
+      await ready
+      event.source.postMessage({ action: "ready" })
+    },
+  }
+
+  // This need to happen only after all event listeners are set up
+  // This needs to run in the main script as there's no controlling
+  // when the service worker script will be torn down and started again
+  // Without this, when we close the browser, `automerge` and `doc`
+  // would be undefined, which is less than ideal :(
+  ;(async function () {
+    let automerge = await AutomergeAPI
+    let doc = automerge.from({
+      value: 1,
+    })
+
+    // You'd likely want to add some persistence here, to IndexedDB most likely
+    // as it's the storage available inside service workers
+
+    Object.assign(MESSAGE_HANDLERS, {
+      getValue(event) {
+        event.source.postMessage({ action: "setValue", value: doc.value })
+      },
+      increment(event) {
+        const { value } = event.data
+        doc = automerge.change(doc, draft => {
+          draft.value += value
+        })
+        console.log("Sending back", doc.value)
+        event.source.postMessage({ action: "setValue", value: doc.value })
+      },
+    })
+
+    console.log("Marking server as ready")
+    markReady()
+  })()
+})

--- a/javascript/examples/rollup/public/index.html
+++ b/javascript/examples/rollup/public/index.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>Simple Rollup for automerge-wasm</title>
+  </head>
+  <body>
+    <script src="main.js" type="module"></script>
+  </body>
+</html>

--- a/javascript/examples/rollup/rollup.config.js
+++ b/javascript/examples/rollup/rollup.config.js
@@ -1,0 +1,100 @@
+import alias from "@rollup/plugin-alias"
+import nodeResolve from "@rollup/plugin-node-resolve"
+import replace from "@rollup/plugin-replace"
+import wasm from "@rollup/plugin-wasm"
+import { defineConfig } from "rollup"
+import tla from "rollup-plugin-tla"
+
+const inPageConfig = {
+  input: "src/index.js",
+  output: {
+    file: "public/main.js",
+  },
+  // Fixes the `this` instance at top level in automerge's `stable.js` file
+  context: "globalThis",
+  plugins: [
+    // Force automerge-wasm to resolve to its web version
+    alias({
+      entries: [
+        {
+          find: "@automerge/automerge-wasm",
+          replacement: "node_modules/@automerge/automerge-wasm/web/index.js",
+        },
+      ],
+    }),
+    // Ensure we call the `WASM` loading function created by `@rollup/plugin-wasm`
+    // See https://www.npmjs.com/package/@rollup/plugin-wasm#using-with-wasm-bindgen-and-wasm-pack
+    // The `initSync` function doesn't need awaiting, unlike the `init` of the plugin's example
+    replace({
+      preventAssignment: true,
+      delimiters: ["", ""],
+      values: {
+        "initSync(WASM);": "initSync(await WASM());",
+      },
+    }),
+    nodeResolve({
+      browser: true,
+    }),
+    wasm({
+      targetEnv: "browser",
+    }),
+  ],
+}
+
+const inServiceWorkerConfig = {
+  // When running inside a service worker automerge needs to be bundled on its own
+  // then brought in the worker script with `importScripts`.
+  // If bundled inside the script, automerge's code would be hoisted at the top,
+  // always delaying the registration of the script's event listeners.
+  // These listeners are critical for telling the page when the worker
+  // has loaded automerge-wasm and is actually ready to roll
+  input: "@automerge/automerge",
+  // Not all browsers support ES module Service Workers
+  // so we'll bundle to an IIFE that'll set up an `AutomergeAPI` global variable.
+  // It'll be a Promise that'll resolve once the wasm is loaded.
+  output: {
+    format: "iife",
+    name: "AutomergeAPI",
+    file: "public/in-service-worker/automerge.js",
+  },
+  // Fixes the `this` instance at top level in automerge's `stable.js` file
+  context: "globalThis",
+  plugins: [
+    // Force automerge-wasm to resolve to its web version
+    alias({
+      entries: [
+        {
+          find: "@automerge/automerge-wasm",
+          replacement: "node_modules/@automerge/automerge-wasm/web/index.js",
+        },
+      ],
+    }),
+    // Ensure we call the `WASM` loading function created by `@rollup/plugin-wasm`
+    // See https://www.npmjs.com/package/@rollup/plugin-wasm#using-with-wasm-bindgen-and-wasm-pack
+    // The `initSync` function doesn't need awaiting, unlike the `init` of the plugin's example
+    replace({
+      preventAssignment: true,
+      delimiters: ["", ""],
+      values: {
+        "initSync(WASM);": "initSync(await WASM());",
+      },
+    }),
+    // The `initSync(await WASM();` call is a top-level await,
+    // which is only supported inside ES Modules (not supported by Firefox)
+    // This is what makes `AutomergeAPI` be a Promise
+    tla(),
+    nodeResolve({
+      browser: true,
+    }),
+    wasm({
+      targetEnv: "browser",
+      // Set the correct prefix to the path
+      // used for loading the `.wasm` file
+      publicPath: "/in-service-worker/",
+    }),
+  ],
+}
+
+export default defineConfig(() => {
+  return [inPageConfig, inServiceWorkerConfig]
+})

--- a/javascript/examples/rollup/src/index.js
+++ b/javascript/examples/rollup/src/index.js
@@ -1,0 +1,9 @@
+import * as Automerge from "@automerge/automerge"
+
+let doc = Automerge.init()
+doc = Automerge.change(doc, d => (d.hello = "from automerge"))
+const result = JSON.stringify(doc)
+
+const element = document.createElement("div")
+element.innerHTML = JSON.stringify(result)
+document.body.appendChild(element)


### PR DESCRIPTION
Illustrates both running on the pages, as well as in a Service Worker, with commented config (and JS files for the service worker as there's a bit of coordination between the page and the worker that needs explaining).

Part of #779.