### PR TITLE
adds marksAt() method and Fixes #646

### DIFF
--- a/javascript/src/next.ts
+++ b/javascript/src/next.ts
@@ -44,6 +44,7 @@ export {
   type Patch,
   type PatchCallback,
   type Mark,
+  type MarkSet,
   type MarkRange,
   type MarkValue,
   type AutomergeValue,
@@ -52,7 +53,7 @@ export {
   type PatchInfo,
 } from "./next_types.js"
 
-import type { Cursor, Mark, MarkRange, MarkValue } from "./next_types.js"
+import type { Cursor, Mark, MarkSet, MarkRange, MarkValue } from "./next_types.js"
 
 import { type PatchCallback } from "./stable.js"
 
@@ -439,7 +440,7 @@ export function marks<T>(doc: Doc<T>, path: stable.Prop[]): Mark[] {
   const state = _state(doc, false)
   const objectId = _obj(doc)
   if (!objectId) {
-    throw new RangeError("invalid object for unmark")
+    throw new RangeError("invalid object for marks")
   }
   path.unshift(objectId)
   const obj = path.join("/")
@@ -447,6 +448,21 @@ export function marks<T>(doc: Doc<T>, path: stable.Prop[]): Mark[] {
     return state.handle.marks(obj)
   } catch (e) {
     throw new RangeError(`Cannot call marks(): ${e}`)
+  }
+}
+
+export function marksAt<T>(doc: Doc<T>, path: stable.Prop[], index: number): MarkSet {
+  const state = _state(doc, false)
+  const objectId = _obj(doc)
+  if (!objectId) {
+    throw new RangeError("invalid object for marksAt")
+  }
+  path.unshift(objectId)
+  const obj = path.join("/")
+  try {
+    return state.handle.marksAt(obj, index)
+  } catch (e) {
+    throw new RangeError(`Cannot call marksAt(): ${e}`)
   }
 }
 

--- a/javascript/src/next_types.ts
+++ b/javascript/src/next_types.ts
@@ -9,6 +9,7 @@ export {
   type Patch,
   type PatchCallback,
   type Mark,
+  type MarkSet,
   type MarkRange,
   type MarkValue,
   type Cursor,

--- a/javascript/src/types.ts
+++ b/javascript/src/types.ts
@@ -5,7 +5,7 @@ export { Int, Uint, Float64 } from "./numbers.js"
 
 import { Counter } from "./counter.js"
 import type { Patch } from "@automerge/automerge-wasm"
-export type { Cursor, Patch, Mark, MarkRange } from "@automerge/automerge-wasm"
+export type { Cursor, Patch, MarkSet, Mark, MarkRange } from "@automerge/automerge-wasm"
 
 export type AutomergeValue =
   | ScalarValue

--- a/javascript/test/marks.ts
+++ b/javascript/test/marks.ts
@@ -102,4 +102,35 @@ describe("Automerge", () => {
     })
     assert.deepStrictEqual(Automerge.marks(doc, ["content"]), [])
   })
+
+  // test thanks to @jjallaire
+  // https://github.com/automerge/automerge/issues/646
+  it("patches properly report marks on end of expand true", () => {
+    let patches: Automerge.Patch[] = []
+    let doc = Automerge.from({ text: "aaabbbccc" }, { patchCallback: (p) => patches.push(...p) });
+
+    doc = Automerge.change(doc, doc => {
+      Automerge.mark(doc, ["text"], { start: 3, end: 6, expand: "both" }, "bold", true);
+      const marks = Automerge.marks(doc, ["text"]);
+      assert.deepStrictEqual(marks, [{ name: 'bold', value: true, start: 3, end: 6 }]);
+    });
+
+    doc = Automerge.change(doc, doc => {
+        Automerge.splice(doc, ["text"], 6, 0, "<");
+        Automerge.splice(doc, ["text"], 3, 0, ">");
+        const marks = Automerge.marks(doc, ["text"]);
+        assert.deepStrictEqual(marks, [{ name: 'bold', value: true, start: 3, end: 8 }]);
+    });
+
+    assert.deepStrictEqual(patches.pop(), {action: 'splice', path: ['text',3], value: '>', marks: { bold: true }});
+    assert.deepStrictEqual(patches.pop(), {action: 'splice', path: ['text',6], value: '<', marks: { bold: true }});
+
+    Automerge.dump(doc);
+
+    assert.deepStrictEqual(Automerge.marksAt(doc, ["text"], 2), {}) // a
+    assert.deepStrictEqual(Automerge.marksAt(doc, ["text"], 3), { bold: true }) // <
+    assert.deepStrictEqual(Automerge.marksAt(doc, ["text"], 5), { bold: true }) // b
+    assert.deepStrictEqual(Automerge.marksAt(doc, ["text"], 7), { bold: true }) // >
+    assert.deepStrictEqual(Automerge.marksAt(doc, ["text"], 8), {}) // c
+  })
 })

--- a/rust/automerge-wasm/index.d.ts
+++ b/rust/automerge-wasm/index.d.ts
@@ -203,7 +203,7 @@ export class Automerge {
   insertObject(obj: ObjID, index: number, value: ObjType): ObjID;
   push(obj: ObjID, value: Value, datatype?: Datatype): void;
   pushObject(obj: ObjID, value: ObjType): ObjID;
-  splice(obj: ObjID, start: number, delete_count: number, text?: string | Array<Value>): ObjID[] | undefined;
+  splice(obj: ObjID, start: number, delete_count: number, text?: string | Array<Value>): void;
   increment(obj: ObjID, prop: Prop, value: number): void;
   delete(obj: ObjID, prop: Prop): void;
 
@@ -211,6 +211,7 @@ export class Automerge {
   mark(obj: ObjID, range: MarkRange, name: string, value: Value, datatype?: Datatype): void;
   unmark(obj: ObjID, range: MarkRange, name: string): void;
   marks(obj: ObjID, heads?: Heads): Mark[];
+  marksAt(obj: ObjID, index: number, heads?: Heads): MarkSet;
 
   diff(before: Heads, after: Heads): Patch[];
 

--- a/rust/automerge-wasm/src/lib.rs
+++ b/rust/automerge-wasm/src/lib.rs
@@ -936,6 +936,27 @@ impl Automerge {
         }
         Ok(result.into())
     }
+
+    #[wasm_bindgen(js_name = marksAt)]
+    pub fn marks_at(
+        &mut self,
+        obj: JsValue,
+        index: f64,
+        heads: Option<Array>,
+    ) -> Result<Object, JsValue> {
+        let (obj, _) = self.import(obj)?;
+        let heads = get_heads(heads)?;
+        let marks = self
+            .doc
+            .get_marks(obj, index as usize, heads.as_deref())
+            .map_err(to_js_err)?;
+        let result = Object::new();
+        for (mark, value) in marks.iter() {
+            let (_datatype, value) = alloc(&value.into(), self.text_rep);
+            js_set(&result, mark, value)?;
+        }
+        Ok(result)
+    }
 }
 
 #[wasm_bindgen(js_name = create)]

--- a/rust/automerge-wasm/test/marks.mts
+++ b/rust/automerge-wasm/test/marks.mts
@@ -629,5 +629,27 @@ describe('Automerge', () => {
       assert.deepEqual(doc1.text(text), "The!editor")
       assert.deepEqual(doc1.marks(text), [])
     })
+
+    it('markAt() can be used to read the marks at a given index', () => {
+      let doc = create()
+      let text = doc.putObject("_root", "text", "aabbcc")
+
+      doc.mark(text, { start: 0, end: 4, expand: "both" }, "bold" , true)
+      doc.mark(text, { start: 2, end: 4, expand: "both" }, "underline" , true)
+
+      doc.splice(text, 4, 0, ">")
+      doc.splice(text, 2, 0, "<")
+
+      assert.deepEqual(doc.marksAt(text, 0), { "bold": true })
+      assert.deepEqual(doc.marksAt(text, 1), { "bold": true })
+
+      assert.deepEqual(doc.marksAt(text, 2), { "bold": true, "underline": true })
+      assert.deepEqual(doc.marksAt(text, 3), { "bold": true, "underline": true })
+      assert.deepEqual(doc.marksAt(text, 4), { "bold": true, "underline": true })
+      assert.deepEqual(doc.marksAt(text, 5), { "bold": true, "underline": true })
+
+      assert.deepEqual(doc.marksAt(text, 6), { })
+      assert.deepEqual(doc.marksAt(text, 7), { })
+    })
   })
 })

--- a/rust/automerge/src/automerge/diff.rs
+++ b/rust/automerge/src/automerge/diff.rs
@@ -412,6 +412,16 @@ impl<'a, 'b> ReadDoc for ReadDocAt<'a, 'b> {
         self.doc.marks_at(obj, heads)
     }
 
+    fn get_marks<O: AsRef<ExId>>(
+        &self,
+        obj: O,
+        index: usize,
+        heads: Option<&[ChangeHash]>,
+    ) -> Result<MarkSet, AutomergeError> {
+        self.doc
+            .get_marks(obj, index, Some(heads.unwrap_or(self.heads)))
+    }
+
     fn get_cursor<O: AsRef<ExId>>(
         &self,
         obj: O,

--- a/rust/automerge/src/marks.rs
+++ b/rust/automerge/src/marks.rs
@@ -100,9 +100,11 @@ impl MarkSet {
     fn inner(&self) -> &BTreeMap<SmolStr, ScalarValue> {
         &self.marks
     }
-}
 
-impl MarkSet {
+    pub fn len(&self) -> usize {
+        self.marks.len()
+    }
+
     fn insert(&mut self, name: SmolStr, value: ScalarValue) {
         self.marks.insert(name, value);
     }
@@ -111,7 +113,7 @@ impl MarkSet {
         self.marks.remove(name);
     }
 
-    fn is_empty(&self) -> bool {
+    pub fn is_empty(&self) -> bool {
         self.inner().is_empty()
     }
 

--- a/rust/automerge/src/read.rs
+++ b/rust/automerge/src/read.rs
@@ -2,7 +2,7 @@ use crate::{
     error::AutomergeError,
     exid::ExId,
     iter::{Keys, ListRange, MapRange, Values},
-    marks::Mark,
+    marks::{Mark, MarkSet},
     parents::Parents,
     Change, ChangeHash, Cursor, ObjType, Prop, Value,
 };
@@ -140,6 +140,13 @@ pub trait ReadDoc {
         obj: O,
         heads: &[ChangeHash],
     ) -> Result<Vec<Mark<'_>>, AutomergeError>;
+
+    fn get_marks<O: AsRef<ExId>>(
+        &self,
+        obj: O,
+        index: usize,
+        heads: Option<&[ChangeHash]>,
+    ) -> Result<MarkSet, AutomergeError>;
 
     /// Get the string represented by the given text object.
     fn text<O: AsRef<ExId>>(&self, obj: O) -> Result<String, AutomergeError>;

--- a/rust/automerge/src/transaction/inner.rs
+++ b/rust/automerge/src/transaction/inner.rs
@@ -566,7 +566,8 @@ impl TransactionInner {
                 values,
                 splice_type: SpliceType::List,
             },
-        )
+        )?;
+        Ok(())
     }
 
     /// Splice string into a text object
@@ -690,7 +691,7 @@ impl TransactionInner {
                     SpliceType::Text(text)
                         if matches!(patch_log.text_rep(), TextRepresentation::String) =>
                     {
-                        patch_log.splice(obj, index, text, marks);
+                        patch_log.splice(obj, index, text, marks.clone());
                     }
                     SpliceType::List | SpliceType::Text(..) => {
                         let start = self.operations.len() - values.len();
@@ -709,7 +710,6 @@ impl TransactionInner {
                 }
             }
         }
-
         Ok(())
     }
 

--- a/rust/automerge/src/transaction/manual_transaction.rs
+++ b/rust/automerge/src/transaction/manual_transaction.rs
@@ -2,7 +2,7 @@ use std::ops::RangeBounds;
 
 use crate::exid::ExId;
 use crate::iter::{Keys, ListRange, MapRange, Values};
-use crate::marks::{ExpandMark, Mark};
+use crate::marks::{ExpandMark, Mark, MarkSet};
 use crate::patches::PatchLog;
 use crate::types::Clock;
 use crate::AutomergeError;
@@ -236,6 +236,16 @@ impl<'a> ReadDoc for Transaction<'a> {
             .marks_for(obj.as_ref(), self.get_scope(Some(heads)))
     }
 
+    fn get_marks<O: AsRef<ExId>>(
+        &self,
+        obj: O,
+        index: usize,
+        heads: Option<&[ChangeHash]>,
+    ) -> Result<MarkSet, AutomergeError> {
+        self.doc
+            .get_marks_for(obj.as_ref(), index, self.get_scope(heads))
+    }
+
     fn get<O: AsRef<ExId>, P: Into<Prop>>(
         &self,
         obj: O,
@@ -372,7 +382,8 @@ impl<'a> Transactable for Transaction<'a> {
         del: isize,
         vals: V,
     ) -> Result<(), AutomergeError> {
-        self.do_tx(|tx, doc, hist| tx.splice(doc, hist, obj.as_ref(), pos, del, vals))
+        self.do_tx(|tx, doc, hist| tx.splice(doc, hist, obj.as_ref(), pos, del, vals))?;
+        Ok(())
     }
 
     fn splice_text<O: AsRef<ExId>>(
@@ -382,7 +393,8 @@ impl<'a> Transactable for Transaction<'a> {
         del: isize,
         text: &str,
     ) -> Result<(), AutomergeError> {
-        self.do_tx(|tx, doc, hist| tx.splice_text(doc, hist, obj.as_ref(), pos, del, text))
+        self.do_tx(|tx, doc, hist| tx.splice_text(doc, hist, obj.as_ref(), pos, del, text))?;
+        Ok(())
     }
 
     fn mark<O: AsRef<ExId>>(


### PR DESCRIPTION
added a `marksAt()` to the js and wasm interface.  The rust version im calling `get_marks()` because `marks_at()` was already taken - but since im going to be removing all the `_at()` methods in the branches PR I chose to take the name I want where there wasn't already a conflict.

Also fixed the issue in issue  #646 where the last mark was not being reported properly in the patch generated by splices at the edge of an expanding mark.