### PR TITLE
Run cron advisories job on `rust` folder

### DIFF
--- a/.github/workflows/advisory-cron.yaml
+++ b/.github/workflows/advisory-cron.yaml
@@ -14,4 +14,5 @@ jobs:
       - uses: actions/checkout@v2
       - uses: EmbarkStudios/cargo-deny-action@v1
         with:
+          arguments: '--manifest-path ./rust/Cargo.toml'
           command: check ${{ matrix.checks }}


### PR DESCRIPTION
Ever since commit dd3c6d130 ("Move rust workspace into ./rust") this job seems to have been failing on not finding a `Cargo.toml` in the root.

This was fixed for the "main" CI on pushes and pull requests in commit e8309495c ("Update `cargo deny` to point at `rust` subdirectory"), but not for the scheduled cron job leading to unnecessary failures in (fork) repos.
