### PR TITLE
Fix a backwards incompatibility in the new sync messages

### DIFF
--- a/rust/automerge/src/sync.rs
+++ b/rust/automerge/src/sync.rs
@@ -229,15 +229,8 @@ impl SyncDoc for Automerge {
                 // deduplicate the changes to send with those we have already sent and clone it now
                 let changes = all_changes
                     .into_iter()
-                    .filter_map(|change| {
-                        if !sync_state.sent_hashes.contains(&change.hash()) {
-                            Some(change.clone())
-                        } else {
-                            None
-                        }
-                    })
-                    .collect::<Vec<_>>();
-                let hashes = changes.iter().map(|c| c.hash()).collect::<Vec<_>>();
+                    .filter(|change| !sync_state.sent_hashes.contains(&change.hash()));
+                let hashes = changes.clone().map(|c| c.hash()).collect::<Vec<_>>();
                 if sync_state.supports_v2_messages() {
                     let encoded = changes
                         .into_iter()
@@ -251,7 +244,7 @@ impl SyncDoc for Automerge {
         } else if sync_state.supports_v2_messages() {
             (MessageBuilder::new_v2(Vec::new()), Vec::new())
         } else {
-            (MessageBuilder::new_v1(Vec::new()), Vec::new())
+            (MessageBuilder::new_v1(std::iter::empty()), Vec::new())
         };
 
         let heads_unchanged = sync_state.last_sent_heads == our_heads;

--- a/rust/automerge/src/sync/message_builder.rs
+++ b/rust/automerge/src/sync/message_builder.rs
@@ -12,15 +12,12 @@ pub(super) struct MessageBuilder {
 }
 
 impl MessageBuilder {
-    pub(super) fn new_v1(changes: Vec<Change>) -> Self {
+    pub(super) fn new_v1<'a, I: Iterator<Item = &'a Change>>(changes: I) -> Self {
         MessageBuilder {
             heads: Vec::new(),
             need: Vec::new(),
             have: Vec::new(),
-            changes: changes
-                .into_iter()
-                .map(|mut c| c.bytes().to_vec())
-                .collect(),
+            changes: changes.map(|c| c.raw_bytes().to_vec()).collect(),
             supported_capabilities: None,
             version: MessageVersion::V1,
         }


### PR DESCRIPTION
Problem: some older clients were throwing an error when parsing sync messages from sync protocol upgrades introduced in d6c67f41e626493bf83612dc58c1829842ebe195. The problem is that the new protocol was encoding changes using `crate::Change::bytes`, rather than `crate::Change::raw_bytes`. The former compresses the change if it larger than a certain threshold but the old sync protocol is not capable of handling compressed changes.

Solution: use `raw_bytes` rather than `bytes` to avoid compressing changes.