### PR TITLE
Fix broken link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ them in `rust/automerge` and `rust/automerge-c` if you are comfortable
 reading the code and tests to figure out how to use them.
 
 If you're familiar with CRDTs and interested in the design of Automerge in
-particular take a look at https://automerge.org/docs/how-it-works/backend/
+particular take a look at https://automerge.org/automerge-binary-format-spec.
 
 Finally, if you want to talk to us about this project please [join the
 Slack](https://join.slack.com/t/automerge/shared_invite/zt-e4p3760n-kKh7r3KRH1YwwNfiZM8ktw)


### PR DESCRIPTION
The link to How It Works is currently broken in the README. Based on the content available in the docs, perhaps the draft spec is the best thing to link to?