### PR TITLE
More helpful error message when assigning `undefined` to a property

### DIFF
--- a/javascript/src/proxies.ts
+++ b/javascript/src/proxies.ts
@@ -143,7 +143,8 @@ function import_value(
   textV2: boolean,
   path: Prop[],
 ): ImportedValue {
-  switch (typeof value) {
+  const type = typeof value
+  switch (type) {
     case "object":
       if (value == null) {
         return [null, "null"]
@@ -188,9 +189,22 @@ function import_value(
       } else {
         return [value, "str"]
       }
+    case "undefined":
+      throw new RangeError(
+        [
+          `Cannot assign undefined value at ${printPath(path)}, `,
+          "because `undefined` is not a valid JSON data type. ",
+          "You might consider setting the property's value to `null`, ",
+          "or using `delete` to remove it altogether.",
+        ].join(""),
+      )
     default:
       throw new RangeError(
-        `Unsupported type ${typeof value} for path ${printPath(path)}`,
+        [
+          `Cannot assign ${type} value at ${printPath(path)}. `,
+          `All JSON primitive datatypes (object, array, string, number, boolean, null) `,
+          `are supported in an Automerge document; ${type} values are not. `,
+        ].join(""),
       )
   }
 }
@@ -683,7 +697,9 @@ function listMethods<T extends Target>(target: T) {
           return import_value(val, textV2, [...path])
         } catch (e) {
           if (e instanceof RangeError) {
-            throw new RangeError(`${e.message} at index ${index} in the input`)
+            throw new RangeError(
+              `${e.message} (at index ${index} in the input)`,
+            )
           } else {
             throw e
           }

--- a/javascript/test/legacy_tests.ts
+++ b/javascript/test/legacy_tests.ts
@@ -499,16 +499,16 @@ describe("Automerge", () => {
         Automerge.change(s1, doc => {
           assert.throws(() => {
             doc.foo = undefined
-          }, /Unsupported type undefined for path \/foo/)
+          }, /Cannot assign undefined value at \/foo/)
           assert.throws(() => {
             doc.foo = { prop: undefined }
-          }, /Unsupported type undefined for path \/foo\/prop/)
+          }, /Cannot assign undefined value at \/foo\/prop/)
           assert.throws(() => {
             doc.foo = () => {}
-          }, /Unsupported type function for path \/foo/)
+          }, /Cannot assign function value at \/foo/)
           assert.throws(() => {
             doc.foo = Symbol("foo")
-          }, /Unsupported type symbol for path \/foo/)
+          }, /Cannot assign symbol value at \/foo/)
         })
       })
     })

--- a/javascript/test/proxies.ts
+++ b/javascript/test/proxies.ts
@@ -93,7 +93,7 @@ describe("Proxies", () => {
       change(doc, d => {
         assert.throws(() => {
           d.list.splice(0, 0, 5, undefined)
-        }, /Unsupported type undefined for path \/list at index 1 in the input/)
+        }, /Cannot assign undefined value at \/list.*at index 1 in the input/)
       })
     })
   })

--- a/javascript/test/proxies.ts
+++ b/javascript/test/proxies.ts
@@ -99,6 +99,23 @@ describe("Proxies", () => {
   })
 
   describe("map proxy", () => {
+    it("does allow null values", () => {
+      let doc = from<any>({})
+      doc = change(doc, doc => {
+        doc.foo = null
+      })
+      assert.equal(doc.foo, null)
+    })
+
+    it("does not allow undefined values", () => {
+      let doc = from<any>({})
+      assert.throws(() => {
+        doc = change(doc, doc => {
+          doc.foo = undefined
+        })
+      }, "Cannot assign undefined")
+    })
+
     it("should print the property path in the error when setting an undefined key", () => {
       const doc = from({ map: {} })
       change(doc, d => {


### PR DESCRIPTION
Ran into this behavior today and was surprised by it.

```js
    it("does not support undefined values", () => {
      let doc = Automerge.init<any>()
      assert.throws(() => {
        doc = Automerge.change(doc, doc => {
          doc.foo = undefined
        })
      }, "Unsupported type undefined")
    })
```

After some head-scratching I realized that `undefined` is not a valid JSON value. 

The full error message you get is `Unsupported type undefined at path /a/b/c", which wasn't super helpful to me. 

This PR changes the error messages for this and similar situations so that they point the developer in the right direction. 
