### PR TITLE
Always send at least one sync message

### DIFF
--- a/javascript/test/sync_test.ts
+++ b/javascript/test/sync_test.ts
@@ -65,7 +65,7 @@ describe("Data sync protocol", () => {
         assert.deepStrictEqual(message.changes, [])
       })
 
-      it("should not reply if we have no data as well", () => {
+      it("should not reply after the first round if we have no data as well", () => {
         let n1 = Automerge.init(),
           n2 = Automerge.init()
         let s1 = initSyncState(),
@@ -76,6 +76,12 @@ describe("Data sync protocol", () => {
         if (m1 != null) {
           ;[n2, s2] = Automerge.receiveSyncMessage(n2, s2, m1)
         }
+        ;[s2, m2] = Automerge.generateSyncMessage(n2, s2)
+        if (m2 != null) {
+          ;[n1, s1] = Automerge.receiveSyncMessage(n1, s1, m2)
+        }
+        ;[s1, m1] = Automerge.generateSyncMessage(n1, s1)
+        assert.deepStrictEqual(m1, null)
         ;[s2, m2] = Automerge.generateSyncMessage(n2, s2)
         assert.deepStrictEqual(m2, null)
       })
@@ -101,10 +107,19 @@ describe("Data sync protocol", () => {
         ;[s1, m1] = Automerge.generateSyncMessage(n1, s1)
         assert.deepStrictEqual(s1.lastSentHeads, getHeads(n1))
 
-        // heads are equal so this message should be null
+        // Run one round of the sync protocol so each side has advertised their heads
         if (m1 != null) {
           ;[n2, s2] = Automerge.receiveSyncMessage(n2, s2, m1)
         }
+        ;[s2, m2] = Automerge.generateSyncMessage(n2, s2)
+        assert.deepStrictEqual(s2.lastSentHeads, getHeads(n2))
+        if (m2 != null) {
+          ;[n1, s1] = Automerge.receiveSyncMessage(n1, s1, m2)
+        }
+
+        // both sides should have the same heads, so no further messages are required
+        ;[s1, m1] = Automerge.generateSyncMessage(n1, s1)
+        assert.deepStrictEqual(m1, null)
         ;[s2, m2] = Automerge.generateSyncMessage(n2, s2)
         assert.strictEqual(m2, null)
       })
@@ -973,20 +988,36 @@ describe("Data sync protocol", () => {
         n2 = Automerge.init<any>("89abcdef")
       let s1 = initSyncState(),
         s2 = initSyncState()
-      let message: Automerge.SyncMessage | null = null
+
+      let m1: Automerge.SyncMessage | null = null
+      let m2: Automerge.SyncMessage | null = null
 
       for (let i = 0; i < 3; i++)
         n1 = Automerge.change(n1, { time: 0 }, doc => (doc.x = i))
       ;[n2] = Automerge.applyChanges(n2, Automerge.getAllChanges(n1))
-      ;[s1, message] = Automerge.generateSyncMessage(n1, s1)
-      const decoded = Automerge.decodeSyncMessage(message!)
+
+      // Run one round of sync protocol so both sides have advertised their heads
+      ;[s1, m1] = Automerge.generateSyncMessage(n1, s1)
+      if (m1 != null) {
+        ;[n2, s2] = Automerge.receiveSyncMessage(n2, s2, m1)
+      }
+      ;[s2, m2] = Automerge.generateSyncMessage(n2, s2)
+      if (m2 != null) {
+        ;[n1, s1] = Automerge.receiveSyncMessage(n1, s1, m2)
+      }
+
+      // Now hack the last m1 to need a nonexistent hash and send it again
+      const decoded = Automerge.decodeSyncMessage(m1!)
       decoded.need = [
         "0000000000000000000000000000000000000000000000000000000000000000",
       ]
-      message = Automerge.encodeSyncMessage(decoded)
-      ;[n2, s2] = Automerge.receiveSyncMessage(n2, s2, message!)
-      ;[s2, message] = Automerge.generateSyncMessage(n2, s2)
-      assert.strictEqual(message, null)
+      m1 = Automerge.encodeSyncMessage(decoded)
+      if (m1 == null) {
+        throw new Error("m1 is null")
+      }
+      ;[n2, s2] = Automerge.receiveSyncMessage(n2, s2, m1!)
+      ;[s2, m2] = Automerge.generateSyncMessage(n2, s2)
+      assert.strictEqual(m2, null)
     })
 
     it("should allow a subset of changes to be sent", () => {

--- a/rust/automerge-wasm/src/interop.rs
+++ b/rust/automerge-wasm/src/interop.rs
@@ -61,6 +61,7 @@ impl From<am::sync::State> for JS {
         } else {
             JsValue::null()
         };
+        let have_responded = state.have_responded.into();
         let result: JsValue = Object::new().into();
         // we can unwrap here b/c we made the object and know its not frozen
         Reflect::set(&result, &"sharedHeads".into(), &shared_heads.0).unwrap();
@@ -70,6 +71,7 @@ impl From<am::sync::State> for JS {
         Reflect::set(&result, &"theirHave".into(), &their_have).unwrap();
         Reflect::set(&result, &"sentHashes".into(), &sent_hashes.0).unwrap();
         Reflect::set(&result, &"inFlight".into(), &state.in_flight.into()).unwrap();
+        Reflect::set(&result, &"haveResponded".into(), &have_responded).unwrap();
         JS(result)
     }
 }
@@ -288,6 +290,10 @@ impl TryFrom<JS> for am::sync::State {
             .0
             .as_bool()
             .ok_or(error::BadSyncState::InFlightNotBoolean)?;
+        let have_responded = js_get(&value, "haveResponded")?
+            .0
+            .as_bool()
+            .unwrap_or(false);
         Ok(am::sync::State {
             shared_heads,
             last_sent_heads,
@@ -296,6 +302,7 @@ impl TryFrom<JS> for am::sync::State {
             their_have,
             sent_hashes,
             in_flight,
+            have_responded,
         })
     }
 }

--- a/rust/automerge/src/sync/state.rs
+++ b/rust/automerge/src/sync/state.rs
@@ -50,6 +50,11 @@ pub struct State {
     /// there are in fact changes to send). If it is `true` then we don't. This flag is cleared
     /// in `receive_sync_message`.
     pub in_flight: bool,
+
+    /// Whether we have ever responded to the other end. This is used to ensure that we always send
+    /// at least on sync message to the other end, even if we have no changes to send, which is
+    /// necessary because we want the other end to know what our heads are.
+    pub have_responded: bool,
 }
 
 /// A summary of the changes that the sender of the message already has.
@@ -104,6 +109,7 @@ impl State {
                 their_have: Some(Vec::new()),
                 sent_hashes: BTreeSet::new(),
                 in_flight: false,
+                have_responded: false,
             },
         ))
     }


### PR DESCRIPTION
Context: The sync protocol maintains a sync state which is updated every time we send or receive a message. This sync state contains a field for the heads the other end has reported. This is useful for applications to understand what local changes the other hand has not yet acknowledged.

Problem: In some cases we never send a response to the first message in the sync protocol and so the other end never learns what our heads are. The reason this happens is that we have some optimisations in the protocol to not send a message if we can tell that the other end has all the same changes as us. One scenario where this happens is if you load a document you previously saved and then synchronise that document with a sync server which already has the document and there have been no new changes.

Solution: Add a field to the sync state to track whether we have ever sent a response and ensure we always send a response if we have not sent one.