### PR TITLE
rust/cli: emit text as string in JSON

### DIFF
--- a/rust/automerge-cli/src/export.rs
+++ b/rust/automerge-cli/src/export.rs
@@ -1,80 +1,11 @@
 use anyhow::Result;
 use automerge as am;
-use automerge::ReadDoc;
 
 use crate::{color_json::print_colored_json, VerifyFlag};
 
-pub(crate) fn map_to_json(doc: &am::Automerge, obj: &am::ObjId) -> serde_json::Value {
-    let keys = doc.keys(obj);
-    let mut map = serde_json::Map::new();
-    for k in keys {
-        let val = doc.get(obj, &k);
-        match val {
-            Ok(Some((am::Value::Object(o), exid)))
-                if o == am::ObjType::Map || o == am::ObjType::Table =>
-            {
-                map.insert(k.to_owned(), map_to_json(doc, &exid));
-            }
-            Ok(Some((am::Value::Object(_), exid))) => {
-                map.insert(k.to_owned(), list_to_json(doc, &exid));
-            }
-            Ok(Some((am::Value::Scalar(v), _))) => {
-                map.insert(k.to_owned(), scalar_to_json(&v));
-            }
-            _ => (),
-        };
-    }
-    serde_json::Value::Object(map)
-}
-
-fn list_to_json(doc: &am::Automerge, obj: &am::ObjId) -> serde_json::Value {
-    let len = doc.length(obj);
-    let mut array = Vec::new();
-    for i in 0..len {
-        let val = doc.get(obj, i);
-        match val {
-            Ok(Some((am::Value::Object(o), exid)))
-                if o == am::ObjType::Map || o == am::ObjType::Table =>
-            {
-                array.push(map_to_json(doc, &exid));
-            }
-            Ok(Some((am::Value::Object(_), exid))) => {
-                array.push(list_to_json(doc, &exid));
-            }
-            Ok(Some((am::Value::Scalar(v), _))) => {
-                array.push(scalar_to_json(&v));
-            }
-            _ => (),
-        };
-    }
-    serde_json::Value::Array(array)
-}
-
-fn scalar_to_json(val: &am::ScalarValue) -> serde_json::Value {
-    match val {
-        am::ScalarValue::Str(s) => serde_json::Value::String(s.to_string()),
-        am::ScalarValue::Bytes(b) | am::ScalarValue::Unknown { bytes: b, .. } => {
-            serde_json::Value::Array(
-                b.iter()
-                    .map(|byte| serde_json::Value::Number((*byte).into()))
-                    .collect(),
-            )
-        }
-        am::ScalarValue::Int(n) => serde_json::Value::Number((*n).into()),
-        am::ScalarValue::Uint(n) => serde_json::Value::Number((*n).into()),
-        am::ScalarValue::F64(n) => serde_json::Number::from_f64(*n)
-            .unwrap_or_else(|| 0_i64.into())
-            .into(),
-        am::ScalarValue::Counter(c) => serde_json::Value::Number(i64::from(c).into()),
-        am::ScalarValue::Timestamp(n) => serde_json::Value::Number((*n).into()),
-        am::ScalarValue::Boolean(b) => serde_json::Value::Bool(*b),
-        am::ScalarValue::Null => serde_json::Value::Null,
-    }
-}
-
 fn get_state_json(input_data: Vec<u8>, skip: VerifyFlag) -> Result<serde_json::Value> {
     let doc = skip.load(&input_data).unwrap(); // FIXME
-    Ok(map_to_json(&doc, &am::ObjId::Root))
+    serde_json::to_value(am::AutoSerde::from(&doc)).map_err(Into::into)
 }
 
 pub(crate) fn export_json(

--- a/rust/automerge/src/autoserde.rs
+++ b/rust/automerge/src/autoserde.rs
@@ -111,7 +111,11 @@ impl<'a, R: crate::ReadDoc> serde::Serialize for AutoSerdeVal<'a, R> {
                 };
                 map.serialize(serializer)
             }
-            Value::Object(ObjType::List | ObjType::Text) => {
+            Value::Object(ObjType::Text) => {
+                let text = self.doc.text(&self.obj).unwrap();
+                text.serialize(serializer)
+            }
+            Value::Object(ObjType::List) => {
                 let seq = AutoSerdeSeq {
                     doc: self.doc,
                     obj: self.obj.clone(),


### PR DESCRIPTION
Problem: the JSON formatting which automerge-cli uses emitted text sequences as arrays of characters. This is counterintuitive as the JS implementation now uses javascript strings and it's also irritating to read.

Solution: switch to emitting text as a JSON string. Also clean up the implementation by using the `automerge::AutoSerde` implementation of `serde::Serialize` to serialize the doc to `serde_json` rather than the custom implementation in `automerge-cli`.