### PR TITLE
Allow empty keys in maps

### DIFF
--- a/javascript/test/error.ts
+++ b/javascript/test/error.ts
@@ -15,15 +15,4 @@ describe("Automerge errors", () => {
 
     assert(error instanceof Error)
   })
-
-  it("Automerge.from throws an error, not a string", () => {
-    let error
-    try {
-      Automerge.from({ "": "bad key" })
-    } catch (err) {
-      error = err
-    }
-
-    assert(error instanceof Error)
-  })
 })

--- a/javascript/test/legacy_tests.ts
+++ b/javascript/test/legacy_tests.ts
@@ -490,10 +490,9 @@ describe("Automerge", () => {
         assert.strictEqual(s1.prop, true)
       })
 
-      it("should require property names to be valid", () => {
-        assert.throws(() => {
-          Automerge.change(s1, "foo", doc => (doc[""] = "x"))
-        }, /must not be an empty string/)
+      it("should not error on empty string keys", () => {
+        s2 = Automerge.change(s1, "set empty string key", doc => (doc[""] = "x"))
+        assert.strictEqual(s2[""], "x")
       })
 
       it("should not allow assignment of unsupported datatypes", () => {
@@ -680,16 +679,6 @@ describe("Automerge", () => {
         s1 = Automerge.change(s1, doc => delete doc.textStyle)
         assert.strictEqual(s1.textStyle, undefined)
         assert.deepStrictEqual(s1, { title: "Hello" })
-      })
-
-      it("should validate field names", () => {
-        s1 = Automerge.change(s1, doc => (doc.nested = {}))
-        assert.throws(() => {
-          Automerge.change(s1, doc => (doc.nested[""] = "x"))
-        }, /must not be an empty string/)
-        assert.throws(() => {
-          Automerge.change(s1, doc => (doc.nested = { "": "x" }))
-        }, /must not be an empty string/)
       })
     })
 

--- a/rust/automerge/src/error.rs
+++ b/rust/automerge/src/error.rs
@@ -12,8 +12,6 @@ pub enum AutomergeError {
     Deflate(#[source] std::io::Error),
     #[error("duplicate seq {0} found for actor {1}")]
     DuplicateSeqNumber(u64, ActorId),
-    #[error("key must not be an empty string")]
-    EmptyStringKey,
     #[error("general failure")]
     Fail,
     #[error("invalid actor ID `{0}`")]

--- a/rust/automerge/src/transaction/inner.rs
+++ b/rust/automerge/src/transaction/inner.rs
@@ -404,10 +404,6 @@ impl TransactionInner {
         prop: String,
         action: OpType,
     ) -> Result<Option<OpIdx>, AutomergeError> {
-        if prop.is_empty() {
-            return Err(AutomergeError::EmptyStringKey);
-        }
-
         let id = self.next_id();
         let prop_index = doc.ops_mut().osd.props.cache(prop.clone());
         let key = Key::Map(prop_index);

--- a/rust/automerge/tests/test.rs
+++ b/rust/automerge/tests/test.rs
@@ -2216,3 +2216,15 @@ fn missing_actors_when_docs_are_forked() {
     // error occurs here
     doc2.save_and_verify().unwrap();
 }
+
+#[test]
+fn allows_empty_keys_in_mappings() {
+    let mut doc = AutoCommit::new();
+    doc.put(&automerge::ROOT, "", 1).unwrap();
+    assert_doc!(
+        &doc,
+        map! {
+            "" => { 1 },
+        }
+    );
+}


### PR DESCRIPTION
According to discussion over on #852, there really isn't a reason why keys can't be empty. 
This PR allows this by simply removing the check and error.

Resolves #852