### PR TITLE
include actor IDs from missing changes in save

### DIFF
--- a/rust/automerge/src/indexed_cache.rs
+++ b/rust/automerge/src/indexed_cache.rs
@@ -57,6 +57,7 @@ where
         self.cache.get(index)
     }
 
+    #[allow(dead_code)]
     pub(crate) fn sorted(&self) -> IndexedCache<T> {
         let mut sorted = Self::new();
         self.cache.iter().sorted().cloned().for_each(|item| {

--- a/rust/automerge/src/op_set/op.rs
+++ b/rust/automerge/src/op_set/op.rs
@@ -328,12 +328,6 @@ impl<'a> Op<'a> {
     pub(crate) fn pred(&self) -> impl ExactSizeIterator<Item = Op<'a>> {
         self.pred_idx().map(|idx| idx.as_opdep(self.osd).pred())
     }
-
-    pub(crate) fn referenced_actors(&self) -> impl Iterator<Item = &'a ActorId> {
-        std::iter::once(self.actor())
-            .chain(self.pred().map(|op| op.actor()))
-            .chain(self.succ().map(|op| op.actor()))
-    }
 }
 
 pub(crate) struct PredIdxIter<'a> {


### PR DESCRIPTION
Problem: in f10981 I modified the logic of `Automerge::save()` to do a scan over the ops in the document when determining which actors to save. This logic fails to account fo empty commits by actors who never make any ops.

Solution: rather than scanning the ops, scan the changes.