### PR TITLE
Upgrade `smol_str` to `0.2`

### DIFF
--- a/rust/automerge-c/Cargo.toml
+++ b/rust/automerge-c/Cargo.toml
@@ -16,7 +16,7 @@ doc = false
 automerge = { path = "../automerge" }
 hex = "^0.4.3"
 libc = "^0.2"
-smol_str = "^0.1.21"
+smol_str = "0.2"
 
 [build-dependencies]
 cbindgen = "^0.24"

--- a/rust/automerge-c/cmake/Cargo.toml.in
+++ b/rust/automerge-c/cmake/Cargo.toml.in
@@ -16,7 +16,7 @@ doc = false
 ${${PROJECT_NAME}-LIBRARY_NAME} = { path = "../${${PROJECT_NAME}-LIBRARY_NAME}" }
 hex = "^0.4.3"
 libc = "^0.2"
-smol_str = "^0.1.21"
+smol_str = "0.2"
 
 [build-dependencies]
 cbindgen = "^0.24"

--- a/rust/automerge-test/Cargo.toml
+++ b/rust/automerge-test/Cargo.toml
@@ -7,11 +7,9 @@ repository = "https://github.com/automerge/automerge"
 rust-version = "1.57.0"
 description = "Utilities for testing automerge libraries"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
 automerge = { version = "0.5.2", path = "../automerge" }
-smol_str = { version = "^0.1.21", features=["serde"] }
+smol_str = { version = "0.2", features=["serde"] }
 serde = { version = "^1.0", features=["derive"] }
 decorum = "0.3.1"
 serde_json = { version = "^1.0.73", features=["float_roundtrip"], default-features=true }

--- a/rust/automerge/Cargo.toml
+++ b/rust/automerge/Cargo.toml
@@ -21,7 +21,7 @@ thiserror = "^1.0.16"
 itertools = "^0.10.3"
 flate2 = "^1.0.22"
 uuid = { version = "^1.2.1", features=["v4", "serde"] }
-smol_str = { version = "^0.1.21", features=["serde"] }
+smol_str = { version = "0.2", features=["serde"] }
 tracing = { version = "^0.1.29" }
 fxhash = "^0.2.1"
 tinyvec = { version = "^1.5.1", features = ["alloc"] }


### PR DESCRIPTION
Bump this dependency to the latest version.  No breaking changes seem to affect the use of this dependency in `automerge`.
