### PR TITLE
chore: fix lint issues

### DIFF
--- a/rust/automerge/src/op_set/op.rs
+++ b/rust/automerge/src/op_set/op.rs
@@ -312,7 +312,7 @@ impl<'a> Op<'a> {
         }
     }
 
-    pub(crate) fn succ(&self) -> impl Iterator<Item = Op<'a>> + ExactSizeIterator {
+    pub(crate) fn succ(&self) -> impl ExactSizeIterator<Item = Op<'a>> {
         self.succ_idx().map(|idx| idx.as_opdep(self.osd).succ())
     }
 
@@ -325,7 +325,7 @@ impl<'a> Op<'a> {
         }
     }
 
-    pub(crate) fn pred(&self) -> impl Iterator<Item = Op<'a>> + ExactSizeIterator {
+    pub(crate) fn pred(&self) -> impl ExactSizeIterator<Item = Op<'a>> {
         self.pred_idx().map(|idx| idx.as_opdep(self.osd).pred())
     }
 }

--- a/rust/automerge/src/sync.rs
+++ b/rust/automerge/src/sync.rs
@@ -578,7 +578,7 @@ impl ChunkList {
         self.0.len()
     }
 
-    pub fn iter(&self) -> impl Iterator<Item = &[u8]> + ExactSizeIterator {
+    pub fn iter(&self) -> impl ExactSizeIterator<Item = &[u8]> {
         self.0.iter().map(|v| v.as_slice())
     }
 }


### PR DESCRIPTION
This implements a few clippy suggestions that were causing the lint GitHub action to fail.
