### PR TITLE
js: don't use put with text, fixes #677

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ build/
 .vim/*
 /target
 .DS_Store
+**/.idea/*

--- a/javascript/.mocharc.json
+++ b/javascript/.mocharc.json
@@ -1,0 +1,8 @@
+{
+  "extensions": ["ts"],
+  "spec": ["test/*"],
+  "node-option": [
+    "experimental-specifier-resolution=node",
+    "loader=ts-node/esm"
+  ]
+}

--- a/javascript/src/proxies.ts
+++ b/javascript/src/proxies.ts
@@ -906,7 +906,7 @@ function textMethods(target: Target) {
   const { context, objectId } = target
   const methods = {
     set(index: number, value: any) {
-      return (this[index] = value)
+      context.splice(objectId, index, 1, value)
     },
     get(index: number): AutomergeValue {
       return this[index]

--- a/javascript/test/text_v1.ts
+++ b/javascript/test/text_v1.ts
@@ -331,4 +331,19 @@ describe("Automerge.Text", () => {
   it("should support slice", () => {
     assert.strictEqual(s1.text.slice(0).toString(), s1.text.toString())
   })
+
+  it("should be able to move insert, delete and set changes to a new document", () => {
+    let doc = Automerge.from({ text: new Automerge.Text("") })
+    doc = Automerge.change(doc, d => {
+      const multipleOpNodes = new Array(32).fill("0").join("")
+      d.text.insertAt(0, multipleOpNodes)
+      d.text.set(0, "1")
+      d.text.set(15, "2")
+    })
+    const [newDoc] = Automerge.applyChanges(
+      Automerge.init<{ text: Automerge.Text }>(),
+      Automerge.getAllChanges(doc),
+    )
+    assert.strictEqual(doc.text.toString(), newDoc.text.toString())
+  })
 })

--- a/rust/automerge-wasm/.mocharc.json
+++ b/rust/automerge-wasm/.mocharc.json
@@ -1,0 +1,8 @@
+{
+  "extensions": ["ts"],
+  "spec": ["test/*"],
+  "node-option": [
+    "experimental-specifier-resolution=node",
+    "loader=ts-node/esm"
+  ]
+}


### PR DESCRIPTION
I traced the issue described in the linked ticket (#677).
For it to happen we need to have multiple nodes in the operations tree.
```ts
const multipleOpNodes = new Array(32).fill("0").join("")
d.text.insertAt(0, multipleOpNodes)
```
Then we need to reset the `never_seen_puts` flag:
```ts
d.text.set(0, "1")
```
And finally we need another put at position that gets us to the second child node of operations tree:
```ts
d.text.set(15, "2")
```
to end up in [this branch](https://github.com/automerge/automerge/blob/main/rust/automerge/src/query/list_state.rs#L90).

Because neither `process_text_node` nor `process_list_node` is called position won't be shifted by [the number of seen nodes](https://github.com/automerge/automerge/blob/main/rust/automerge/src/query/list_state.rs#L120) and instead of inserting text at position 15 we'll insert it at position 0.

My fix is to use splice instead of set in text proxy:
```patch
- return (this[index] = value)
+ context.splice(objectId, index, 1, value)
```
as suggested in the comment of the code I referenced before:
```
// text nodes are intended to only be interacted with splice()
// meaning all ops are inserts or deleted inserts
// the indexes are written with this assumption in mind
// if conflicted put()'s with different character widths exist
// we cannot trust the indexs and need to descend
```

This fix will work for JS, but why was it implemented like this in Rust? 
Won't it be better to throw InvalidOp when trying to `.put` on a text object?
```rust
#[test]
fn wrong_behaviour() {
    let mut doc = AutoCommit::new();
    let oid = doc.put_object(&automerge::ROOT, "t", ObjType::Text).unwrap();
    doc.splice_text(&oid, 0, 0, "00000000000000000000000000000000").unwrap();
    doc.put(&oid, 0, "1").unwrap();
    doc.put(&oid, 15, "2").unwrap();

    let changes: Vec<Change> = doc.get_changes(&[])
        .into_iter()
        .map(|c| c.clone())
        .collect();
    let mut another_doc = AutoCommit::new();
    another_doc.update_diff_cursor();
    another_doc.apply_changes(changes).unwrap();

    assert_eq!(doc.text(&oid), another_doc.text(&oid));
}
```
This test will fail 👆 