### PR TITLE
javascript: Better errors when setting invalid values

### DIFF
--- a/javascript/src/proxies.ts
+++ b/javascript/src/proxies.ts
@@ -138,7 +138,11 @@ type ImportedValue =
   | [Record<string, any>, "map"]
   | [boolean, "boolean"]
 
-function import_value(value: any, textV2: boolean): ImportedValue {
+function import_value(
+  value: any,
+  textV2: boolean,
+  path: Prop[],
+): ImportedValue {
   switch (typeof value) {
     case "object":
       if (value == null) {
@@ -185,7 +189,9 @@ function import_value(value: any, textV2: boolean): ImportedValue {
         return [value, "str"]
       }
     default:
-      throw new RangeError(`Unsupported type of value: ${typeof value}`)
+      throw new RangeError(
+        `Unsupported type ${typeof value} for path ${printPath(path)}`,
+      )
   }
 }
 
@@ -249,7 +255,7 @@ const MapHandler = {
     if (key === CLEAR_CACHE) {
       return true
     }
-    const [value, datatype] = import_value(val, textV2)
+    const [value, datatype] = import_value(val, textV2, [...path, key])
     switch (datatype) {
       case "list": {
         const list = context.putObject(objectId, key, [])
@@ -368,7 +374,7 @@ const ListHandler = {
     if (typeof index == "string") {
       throw new RangeError("list index must be a number")
     }
-    const [value, datatype] = import_value(val, textV2)
+    const [value, datatype] = import_value(val, textV2, [...path, index])
     switch (datatype) {
       case "list": {
         let list: ObjID
@@ -582,7 +588,7 @@ function listMethods<T extends Target>(target: T) {
     },
 
     fill(val: ScalarValue, start: number, end: number) {
-      const [value, datatype] = import_value(val, textV2)
+      const [value, datatype] = import_value(val, textV2, [...path, start])
       const length = context.length(objectId)
       start = parseListIndex(start || 0)
       end = parseListIndex(end || length)
@@ -672,7 +678,17 @@ function listMethods<T extends Target>(target: T) {
         }
         context.delete(objectId, index)
       }
-      const values = vals.map(val => import_value(val, textV2))
+      const values = vals.map((val, index) => {
+        try {
+          return import_value(val, textV2, [...path])
+        } catch (e) {
+          if (e instanceof RangeError) {
+            throw new RangeError(`${e.message} at index ${index} in the input`)
+          } else {
+            throw e
+          }
+        }
+      })
       for (const [value, datatype] of values) {
         switch (datatype) {
           case "list": {
@@ -946,5 +962,23 @@ function assertText(value: Text | string): asserts value is Text {
 function assertString(value: Text | string): asserts value is string {
   if (typeof value !== "string") {
     throw new Error("value was not a string")
+  }
+}
+
+function printPath(path: Prop[]): string {
+  // print the path as a json pointer
+  const jsonPointerComponents = path.map(component => {
+    // if its a number just turn it into a string
+    if (typeof component === "number") {
+      return component.toString()
+    } else if (typeof component === "string") {
+      // otherwise we have to escape `/` and `~` characters
+      return component.replace(/~/g, "~0").replace(/\//g, "~1")
+    }
+  })
+  if (path.length === 0) {
+    return ""
+  } else {
+    return "/" + jsonPointerComponents.join("/")
   }
 }

--- a/javascript/test/legacy_tests.ts
+++ b/javascript/test/legacy_tests.ts
@@ -500,16 +500,16 @@ describe("Automerge", () => {
         Automerge.change(s1, doc => {
           assert.throws(() => {
             doc.foo = undefined
-          }, /Unsupported type of value: undefined/)
+          }, /Unsupported type undefined for path \/foo/)
           assert.throws(() => {
             doc.foo = { prop: undefined }
-          }, /Unsupported type of value: undefined/)
+          }, /Unsupported type undefined for path \/foo\/prop/)
           assert.throws(() => {
             doc.foo = () => {}
-          }, /Unsupported type of value: function/)
+          }, /Unsupported type function for path \/foo/)
           assert.throws(() => {
             doc.foo = Symbol("foo")
-          }, /Unsupported type of value: symbol/)
+          }, /Unsupported type symbol for path \/foo/)
         })
       })
     })

--- a/javascript/test/proxies.ts
+++ b/javascript/test/proxies.ts
@@ -87,5 +87,36 @@ describe("Proxies", () => {
 
       assert.deepEqual(doc.list, ["a"])
     })
+
+    it("should throw a useful RangeError when attempting to splice undefined values", () => {
+      const doc = from<{ list: (undefined | number)[] }>({ list: [] })
+      change(doc, d => {
+        assert.throws(() => {
+          d.list.splice(0, 0, 5, undefined)
+        }, /Unsupported type undefined for path \/list at index 1 in the input/)
+      })
+    })
+  })
+
+  describe("map proxy", () => {
+    it("should print the property path in the error when setting an undefined key", () => {
+      const doc = from({ map: {} })
+      change(doc, d => {
+        assert.throws(() => {
+          d.map["a"] = undefined
+        }, /map\/a/)
+      })
+    })
+  })
+
+  describe("list proxy", () => {
+    it("should print the property path in the error when setting an undefined key", () => {
+      const doc = from<{ list: undefined[] }>({ list: [] })
+      change(doc, d => {
+        assert.throws(() => {
+          d.list[0] = undefined
+        }, /list\/0/)
+      })
+    })
   })
 })


### PR DESCRIPTION
Context: The change callback which is used to modify an automerge document is passed a proxy which looks like a POJO but intercepts mutating calls and converts them into operations on the underlying document.

Problem: When setting a key of one of the proxies in the change handler to `undefined` the proxy throws a RangeError. This is necessary because automerge doesn't support `undefined` - only `null`. However, the `RangeError` doesn't contain any information which allows the developer to figure out where they passed in an invalid value.

Solution: Include a JSON pointer to the path the developer attempted to insert the invalid value at so they can identify what part of their data they need to change.