### PR TITLE
Ensure cargo-deny and lint actions pass

### DIFF
--- a/.github/workflows/advisory-cron.yaml
+++ b/.github/workflows/advisory-cron.yaml
@@ -14,5 +14,5 @@ jobs:
       - uses: actions/checkout@v2
       - uses: EmbarkStudios/cargo-deny-action@v1
         with:
-          arguments: '--manifest-path ./rust/Cargo.toml'
+          manifest-path: './rust/Cargo.toml'
           command: check ${{ matrix.checks }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -64,7 +64,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: EmbarkStudios/cargo-deny-action@v1
         with:
-          arguments: '--manifest-path ./rust/Cargo.toml'
+          manifest-path: './rust/Cargo.toml'
           command: check ${{ matrix.checks }}
 
   wasm_tests:

--- a/rust/automerge/src/op_set/op.rs
+++ b/rust/automerge/src/op_set/op.rs
@@ -312,7 +312,7 @@ impl<'a> Op<'a> {
         }
     }
 
-    pub(crate) fn succ(&self) -> impl Iterator<Item = Op<'a>> + ExactSizeIterator {
+    pub(crate) fn succ(&self) -> impl ExactSizeIterator<Item = Op<'a>> {
         self.succ_idx().map(|idx| idx.as_opdep(self.osd).succ())
     }
 
@@ -325,7 +325,7 @@ impl<'a> Op<'a> {
         }
     }
 
-    pub(crate) fn pred(&self) -> impl Iterator<Item = Op<'a>> + ExactSizeIterator {
+    pub(crate) fn pred(&self) -> impl ExactSizeIterator<Item = Op<'a>> {
         self.pred_idx().map(|idx| idx.as_opdep(self.osd).pred())
     }
 }

--- a/rust/automerge/src/sync.rs
+++ b/rust/automerge/src/sync.rs
@@ -578,7 +578,7 @@ impl ChunkList {
         self.0.len()
     }
 
-    pub fn iter(&self) -> impl Iterator<Item = &[u8]> + ExactSizeIterator {
+    pub fn iter(&self) -> impl ExactSizeIterator<Item = &[u8]> {
         self.0.iter().map(|v| v.as_slice())
     }
 }


### PR DESCRIPTION
It looks like cargo-deny stopped working after the [1.5.14 release](https://github.com/EmbarkStudios/cargo-deny-action/releases/tag/v1.5.14). I noticed the runs fail on [my previous PR](https://github.com/automerge/automerge/actions/runs/8125155370/job/22207538386?pr=862).

I found [a ticket noting such](https://github.com/EmbarkStudios/cargo-deny-action/issues/73), and this PR should resolve the issue for now, but it's also worth considering pinning the action to a specific version.

Additionally, this implements a few clippy suggestions that were causing the lint GitHub action to fail.
