### PR TITLE
generate and patch js objects more efficiently

### DIFF
--- a/rust/automerge-wasm/src/value.rs
+++ b/rust/automerge-wasm/src/value.rs
@@ -1,7 +1,7 @@
 use automerge::{ObjType, ScalarValue, Value};
 use wasm_bindgen::prelude::*;
 
-#[derive(Debug, Clone, Hash, Eq, PartialEq)]
+#[derive(Debug, Copy, Clone, Hash, Eq, PartialEq)]
 pub(crate) enum Datatype {
     Map,
     Table,
@@ -44,7 +44,7 @@ impl From<ObjType> for Datatype {
 
 impl std::fmt::Display for Datatype {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
-        write!(f, "{}", String::from(self.clone()))
+        write!(f, "{}", String::from(*self))
     }
 }
 

--- a/rust/edit-trace/package.json
+++ b/rust/edit-trace/package.json
@@ -4,7 +4,7 @@
   "main": "wasm-text.js",
   "license": "MIT",
   "scripts": {
-    "wasm": "0x -D prof automerge-wasm.js"
+    "prof": "0x -D prof"
   },
   "devDependencies": {
     "0x": "^5.4.1"


### PR DESCRIPTION
Optimize the code that generates and patches js objects from wasm.   Gives a 10x performance boost over the main branch on a problem document supplied by @pvh  (10246 ms vs 1061 ms)

Of the remaining 1000ms 

30% is spent creating the javascript object -  this is what this PR optimizes - not obvious how to make this faster
30% is spent loading the document - this will speed up with the faster load PR
15% is spent creating the rust patches 
25% if spent converting those patches into js objects.

I'm wondering if some system to make the patches lazily would be better since those patches are taking 40% of the load time and are not always used.  Something for future work
