### PR TITLE
Update discord invite link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ reading the code and tests to figure out how to use them.
 If you're familiar with CRDTs and interested in the design of Automerge in
 particular take a look at https://automerge.org/automerge-binary-format-spec.
 
-Finally, if you want to talk to us about this project please [join our Discord server](https://discord.gg/XcbDtgJVdN)!
+Finally, if you want to talk to us about this project please [join our Discord server](https://discord.gg/HrpnPAU5zx)!
 
 ## Status
 


### PR DESCRIPTION
The current one expired, I got this new one (which will supposedly never expire) from slack.