### PR TITLE
Add a clock argument to MarkMap::process

### DIFF
--- a/rust/automerge/src/query/insert.rs
+++ b/rust/automerge/src/query/insert.rs
@@ -152,7 +152,7 @@ impl<'a> TreeQuery<'a> for InsertNth<'a> {
 
     fn query_element(&mut self, op: Op<'a>) -> QueryResult {
         if !self.list_state.done() {
-            self.marks.process(op);
+            self.marks.process(op, self.clock.as_ref());
         }
         let key = op.elemid_or_key();
         let visible = op.visible_at(self.clock.as_ref());
@@ -160,7 +160,7 @@ impl<'a> TreeQuery<'a> for InsertNth<'a> {
         if visible {
             if !self.candidates.is_empty() {
                 for op in self.candidates.iter().filter_map(|c| c.id) {
-                    self.marks.process(op);
+                    self.marks.process(op, self.clock.as_ref());
                 }
                 return QueryResult::Finish;
             }

--- a/rust/automerge/src/query/list_state.rs
+++ b/rust/automerge/src/query/list_state.rs
@@ -1,3 +1,4 @@
+use crate::clock::Clock;
 use crate::marks::MarkData;
 use crate::op_set::{Op, OpSetData};
 use crate::op_tree::{LastInsert, OpTreeNode};
@@ -12,7 +13,12 @@ pub(crate) struct MarkMap<'a> {
 }
 
 impl<'a> MarkMap<'a> {
-    pub(crate) fn process(&mut self, op: Op<'a>) {
+    pub(crate) fn process(&mut self, op: Op<'a>, clock: Option<&Clock>) {
+        if !(clock.map(|c| c.covers(op.id())).unwrap_or(true)) {
+            // if the op is not visible in the current clock
+            // we can ignore it
+            return;
+        };
         match op.action() {
             OpType::MarkBegin(_, data) => {
                 self.map.insert(*op.id(), data);

--- a/rust/automerge/src/query/nth.rs
+++ b/rust/automerge/src/query/nth.rs
@@ -112,9 +112,7 @@ impl<'a> TreeQuery<'a> for Nth<'a> {
             QueryResult::Finish
         } else {
             if let Some(m) = self.marks.as_mut() {
-                if op.visible_or_mark(self.clock.as_ref()) {
-                    m.process(op)
-                }
+                m.process(op, self.clock.as_ref())
             }
             let visible = op.visible_at(self.clock.as_ref());
             let key = op.elemid_or_key();

--- a/rust/automerge/src/query/opid.rs
+++ b/rust/automerge/src/query/opid.rs
@@ -107,7 +107,7 @@ impl<'a> TreeQuery<'a> for OpIdSearch<'a> {
     }
 
     fn query_element(&mut self, op: Op<'a>) -> QueryResult {
-        self.marks.process(op);
+        self.marks.process(op, self.clock);
         match self.target {
             SearchTarget::OpId(target, None) => {
                 if op.id() == &target {


### PR DESCRIPTION
Problem: In 70438774f2f8a52a1346458a968249b3634696bc I fixed a bug where marks were not being correctly calculated when a clock was passed to the `nth` query. This was actually a special case of a more general problem where we were not taking account of clocks passed to various queries when processing marks.

Solution: Add an `Option<Clock>` argument to `MarkMap::process` and do the visibility check in `process` rather than in the caller.