### PR TITLE
fix: Automerge::Spans -> don't double count after block markers

### DIFF
--- a/rust/automerge/src/iter/spans.rs
+++ b/rust/automerge/src/iter/spans.rs
@@ -96,7 +96,6 @@ impl<'a> SpansState<'a> {
                         let mut result = None;
                         if next_marks == self.current_marks {
                             self.len += op.width(ListEncoding::Text);
-                            self.text.push_str(op.as_str());
                         } else {
                             // only flush if the marks are actually changing. One situation where
                             // they might not change is if a zero length mark was encountered in


### PR DESCRIPTION
Problem: e6d60d32 fixed an error where empty marks split spans which had equal marks on either side. The fix introduced a bug where the character after a block marker and an empty mark was double counter.

Solution: don't double count the character.