### PR TITLE
Fix relative path for exports.types

### DIFF
--- a/rust/automerge-wasm/package.json
+++ b/rust/automerge-wasm/package.json
@@ -61,7 +61,7 @@
     "uuid": "^9.0.0"
   },
   "exports": {
-    "types": "index.d.ts",
+    "types": "./index.d.ts",
     "workerd": "./web/index.js",
     "browser": "./bundler/automerge_wasm.js",
     "require": "./nodejs/automerge_wasm.cjs",


### PR DESCRIPTION
# Background

This fixes an issue related to importing/resolving types when using Typescript `moduleResolution: Node16 | NodeNext | Bundler`

Before this change, you would get the following error when trying to import types directly from `@automerge/automerge-wasm`:
```
// Example import
import { Patch } from "@automerge/automerge-wasm";

// Error
Diagnostics:
 typescript: Could not find a declaration file for module '@automerge/automerge-wasm'. 'node_modules/@automerge/automerge-wasm/nodejs/automerge_wasm.cjs' implicitly has an 'any' type.
   There are types at 'node_modules/@automerge/automerge-wasm/index.d.ts', but this result could not be resolved when respecting package.json "exports". The '@automerge/automerge-wasm' library may need to update its package.json or typings. [7016]
```
After the change in this PR, the type import works as expected without any error.

This seem to only happen when using Typescript compiler options `moduleResolution: Node16 | NodeNext | Bundler`, as they are the only ones the respect the `exports` field in `package.json`.

# Consequences

Even worse, this has the side-effect that you can't import types from `@automerge/automerge` that are re-exported from `@automerge/automerge-wasm`, e.g. the following fails without any error (it just assumes the type `any` silently instead):
```ts
import { Patch } from "@automerge/automerge/next";

const myPatch: Patch = "this is obviously not a patch, but there won't be any error";
```

It's very likely this could be a bug on typescript side (I'm on Typescript version 5.3.3), but the "fix" in this PR seem innocent enough that I think this work-around is useful.
