### PR TITLE
Only commit conversion transaction when there are valid conversions

### DIFF
--- a/rust/automerge/src/automerge.rs
+++ b/rust/automerge/src/automerge.rs
@@ -1599,12 +1599,16 @@ impl Automerge {
                 _ => {}
             }
         }
-        let mut tx = self.transaction();
-        for Conversion { obj_id, prop, text } in to_convert {
-            let text_id = tx.put_object(obj_id, prop, ObjType::Text)?;
-            tx.splice_text(&text_id, 0, 0, &text)?;
+
+        if !to_convert.is_empty() {
+            let mut tx = self.transaction();
+            for Conversion { obj_id, prop, text } in to_convert {
+                let text_id = tx.put_object(obj_id, prop, ObjType::Text)?;
+                tx.splice_text(&text_id, 0, 0, &text)?;
+            }
+            tx.commit();
         }
-        tx.commit();
+
         Ok(())
     }
 }

--- a/rust/automerge/tests/convert_string_to_text.rs
+++ b/rust/automerge/tests/convert_string_to_text.rs
@@ -56,3 +56,17 @@ fn test_strings_in_lists_are_converted_to_text() {
     let text = loaded.text(obj_id).unwrap();
     assert_eq!(text, "hello");
 }
+
+#[test]
+fn test_does_not_add_size_when_strings_are_not_converted() {
+    let empty_document = AutoCommit::new().save();
+    let mut loaded = AutoCommit::load_with_options(
+        &empty_document,
+        LoadOptions::new().migrate_strings(StringMigration::ConvertToText),
+    )
+    .unwrap();
+
+    let saved_again = loaded.save();
+
+    assert_eq!(empty_document.len(), saved_again.len());
+}


### PR DESCRIPTION
Fixes https://github.com/automerge/automerge/issues/872

When using `StringMigration::ConvertToText`, a transaction is made when loading the document. This isn't necessary and just causes ballooning of the document for no reason.

This PR corrects this issue by only committing the transaction if there are strings to convert.