### PR TITLE
splice: fix no-expand marks at the end of text

### DIFF
--- a/rust/automerge/tests/text.rs
+++ b/rust/automerge/tests/text.rs
@@ -4,6 +4,7 @@ use automerge::{
     hydrate_list, hydrate_map,
     iter::Span,
     marks::{ExpandMark, Mark},
+    op_tree::B,
     transaction::Transactable,
     ActorId, AutoCommit, ObjType, Patch, PatchAction, ReadDoc, ScalarValue, ROOT,
 };
@@ -311,11 +312,6 @@ fn spans_are_consolidated_in_the_presence_of_zero_length_spans() {
     )
     .unwrap();
 
-    #[cfg(feature = "optree-visualisation")]
-    {
-        println!("{}", doc.visualise_optree(None));
-    }
-
     let spans = doc.spans(&text).unwrap().collect::<Vec<_>>();
     println!("{:?}", spans);
     assert!(marks_are_consolidated(&spans));
@@ -397,11 +393,6 @@ fn insertions_after_noexpand_spans_are_not_marked() {
 
     doc.update_blocks(&text, new_blocks).unwrap();
 
-    #[cfg(feature = "optree-visualisation")]
-    {
-        println!("{}", doc.visualise_optree(None));
-    }
-
     let marks = doc.marks(&text).unwrap();
     println!("marks: {:?}", marks);
 
@@ -431,64 +422,71 @@ fn insertions_after_noexpand_spans_are_not_marked() {
 
 #[test]
 fn marks_which_cross_optree_boundaries_are_not_double_counted_in_splice_patches() {
+    // This test exposese an issue where marks suddenly appeared on characters in a document after
+    // a mark which had ended much earlier in the document.The problem was caused by an interaction
+    // between the indexes on optree pages and a bug in the way the insert query keeps track of
+    // marks as it searches for its target.
+    //
+    // As the insert query traverses the op tree it keeps track of a HashMap<OpId, MarkData>. The
+    // OpId is the ID of the op which created the mark and the MarkData is the data associated with
+    // that mark. Whenever the query encounters a BeginMark operation it adds it to the map and
+    // whenever it encounters an EndMark operation it removes it. Once the query has found its
+    // target the map can be evaluated to determine the marks active at the insertion point, which
+    // are then passed to the patch.
+    //
+    // The OpTree nodes have indexes on them which the insert query uses to skip sections of the
+    // tree which definitely don't contain the target op. The primary useful thing the index
+    // contains is the visible length - the number of visible ops - in the node and its children.
+    // This allows the insert query to skip past the entire node if the target is beyond the
+    // visible length of the index.
+    //
+    // In order to account for the fact that the skipped nodes may contain begin or end mark
+    // operations the indexes also have a `mark_begin: HashMap<OpId, MarkData>` and a `mark_end:
+    // Vec<OpId>` field which keep track of the begin and end operations in the node and its
+    // children. When the insert query skips a node it also updates its map of active marks by
+    // removing the marks which have an end operation in the node and adding the marks which have a
+    // begin operation.
+    //
+    // The bug was that the removal code was doing this:
+    //
+    //     for id in index.mark_end.iter() {
+    //         marks.remove(&id);
+    //     }
+    //
+    // Recall that `marks` is a HashMap<OpId, MarkData> which maps the ID of the op which created
+    // the mark, but the `mark_end` field is a Vec<OpId> which contains the ID of the end mark. End
+    // mark operations are always the operation immediately following the begin mark operation, so
+    // we can calculate the op we actually need to remove by calling `id.prev()`. Like so:
+    //
+    //    for id in index.mark_end.iter() {
+    //        marks.remove(&id.prev());
+    //    }
     let mut doc = AutoCommit::new();
     let text = doc.put_object(ROOT, "text", ObjType::Text).unwrap();
-    let block1 = doc.split_block(&text, 0).unwrap();
-    doc.update_object(
-        &block1,
-        &hydrate_map! {
-            "type" => "heading",
-            "parents" => hydrate_list![],
-            "attrs" => hydrate_map!{},
-        }
-        .into(),
-    )
-    .unwrap();
-    doc.splice_text(&text, 1, 0, "Heading").unwrap();
-    let block2 = doc.split_block(&text, 8).unwrap();
-    doc.update_object(
-        &block2,
-        &hydrate_map! {
-            "type" => "paragraph",
-            "parents" => hydrate_list![],
-            "attrs" => hydrate_map!{},
-        }
-        .into(),
-    )
-    .unwrap();
-    doc.splice_text(&text, 9, 0, "Hello world").unwrap();
+    // insert enough text that we cover two pages of the op tree
+    let one_page = "a".repeat(B * 2);
+    doc.splice_text(&text, doc.length(&text), 0, &one_page)
+        .unwrap();
+    // Add a mark that starts in one page and ends in the next
     doc.mark(
         &text,
-        Mark::new("strong".to_string(), ScalarValue::from(true), 15, 20),
+        Mark::new("strong".to_string(), ScalarValue::from(true), B - 1, B + 1),
         automerge::marks::ExpandMark::None,
     )
     .unwrap();
 
-    let start = 20;
-    for i in 0..100 {
-        let spans = doc.spans(&text).unwrap();
-        let mut new_blocks = spans
-            .map(|s| match s {
-                Span::Text(s, _) => automerge::BlockOrText::Text(s.into()),
-                Span::Block(m) => automerge::BlockOrText::Block(m),
-            })
-            .collect::<Vec<_>>();
-        new_blocks.push(automerge::BlockOrText::Block(hydrate_map! {
-            "type" => "paragraph",
-            "parents" => hydrate_list![],
-            "attrs" => hydrate_map!{},
-        }));
-
-        doc.update_blocks(&text, new_blocks).unwrap();
-
+    // Now add characters. Eventually the end mark will be in an op tree page which is skipped by
+    // the insert query, exposing the faulty logic.
+    for _ in 0..100 {
+        // This is necessary to clear the `Index::last_insert cache, which otherwise just uses the
+        // marks of the last inserted character when generating the patch.
+        doc.split_block(&text, doc.length(&text)).unwrap();
+        // This is necessary because otherwise the patches can be generated from scratch, which
+        // will mean we don't use the logic in the insert query
         doc.update_diff_cursor();
         let heads_before = doc.get_heads();
-        let end = start + (i * 2) + 1;
-        doc.splice_text(&text, end, 0, "a").unwrap();
+        doc.splice_text(&text, doc.length(&text), 0, "a").unwrap();
         let heads_after = doc.get_heads();
-        //let marks = doc.marks(&text).unwrap();
-
-        //let patches = doc.diff_incremental();
 
         let patches = doc.diff(&heads_before, &heads_after);
         assert_eq!(patches.len(), 1);
@@ -500,12 +498,125 @@ fn marks_which_cross_optree_boundaries_are_not_double_counted_in_splice_patches(
         else {
             panic!("expected single splice patch, got: {:?}", patches);
         };
+        // If the end mark is not removed correctly then we will see unexpected marks
         assert_eq!(
             marks, &None,
             "expected marks to be none, got {:?}",
             patches[0]
         );
     }
+}
+
+#[test]
+fn noexpand_marks_at_the_end_of_text_should_not_emit_marked_patches_on_following_insertions() {
+    let mut doc = AutoCommit::new();
+    let text = doc.put_object(ROOT, "text", ObjType::Text).unwrap();
+    doc.splice_text(&text, doc.length(&text), 0, "Hello world")
+        .unwrap();
+    let mark_start = doc.length(&text) - 1;
+    let mark_end = doc.length(&text);
+    doc.mark(
+        &text,
+        Mark::new(
+            "strong".to_string(),
+            ScalarValue::from(true),
+            mark_start,
+            mark_end,
+        ),
+        automerge::marks::ExpandMark::None,
+    )
+    .unwrap();
+
+    doc.update_diff_cursor();
+    let heads_before = doc.get_heads();
+    println!("doing splice");
+    doc.splice_text(&text, doc.length(&text), 0, "a").unwrap();
+    println!("done splice");
+    let heads_after = doc.get_heads();
+
+    let patches = doc.diff(&heads_before, &heads_after);
+    assert_eq!(patches.len(), 1);
+
+    let Patch {
+        action: PatchAction::SpliceText { marks, .. },
+        ..
+    } = &patches[0]
+    else {
+        panic!("expected single splice patch, got: {:?}", patches);
+    };
+    assert_eq!(marks, &None,);
+}
+
+#[test]
+fn expand_marks_are_reported_in_patches() {
+    let mut doc = AutoCommit::new();
+    let text = doc.put_object(ROOT, "text", ObjType::Text).unwrap();
+    doc.splice_text(&text, 0, 0, "aaabbbccc").unwrap();
+    doc.mark(
+        &text,
+        Mark::new("strong".to_string(), ScalarValue::from(true), 3, 6),
+        automerge::marks::ExpandMark::Both,
+    )
+    .unwrap();
+
+    doc.update_diff_cursor();
+    let mut patches = Vec::new();
+
+    doc.splice_text(&text, 6, 0, "<").unwrap();
+    patches.extend(doc.diff_incremental());
+
+    doc.splice_text(&text, 3, 0, ">").unwrap();
+    patches.extend(doc.diff_incremental());
+
+    assert_eq!(patches.len(), 2);
+
+    let Patch {
+        action:
+            PatchAction::SpliceText {
+                marks,
+                index,
+                value,
+                ..
+            },
+        ..
+    } = &patches[0]
+    else {
+        panic!("expected a patch, got: {:?}", patches);
+    };
+    assert_eq!(*index, 6);
+    assert_eq!(value.make_string(), "<".to_string());
+    assert_eq!(
+        marks,
+        &Some(
+            vec![("strong".to_string(), ScalarValue::from(true))]
+                .into_iter()
+                .collect()
+        )
+    );
+
+    let Patch {
+        action:
+            PatchAction::SpliceText {
+                marks,
+                index,
+                value,
+                ..
+            },
+        ..
+    } = &patches[1]
+    else {
+        panic!("expected a patch, got: {:?}", patches);
+    };
+    assert_eq!(*index, 3);
+    assert_eq!(value.make_string(), ">".to_string());
+    assert_eq!(
+        marks,
+        &Some(
+            vec![("strong".to_string(), ScalarValue::from(true))]
+                .into_iter()
+                .collect()
+        )
+    );
 }
 
 proptest::proptest! {


### PR DESCRIPTION
Problem: in text which has a mark ending at the end of the text but which was set to not expand on insertions at the end, insertions were nevertheless still producting patches which contained the mark. The reason was that the logic in the insert query for processing the end-mark operations was only running when the next visible operation _after_ the mark operations was processed.

Solution: run the mark processing logic when we encounter the end mark operation.

While I was here I also added some exposition to the earlier test exposing a problem with marks which cross optree boundaries and generally cleaned that test up.