### PR TITLE
Introduce Automerge.updateText (rust: Transactable::update_text)

### DIFF
--- a/javascript/src/next.ts
+++ b/javascript/src/next.ts
@@ -323,6 +323,50 @@ export function splice<T>(
 }
 
 /**
+ * Update the value of a string
+ *
+ * @typeParam T - The type of the value contained in the document
+ * @param doc - The document to modify
+ * @param path - The path to the string to modify
+ * @param newText - The new text to update the value to
+ *
+ * @remarks
+ * This will calculate a diff between the current value and the new value and
+ * then convert that diff into calls to {@link splice}. This will produce results
+ * which don't merge as well as directly capturing the user input actions, but
+ * sometimes it's not possible to capture user input and this is the best you
+ * can do.
+ *
+ * This is an experimental API and may change in the future.
+ *
+ * @beta
+ */
+export function updateText(
+  doc: Doc<unknown>,
+  path: stable.Prop[],
+  newText: string,
+) {
+  if (!_is_proxy(doc)) {
+    throw new RangeError("object cannot be modified outside of a change block")
+  }
+  const state = _state(doc, false)
+  const objectId = _obj(doc)
+  if (!objectId) {
+    throw new RangeError("invalid object for updateText")
+  }
+  _clear_cache(doc)
+
+  path.unshift(objectId)
+  const value = path.join("/")
+
+  try {
+    return state.handle.updateText(value, newText)
+  } catch (e) {
+    throw new RangeError(`Cannot updateText: ${e}`)
+  }
+}
+
+/**
  * Returns a cursor for the given position in a string.
  *
  * @remarks

--- a/javascript/test/text_test.ts
+++ b/javascript/test/text_test.ts
@@ -127,4 +127,38 @@ describe("Automerge.Text", () => {
     })
     assert.strictEqual(doc.dom[0][0], "Hello world")
   })
+
+  describe("updateText", () => {
+    it("should calculate a diff when updating text", () => {
+      let doc1 = Automerge.from({ text: "Hello world!" }, { actor: "aaaaaa" })
+
+      let doc2 = Automerge.clone(doc1, { actor: "bbbbbb" })
+      doc2 = Automerge.change(doc2, d => {
+        Automerge.updateText(d, ["text"], "Goodbye world!")
+      })
+
+      doc1 = Automerge.change(doc1, d => {
+        Automerge.updateText(d, ["text"], "Hello friends!")
+      })
+
+      const merged = Automerge.merge(doc1, doc2)
+      assert.strictEqual(merged.text, "Goodbye friends!")
+    })
+
+    it("should handle multi character grapheme clusters", () => {
+      let doc1 = Automerge.from({ text: "left👨‍👩‍👦right" }, { actor: "aaaaaa" })
+
+      let doc2 = Automerge.clone(doc1, { actor: "bbbbbb" })
+      doc2 = Automerge.change(doc2, d => {
+        Automerge.updateText(d, ["text"], "left👨‍👩‍👧right")
+      })
+
+      doc1 = Automerge.change(doc1, d => {
+        Automerge.updateText(d, ["text"], "left👨‍👩‍👦‍👦right")
+      })
+
+      const merged = Automerge.merge(doc1, doc2)
+      assert.strictEqual(merged.text, "left👨‍👩‍👧👨‍👩‍👦‍👦right")
+    })
+  })
 })

--- a/rust/automerge-wasm/index.d.ts
+++ b/rust/automerge-wasm/index.d.ts
@@ -206,6 +206,7 @@ export class Automerge {
   splice(obj: ObjID, start: number, delete_count: number, text?: string | Array<Value>): void;
   increment(obj: ObjID, prop: Prop, value: number): void;
   delete(obj: ObjID, prop: Prop): void;
+  updateText(obj: ObjID, newText: string): void;
 
   // marks
   mark(obj: ObjID, range: MarkRange, name: string, value: Value, datatype?: Datatype): void;

--- a/rust/automerge-wasm/test/update_text.mts
+++ b/rust/automerge-wasm/test/update_text.mts
@@ -1,0 +1,31 @@
+import { describe, it } from 'mocha';
+import assert from 'assert'
+import { create } from '../nodejs/automerge_wasm.cjs'
+
+describe('update_text', () => {
+  it("should calculate a diff when updating text", () => {
+    const doc1 = create()
+    const text = doc1.putObject("_root", "text", "");
+    doc1.splice(text, 0, 0, "Hello world!")
+
+    const doc2 = doc1.fork()
+    doc2.updateText(text, "Goodbye world!")
+
+    doc1.updateText(text, "Hello friends!")
+    doc1.merge(doc2)
+    assert.strictEqual(doc1.text(text), "Goodbye friends!")
+  })
+
+  it("should handle multi character grapheme clusters", () => {
+    const doc1 = create({actor: "aaaaaa"})
+    const text = doc1.putObject("_root", "text", "");
+    doc1.splice(text, 0, 0, "left👨‍👩‍👦right")
+
+    const doc2 = doc1.fork("bbbbbb")
+    doc2.updateText(text, "left👨‍👩‍👧right");
+
+    doc1.updateText(text, "left👨‍👩‍👦‍👦right");
+    doc1.merge(doc2)
+    assert.strictEqual(doc1.text(text), "left👨‍👩‍👧👨‍👩‍👦‍👦right")
+  })
+})

--- a/rust/automerge/Cargo.toml
+++ b/rust/automerge/Cargo.toml
@@ -33,6 +33,7 @@ js-sys = { version = "^0.3", optional = true }
 wasm-bindgen = { version = "^0.2", optional = true }
 rand = { version = "^0.8.4", optional = true }
 im = "15.1.0"
+unicode-segmentation = "1.10.1"
 
 [dependencies.web-sys]
 version = "^0.3.55"

--- a/rust/automerge/src/autocommit.rs
+++ b/rust/automerge/src/autocommit.rs
@@ -947,6 +947,16 @@ impl Transactable for AutoCommit {
             self.doc.get_heads()
         }
     }
+
+    fn update_text<S: AsRef<str>>(
+        &mut self,
+        obj: &ExId,
+        new_text: S,
+    ) -> Result<(), AutomergeError> {
+        self.ensure_transaction_open();
+        let (patch_log, tx) = self.transaction.as_mut().unwrap();
+        crate::text_diff::myers_diff(&mut self.doc, tx, patch_log, obj, new_text)
+    }
 }
 
 // A wrapper we return from [`AutoCommit::sync()`] to ensure that transactions are closed before we

--- a/rust/automerge/src/lib.rs
+++ b/rust/automerge/src/lib.rs
@@ -281,6 +281,7 @@ mod read;
 mod sequence_tree;
 mod storage;
 pub mod sync;
+mod text_diff;
 mod text_value;
 pub mod transaction;
 mod types;

--- a/rust/automerge/src/text_diff.rs
+++ b/rust/automerge/src/text_diff.rs
@@ -1,0 +1,126 @@
+use unicode_segmentation::UnicodeSegmentation;
+
+use crate::{
+    text_value::TextValue, transaction::TransactionInner, Automerge, ObjId as ExId, PatchLog,
+    ReadDoc,
+};
+mod myers;
+mod utils;
+
+pub(crate) fn myers_diff<'a, S: AsRef<str>>(
+    doc: &'a mut Automerge,
+    tx: &'a mut TransactionInner,
+    patch_log: &mut PatchLog,
+    text_obj: &ExId,
+    new: S,
+) -> Result<(), crate::AutomergeError> {
+    let old = doc.text(text_obj)?;
+    let new = new.as_ref();
+    let old_graphemes = old.graphemes(true).collect::<Vec<&str>>();
+    let new_graphemes = new.graphemes(true).collect::<Vec<&str>>();
+    let mut hook = TxHook {
+        tx,
+        doc,
+        patch_log,
+        obj: text_obj,
+        idx: 0,
+        old: &old_graphemes,
+        new: &new_graphemes,
+    };
+    myers::diff(
+        &mut hook,
+        &old_graphemes,
+        0..old_graphemes.len(),
+        &new_graphemes,
+        0..new_graphemes.len(),
+    )
+}
+
+struct TxHook<'a> {
+    doc: &'a mut Automerge,
+    tx: &'a mut TransactionInner,
+    patch_log: &'a mut PatchLog,
+    old: &'a [&'a str],
+    new: &'a [&'a str],
+    obj: &'a ExId,
+    idx: usize,
+}
+
+impl<'a> myers::DiffHook for TxHook<'a> {
+    type Error = crate::AutomergeError;
+
+    fn equal(
+        &mut self,
+        old_index: usize,
+        _new_index: usize,
+        len: usize,
+    ) -> Result<(), Self::Error> {
+        self.idx += self.old[old_index..old_index + len]
+            .iter()
+            .map(|c| TextValue::width(c))
+            .sum::<usize>();
+        Ok(())
+    }
+
+    fn replace(
+        &mut self,
+        old_index: usize,
+        old_len: usize,
+        new_index: usize,
+        new_len: usize,
+    ) -> Result<(), Self::Error> {
+        let new_chars = self.new[new_index..new_index + new_len].concat();
+        let deleted = self.old[old_index..old_index + old_len]
+            .iter()
+            .map(|s| TextValue::width(s))
+            .sum::<usize>();
+        self.tx.splice_text(
+            self.doc,
+            self.patch_log,
+            self.obj,
+            self.idx,
+            deleted as isize,
+            &new_chars,
+        )?;
+        self.idx += TextValue::width(&new_chars);
+        Ok(())
+    }
+
+    fn finish(&mut self) -> Result<(), Self::Error> {
+        Ok(())
+    }
+
+    fn delete(
+        &mut self,
+        old_index: usize,
+        old_len: usize,
+        _new_index: usize,
+    ) -> Result<(), Self::Error> {
+        let deleted_len: usize = self.old[old_index..old_index + old_len]
+            .iter()
+            .map(|s| TextValue::width(s))
+            .sum();
+        self.tx.splice_text(
+            self.doc,
+            self.patch_log,
+            self.obj,
+            self.idx,
+            deleted_len as isize,
+            "",
+        )?;
+        Ok(())
+    }
+
+    fn insert(
+        &mut self,
+        _old_index: usize,
+        new_index: usize,
+        new_len: usize,
+    ) -> Result<(), Self::Error> {
+        let new_chars = self.new[new_index..new_index + new_len].concat();
+        self.tx
+            .splice_text(self.doc, self.patch_log, self.obj, self.idx, 0, &new_chars)?;
+        self.idx += TextValue::width(&new_chars);
+        Ok(())
+    }
+}

--- a/rust/automerge/src/text_diff/LICENSE
+++ b/rust/automerge/src/text_diff/LICENSE
@@ -1,0 +1,201 @@
+                              Apache License
+                        Version 2.0, January 2004
+                     http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+   To apply the Apache License to your work, attach the following
+   boilerplate notice, with the fields enclosed by brackets "[]"
+   replaced with your own identifying information. (Don't include
+   the brackets!)  The text should be enclosed in the appropriate
+   comment syntax for the file format. We also recommend that a
+   file or class name and description of purpose be included on the
+   same "printed page" as the copyright notice for easier
+   identification within third-party archives.
+
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/rust/automerge/src/text_diff/myers.rs
+++ b/rust/automerge/src/text_diff/myers.rs
@@ -1,0 +1,332 @@
+// This file was copied from the similar crate at
+// https://github.com/mitsuhiko/similar/blob/2b31f65445df9093ba007ca5a5ae6a71b899d491/src/algorithms/myers.rs
+// The original license is in the LICENSE file in the same directory as this file
+//
+// This file was modified to use a Diff trait defined in this file rather than the DiffHook trait
+// defined in `similar` and to remote the deadline parameter to the `diff` function.
+//! Myers' diff algorithm.
+//!
+//! * time: `O((N+M)D)`
+//! * space `O(N+M)`
+//!
+//! See [the original article by Eugene W. Myers](http://www.xmailserver.org/diff2.pdf)
+//! describing it.
+//!
+//! The implementation of this algorithm is based on the implementation by
+//! Brandon Williams.
+//!
+//! # Heuristics
+//!
+//! At present this implementation of Myers' does not implement any more advanced
+//! heuristics that would solve some pathological cases.  For instance passing two
+//! large and completely distinct sequences to the algorithm will make it spin
+//! without making reasonable progress.
+
+use std::ops::{Index, IndexMut, Range};
+
+use super::utils::{common_prefix_len, common_suffix_len, is_empty_range};
+
+pub(super) trait DiffHook: Sized {
+    type Error;
+    fn equal(&mut self, old_index: usize, new_index: usize, len: usize) -> Result<(), Self::Error>;
+    fn delete(
+        &mut self,
+        old_index: usize,
+        old_len: usize,
+        new_index: usize,
+    ) -> Result<(), Self::Error>;
+    fn insert(
+        &mut self,
+        old_index: usize,
+        new_index: usize,
+        new_len: usize,
+    ) -> Result<(), Self::Error>;
+    fn replace(
+        &mut self,
+        old_index: usize,
+        old_len: usize,
+        new_index: usize,
+        new_len: usize,
+    ) -> Result<(), Self::Error>;
+    fn finish(&mut self) -> Result<(), Self::Error>;
+}
+
+/// Myers' diff algorithm.
+///
+/// Diff `old`, between indices `old_range` and `new` between indices `new_range`.
+pub(super) fn diff<Old, New, D>(
+    d: &mut D,
+    old: &Old,
+    old_range: Range<usize>,
+    new: &New,
+    new_range: Range<usize>,
+) -> Result<(), D::Error>
+where
+    Old: Index<usize> + ?Sized,
+    New: Index<usize> + ?Sized,
+    D: DiffHook,
+    New::Output: PartialEq<Old::Output>,
+{
+    let max_d = max_d(old_range.len(), new_range.len());
+    let mut vb = V::new(max_d);
+    let mut vf = V::new(max_d);
+    conquer(d, old, old_range, new, new_range, &mut vf, &mut vb)?;
+    d.finish()
+}
+
+// A D-path is a path which starts at (0,0) that has exactly D non-diagonal
+// edges. All D-paths consist of a (D - 1)-path followed by a non-diagonal edge
+// and then a possibly empty sequence of diagonal edges called a snake.
+
+/// `V` contains the endpoints of the furthest reaching `D-paths`. For each
+/// recorded endpoint `(x,y)` in diagonal `k`, we only need to retain `x` because
+/// `y` can be computed from `x - k`. In other words, `V` is an array of integers
+/// where `V[k]` contains the row index of the endpoint of the furthest reaching
+/// path in diagonal `k`.
+///
+/// We can't use a traditional Vec to represent `V` since we use `k` as an index
+/// and it can take on negative values. So instead `V` is represented as a
+/// light-weight wrapper around a Vec plus an `offset` which is the maximum value
+/// `k` can take on in order to map negative `k`'s back to a value >= 0.
+#[derive(Debug)]
+struct V {
+    offset: isize,
+    v: Vec<usize>, // Look into initializing this to -1 and storing isize
+}
+
+impl V {
+    fn new(max_d: usize) -> Self {
+        Self {
+            offset: max_d as isize,
+            v: vec![0; 2 * max_d],
+        }
+    }
+
+    fn len(&self) -> usize {
+        self.v.len()
+    }
+}
+
+impl Index<isize> for V {
+    type Output = usize;
+
+    fn index(&self, index: isize) -> &Self::Output {
+        &self.v[(index + self.offset) as usize]
+    }
+}
+
+impl IndexMut<isize> for V {
+    fn index_mut(&mut self, index: isize) -> &mut Self::Output {
+        &mut self.v[(index + self.offset) as usize]
+    }
+}
+
+fn max_d(len1: usize, len2: usize) -> usize {
+    // XXX look into reducing the need to have the additional '+ 1'
+    (len1 + len2 + 1) / 2 + 1
+}
+
+#[inline(always)]
+fn split_at(range: Range<usize>, at: usize) -> (Range<usize>, Range<usize>) {
+    (range.start..at, at..range.end)
+}
+
+/// A `Snake` is a sequence of diagonal edges in the edit graph.  Normally
+/// a snake has a start end end point (and it is possible for a snake to have
+/// a length of zero, meaning the start and end points are the same) however
+/// we do not need the end point which is why it's not implemented here.
+///
+/// The divide part of a divide-and-conquer strategy. A D-path has D+1 snakes
+/// some of which may be empty. The divide step requires finding the ceil(D/2) +
+/// 1 or middle snake of an optimal D-path. The idea for doing so is to
+/// simultaneously run the basic algorithm in both the forward and reverse
+/// directions until furthest reaching forward and reverse paths starting at
+/// opposing corners 'overlap'.
+fn find_middle_snake<Old, New>(
+    old: &Old,
+    old_range: Range<usize>,
+    new: &New,
+    new_range: Range<usize>,
+    vf: &mut V,
+    vb: &mut V,
+) -> Option<(usize, usize)>
+where
+    Old: Index<usize> + ?Sized,
+    New: Index<usize> + ?Sized,
+    New::Output: PartialEq<Old::Output>,
+{
+    let n = old_range.len();
+    let m = new_range.len();
+
+    // By Lemma 1 in the paper, the optimal edit script length is odd or even as
+    // `delta` is odd or even.
+    let delta = n as isize - m as isize;
+    let odd = delta & 1 == 1;
+
+    // The initial point at (0, -1)
+    vf[1] = 0;
+    // The initial point at (N, M+1)
+    vb[1] = 0;
+
+    // We only need to explore ceil(D/2) + 1
+    let d_max = max_d(n, m);
+    assert!(vf.len() >= d_max);
+    assert!(vb.len() >= d_max);
+
+    for d in 0..d_max as isize {
+        // Forward path
+        for k in (-d..=d).rev().step_by(2) {
+            let mut x = if k == -d || (k != d && vf[k - 1] < vf[k + 1]) {
+                vf[k + 1]
+            } else {
+                vf[k - 1] + 1
+            };
+            let y = (x as isize - k) as usize;
+
+            // The coordinate of the start of a snake
+            let (x0, y0) = (x, y);
+            //  While these sequences are identical, keep moving through the
+            //  graph with no cost
+            if x < old_range.len() && y < new_range.len() {
+                let advance = common_prefix_len(
+                    old,
+                    old_range.start + x..old_range.end,
+                    new,
+                    new_range.start + y..new_range.end,
+                );
+                x += advance;
+            }
+
+            // This is the new best x value
+            vf[k] = x;
+
+            // Only check for connections from the forward search when N - M is
+            // odd and when there is a reciprocal k line coming from the other
+            // direction.
+            if odd && (k - delta).abs() <= (d - 1) {
+                // TODO optimize this so we don't have to compare against n
+                if vf[k] + vb[-(k - delta)] >= n {
+                    // Return the snake
+                    return Some((x0 + old_range.start, y0 + new_range.start));
+                }
+            }
+        }
+
+        // Backward path
+        for k in (-d..=d).rev().step_by(2) {
+            let mut x = if k == -d || (k != d && vb[k - 1] < vb[k + 1]) {
+                vb[k + 1]
+            } else {
+                vb[k - 1] + 1
+            };
+            let mut y = (x as isize - k) as usize;
+
+            // The coordinate of the start of a snake
+            if x < n && y < m {
+                let advance = common_suffix_len(
+                    old,
+                    old_range.start..old_range.start + n - x,
+                    new,
+                    new_range.start..new_range.start + m - y,
+                );
+                x += advance;
+                y += advance;
+            }
+
+            // This is the new best x value
+            vb[k] = x;
+
+            if !odd && (k - delta).abs() <= d {
+                // TODO optimize this so we don't have to compare against n
+                if vb[k] + vf[-(k - delta)] >= n {
+                    // Return the snake
+                    return Some((n - x + old_range.start, m - y + new_range.start));
+                }
+            }
+        }
+
+        // TODO: Maybe there's an opportunity to optimize and bail early?
+    }
+
+    // deadline reached
+    None
+}
+
+#[allow(clippy::too_many_arguments)]
+fn conquer<Old, New, D>(
+    d: &mut D,
+    old: &Old,
+    mut old_range: Range<usize>,
+    new: &New,
+    mut new_range: Range<usize>,
+    vf: &mut V,
+    vb: &mut V,
+) -> Result<(), D::Error>
+where
+    Old: Index<usize> + ?Sized,
+    New: Index<usize> + ?Sized,
+    D: DiffHook,
+    New::Output: PartialEq<Old::Output>,
+{
+    // Check for common prefix
+    let common_prefix_len = common_prefix_len(old, old_range.clone(), new, new_range.clone());
+    if common_prefix_len > 0 {
+        d.equal(old_range.start, new_range.start, common_prefix_len)?;
+    }
+    old_range.start += common_prefix_len;
+    new_range.start += common_prefix_len;
+
+    // Check for common suffix
+    let common_suffix_len = common_suffix_len(old, old_range.clone(), new, new_range.clone());
+    let common_suffix = (
+        old_range.end - common_suffix_len,
+        new_range.end - common_suffix_len,
+    );
+    old_range.end -= common_suffix_len;
+    new_range.end -= common_suffix_len;
+
+    if is_empty_range(&old_range) && is_empty_range(&new_range) {
+        // Do nothing
+    } else if is_empty_range(&new_range) {
+        d.delete(old_range.start, old_range.len(), new_range.start)?;
+    } else if is_empty_range(&old_range) {
+        d.insert(old_range.start, new_range.start, new_range.len())?;
+    } else if let Some((x_start, y_start)) =
+        find_middle_snake(old, old_range.clone(), new, new_range.clone(), vf, vb)
+    {
+        let (old_a, old_b) = split_at(old_range, x_start);
+        let (new_a, new_b) = split_at(new_range, y_start);
+        conquer(d, old, old_a, new, new_a, vf, vb)?;
+        conquer(d, old, old_b, new, new_b, vf, vb)?;
+    } else {
+        d.delete(
+            old_range.start,
+            old_range.end - old_range.start,
+            new_range.start,
+        )?;
+        d.insert(
+            old_range.start,
+            new_range.start,
+            new_range.end - new_range.start,
+        )?;
+    }
+
+    if common_suffix_len > 0 {
+        d.equal(common_suffix.0, common_suffix.1, common_suffix_len)?;
+    }
+
+    Ok(())
+}
+
+#[test]
+fn test_find_middle_snake() {
+    let a = &b"ABCABBA"[..];
+    let b = &b"CBABAC"[..];
+    let max_d = max_d(a.len(), b.len());
+    let mut vf = V::new(max_d);
+    let mut vb = V::new(max_d);
+    let (x_start, y_start) =
+        find_middle_snake(a, 0..a.len(), b, 0..b.len(), &mut vf, &mut vb).unwrap();
+    assert_eq!(x_start, 4);
+    assert_eq!(y_start, 1);
+}

--- a/rust/automerge/src/text_diff/utils.rs
+++ b/rust/automerge/src/text_diff/utils.rs
@@ -1,0 +1,118 @@
+// This file was copied from the similar crate at
+// https://github.com/mitsuhiko/similar/blob/2b31f65445df9093ba007ca5a5ae6a71b899d491/src/algorithms/utils.rs
+// The original license is in the LICENSE file in the same directory as this file
+//
+// The original file was modified to remove the `UniqueItem` and `IdentifyDistinct` types as well
+// as the `unique` function as none of these were used by the myers diff implementation in this
+// crate.
+use std::ops::{Index, Range};
+
+/// Utility function to check if a range is empty that works on older rust versions
+#[inline(always)]
+#[allow(clippy::neg_cmp_op_on_partial_ord)]
+pub(super) fn is_empty_range<T: PartialOrd<T>>(range: &Range<T>) -> bool {
+    !(range.start < range.end)
+}
+
+/// Given two lookups and ranges calculates the length of the common prefix.
+pub(super) fn common_prefix_len<Old, New>(
+    old: &Old,
+    old_range: Range<usize>,
+    new: &New,
+    new_range: Range<usize>,
+) -> usize
+where
+    Old: Index<usize> + ?Sized,
+    New: Index<usize> + ?Sized,
+    New::Output: PartialEq<Old::Output>,
+{
+    if is_empty_range(&old_range) || is_empty_range(&new_range) {
+        return 0;
+    }
+    new_range
+        .zip(old_range)
+        .take_while(
+            #[inline(always)]
+            |x| new[x.0] == old[x.1],
+        )
+        .count()
+}
+
+/// Given two lookups and ranges calculates the length of common suffix.
+pub(super) fn common_suffix_len<Old, New>(
+    old: &Old,
+    old_range: Range<usize>,
+    new: &New,
+    new_range: Range<usize>,
+) -> usize
+where
+    Old: Index<usize> + ?Sized,
+    New: Index<usize> + ?Sized,
+    New::Output: PartialEq<Old::Output>,
+{
+    if is_empty_range(&old_range) || is_empty_range(&new_range) {
+        return 0;
+    }
+    new_range
+        .rev()
+        .zip(old_range.rev())
+        .take_while(
+            #[inline(always)]
+            |x| new[x.0] == old[x.1],
+        )
+        .count()
+}
+
+struct OffsetLookup<Int> {
+    offset: usize,
+    vec: Vec<Int>,
+}
+
+impl<Int> Index<usize> for OffsetLookup<Int> {
+    type Output = Int;
+
+    #[inline(always)]
+    fn index(&self, index: usize) -> &Self::Output {
+        &self.vec[index - self.offset]
+    }
+}
+
+#[test]
+fn test_common_prefix_len() {
+    assert_eq!(
+        common_prefix_len("".as_bytes(), 0..0, "".as_bytes(), 0..0),
+        0
+    );
+    assert_eq!(
+        common_prefix_len("foobarbaz".as_bytes(), 0..9, "foobarblah".as_bytes(), 0..10),
+        7
+    );
+    assert_eq!(
+        common_prefix_len("foobarbaz".as_bytes(), 0..9, "blablabla".as_bytes(), 0..9),
+        0
+    );
+    assert_eq!(
+        common_prefix_len("foobarbaz".as_bytes(), 3..9, "foobarblah".as_bytes(), 3..10),
+        4
+    );
+}
+
+#[test]
+fn test_common_suffix_len() {
+    assert_eq!(
+        common_suffix_len("".as_bytes(), 0..0, "".as_bytes(), 0..0),
+        0
+    );
+    assert_eq!(
+        common_suffix_len("1234".as_bytes(), 0..4, "X0001234".as_bytes(), 0..8),
+        4
+    );
+    assert_eq!(
+        common_suffix_len("1234".as_bytes(), 0..4, "Xxxx".as_bytes(), 0..4),
+        0
+    );
+    assert_eq!(
+        common_suffix_len("1234".as_bytes(), 2..4, "01234".as_bytes(), 2..5),
+        2
+    );
+}

--- a/rust/automerge/src/transaction/manual_transaction.rs
+++ b/rust/automerge/src/transaction/manual_transaction.rs
@@ -423,6 +423,14 @@ impl<'a> Transactable for Transaction<'a> {
             .map(|d| d.get_deps())
             .unwrap_or_default()
     }
+
+    fn update_text<S: AsRef<str>>(
+        &mut self,
+        obj: &ExId,
+        new_text: S,
+    ) -> Result<(), AutomergeError> {
+        self.do_tx(|tx, doc, hist| crate::text_diff::myers_diff(doc, tx, hist, obj, new_text))
+    }
 }
 
 impl<'a> Drop for Transaction<'a> {

--- a/rust/automerge/src/transaction/transactable.rs
+++ b/rust/automerge/src/transaction/transactable.rs
@@ -112,4 +112,14 @@ pub trait Transactable: ReadDoc {
 
     /// The heads this transaction will be based on
     fn base_heads(&self) -> Vec<ChangeHash>;
+
+    /// Update the value of a string
+    ///
+    /// This will calculate a diff between the current value and the new value and
+    /// then convert that diff into calls to {@link splice}. This will produce results
+    /// which don't merge as well as directly capturing the user input actions, but
+    /// sometimes it's not possible to capture user input and this is the best you
+    /// can do.
+    fn update_text<S: AsRef<str>>(&mut self, obj: &ExId, new_text: S)
+        -> Result<(), AutomergeError>;
 }

--- a/rust/automerge/tests/text.rs
+++ b/rust/automerge/tests/text.rs
@@ -1,0 +1,43 @@
+use std::str::FromStr;
+
+use automerge::{transaction::Transactable, ActorId, AutoCommit, ObjType, ReadDoc, ROOT};
+use test_log::test;
+
+#[test]
+fn simple_update_text() {
+    let mut doc = AutoCommit::new();
+    let text = doc.put_object(ROOT, "text", ObjType::Text).unwrap();
+    doc.splice_text(&text, 0, 0, "Hello, world!").unwrap();
+
+    let mut doc2 = doc.fork();
+    doc2.update_text(&text, "Goodbye, world!").unwrap();
+
+    doc.update_text(&text, "Hello, friends!").unwrap();
+
+    doc.merge(&mut doc2).unwrap();
+
+    assert_eq!(doc.text(&text).unwrap(), "Goodbye, friends!");
+}
+
+#[test]
+fn update_text_big_ole_graphemes() {
+    let actor1 = ActorId::from_str("aaaaaa").unwrap();
+    let actor2 = ActorId::from_str("bbbbbb").unwrap();
+    let mut doc = AutoCommit::new().with_actor(actor1);
+    let text = doc.put_object(ROOT, "text", ObjType::Text).unwrap();
+
+    // <200d> is a "zero-width joiner" which is used to combine multiple graphemes into one.
+    // combining man+woman+boy should render as a single emoji of a familry of three
+    doc.splice_text(&text, 0, 0, "left👨‍👩‍👦right").unwrap();
+
+    let mut doc2 = doc.fork().with_actor(actor2);
+    // man, woman, girl - a different family of three
+    doc2.update_text(&text, "left👨‍👩‍👧right").unwrap();
+
+    // man, woman, boy, boy - a family of four
+    doc.update_text(&text, "left👨‍👩‍👦‍👦right").unwrap();
+
+    doc.merge(&mut doc2).unwrap();
+    // should render as a family of three followed by a family of four
+    assert_eq!(doc.text(&text).unwrap(), "left👨‍👩‍👧👨‍👩‍👦‍👦right");
+}


### PR DESCRIPTION
Problem: updating text fields in an automerge documents requires using splice, which is intended for use when capturing individual input events as the user creates them. In some environments it is impossible to capture these events, leaving the developer to try and figure out a set of splice calls. This is reasonably fiddly work.

Solution: introduce Transactable::update_text (which is exposed in javascript as Automerge.updateText). This method performs a myers diff to calculate a minimal set of edits to make based on the new text which is passed to it.

The implementation is copied from the `similar` crate, which is licensed under the Apache license. This necessitates including the Apache 2 license alongside the cribbed code as well as attribution comments in the (2) files which were copied. This is preferable to pulling in the entire `similar` crate because similar is quite large and we only need a few hundred lines from it.