### PR TITLE
fix: correct index calculations for large patch sets

### DIFF
--- a/rust/automerge/src/automerge.rs
+++ b/rust/automerge/src/automerge.rs
@@ -1689,9 +1689,13 @@ impl Automerge {
                         let prop = match op.key() {
                             Key::Map(prop) => Prop::Map(self.ops.osd.props.get(*prop).clone()),
                             Key::Seq(_) => {
+                                let encoding = match obj.typ {
+                                    ObjType::Text => ListEncoding::Text,
+                                    _ => ListEncoding::List,
+                                };
                                 let found = self
                                     .ops
-                                    .seek_list_opid(&obj.id, *op.id(), ListEncoding::Text, None)
+                                    .seek_list_opid(&obj.id, *op.id(), encoding, at.as_ref())
                                     .unwrap();
                                 Prop::Seq(found.index)
                             }


### PR DESCRIPTION
Problem: when a change produced large numbers of patches (more than 100) some patches could end up with incorrect indexes. The reason for this was that the optimization which kicks in at > 100 patches which precalculates the paths for every visible object in the document was using the wrong encoding for calculating the indexes in lists.

Solution: use the correct encoding.