### PR TITLE
rust: Improve some intradoc links

### DIFF
--- a/rust/automerge/Cargo.toml
+++ b/rust/automerge/Cargo.toml
@@ -20,12 +20,12 @@ sha2 = "^0.10.0"
 thiserror = "^1.0.16"
 itertools = "^0.10.3"
 flate2 = "^1.0.22"
-uuid = { version = "^1.2.1", features=["v4", "serde"] }
-smol_str = { version = "0.2", features=["serde"] }
+uuid = { version = "^1.2.1", features = ["v4", "serde"] }
+smol_str = { version = "0.2", features = ["serde"] }
 tracing = { version = "^0.1.29" }
 fxhash = "^0.2.1"
 tinyvec = { version = "^1.5.1", features = ["alloc"] }
-serde = { version = "^1.0", features=["derive"] }
+serde = { version = "^1.0", features = ["derive"] }
 
 # optional deps
 dot = { version = "0.1.4", optional = true }
@@ -42,11 +42,11 @@ optional = true
 [dev-dependencies]
 pretty_assertions = "1.0.0"
 proptest = { version = "^1.0.0", default-features = false, features = ["std"] }
-serde_json = { version = "^1.0.73", features=["float_roundtrip"], default-features=true }
+serde_json = { version = "^1.0.73", features=["float_roundtrip"], default-features = true }
 maplit = { version = "^1.0" }
 criterion = "0.4.0"
-test-log = { version = "0.2.10", features=["trace"], default-features = false}
-tracing-subscriber = {version = "0.3.9", features = ["fmt", "env-filter"] }
+test-log = { version = "0.2.10", features = ["trace"], default-features = false}
+tracing-subscriber = { version = "0.3.9", features = ["fmt", "env-filter"] }
 automerge-test = { path = "../automerge-test" }
 prettytable = "0.10.0"
 

--- a/rust/automerge/src/autocommit.rs
+++ b/rust/automerge/src/autocommit.rs
@@ -21,15 +21,15 @@ use crate::{LoadOptions, VerificationMode};
 ///
 /// ## Creating, loading, merging and forking documents
 ///
-/// A new document can be created with [`Self::new`], which will create a document with a random
-/// [`ActorId`]. Existing documents can be loaded with [`Self::load`].
+/// A new document can be created with [`Self::new()`], which will create a document with a random
+/// [`ActorId`]. Existing documents can be loaded with [`Self::load()`].
 ///
 /// If you have two documents and you want to merge the changes from one into the other you can use
-/// [`Self::merge`].
+/// [`Self::merge()`].
 ///
 /// If you have a document you want to split into two concurrent threads of execution you can use
-/// [`Self::fork`]. If you want to split a document from ealier in its history you can use
-/// [`Self::fork_at`].
+/// [`Self::fork()`]. If you want to split a document from ealier in its history you can use
+/// [`Self::fork_at()`].
 ///
 /// ## Reading values
 ///
@@ -41,16 +41,17 @@ use crate::{LoadOptions, VerificationMode};
 ///
 /// ## Synchronization
 ///
-/// To synchronise call [`Self::sync`] which returns an implementation of [`SyncDoc`]
+/// To synchronise call [`Self::sync()`] which returns an implementation of [`SyncDoc`]
 ///
 /// ## Patches, maintaining materialized views
 ///
 /// [`AutoCommit`] allows you to generate [`Patch`]es representing changes to the current state of
 /// the document which you can use to maintain a materialized view of the current state. There are
-/// several ways to use this. See the documentation on `Self::diff` for more details, but the key
+/// several ways to use this. See the documentation on [`Self::diff()`] for more details, but the key
 /// point to remember is that [`AutoCommit`] manages an internal "diff cursor" for you. This is a
-/// representation of the heads of the document last time you called `diff_incremental` but you can
-/// also manage it directly using [`Self::update_diff_cursor`] and [`Self::reset_diff_cursor`].
+/// representation of the heads of the document last time you called [`Self::diff_incremental()`]
+/// but you can also manage it directly using [`Self::update_diff_cursor()`] and
+/// [`Self::reset_diff_cursor()`].
 #[derive(Debug, Clone)]
 pub struct AutoCommit {
     pub(crate) doc: Automerge,
@@ -140,7 +141,7 @@ impl AutoCommit {
         })
     }
 
-    /// Erases the diff cursor created by [`Self::update_diff_cursor`] and no
+    /// Erases the diff cursor created by [`Self::update_diff_cursor()`] and no
     /// longer indexes changes to the document.
     pub fn reset_diff_cursor(&mut self) {
         self.ensure_transaction_closed();
@@ -148,14 +149,14 @@ impl AutoCommit {
         self.diff_cursor = Vec::new();
     }
 
-    /// Sets the [`Self::diff_cursor`] to current heads of the document and will begin
+    /// Sets the [`Self::diff_cursor()`] to current heads of the document and will begin
     /// building an index with every change moving forward.
     ///
-    /// If [`Self::diff`] is called with [`Self::diff_cursor`] as `before` and
-    /// [`Self::get_heads`] as `after` - the index will be used
+    /// If [`Self::diff()`] is called with [`Self::diff_cursor()`] as `before` and
+    /// [`Self::get_heads`()] as `after` - the index will be used
     ///
     /// If the cursor is no longer needed it can be reset with
-    /// [`Self::reset_diff_cursor`]
+    /// [`Self::reset_diff_cursor()`]
     pub fn update_diff_cursor(&mut self) {
         self.ensure_transaction_closed();
         self.patch_log.set_active(true);
@@ -163,7 +164,7 @@ impl AutoCommit {
         self.diff_cursor = self.doc.get_heads();
     }
 
-    /// Returns the cursor set by [`Self::update_diff_cursor`]
+    /// Returns the cursor set by [`Self::update_diff_cursor()`]
     pub fn diff_cursor(&self) -> Vec<ChangeHash> {
         self.diff_cursor.clone()
     }
@@ -177,9 +178,9 @@ impl AutoCommit {
     ///
     /// By default the diff requires a sequental scan of all the ops in the doc.
     ///
-    /// To do a fast indexed diff `before` must equal [`Self::diff_cursor`] and
-    /// `after` must equal [`Self::get_heads`]. The diff cursor is managed with
-    /// [`Self::update_diff_cursor`] and [`Self::reset_diff_cursor`]
+    /// To do a fast indexed diff `before` must equal [`Self::diff_cursor()`] and
+    /// `after` must equal [`Self::get_heads()`]. The diff cursor is managed with
+    /// [`Self::update_diff_cursor()`] and [`Self::reset_diff_cursor()`]
     ///
     /// Managing the diff index has a small but non-zero overhead.  It should be
     /// disabled if no longer needed.  If a signifigantly large change is applied
@@ -207,7 +208,7 @@ impl AutoCommit {
     /// doc.update_diff_cursor();
     /// ```
     ///
-    /// See [`Self::diff_incremental`] for encapsulating this pattern.
+    /// See [`Self::diff_incremental()`] for encapsulating this pattern.
     pub fn diff(&mut self, before: &[ChangeHash], after: &[ChangeHash]) -> Vec<Patch> {
         self.ensure_transaction_closed();
         let range = OpRange::new(before, after);
@@ -343,8 +344,8 @@ impl AutoCommit {
 
     /// Load an incremental save of a document.
     ///
-    /// Unlike `load` this imports changes into an existing document. It will work with both the
-    /// output of [`Self::save`] and [`Self::save_incremental`]
+    /// Unlike [`Self::load()`] this imports changes into an existing document. It will work with both
+    /// the output of [`Self::save()`] and [`Self::save_incremental()`]
     ///
     /// The return value is the number of ops which were applied, this is not useful and will
     /// change in future.
@@ -415,10 +416,10 @@ impl AutoCommit {
         })
     }
 
-    /// Save the changes since the last call to [Self::save`]
+    /// Save the changes since the last call to [`Self::save()`]
     ///
     /// The output of this will not be a compressed document format, but a series of individual
-    /// changes. This is useful if you know you have only made a small change since the last `save`
+    /// changes. This is useful if you know you have only made a small change since the last [`Self::save()`]
     /// and you want to immediately send it somewhere (e.g. you've inserted a single character in a
     /// text object).
     pub fn save_incremental(&mut self) -> Vec<u8> {
@@ -457,7 +458,7 @@ impl AutoCommit {
         self.doc.get_change_by_hash(hash)
     }
 
-    /// Get changes in `other` that are not in `self
+    /// Get changes in `other` that are not in `self`
     pub fn get_changes_added<'a>(&mut self, other: &'a mut Self) -> Vec<&'a Change> {
         self.ensure_transaction_closed();
         other.ensure_transaction_closed();
@@ -518,14 +519,14 @@ impl AutoCommit {
 
     /// Commit any uncommitted changes
     ///
-    /// Returns `None` if there were no operations to commit
+    /// Returns [`None`] if there were no operations to commit
     pub fn commit(&mut self) -> Option<ChangeHash> {
         self.commit_with(CommitOptions::default())
     }
 
     /// Commit the current operations with some options.
     ///
-    /// Returns `None` if there were no operations to commit
+    /// Returns [`None`] if there were no operations to commit
     ///
     /// ```
     /// # use automerge::transaction::CommitOptions;
@@ -567,7 +568,7 @@ impl AutoCommit {
     ///
     /// Because this structure is an "autocommit" there may actually be outstanding operations to
     /// submit. If this is the case this function will create two changes, one with the outstanding
-    /// operations and a new one with no operations. The returned `ChangeHash` will always be the
+    /// operations and a new one with no operations. The returned [`ChangeHash`] will always be the
     /// hash of the empty change.
     pub fn empty_change(&mut self, options: CommitOptions) -> ChangeHash {
         self.ensure_transaction_closed();
@@ -584,12 +585,12 @@ impl AutoCommit {
         SyncWrapper { inner: self }
     }
 
-    /// Get the hash of the change that contains the given opid.
+    /// Get the hash of the change that contains the given `opid`.
     ///
-    /// Returns none if the opid:
-    /// - is the root object id
-    /// - does not exist in this document
-    /// - is for an operation in a transaction
+    /// Returns [`None`] if the `opid`:
+    /// - Is the root object id
+    /// - Does not exist in this document
+    /// - Is for an operation in a transaction
     pub fn hash_for_opid(&self, opid: &ExId) -> Option<ChangeHash> {
         self.doc.hash_for_opid(opid)
     }
@@ -948,7 +949,7 @@ impl Transactable for AutoCommit {
     }
 }
 
-// A wrapper we return from `AutoCommit::sync` to ensure that transactions are closed before we
+// A wrapper we return from [`AutoCommit::sync()`] to ensure that transactions are closed before we
 // start syncing
 struct SyncWrapper<'a> {
     inner: &'a mut AutoCommit,

--- a/rust/automerge/src/automerge.rs
+++ b/rust/automerge/src/automerge.rs
@@ -139,15 +139,15 @@ impl std::default::Default for LoadOptions<'static> {
 ///
 /// ## Creating, loading, merging and forking documents
 ///
-/// A new document can be created with [`Self::new`], which will create a document with a random
-/// [`ActorId`]. Existing documents can be loaded with [`Self::load`], or [`Self::load_with`].
+/// A new document can be created with [`Self::new()`], which will create a document with a random
+/// [`ActorId`]. Existing documents can be loaded with [`Self::load()`], or [`Self::load_with()`].
 ///
 /// If you have two documents and you want to merge the changes from one into the other you can use
-/// [`Self::merge`] or [`Self::merge_and_log_patches`].
+/// [`Self::merge()`] or [`Self::merge_and_log_patches()`].
 ///
 /// If you have a document you want to split into two concurrent threads of execution you can use
-/// [`Self::fork`]. If you want to split a document from ealier in its history you can use
-/// [`Self::fork_at`].
+/// [`Self::fork()`]. If you want to split a document from ealier in its history you can use
+/// [`Self::fork_at()`].
 ///
 /// ## Reading values
 ///
@@ -156,8 +156,8 @@ impl std::default::Default for LoadOptions<'static> {
 /// ## Modifying a document (Transactions)
 ///
 /// [`Automerge`] provides an interface for viewing and modifying automerge documents which does
-/// not manage transactions for you. To create changes you use either [`Automerge::transaction`] or
-/// [`Automerge::transact`] (or the `_with` variants).
+/// not manage transactions for you. To create changes you use either [`Automerge::transaction()`] or
+/// [`Automerge::transact()`] (or the `_with` variants).
 ///
 /// ## Sync
 ///
@@ -234,7 +234,7 @@ impl Automerge {
     ///
     /// # Panics
     ///
-    /// If the last actor in the OpSet is not the actor ID of this document
+    /// If the last actor in the [`OpSet`] is not the actor ID of this document
     pub(crate) fn rollback_last_actor(&mut self) {
         if let Actor::Cached(actor_idx) = self.actor {
             if self.states.get(&actor_idx).is_none() && self.ops.osd.actors.len() > 0 {
@@ -351,7 +351,7 @@ impl Automerge {
         self.transact_with_impl(None::<&dyn Fn(&O) -> CommitOptions>, f)
     }
 
-    /// Like [`Self::transact`] but with a function for generating the commit options.
+    /// Like [`Self::transact()`] but with a function for generating the commit options.
     pub fn transact_with<F, O, E, C>(&mut self, c: C, f: F) -> transaction::Result<O, E>
     where
         F: FnOnce(&mut Transaction<'_>) -> Result<O, E>,
@@ -392,7 +392,7 @@ impl Automerge {
     /// Run a transaction on this document in a closure, collecting patches, automatically handling commit or rollback
     /// afterwards.
     ///
-    /// The collected patches are available in the return value of [`Transaction::commit`]
+    /// The collected patches are available in the return value of [`Transaction::commit()`]
     pub fn transact_and_log_patches<F, O, E>(
         &mut self,
         text_rep: TextRepresentation,
@@ -404,7 +404,7 @@ impl Automerge {
         self.transact_and_log_patches_with_impl(text_rep, None::<&dyn Fn(&O) -> CommitOptions>, f)
     }
 
-    /// Like [`Self::transact_and_log_patches`] but with a function for generating the commit options
+    /// Like [`Self::transact_and_log_patches()`] but with a function for generating the commit options
     pub fn transact_and_log_patches_with<F, O, E, C>(
         &mut self,
         text_rep: TextRepresentation,
@@ -687,7 +687,9 @@ impl Automerge {
 
     /// Get a set of [`Patch`]es which materialize the current state of the document
     ///
-    /// This is a convienence method for `doc.diff(&[], current_heads)`
+    /// This is a convienence method for [`doc.diff(&[], current_heads)`][diff]
+    ///
+    /// [diff]: Self::diff()
     pub fn current_state(&self, text_rep: TextRepresentation) -> Vec<Patch> {
         let mut patch_log = PatchLog::active(text_rep);
         current_state::log_current_state_patches(self, &mut patch_log);
@@ -696,8 +698,8 @@ impl Automerge {
 
     /// Load an incremental save of a document.
     ///
-    /// Unlike `load` this imports changes into an existing document. It will work with both the
-    /// output of [`Self::save`] and [`Self::save_after`]
+    /// Unlike [`Self::load()`] this imports changes into an existing document. It will work with
+    /// both the output of [`Self::save()`] and [`Self::save_after()`]
     ///
     /// The return value is the number of ops which were applied, this is not useful and will
     /// change in future.
@@ -708,8 +710,8 @@ impl Automerge {
         )
     }
 
-    /// Like [`Self::load_incremental`] but log the changes to the current state of the document to
-    /// [`PatchLog`]
+    /// Like [`Self::load_incremental()`] but log the changes to the current state of the document
+    /// to [`PatchLog`]
     pub fn load_incremental_log_patches(
         &mut self,
         data: &[u8],
@@ -754,7 +756,7 @@ impl Automerge {
 
     /// Apply changes to this document.
     ///
-    /// This is idemptotent in the sense that if a change has already been applied it will be
+    /// This is idempotent in the sense that if a change has already been applied it will be
     /// ignored.
     pub fn apply_changes(
         &mut self,
@@ -766,7 +768,7 @@ impl Automerge {
         )
     }
 
-    /// Like [`Self::apply_changes`] but log the resulting changes to the current state of the
+    /// Like [`Self::apply_changes()`] but log the resulting changes to the current state of the
     /// document to `patch_log`
     pub fn apply_changes_log_patches<I: IntoIterator<Item = Change>>(
         &mut self,
@@ -949,7 +951,7 @@ impl Automerge {
         Ok(bytes)
     }
 
-    /// Save this document, but don't run it through DEFLATE afterwards
+    /// Save this document, but don't run it through `DEFLATE` afterwards
     pub fn save_nocompress(&self) -> Vec<u8> {
         self.save_with_options(SaveOptions {
             deflate: false,
@@ -960,9 +962,9 @@ impl Automerge {
     /// Save the changes since the given heads
     ///
     /// The output of this will not be a compressed document format, but a series of individual
-    /// changes. This is useful if you know you have only made a small change since the last `save`
-    /// and you want to immediately send it somewhere (e.g. you've inserted a single character in a
-    /// text object).
+    /// changes. This is useful if you know you have only made a small change since the last
+    /// [`Self::save()`] and you want to immediately send it somewhere (e.g. you've inserted a
+    /// single character in a text object).
     pub fn save_after(&self, heads: &[ChangeHash]) -> Vec<u8> {
         let changes = self.get_changes(heads);
         let mut bytes = vec![];
@@ -1254,7 +1256,7 @@ impl Automerge {
     }
 
     /// Create patches representing the change in the current state of the document between the
-    /// 'before' and 'after' heads.  If the arguments are reverse it will observe the same changes
+    /// `before` and `after` heads.  If the arguments are reverse it will observe the same changes
     /// in the opposite order.
     pub fn diff(
         &self,
@@ -1281,7 +1283,7 @@ impl Automerge {
         self.get_changes_clock(have_deps)
     }
 
-    /// Get changes in `other` that are not in `self
+    /// Get changes in `other` that are not in `self`
     pub fn get_changes_added<'a>(&self, other: &'a Self) -> Vec<&'a Change> {
         // Depth-first traversal from the heads through the dependency graph,
         // until we reach a change that is already present in other
@@ -1307,9 +1309,9 @@ impl Automerge {
             .collect()
     }
 
-    /// Get the hash of the change that contains the given opid.
+    /// Get the hash of the change that contains the given `opid`.
     ///
-    /// Returns none if the opid:
+    /// Returns [`None`] if the `opid`:
     /// - is the root object id
     /// - does not exist in this document
     pub fn hash_for_opid(&self, exid: &ExId) -> Option<ChangeHash> {
@@ -1818,7 +1820,7 @@ impl Default for Automerge {
     }
 }
 
-/// Options to pass to `[Automerge::save_with_options]` and [`crate::AutoCommit::save_with_options`]
+/// Options to pass to [`Automerge::save_with_options()`] and [`crate::AutoCommit::save_with_options()`]
 #[derive(Debug)]
 pub struct SaveOptions {
     /// Whether to apply DEFLATE compression to the RLE encoded columns in the document

--- a/rust/automerge/src/cursor.rs
+++ b/rust/automerge/src/cursor.rs
@@ -1,6 +1,8 @@
 use crate::op_set::OpSetData;
 use crate::storage::parse;
 use crate::types::OpId;
+#[cfg(doc)]
+use crate::ReadDoc;
 use crate::{ActorId, AutomergeError};
 use std::fmt;
 
@@ -10,10 +12,10 @@ use std::fmt;
 /// While ExId is our default external representation of the Operation ID, it can be quite heavy.
 /// Therefore, we use this lightweight specialized structure.
 ///
-/// This can be persisted using to_bytes and TryFrom<&[u8]>.
+/// This can be persisted using [`Self::to_bytes()`] and [`TryFrom<&[u8]>`][TryFrom].
 ///
-/// A cursor is obtained from [`ReadDoc::get_cursor`](crate::ReadDoc::get_cursor) and dereferenced
-/// with [`ReadDoc::get_cursor_position`](crate::ReadDoc::get_cursor_position).
+/// A cursor is obtained from [`ReadDoc::get_cursor()`] and dereferenced with
+/// [`ReadDoc::get_cursor_position()`].
 #[derive(Clone, PartialEq, Debug)]
 pub struct Cursor {
     ctr: u64,

--- a/rust/automerge/src/lib.rs
+++ b/rust/automerge/src/lib.rs
@@ -2,7 +2,7 @@
 //!
 //! Automerge is a library of data structures for building collaborative,
 //! [local-first](https://www.inkandswitch.com/local-first/) applications. The
-//! idea of automerge is to provide a data structure which is quite general,
+//! idea of automerge is to provide a data structure which is quite general
 //! \- consisting of nested key/value maps and/or lists - which can be modified
 //! entirely locally but which can at any time be merged with other instances of
 //! the same data structure.
@@ -23,7 +23,7 @@
 //!
 //! NOTE: The API this library provides for modifying data is quite low level
 //! (somewhat analogous to directly creating JSON values rather than using
-//! `serde` derive macros or equivalent). If you're writing a Rust application which uses automerge
+//! [`serde`] derive macros or equivalent). If you're writing a Rust application which uses automerge
 //! you may want to look at [autosurgeon](https://github.com/automerge/autosurgeon).
 //!
 //! ## Data Model
@@ -56,19 +56,19 @@
 //! There are some things automerge cannot merge sensibly. For example, two
 //! actors concurrently setting the key "name" to different values. In this case
 //! automerge will pick a winning value in a random but deterministic way, but
-//! the conflicting value is still available via the [`ReadDoc::get_all`] method.
+//! the conflicting value is still available via the [`ReadDoc::get_all()`] method.
 //!
 //! ### Change hashes and historical values
 //!
 //! Like git, points in the history of a document are identified by hash. Unlike
 //! git there can be multiple hashes representing a particular point (because
 //! automerge supports concurrent changes). These hashes can be obtained using
-//! either [`Automerge::get_heads`] or [`AutoCommit::get_heads`] (note these
+//! either [`Automerge::get_heads()`] or [`AutoCommit::get_heads()`] (note these
 //! methods are not part of [`ReadDoc`] because in the case of [`AutoCommit`] it
 //! requires a mutable reference to the document).
 //!
 //! These hashes can be used to read values from the document at a particular
-//! point in history using the various `*_at` methods on [`ReadDoc`] which take a
+//! point in history using the various `*_at()` methods on [`ReadDoc`] which take a
 //! slice of [`ChangeHash`] as an argument.
 //!
 //! ### Actor IDs
@@ -83,7 +83,7 @@
 //!
 //! ### Text Encoding
 //!
-//! Text is encoded in utf8 by default but uses Utf16 when using the wasm target.
+//! Text is encoded in UTF-8 by default but uses UTF-16 when using the wasm target.
 //!
 //! ## Sync Protocol
 //!
@@ -94,17 +94,17 @@
 //! Often you will have some state which represents the "current" state of the document. E.g. some
 //! text in a UI which is a view of a text object in the document. Rather than re-rendering this
 //! text every single time a change comes in you can use a [`PatchLog`] to capture incremental
-//! changes made to the document and then use [`Automerge::make_patches`] to get a set of patches
+//! changes made to the document and then use [`Automerge::make_patches()`] to get a set of patches
 //! to apply to the materialized state.
 //!
 //! Many of the methods on [`Automerge`], [`crate::sync::SyncDoc`] and
-//! [`crate::transaction::Transactable`] have a `*_log_patches` variant which allow you to pass in
+//! [`crate::transaction::Transactable`] have a `*_log_patches()` variant which allow you to pass in
 //! a [`PatchLog`] to collect these incremental changes.
 //!
 //! ## Serde serialization
 //!
 //! Sometimes you just want to get the JSON value of an automerge document. For
-//! this you can use [`AutoSerde`], which implements `serde::Serialize` for an
+//! this you can use [`AutoSerde`], which implements [`serde::Serialize`] for an
 //! automerge document.
 //!
 //! ## Example
@@ -197,10 +197,10 @@
 //! When working with text or other sequences it is often useful to be able to
 //! refer to a specific position within the sequence whilst merging remote
 //! changes. You can manually do this by maintaining your own offsets and
-//! observing patches, but this is error prone. The `Cursor` type provides
+//! observing patches, but this is error prone. The [`Cursor`] type provides
 //! an API for allowing automerge to do the index translations for you. Cursors
-//! are created with [`ReadDoc::get_cursor`] and dereferneced with
-//! [`ReadDoc::get_cursor_position`].
+//! are created with [`ReadDoc::get_cursor()`] and dereferenced with
+//! [`ReadDoc::get_cursor_position()`].
 
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/automerge/automerge/main/img/brandmark.svg",

--- a/rust/automerge/src/patches/patch_log.rs
+++ b/rust/automerge/src/patches/patch_log.rs
@@ -17,11 +17,11 @@ use super::{PatchBuilder, TextRepresentation};
 /// in a text editor you may be rendering the current state a text field in the UI. In order to
 /// efficiently update the state of the materialized view any method which adds operations to the
 /// document has a variant which takes a [`PatchLog`] as an argument. This allows the caller to
-/// record the changes made and then use either [`crate::Automerge::make_patches`] or
-/// [`crate::AutoCommit::make_patches`] to generate a `Vec<Patch>` which can be used to update the
+/// record the changes made and then use either [`crate::Automerge::make_patches()`] or
+/// [`crate::AutoCommit::make_patches()`] to generate a [`Vec<Patch>`] which can be used to update the
 /// materialized view.
 ///
-/// A `PatchLog` is a set of _relative_ changes. It represents the changes required to go from the
+/// A [`PatchLog`] is a set of _relative_ changes. It represents the changes required to go from the
 /// state at one point in history to another. What those two points are depends on how you use the
 /// log. A typical reason to create a [`PatchLog`] is to record the changes made by remote peers.
 /// Consider this example:
@@ -107,14 +107,14 @@ impl PatchLog {
     ///
     /// # Arguments
     ///
-    /// * `active`   - If `true` the log will record all changes made to the document. If `false`
+    /// * `active`   - If `true` the log will record all changes made to the document. If [`false`]
     ///                then no changes will be recorded.
     /// * `text_rep` - How text will be represented in the generated patches
     ///
     /// Why, you ask, would you create a [`PatchLog`] which doesn't record any changes? Operations
     /// which record patches are more expensive, so sometimes you may wish to turn off patch
     /// logging for parts of the application, but not others; but you don't want to complicate your
-    /// code with an `Option<PatchLog>`. In that case you can use an inactive [`PatchLog`].
+    /// code with an [`Option<PatchLog>`]. In that case you can use an inactive [`PatchLog`].
     pub fn new(active: bool, text_rep: TextRepresentation) -> Self {
         PatchLog {
             active,
@@ -127,7 +127,7 @@ impl PatchLog {
 
     /// Create a new [`PatchLog`] which doesn't record any changes.
     ///
-    /// See also: [`PatchLog::new`] for a more detailed explanation.
+    /// See also: [`PatchLog::new()`] for a more detailed explanation.
     pub fn inactive(text_rep: TextRepresentation) -> Self {
         Self::new(false, text_rep)
     }
@@ -138,7 +138,7 @@ impl PatchLog {
 
     /// Create a new [`PatchLog`] which does record changes.
     ///
-    /// See also: [`PatchLog::new`] for a more detailed explanation.
+    /// See also: [`PatchLog::new()`] for a more detailed explanation.
     pub fn active(text_rep: TextRepresentation) -> Self {
         Self::new(true, text_rep)
     }

--- a/rust/automerge/src/read.rs
+++ b/rust/automerge/src/read.rs
@@ -33,7 +33,7 @@ pub trait ReadDoc {
 
     /// Get the parents of the object `obj` as at `heads`
     ///
-    /// See [`Self::parents`]
+    /// See [`Self::parents()`]
     fn parents_at<O: AsRef<ExId>>(
         &self,
         obj: O,
@@ -48,7 +48,7 @@ pub trait ReadDoc {
 
     /// Get the keys of the object `obj` as at `heads`
     ///
-    /// See [`Self::keys`]
+    /// See [`Self::keys()`]
     fn keys_at<O: AsRef<ExId>>(&self, obj: O, heads: &[ChangeHash]) -> Keys<'_>;
 
     /// Iterate over the keys and values of the map `obj` in the given range.
@@ -71,7 +71,7 @@ pub trait ReadDoc {
     /// The returned iterator yields `(key, value, exid)` tuples, where the
     /// third element is the ID of the operation which created the value.
     ///
-    /// See [`Self::map_range`]
+    /// See [`Self::map_range()`]
     fn map_range_at<'a, O: AsRef<ExId>, R: RangeBounds<String> + 'a>(
         &'a self,
         obj: O,
@@ -94,7 +94,7 @@ pub trait ReadDoc {
     /// The returned iterator yields `(index, value, exid)` tuples, where the third
     /// element is the ID of the operation which created the value.
     ///
-    /// See [`Self::list_range`]
+    /// See [`Self::list_range()`]
     fn list_range_at<O: AsRef<ExId>, R: RangeBounds<usize>>(
         &self,
         obj: O,
@@ -113,7 +113,7 @@ pub trait ReadDoc {
     /// The returned iterator yields `(value, exid)` tuples, where the second element
     /// is the ID of the operation which created the value.
     ///
-    /// See [`Self::values`]
+    /// See [`Self::values()`]
     fn values_at<O: AsRef<ExId>>(&self, obj: O, heads: &[ChangeHash]) -> Values<'_>;
 
     /// Get the length of the given object.
@@ -125,7 +125,7 @@ pub trait ReadDoc {
     ///
     /// If the given object is not in this document this method will return `0`
     ///
-    /// See [`Self::length`]
+    /// See [`Self::length()`]
     fn length_at<O: AsRef<ExId>>(&self, obj: O, heads: &[ChangeHash]) -> usize;
 
     /// Get the type of this object, if it is an object.
@@ -152,20 +152,20 @@ pub trait ReadDoc {
     fn text<O: AsRef<ExId>>(&self, obj: O) -> Result<String, AutomergeError>;
 
     /// Get the string represented by the given text object as at `heads`, see
-    /// [`Self::text`]
+    /// [`Self::text()`]
     fn text_at<O: AsRef<ExId>>(
         &self,
         obj: O,
         heads: &[ChangeHash],
     ) -> Result<String, AutomergeError>;
 
-    /// Obtain the stable address (Cursor) for a `usize` position in a Sequence (either `Self::List` or `Self::Text`).
+    /// Obtain the stable address (Cursor) for a [`usize`] position in a Sequence (either [`ObjType::List`] or [`ObjType::Text`]).
     ///
     /// Example use cases:
     /// 1. User cursor tracking, to maintain contextual position while merging remote changes.
     /// 2. Indexing sentences in a text field.
     ///
-    /// To reverse the operation, see [`Self::get_cursor_position`].
+    /// To reverse the operation, see [`Self::get_cursor_position()`].
     fn get_cursor<O: AsRef<ExId>>(
         &self,
         obj: O,
@@ -173,11 +173,11 @@ pub trait ReadDoc {
         at: Option<&[ChangeHash]>,
     ) -> Result<Cursor, AutomergeError>;
 
-    /// Translate Cursor in a Sequence into an absolute position of type `usize`.
+    /// Translate Cursor in a Sequence into an absolute position of type [`usize`].
     ///
-    /// Applicable only for Sequences (either `Self::List` or `Self::Text`).
+    /// Applicable only for Sequences (either [`ObjType::List`] or [`ObjType::Text`]).
     ///
-    /// To reverse the operation, see [`Self::get_cursor`].
+    /// To reverse the operation, see [`Self::get_cursor()`].
     fn get_cursor_position<O: AsRef<ExId>>(
         &self,
         obj: O,
@@ -189,7 +189,7 @@ pub trait ReadDoc {
     ///
     /// This returns a tuple of `(value, object ID)`. This is for two reasons:
     ///
-    /// 1. If `value` is an object (represented by `Value::Object`) then the ID
+    /// 1. If `value` is an object (represented by [`Value::Object`]) then the ID
     ///    is the ID of that object. This can then be used to retrieve nested
     ///    values from the document.
     /// 2. Even if `value` is a scalar, the ID represents the operation which
@@ -199,14 +199,14 @@ pub trait ReadDoc {
     /// In the case of a key which has conflicting values, this method will
     /// return a single arbitrarily chosen value. This value will be chosen
     /// deterministically on all nodes. If you want to get all the values for a
-    /// key use [`Self::get_all`].
+    /// key use [`Self::get_all()`].
     fn get<O: AsRef<ExId>, P: Into<Prop>>(
         &self,
         obj: O,
         prop: P,
     ) -> Result<Option<(Value<'_>, ExId)>, AutomergeError>;
 
-    /// Get the value of the given key as at `heads`, see `[Self::get]`
+    /// Get the value of the given key as at `heads`, see [`Self::get()`]
     fn get_at<O: AsRef<ExId>, P: Into<Prop>>(
         &self,
         obj: O,
@@ -227,7 +227,7 @@ pub trait ReadDoc {
 
     /// Get all possibly conflicting values for a key as at `heads`
     ///
-    /// See `[Self::get_all]`
+    /// See [`Self::get_all()`]
     fn get_all_at<O: AsRef<ExId>, P: Into<Prop>>(
         &self,
         obj: O,

--- a/rust/automerge/src/sync.rs
+++ b/rust/automerge/src/sync.rs
@@ -10,12 +10,12 @@
 //! can take part in the sync protocol. The flow goes something like this:
 //!
 //! * The initiating peer creates an empty [`State`] and then calls
-//!   [`SyncDoc::generate_sync_message`] to generate new sync message and sends
+//!   [`SyncDoc::generate_sync_message()`] to generate new sync message and sends
 //!   it to the receiving peer.
 //! * The receiving peer receives a message from the initiator, creates a new
-//!   [`State`], and calls [`SyncDoc::receive_sync_message`] on it's view of the
+//!   [`State`], and calls [`SyncDoc::receive_sync_message()`] on it's view of the
 //!   document
-//! * The receiving peer then calls [`SyncDoc::generate_sync_message`] to generate
+//! * The receiving peer then calls [`SyncDoc::generate_sync_message()`] to generate
 //!   a new sync message and send it back to the initiator
 //! * From this point on each peer operates in a loop, receiving a sync message
 //!   from the other peer and then generating a new message to send back.
@@ -95,7 +95,7 @@ pub use state::{Have, State};
 pub trait SyncDoc {
     /// Generate a sync message for the remote peer represented by `sync_state`
     ///
-    /// If this returns `None` then there are no new messages to send, either because we are
+    /// If this returns [`None`] then there are no new messages to send, either because we are
     /// waiting for an acknolwedgement of an in-flight message, or because the remote is up to
     /// date.
     ///
@@ -115,7 +115,7 @@ pub trait SyncDoc {
     /// Apply a received sync message to this document and `sync_state`, logging any changes that
     /// are made to `patch_log`
     ///
-    /// If this returns `None` then there are no new messages to send, either because we are
+    /// If this returns [`None`] then there are no new messages to send, either because we are
     /// waiting for an acknolwedgement of an in-flight message, or because the remote is up to
     /// date.
     ///
@@ -540,7 +540,7 @@ pub struct Message {
     pub version: MessageVersion,
 }
 
-/// An array of changes, each of which should be passed to [`Automerge::load_incremental`]
+/// An array of changes, each of which should be passed to [`Automerge::load_incremental()`]
 #[derive(Clone, Debug, PartialEq)]
 pub struct ChunkList(Vec<Vec<u8>>);
 

--- a/rust/automerge/src/sync/state.rs
+++ b/rust/automerge/src/sync/state.rs
@@ -1,5 +1,7 @@
 use std::collections::BTreeSet;
 
+#[cfg(doc)]
+use super::SyncDoc;
 use super::{encode_hashes, BloomFilter, Capability};
 use crate::storage::parse;
 use crate::ChangeHash;
@@ -24,8 +26,8 @@ impl From<parse::leb128::Error> for DecodeError {
 
 /// The state of synchronisation with a peer.
 ///
-/// This should be persisted using [`Self::encode`] when you know you will be interacting with the
-/// same peer in multiple sessions. [`Self::encode`] only encodes state which should be reused
+/// This should be persisted using [`Self::encode()`] when you know you will be interacting with the
+/// same peer in multiple sessions. [`Self::encode()`] only encodes state which should be reused
 /// across connections.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Hash)]
 pub struct State {
@@ -42,13 +44,13 @@ pub struct State {
     /// The hashes we have sent in this session
     pub sent_hashes: BTreeSet<ChangeHash>,
 
-    /// `generate_sync_message` should return `None` if there are no new changes to send. In
-    /// particular, if there are changes in flight which the other end has not yet acknowledged we
-    /// do not wish to generate duplicate sync messages. This field tracks whether the changes we
-    /// expect to send to the peer based on this sync state have been sent or not. If
-    /// `in_flight` is `false` then `generate_sync_message` will return a new message (provided
-    /// there are in fact changes to send). If it is `true` then we don't. This flag is cleared
-    /// in `receive_sync_message`.
+    /// [`SyncDoc::generate_sync_message()`] should return [`None`] if there are no new changes
+    /// to send. In particular, if there are changes in flight which the other end has not yet
+    /// acknowledged we do not wish to generate duplicate sync messages. This field tracks whether
+    /// the changes we expect to send to the peer based on this sync state have been sent or not. If
+    /// [`Self::in_flight`] is [`false`] then [`SyncDoc::generate_sync_message()`] will return a new
+    /// message (provided there are in fact changes to send). If it is [`true`] then we don't. This
+    /// flag is cleared in [`SyncDoc::receive_sync_message()`].
     pub in_flight: bool,
 
     /// Whether we have ever responded to the other end. This is used to ensure that we always send

--- a/rust/automerge/src/transaction/manual_transaction.rs
+++ b/rust/automerge/src/transaction/manual_transaction.rs
@@ -14,14 +14,14 @@ use super::{CommitOptions, Transactable, TransactionArgs, TransactionInner};
 /// Transactions group operations into a single change so that no other operations can happen
 /// in-between.
 ///
-/// Created from [`Automerge::transaction`].
+/// Created from [`Automerge::transaction()`].
 ///
 /// ## Drop
 ///
 /// This transaction should be manually committed or rolled back. If not done manually then it will
 /// be rolled back when it is dropped. This is to prevent the document being in an unsafe
 /// intermediate state.
-/// This is consistent with `?` error handling.
+/// This is consistent with [`?`][std::ops::Try] error handling.
 #[derive(Debug)]
 pub struct Transaction<'a> {
     // this is an option so that we can take it during commit and rollback to prevent it being
@@ -425,11 +425,11 @@ impl<'a> Transactable for Transaction<'a> {
     }
 }
 
-// If a transaction is not commited or rolled back manually then it can leave the document in an
-// intermediate state.
-// This defaults to rolling back the transaction to be compatible with `?` error returning before
-// reaching a call to `commit`.
 impl<'a> Drop for Transaction<'a> {
+    /// If a transaction is not commited or rolled back manually then it can leave the document in
+    /// an intermediate state.
+    /// This defaults to rolling back the transaction to be compatible with [`?`][std::ops::Try]
+    /// error returning before reaching a call to [`Self::commit()`].
     fn drop(&mut self) {
         if let Some(txn) = self.inner.take() {
             txn.rollback(self.doc);

--- a/rust/automerge/src/value.rs
+++ b/rust/automerge/src/value.rs
@@ -8,7 +8,7 @@ use std::fmt;
 /// The type of values in an automerge document
 #[derive(Debug, Clone, PartialEq)]
 pub enum Value<'a> {
-    /// An composite object of type `ObjType`
+    /// A composite object of type [`ObjType`]
     Object(ObjType),
     /// A non composite value
     // TODO: if we don't have to store this in patches any more then it might be able to be just a


### PR DESCRIPTION
Found some markdown that was either:
- Missing backticks;
- Had the ` `` ` around `[]` so that it wouldn't turn into a link but display as a single-item array;
- Missing `[]` so that it would not link to an item/function;
- Some invalid `Self::` references that should have pointed to another type (rustdoc points this out and it helps the user understand and click what the docs are referring to);
- Added `()` at the end of functions for readability (and forces `rustdoc` to ensure that the target item really is an `fn`).
