### PR TITLE
WeakMap metadata plus many load/materialize/apply_patch performance upgrades

### DIFF
--- a/javascript/src/constants.ts
+++ b/javascript/src/constants.ts
@@ -1,9 +1,8 @@
 // Properties of the document root object
 
-export const STATE = Symbol.for("_am_meta") // symbol used to hide application metadata on automerge objects
+export const OBJ_META = Symbol.for("_am_obj_meta") // symbol used to hide automerge metadata on the proxy object
+
 export const TRACE = Symbol.for("_am_trace") // used for debugging
-export const OBJECT_ID = Symbol.for("_am_objectId") // symbol used to hide the object id on automerge objects
-export const IS_PROXY = Symbol.for("_am_isProxy") // symbol used to test if the document is a proxy object
 export const CLEAR_CACHE = Symbol.for("_am_clearCache") // symbol used to tell a proxy object to clear its cache
 
 export const UINT = Symbol.for("_am_uint")

--- a/javascript/src/low_level.ts
+++ b/javascript/src/low_level.ts
@@ -4,6 +4,8 @@ import {
   type Change,
   type DecodedChange,
   SyncState,
+  type Metadata,
+  type ObjMetadata,
   type SyncMessage,
   type JsSyncState,
   type DecodedSyncMessage,
@@ -54,6 +56,9 @@ export const ApiHandler: API = {
   },
   importSyncState(state: JsSyncState): SyncState {
     throw new RangeError("Automerge.use() not called (importSyncState)")
+  },
+  getObjMetadata<U>(meta: Metadata, obj: Object): ObjMetadata<U> | undefined {
+    throw new RangeError("Automerge.use() not called (getObjMetadata)")
   },
 }
 /* eslint-enable */

--- a/javascript/src/next.ts
+++ b/javascript/src/next.ts
@@ -158,7 +158,13 @@ export { RawString } from "./raw_string.js"
 /** @hidden */
 export const getBackend = stable.getBackend
 
-import { _is_proxy, _state, _obj, _clear_cache } from "./internal_state.js"
+import {
+  _strict_meta,
+  _obj,
+  _state,
+  _is_proxy,
+  _clear_cache,
+} from "./internal_state.js"
 
 /**
  * Create a new automerge document
@@ -300,13 +306,11 @@ export function splice<T>(
   del: number,
   newText?: string,
 ) {
-  if (!_is_proxy(doc)) {
+  const meta = _strict_meta(doc, false)
+  const state = meta.user_data
+  const objectId = meta.obj
+  if (!meta.proxy) {
     throw new RangeError("object cannot be modified outside of a change block")
-  }
-  const state = _state(doc, false)
-  const objectId = _obj(doc)
-  if (!objectId) {
-    throw new RangeError("invalid object for splice")
   }
   _clear_cache(doc)
 
@@ -345,11 +349,9 @@ export function getCursor<T>(
   path: stable.Prop[],
   index: number,
 ): Cursor {
-  const state = _state(doc, false)
-  const objectId = _obj(doc)
-  if (!objectId) {
-    throw new RangeError("invalid object for getCursor")
-  }
+  const meta = _strict_meta(doc, false)
+  const state = meta.user_data
+  const objectId = meta.obj
 
   path.unshift(objectId)
   const value = path.join("/")
@@ -375,11 +377,9 @@ export function getCursorPosition<T>(
   path: stable.Prop[],
   cursor: Cursor,
 ): number {
-  const state = _state(doc, false)
-  const objectId = _obj(doc)
-  if (!objectId) {
-    throw new RangeError("invalid object for getCursorPosition")
-  }
+  const meta = _strict_meta(doc, false)
+  const state = meta.user_data
+  const objectId = meta.obj
 
   path.unshift(objectId)
   const value = path.join("/")
@@ -398,14 +398,12 @@ export function mark<T>(
   name: string,
   value: MarkValue,
 ) {
-  if (!_is_proxy(doc)) {
+  const meta = _strict_meta(doc, false)
+  if (!meta.proxy) {
     throw new RangeError("object cannot be modified outside of a change block")
   }
-  const state = _state(doc, false)
-  const objectId = _obj(doc)
-  if (!objectId) {
-    throw new RangeError("invalid object for mark")
-  }
+  const state = meta.user_data
+  const objectId = meta.obj
 
   path.unshift(objectId)
   const obj = path.join("/")
@@ -423,14 +421,12 @@ export function unmark<T>(
   range: MarkRange,
   name: string,
 ) {
-  if (!_is_proxy(doc)) {
+  const meta = _strict_meta(doc, false)
+  if (!meta.proxy) {
     throw new RangeError("object cannot be modified outside of a change block")
   }
-  const state = _state(doc, false)
-  const objectId = _obj(doc)
-  if (!objectId) {
-    throw new RangeError("invalid object for unmark")
-  }
+  const state = meta.user_data
+  const objectId = meta.obj
 
   path.unshift(objectId)
   const obj = path.join("/")
@@ -443,11 +439,10 @@ export function unmark<T>(
 }
 
 export function marks<T>(doc: Doc<T>, path: stable.Prop[]): Mark[] {
-  const state = _state(doc, false)
-  const objectId = _obj(doc)
-  if (!objectId) {
-    throw new RangeError("invalid object for marks")
-  }
+  const meta = _strict_meta(doc, false)
+  const state = meta.user_data
+  const objectId = meta.obj
+
   path.unshift(objectId)
   const obj = path.join("/")
   try {
@@ -462,11 +457,10 @@ export function marksAt<T>(
   path: stable.Prop[],
   index: number,
 ): MarkSet {
-  const state = _state(doc, false)
-  const objectId = _obj(doc)
-  if (!objectId) {
-    throw new RangeError("invalid object for marksAt")
-  }
+  const meta = _strict_meta(doc, false)
+  const state = meta.user_data
+  const objectId = meta.obj
+
   path.unshift(objectId)
   const obj = path.join("/")
   try {
@@ -524,11 +518,12 @@ export function getConflicts<T>(
   doc: Doc<T>,
   prop: stable.Prop,
 ): Conflicts | undefined {
-  const state = _state(doc, false)
+  const meta = _strict_meta(doc, false)
+  const state = meta.user_data
   if (!state.textV2) {
     throw new Error("use getConflicts for a stable document")
   }
-  const objectId = _obj(doc)
+  const objectId = meta.obj
   if (objectId != null) {
     return unstableConflictAt(state.handle, objectId, prop)
   } else {

--- a/javascript/src/text.ts
+++ b/javascript/src/text.ts
@@ -1,6 +1,8 @@
 import type { Value } from "@automerge/automerge-wasm"
-import { TEXT, STATE } from "./constants.js"
+import { TEXT, OBJ_META } from "./constants.js"
 import type { InternalState } from "./internal_state.js"
+import { _meta } from "./internal_state.js"
+import type { ObjMetadata } from "./types.js"
 
 export class Text {
   //eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -10,7 +12,7 @@ export class Text {
   spans: Array<any> | undefined;
   /** @hidden */
   //eslint-disable-next-line @typescript-eslint/no-explicit-any
-  [STATE]?: InternalState<any>
+  [OBJ_META]?: ObjMetadata<InternalState<any>>
 
   constructor(text?: string | string[] | Value[]) {
     if (typeof text === "string") {
@@ -112,7 +114,7 @@ export class Text {
    * Updates the list item at position `index` to a new value `value`.
    */
   set(index: number, value: Value) {
-    if (this[STATE]) {
+    if (_meta(this)) {
       throw new RangeError(
         "object cannot be modified outside of a change block",
       )
@@ -124,7 +126,7 @@ export class Text {
    * Inserts new list items `values` starting at position `index`.
    */
   insertAt(index: number, ...values: Array<Value | object>) {
-    if (this[STATE]) {
+    if (_meta(this)) {
       throw new RangeError(
         "object cannot be modified outside of a change block",
       )
@@ -141,7 +143,7 @@ export class Text {
    * if `numDelete` is not given, one item is deleted.
    */
   deleteAt(index: number, numDelete = 1) {
-    if (this[STATE]) {
+    if (this[OBJ_META]) {
       throw new RangeError(
         "object cannot be modified outside of a change block",
       )

--- a/javascript/src/types.ts
+++ b/javascript/src/types.ts
@@ -13,6 +13,13 @@ export type {
   MarkRange,
 } from "@automerge/automerge-wasm"
 
+export type ObjMetadata<U> = {
+  obj: string
+  datatype: string
+  user_data: U
+  proxy?: boolean
+}
+
 export type AutomergeValue =
   | ScalarValue
   | { [key: string]: AutomergeValue }

--- a/javascript/test/basic_test.ts
+++ b/javascript/test/basic_test.ts
@@ -293,7 +293,7 @@ describe("Automerge", () => {
 
     it("allows access to the backend", () => {
       let doc = Automerge.from({ hello: "world" })
-      assert.deepEqual(Automerge.getBackend(doc).materialize(), {
+      assert.deepEqual(Automerge.getBackend(doc).toJS(), {
         hello: "world",
       })
     })

--- a/rust/automerge-c/src/byte_span.rs
+++ b/rust/automerge-c/src/byte_span.rs
@@ -64,7 +64,7 @@ impl Eq for AMbyteSpan {}
 
 impl From<&am::ActorId> for AMbyteSpan {
     fn from(actor: &am::ActorId) -> Self {
-        let slice = actor.to_bytes();
+        let slice = actor.as_bytes();
         Self {
             src: slice.as_ptr(),
             count: slice.len(),

--- a/rust/automerge-wasm/Cargo.toml
+++ b/rust/automerge-wasm/Cargo.toml
@@ -37,7 +37,7 @@ thiserror = "^1.0.16"
 fxhash = "^0.2.1"
 
 [dependencies.wasm-bindgen]
-version = "^0.2.85"
+version = "^0.2.89"
 #features = ["std"]
 features = ["serde-serialize", "std"]
 

--- a/rust/automerge-wasm/README.md
+++ b/rust/automerge-wasm/README.md
@@ -130,7 +130,9 @@ Maps are key/value stores.  The root object is always a map.  The keys are alway
                               // make a new empty object and assign it to the key `sub` of mymap
 
     doc.keys(mymap)           // returns ["bytes","foo","sub"]
-    doc.materialize("_root")  // returns { mymap: { bytes: new Uint8Array([1,2,3]), foo: "bar", sub: {}}}
+    doc.toJS("_root")         // returns { mymap: { bytes: new Uint8Array([1,2,3]), foo: "bar", sub: {}}}
+    doc.toJS("/")             // same as above
+    doc.toJS()                // same as above
 ```
 
 ### Lists
@@ -148,7 +150,7 @@ Lists are index addressable sets of values.  These values can be any scalar or o
     doc.insert(items, 0, "bat")                   // insert "bat" to the beginning of the list
     doc.insertObject(items, 1, [1,2])             // insert a list with 2 values at pos 1
 
-    doc.materialize(items)                        // returns [ "bat", [1,2], { hello : "world" }, true, "bag", "brick"]
+    doc.toJS(items)                               // returns [ "bat", [1,2], { hello : "world" }, true, "bag", "brick"]
     doc.length(items)                             // returns 6
 ```
 
@@ -211,7 +213,7 @@ Counters are 64 bit ints that support the increment operation.  Frequently diffe
 
     doc1.merge(doc2)
 
-    doc1.materialize("_root")  // returns { number: 10, total: 33 }
+    doc1.toJS()  // returns { number: 10, total: 33 }
 ```
 
 ### Transactions
@@ -262,7 +264,7 @@ All query functions can take an optional argument of `heads` which allow you to 
     doc.get("_root","key",[])       // returns undefined
 ```
 
-This works for `get()`, `getAll()`, `keys()`, `length()`, `text()`, and `materialize()`
+This works for `get()`, `getAll()`, `keys()`, `length()`, `text()`, and `toJS()`
 
 Queries of old document states are not indexed internally and will be slower than normal access.  If you need a fast indexed version of a document at a previous point in time you can create one with `doc.forkAt(heads, actor?)`
 
@@ -283,8 +285,8 @@ The `merge()` command applies all changes in the argument doc into the calling d
 
     doc1.merge(doc2)
 
-    doc1.materialize("_root")       // returns { key1: "val1", key2: "val2", key3: "val3" }
-    doc2.materialize("_root")       // returns { key1: "val1", key3: "val3" }
+    doc1.toJS()       // returns { key1: "val1", key2: "val2", key3: "val3" }
+    doc2.toJS()       // returns { key1: "val1", key3: "val3" }
 ```
 
 Note that calling `a.merge(a)` will produce an unrecoverable error from the wasm-bindgen layer which (as of this writing) there is no workaround for.
@@ -308,7 +310,7 @@ The `load()` function takes a `Uint8Array()` of bytes produced in this way and c
 
   let doc2 = load(save1)
 
-  doc2.materialize("_root")  // returns { key1: "value1" }
+  doc2.toJS()  // returns { key1: "value1" }
 
   doc1.put("_root", "key2", "value2")
 
@@ -326,10 +328,10 @@ The `load()` function takes a `Uint8Array()` of bytes produced in this way and c
 
   let doc4 = load(save3)
 
-  doc1.materialize("_root")  // returns { key1: "value1", key2: "value2" }
-  doc2.materialize("_root")  // returns { key1: "value1", key2: "value2" }
-  doc3.materialize("_root")  // returns { key1: "value1", key2: "value2" }
-  doc4.materialize("_root")  // returns { key1: "value1", key2: "value2" }
+  doc1.toJS()  // returns { key1: "value1", key2: "value2" }
+  doc2.toJS()  // returns { key1: "value1", key2: "value2" }
+  doc3.toJS()  // returns { key1: "value1", key2: "value2" }
+  doc4.toJS()  // returns { key1: "value1", key2: "value2" }
 ```
 
 One interesting feature of automerge binary saves is that they can be concatenated together in any order and can still be loaded into a coherent merged document.
@@ -344,7 +346,7 @@ let file2 = fs.readFileSync("automerge_save_2");
 let docA = load(file1).merge(load(file2))
 let docB = load(Buffer.concat([ file1, file2 ]))
 
-assert.deepEqual(docA.materialize("/"), docB.materialize("/"))
+assert.deepEqual(docA.toJS(), docB.toJS())
 assert.equal(docA.save(), docB.save())
 ```
 
@@ -425,7 +427,7 @@ Object Ids uniquely identify an object within a document.  They are represented 
   let o2 = doc.putObject("_root", "o2", {})
   doc.put(o1, "hello", "world")
 
-  assert.deepEqual(doc.materialize("_root"), { "o1": { hello: "world" }, "o2": {} })
+  assert.deepEqual(doc.toJS(), { "o1": { hello: "world" }, "o2": {} })
   assert.equal(o1, "1@aabbcc")
   assert.equal(o2, "2@aabbcc")
 
@@ -434,7 +436,7 @@ Object Ids uniquely identify an object within a document.  They are represented 
   doc.put(o1, "a", "b")    // modifying an overwritten object - does nothing
   doc.put(o1v2, "x", "y")  // modifying the new "o1" object
 
-  assert.deepEqual(doc.materialize("_root"), { "o1": { x: "y" }, "o2": {} })
+  assert.deepEqual(doc.toJS("_root"), { "o1": { x: "y" }, "o2": {} })
 ```
 
 ### Appendix: Building

--- a/rust/automerge-wasm/index.d.ts
+++ b/rust/automerge-wasm/index.d.ts
@@ -2,6 +2,7 @@ export type Actor = string;
 export type ObjID = string;
 export type Change = Uint8Array;
 export type SyncMessage = Uint8Array;
+export type Metadata = WeakMap<Object,Object>;
 export type Prop = string | number;
 export type Hash = string;
 export type Heads = Hash[];
@@ -169,9 +170,17 @@ export type Mark = {
   end: number,
 }
 
+export type ObjMetadata<U> = {
+  obj: ObjID,
+  datatype: Datatype,
+  user_data: U,
+  raw?: MaterializeValue,
+}
+
 export function encodeChange(change: ChangeToEncode): Change;
 export function create(options?: InitOptions): Automerge;
 export function load(data: Uint8Array, options?: LoadOptions): Automerge;
+export function getObjMetadata<U>(metadata: Metadata, obj: Object): ObjMetadata<U> | undefined;
 export function decodeChange(change: Change): DecodedChange;
 export function initSyncState(): SyncState;
 export function encodeSyncMessage(message: DecodedSyncMessage): SyncMessage;
@@ -184,6 +193,7 @@ export function importSyncState(state: JsSyncState): SyncState;
 export interface API {
   create(options?: InitOptions): Automerge;
   load(data: Uint8Array, options?: LoadOptions): Automerge;
+  getObjMetadata<U>(meta: Metadata, obj: Object): ObjMetadata<U> | undefined;
   encodeChange(change: ChangeToEncode): Change;
   decodeChange(change: Change): DecodedChange;
   initSyncState(): SyncState;
@@ -231,8 +241,8 @@ export class Automerge {
   keys(obj: ObjID, heads?: Heads): string[];
   text(obj: ObjID, heads?: Heads): string;
   length(obj: ObjID, heads?: Heads): number;
-  materialize(obj?: ObjID, heads?: Heads, metadata?: unknown): MaterializeValue;
-  toJS(): MaterializeValue;
+  materialize<U>(metadata: Metadata, obj?: ObjID, heads?: Heads, userdata?: U): MaterializeValue;
+  toJS(obj?: ObjID, heads?: Heads): MaterializeValue;
 
   // transactions
   commit(message?: string, time?: number): Hash | null;
@@ -279,8 +289,8 @@ export class Automerge {
   dump(): void;
 
   // experimental api can go here
-  applyPatches<Doc>(obj: Doc, meta?: unknown): Doc;
-  applyAndReturnPatches<Doc>(obj: Doc, meta?: unknown): {value: Doc, patches: Patch[]};
+  applyPatches<Doc>(metadata: Metadata, obj: Doc, userdata?: unknown): Doc;
+  applyAndReturnPatches<Doc>(metadata: Metadata, obj: Doc, userdata?: unknown): {value: Doc, patches: Patch[]};
 }
 
 export interface JsSyncState {

--- a/rust/automerge-wasm/test/readme.mts
+++ b/rust/automerge-wasm/test/readme.mts
@@ -21,7 +21,7 @@ describe('Automerge', () => {
       doc.put("/", "prop6", true)
       doc.put("/", "prop7", null)
 
-      assert.deepEqual(doc.materialize("/"), {
+      let finalState = {
         prop1: 100,
         prop2: 3.14,
         prop3: "hello world",
@@ -29,8 +29,13 @@ describe('Automerge', () => {
         prop5: new Uint8Array([1,2,3]),
         prop6: true,
         prop7: null
-      })
+      }
+
+      assert.deepEqual(doc.toJS("_root"), finalState);
+      assert.deepEqual(doc.toJS("/"), finalState);
+      assert.deepEqual(doc.toJS(), finalState);
     })
+
     it('Automerge Scalar Types (2)', () => {
       const doc = create()
       doc.put("/", "prop1", 100, "int")
@@ -80,7 +85,7 @@ describe('Automerge', () => {
 
       doc.put("/config", "align", "right")
 
-      assert.deepEqual(doc.materialize("/"), {
+      assert.deepEqual(doc.toJS(), {
          config: { align: "right", archived: false, cycles: [ 10, 19, 21 ] }
       })
     })
@@ -96,7 +101,7 @@ describe('Automerge', () => {
                                 // make a new empty object and assign it to the key `sub` of mymap
 
       assert.deepEqual(doc.keys(mymap),["bytes","foo","sub"])
-      assert.deepEqual(doc.materialize("_root"), { mymap: { bytes: new Uint8Array([1,2,3]), foo: "bar", sub: {} }})
+      assert.deepEqual(doc.toJS(), { mymap: { bytes: new Uint8Array([1,2,3]), foo: "bar", sub: {} }})
     })
     it('Lists (1)', () => {
       const doc = create()
@@ -109,7 +114,7 @@ describe('Automerge', () => {
       doc.insert(items, 0, "bat")                   // insert "bat" to the beginning of the list
       doc.insertObject(items, 1, [ 1, 2 ])          // insert a list with 2 values at pos 1
 
-      assert.deepEqual(doc.materialize(items),[ "bat", [ 1 ,2 ], { hello : "world" }, true, "bag", "brick" ])
+      assert.deepEqual(doc.toJS(items),[ "bat", [ 1 ,2 ], { hello : "world" }, true, "bag", "brick" ])
       assert.deepEqual(doc.length(items),6)
     })
     it('Text (1)', () => {
@@ -153,7 +158,7 @@ describe('Automerge', () => {
 
       doc1.merge(doc2)
 
-      assert.deepEqual(doc1.materialize("_root"), { number: 10, total: 33 })
+      assert.deepEqual(doc1.toJS("_root"), { number: 10, total: 33 })
     })
     it('Transactions (1)', () => {
       const doc = create()
@@ -204,8 +209,8 @@ describe('Automerge', () => {
 
       doc1.merge(doc2)
 
-      assert.deepEqual(doc1.materialize("_root"), { key1: "val1", key2: "val2", key3: "val3" })
-      assert.deepEqual(doc2.materialize("_root"), { key1: "val1", key3: "val3" })
+      assert.deepEqual(doc1.toJS("_root"), { key1: "val1", key2: "val2", key3: "val3" })
+      assert.deepEqual(doc2.toJS("_root"), { key1: "val1", key3: "val3" })
     })
     it('Saving And Loading (1)', () => {
       const doc1 = create()
@@ -216,7 +221,7 @@ describe('Automerge', () => {
 
       const doc2 = load(save1)
 
-      doc2.materialize("_root")  // returns { key1: "value1" }
+      doc2.toJS("_root")  // returns { key1: "value1" }
 
       doc1.put("_root", "key2", "value2")
 
@@ -234,10 +239,10 @@ describe('Automerge', () => {
 
       const doc4 = load(save3)
 
-      assert.deepEqual(doc1.materialize("_root"), { key1: "value1", key2: "value2" })
-      assert.deepEqual(doc2.materialize("_root"), { key1: "value1", key2: "value2" })
-      assert.deepEqual(doc3.materialize("_root"), { key1: "value1", key2: "value2" })
-      assert.deepEqual(doc4.materialize("_root"), { key1: "value1", key2: "value2" })
+      assert.deepEqual(doc1.toJS(), { key1: "value1", key2: "value2" })
+      assert.deepEqual(doc2.toJS(), { key1: "value1", key2: "value2" })
+      assert.deepEqual(doc3.toJS(), { key1: "value1", key2: "value2" })
+      assert.deepEqual(doc4.toJS(), { key1: "value1", key2: "value2" })
     })
     //it.skip('Syncing (1)', () => { })
   })

--- a/rust/automerge/src/cursor.rs
+++ b/rust/automerge/src/cursor.rs
@@ -57,7 +57,7 @@ impl Cursor {
         //
         // Version is currently always `0`
         //
-        let actor_bytes = self.actor.to_bytes();
+        let actor_bytes = self.actor.as_bytes();
         let mut bytes = Vec::with_capacity(actor_bytes.len() + 4 + 4 + 1);
         bytes.push(SERIALIZATION_VERSION_TAG);
         leb128::write::unsigned(&mut bytes, actor_bytes.len() as u64).unwrap();

--- a/rust/automerge/src/exid.rs
+++ b/rust/automerge/src/exid.rs
@@ -26,6 +26,7 @@ impl ExId {
     ///
     /// This serialization format is versioned and incompatible changes to it will be considered a
     /// breaking change for the version of this library.
+    #[inline(never)]
     pub fn to_bytes(&self) -> Vec<u8> {
         // The serialized format is
         //
@@ -55,7 +56,7 @@ impl ExId {
                 vec![val]
             }
             ExId::Id(id, actor, counter) => {
-                let actor_bytes = actor.to_bytes();
+                let actor_bytes = actor.as_bytes();
                 let mut bytes = Vec::with_capacity(actor_bytes.len() + 4 + 4);
                 let tag = SERIALIZATION_VERSION_TAG | (TYPE_ID << 4);
                 bytes.push(tag);
@@ -64,6 +65,31 @@ impl ExId {
                 leb128::write::unsigned(&mut bytes, *counter as u64).unwrap();
                 leb128::write::unsigned(&mut bytes, *id).unwrap();
                 bytes
+            }
+        }
+    }
+
+    #[inline(never)]
+    pub fn to_unsafe_u8(&self) -> Vec<u8> {
+        let mut bytes = Vec::new();
+        match self {
+            Self::Root => {
+                leb128::write::unsigned(&mut bytes, 0).unwrap();
+            }
+            Self::Id(counter, _, actor) => {
+                leb128::write::unsigned(&mut bytes, *counter).unwrap();
+                leb128::write::unsigned(&mut bytes, *actor as u64).unwrap();
+            }
+        }
+        bytes
+    }
+
+    #[inline(never)]
+    pub fn to_unsafe_u64(&self) -> u64 {
+        match self {
+            Self::Root => 0,
+            Self::Id(counter, _, actor) => {
+                ((*counter as u32) as u64) << 32 | (*actor as u32) as u64
             }
         }
     }

--- a/rust/automerge/src/op_set.rs
+++ b/rust/automerge/src/op_set.rs
@@ -5,7 +5,7 @@ use crate::indexed_cache::IndexedCache;
 use crate::iter::{Keys, ListRange, MapRange, TopOps};
 use crate::op_tree::OpTreeIter;
 use crate::op_tree::{
-    self, FoundOpId, FoundOpWithPatchLog, FoundOpWithoutPatchLog, LastInsert, OpTree,
+    self, FoundOpId, FoundOpWithPatchLog, FoundOpWithoutPatchLog, LastInsert, OpTree, OpTreeIndex,
     OpTreeInternal, OpsFound,
 };
 use crate::parents::Parents;
@@ -338,7 +338,7 @@ impl OpSetInternal {
             self.trees.insert(
                 op.id().into(),
                 OpTree {
-                    internal: OpTreeInternal::new(*typ),
+                    internal: OpTreeInternal::new(OpTreeIndex::from(*typ)),
                     objtype: *typ,
                     last_insert: None,
                     parent: Some(idx),
@@ -361,7 +361,7 @@ impl OpSetInternal {
             self.trees.insert(
                 op.id().into(),
                 OpTree {
-                    internal: OpTreeInternal::new(*typ),
+                    internal: OpTreeInternal::new(OpTreeIndex::None),
                     objtype: *typ,
                     last_insert: None,
                     parent: Some(idx),

--- a/rust/automerge/src/op_tree.rs
+++ b/rust/automerge/src/op_tree.rs
@@ -47,7 +47,7 @@ pub(crate) struct LastInsert {
 impl OpTree {
     pub(crate) fn new(objtype: ObjType) -> Self {
         Self {
-            internal: OpTreeInternal::new(objtype),
+            internal: OpTreeInternal::new(OpTreeIndex::from(objtype)),
             objtype,
             parent: None,
             last_insert: None,
@@ -202,10 +202,34 @@ pub(crate) struct OpTreeInternal {
     pub(crate) has_index: bool,
 }
 
+pub(crate) enum OpTreeIndex {
+    Some,
+    None,
+}
+
+impl From<ObjType> for OpTreeIndex {
+    fn from(obj_type: ObjType) -> OpTreeIndex {
+        if obj_type.is_sequence() {
+            OpTreeIndex::Some
+        } else {
+            OpTreeIndex::None
+        }
+    }
+}
+
+impl From<OpTreeIndex> for bool {
+    fn from(index: OpTreeIndex) -> bool {
+        match index {
+            OpTreeIndex::Some => true,
+            OpTreeIndex::None => false,
+        }
+    }
+}
+
 impl OpTreeInternal {
     /// Construct a new, empty, sequence.
-    pub(crate) fn new(obj_type: ObjType) -> Self {
-        let has_index = obj_type.is_sequence();
+    pub(crate) fn new(index: OpTreeIndex) -> Self {
+        let has_index = index.into();
         Self {
             root_node: None,
             has_index,

--- a/rust/automerge/src/op_tree/iter.rs
+++ b/rust/automerge/src/op_tree/iter.rs
@@ -375,7 +375,7 @@ mod tests {
     }
 
     fn make_optree(actions: &[Action], osd: &OpSetData) -> super::OpTreeInternal {
-        let mut optree = OpTreeInternal::new(ObjType::List);
+        let mut optree = OpTreeInternal::new(ObjType::List.into());
         for action in actions {
             match action {
                 Action::Insert(index, idx) => {

--- a/rust/automerge/src/storage/document.rs
+++ b/rust/automerge/src/storage/document.rs
@@ -235,8 +235,8 @@ impl<'a> Document<'a> {
         let mut data = Vec::with_capacity(ops_out.len() + change_out.len());
         leb128::write::unsigned(&mut data, actors.len() as u64).unwrap();
         for actor in &actors {
-            leb128::write::unsigned(&mut data, actor.to_bytes().len() as u64).unwrap();
-            data.extend(actor.to_bytes());
+            leb128::write::unsigned(&mut data, actor.as_bytes().len() as u64).unwrap();
+            data.extend(actor.as_bytes());
         }
         leb128::write::unsigned(&mut data, heads_with_indices.len() as u64).unwrap();
         for (head, _) in &heads_with_indices {

--- a/rust/automerge/src/types.rs
+++ b/rust/automerge/src/types.rs
@@ -51,7 +51,7 @@ impl ActorId {
         ActorId(TinyVec::from(*uuid::Uuid::new_v4().as_bytes()))
     }
 
-    pub fn to_bytes(&self) -> &[u8] {
+    pub fn as_bytes(&self) -> &[u8] {
         &self.0
     }
 


### PR DESCRIPTION
* move wasm metadata from defineProperty to WeakMap (40% speedup of materialize)
* cleanup js internal metadata APIs
* dont generate patches if they aren't needed (major speedup on progressDocument() - large scene no longer tuns out of memory)
* more materialize cleanup and speedup
* fix `add_index` performance regression. (20% speedup of reconstruct_document)

### Issues:

~~The WeakMap is stored on the global object.  I could possibly store it in some kind of rust based global instead.  Are global contexts in all versions of js?~~
Weakmap is now managed externally to the wasm api

Names have changed - maybe not for the better - the weak_map is now called `metadata`, what was called `metadata` is now called `user_data` and all the hidden properties plus user_data are collectivly called `object_metadata`.   Would like a second opinion on this before making it final.
