### PR TITLE
Better check for plain objects

### DIFF
--- a/javascript/src/proxies.ts
+++ b/javascript/src/proxies.ts
@@ -165,7 +165,7 @@ function import_value(
         return [value, "bytes"]
       } else if (value instanceof Array) {
         return [value, "list"]
-      } else if (Object.getPrototypeOf(value) === Object.getPrototypeOf({})) {
+      } else if (Object.prototype.toString.call(value) === '[object Object]') {
         return [value, "map"]
       } else if (isSameDocument(value, context)) {
         throw new RangeError(

--- a/javascript/test/proxies.ts
+++ b/javascript/test/proxies.ts
@@ -119,4 +119,12 @@ describe("Proxies", () => {
       })
     })
   })
+
+  describe("structuredClone support", () => {
+    it("should support objects cloned with structuredClone", () => {
+      const doc = from({ map: structuredClone({ key: 'value', number: 2 }) });
+
+      assert.deepEqual(doc, { map: { key: 'value', number: 2 } })
+    });
+  })
 })


### PR DESCRIPTION
The global function [`structuredClone`](https://developer.mozilla.org/en-US/docs/Web/API/structuredClone) does not copy the prototype chain and because of it, objects resulting from this function fail the current check.

This PR resolves this issue by using a different check described in [this blog post](https://www.zhenghao.io/posts/js-data-type).

Resolves https://github.com/automerge/automerge/issues/915