### PR TITLE
Fix missing objects in reverse patches

### DIFF
--- a/javascript/test/patches.ts
+++ b/javascript/test/patches.ts
@@ -113,4 +113,28 @@ describe("patches", () => {
       )
     })
   })
+
+  it("should correctly diff the reverse of deleting a string value on next", () => {
+    const doc = Automerge.from<{ list: string[] }>({ list: ["a", "b", "c"] })
+
+    Automerge.change(
+      doc,
+      {
+        patchCallback: (_, patchInfo) => {
+          const reverse = Automerge.diff(
+            patchInfo.after,
+            Automerge.getHeads(patchInfo.after),
+            Automerge.getHeads(patchInfo.before),
+          )
+          assert.deepEqual(reverse, [
+            { action: "insert", path: ["list", 1], values: [""] },
+            { action: "splice", path: ["list", 1, 0], value: "b" },
+          ])
+        },
+      },
+      doc => {
+        Automerge.deleteAt(doc.list, 1)
+      },
+    )
+  })
 })

--- a/rust/automerge/src/patches/patch_log.rs
+++ b/rust/automerge/src/patches/patch_log.rs
@@ -315,6 +315,10 @@ impl PatchLog {
         }
     }
 
+    pub(crate) fn expose(&mut self, id: OpId) {
+        self.expose.insert(id);
+    }
+
     fn make_patches_inner<R: ReadDocInternal>(
         events: &[(ObjId, Event)],
         mut expose_queue: ExposeQueue,


### PR DESCRIPTION
Problem: when diffing "in reverse", i.e. where the start heads are topologically after the end heads in the change graph, the patches produced would not include objects which are "undeleted".

Solution: when traversing the OpSet if we encounter ops which make create an object and which were visible before the heads we are starting from, then mark the object as exposed so that the ExposeQueue will render the object to the patch log later.

fixes #708 