### PR TITLE
Fix a panic when rolling back a transaction

### DIFF
--- a/rust/automerge/src/automerge.rs
+++ b/rust/automerge/src/automerge.rs
@@ -225,26 +225,6 @@ impl Automerge {
         }
     }
 
-    /// Remove the current actor from the opset if it has no ops
-    ///
-    /// If the current actor ID has no ops in the opset then remove it from the cache of actor IDs.
-    /// This us used when rolling back a transaction. If the rolled back ops are the only ops for
-    /// the current actor then we want to remove that actor from the opset so it doesn't end up in
-    /// any saved version of the document.
-    ///
-    /// # Panics
-    ///
-    /// If the last actor in the [`OpSet`] is not the actor ID of this document
-    pub(crate) fn rollback_last_actor(&mut self) {
-        if let Actor::Cached(actor_idx) = self.actor {
-            if self.states.get(&actor_idx).is_none() && self.ops.osd.actors.len() > 0 {
-                assert!(self.ops.osd.actors.len() == actor_idx + 1);
-                let actor = self.ops.osd.actors.remove_last();
-                self.actor = Actor::Unused(actor);
-            }
-        }
-    }
-
     /// Set the actor id for this document.
     pub fn with_actor(mut self, actor: ActorId) -> Self {
         self.actor = Actor::Unused(actor);

--- a/rust/automerge/src/indexed_cache.rs
+++ b/rust/automerge/src/indexed_cache.rs
@@ -44,6 +44,7 @@ where
         self.lookup.get(item).cloned()
     }
 
+    #[allow(dead_code)]
     pub(crate) fn len(&self) -> usize {
         self.cache.len()
     }
@@ -54,19 +55,6 @@ where
 
     pub(crate) fn safe_get(&self, index: usize) -> Option<&T> {
         self.cache.get(index)
-    }
-
-    /// Remove the last inserted entry into this cache.
-    /// This is safe to do as it does not require reshuffling other entries.
-    ///
-    /// # Panics
-    ///
-    /// Panics on an empty cache.
-    pub(crate) fn remove_last(&mut self) -> T {
-        let last = self.cache.len() - 1;
-        let t = self.cache.remove(last);
-        self.lookup.remove(&t);
-        t
     }
 
     pub(crate) fn sorted(&self) -> IndexedCache<T> {

--- a/rust/automerge/src/op_set/op.rs
+++ b/rust/automerge/src/op_set/op.rs
@@ -111,7 +111,7 @@ impl<'a> Ord for Op<'a> {
 }
 
 impl<'a> Op<'a> {
-    pub(crate) fn actor(&self) -> &ActorId {
+    pub(crate) fn actor(&self) -> &'a ActorId {
         &self.osd.actors[self.op().id.actor()]
     }
 
@@ -327,6 +327,12 @@ impl<'a> Op<'a> {
 
     pub(crate) fn pred(&self) -> impl ExactSizeIterator<Item = Op<'a>> {
         self.pred_idx().map(|idx| idx.as_opdep(self.osd).pred())
+    }
+
+    pub(crate) fn referenced_actors(&self) -> impl Iterator<Item = &'a ActorId> {
+        std::iter::once(self.actor())
+            .chain(self.pred().map(|op| op.actor()))
+            .chain(self.succ().map(|op| op.actor()))
     }
 }
 

--- a/rust/automerge/src/transaction/inner.rs
+++ b/rust/automerge/src/transaction/inner.rs
@@ -195,8 +195,6 @@ impl TransactionInner {
             }
         }
 
-        doc.rollback_last_actor();
-
         num
     }
 

--- a/rust/automerge/tests/test.rs
+++ b/rust/automerge/tests/test.rs
@@ -1935,3 +1935,62 @@ fn conflicting_unicode_text_with_different_widths() -> Result<(), AutomergeError
     Ok(())
 }
 */
+
+#[test]
+fn rollback_with_no_ops() {
+    let mut doc = Automerge::new();
+
+    doc.transact::<_, _, AutomergeError>(|tx| {
+        tx.put(ROOT, "a", 1)?;
+        Ok::<_, AutomergeError>(())
+    })
+    .unwrap();
+
+    let mut doc2 = doc.fork();
+
+    let tx = doc2.transaction();
+    tx.commit();
+
+    let mut doc3 = doc.fork();
+    doc3.transact::<_, _, AutomergeError>(|tx| {
+        tx.put(ROOT, "b", 2)?;
+        Ok::<_, AutomergeError>(())
+    })
+    .unwrap();
+
+    doc2.merge(&mut doc3).unwrap();
+
+    let tx = doc2.transaction();
+    tx.rollback();
+}
+
+#[test]
+fn save_with_ops_which_reference_actors_only_via_delete() {
+    let mut doc = Automerge::new();
+
+    doc.transact::<_, _, AutomergeError>(|tx| {
+        tx.put(ROOT, "a", 1)?;
+        Ok::<_, AutomergeError>(())
+    })
+    .unwrap();
+
+    let mut forked = doc.fork();
+    forked
+        .transact::<_, _, AutomergeError>(|tx| {
+            tx.delete(ROOT, "a")?;
+            Ok::<_, AutomergeError>(())
+        })
+        .unwrap();
+
+    doc.merge(&mut forked).unwrap();
+
+    // `doc` now contains a delete op which uses the actor of the fork. Delete
+    // ops don't exist explicitly in the document ops, they are referenced in
+    // the "successors" of the encoded ops. This means that when we're encoding
+    // actor IDs into the document we need to check that any actor IDs which
+    // are referenced in the `successors` of an op are encoded as well.
+
+    let saved = doc.save();
+    // This will panic if we failed to encode the referenced actor ID
+    let _ = Automerge::load(&saved).unwrap();
+}


### PR DESCRIPTION
Context: The logic to rollback a transaction removed the actor ID of the current actor if actor had no ops in the document. The purpose of this was to stop actors with no ops in the OpSet from being written to the document when calling `Automerge::save`. Also of note, actor IDs in the document are not references to `ActorId`s, but indexes into a cached array of `ActorId`s.

Problem: the logic to remove the actor ID contained a check that the actor ID being removed was the last actor in the cached array of actor IDs. This was not always true. For example, committing an empty transaction, then merging changes from another peer would mean that the final index in the cache was for a different actor ID to the current actor.

Solution: Instead of attempting to remove the actor ID on rollback, just filter the actor IDs when we save to ensure that no actors without ops are saved. This is more robust but comes at the cost of an additional scan over the `OpSet` when saving.

Fixes #861 