### PR TITLE
precompute visible paths when generating patches

### DIFF
--- a/rust/automerge/src/automerge/diff.rs
+++ b/rust/automerge/src/automerge/diff.rs
@@ -3,6 +3,7 @@ use std::ops::RangeBounds;
 use std::sync::Arc;
 
 use crate::patches::TextRepresentation;
+use crate::read::ReadDocInternal;
 use crate::{
     exid::ExId,
     iter::{Keys, ListRange, MapRange, Values},
@@ -497,12 +498,18 @@ impl<'a, 'b> ReadDoc for ReadDocAt<'a, 'b> {
     }
 }
 
+impl<'a, 'b> ReadDocInternal for ReadDocAt<'a, 'b> {
+    fn live_obj_paths(&self) -> std::collections::HashMap<ExId, Vec<(ExId, Prop)>> {
+        self.doc.visible_obj_paths(Some(self.heads))
+    }
+}
+
 #[cfg(test)]
 mod tests {
 
     use crate::{
-        marks::Mark, transaction::Transactable, types::MarkData, AutoCommit, ObjType, Patch,
-        PatchAction, Prop, ScalarValue, Value, ROOT,
+        marks::Mark, patches::TextRepresentation, transaction::Transactable, types::MarkData,
+        AutoCommit, ObjType, Patch, PatchAction, Prop, ScalarValue, Value, ROOT,
     };
     use itertools::Itertools;
 
@@ -1301,6 +1308,56 @@ mod tests {
                     value: ScalarValue::Null,
                 }]),
             }]
+        );
+    }
+
+    #[test]
+    fn diff_with_before_and_after_heads() {
+        let mut doc = AutoCommit::new();
+        doc.set_text_rep(TextRepresentation::String);
+
+        let text = doc.put_object(ROOT, "value", ObjType::Text).unwrap();
+        doc.splice_text(&text, 0, 0, "aaa").unwrap();
+        let heads1 = doc.get_heads();
+
+        let text = doc.put_object(ROOT, "value", ObjType::Text).unwrap();
+        doc.splice_text(&text, 0, 0, "bbb").unwrap();
+        let heads2 = doc.get_heads();
+
+        let patch12 = doc.diff(&heads1, &heads2);
+        assert_eq!(
+            exp(patch12),
+            vec![
+                ObservedPatch {
+                    path: "/value".into(),
+                    action: ObservedAction::PutMap {
+                        value: Value::Object(ObjType::Text),
+                        conflict: false,
+                    }
+                },
+                ObservedPatch {
+                    path: "/value/0".into(),
+                    action: ObservedAction::SpliceText("bbb".to_string()),
+                },
+            ]
+        );
+
+        let patch21 = doc.diff(&heads2, &heads1);
+        assert_eq!(
+            exp(patch21),
+            vec![
+                ObservedPatch {
+                    path: "/value".into(),
+                    action: ObservedAction::PutMap {
+                        value: Value::Object(ObjType::Text),
+                        conflict: false,
+                    }
+                },
+                ObservedPatch {
+                    path: "/value/0".into(),
+                    action: ObservedAction::SpliceText("aaa".to_string()),
+                },
+            ]
         );
     }
 }

--- a/rust/automerge/src/read.rs
+++ b/rust/automerge/src/read.rs
@@ -7,7 +7,7 @@ use crate::{
     Change, ChangeHash, Cursor, ObjType, Prop, Value,
 };
 
-use std::ops::RangeBounds;
+use std::{collections::HashMap, ops::RangeBounds};
 
 /// Methods for reading values from an automerge document
 ///
@@ -241,4 +241,9 @@ pub trait ReadDoc {
 
     /// Get a change by its hash.
     fn get_change_by_hash(&self, hash: &ChangeHash) -> Option<&Change>;
+}
+
+pub(crate) trait ReadDocInternal: ReadDoc {
+    /// Produce a map from object ID to path for all visible objects in this doc
+    fn live_obj_paths(&self) -> HashMap<ExId, Vec<(ExId, Prop)>>;
 }


### PR DESCRIPTION
Problem: in documents with histories that create a large number of objects patch generation can become slow due to the cost of computing the path for each path. We don't store the path anywhere in the document, instead each OpTree stores the ID of op which created it; this in turn means that to compute the path to an object we recursively seek through the opset for each object in the path. In documents which have a large number of ops - and especially if these ops are split over many small objects - these seek operations can take a long time.

Solution: when we think we have more than a few paths to generate (this patch arbitrarily choosese 100 paths) first precompute all the visible paths in the document and then use this lookup table. To put this in concrete terms, I have a document which prior to this patch took 50 seconds to diff and which after this patch takes 250ms to diff.

The implementation works by adding `Automerge::visible_object_paths` which returns a map from object ID to path. This can be passed a set of heads to generate the visible paths as at some point in time. In order to make passing the to the `PatchLog` cleaner we add a `ReadDocInternal` trait which exposes a `visible_object_paths` method, this trait is implemented by both `Automerge` and `ReadDocAt`. We paramterise the `PatchBuilder` on a `ReadDocInternal` implementation which means that we can pass the `ReadDocInternal` into the `PatchBuilder` constructor and then be sure that we are using the same paths throughout by using the parameterised `ReadDocInternal` rather than passing a `ReadDoc` in to each method on `PatchBuilder`.