### PR TITLE
Fix lint errors

### DIFF
--- a/javascript/src/internal_state.ts
+++ b/javascript/src/internal_state.ts
@@ -1,14 +1,18 @@
-import { type ObjID, type Heads, Automerge } from "@automerge/automerge-wasm"
+import { Automerge, type Heads, type ObjID, Patch } from "@automerge/automerge-wasm"
 
-import { STATE, OBJECT_ID, CLEAR_CACHE, TRACE, IS_PROXY } from "./constants.js"
+import { CLEAR_CACHE, IS_PROXY, OBJECT_ID, STATE, TRACE } from "./constants.js"
 
-import type { Doc, PatchCallback } from "./types.js"
+import { Doc, PatchCallback } from "./types.js"
 
 export interface InternalState<T> {
   handle: Automerge
   heads: Heads | undefined
   freeze: boolean
-  mostRecentPatch: any // TODO: type this
+  mostRecentPatch: {
+    before: Heads | undefined
+    after: Heads | undefined
+    patches: Patch[]
+  }
   patchCallback?: PatchCallback<T>
   textV2: boolean
 }

--- a/javascript/src/stable.ts
+++ b/javascript/src/stable.ts
@@ -110,7 +110,7 @@ export function insertAt<T>(list: T[], index: number, ...values: T[]) {
     throw new RangeError("object cannot be modified outside of a change block")
   }
 
-  ;(list as List<T>).insertAt(index, ...values)
+  (list as List<T>).insertAt(index, ...values)
 }
 
 /**
@@ -124,7 +124,7 @@ export function deleteAt<T>(list: T[], index: number, numDelete?: number) {
     throw new RangeError("object cannot be modified outside of a change block")
   }
 
-  ;(list as List<T>).deleteAt(index, numDelete)
+  (list as List<T>).deleteAt(index, numDelete)
 }
 
 /**
@@ -486,7 +486,6 @@ function progressDocument<T>(
       before: _state(doc).heads,
       after: newState.handle.getHeads(),
       patches,
-      source,
     }
   }
 

--- a/javascript/src/uuid.deno.ts
+++ b/javascript/src/uuid.deno.ts
@@ -8,9 +8,10 @@ function defaultFactory() {
 
 let factory = defaultFactory
 
-interface UUIDFactory extends Function {
+interface UUIDFactory {
   setFactory(f: typeof factory): void
   reset(): void
+  (): string
 }
 
 export const uuid: UUIDFactory = () => {

--- a/javascript/src/uuid.ts
+++ b/javascript/src/uuid.ts
@@ -6,9 +6,10 @@ function defaultFactory() {
 
 let factory = defaultFactory
 
-interface UUIDFactory extends Function {
+interface UUIDFactory {
   setFactory(f: typeof factory): void
   reset(): void
+  (): string
 }
 
 export const uuid: UUIDFactory = () => {


### PR DESCRIPTION
When running `npm run lint`, a few errors appear:

```
$ npm run lint --fix

> @automerge/automerge@2.2.2 lint
> eslint src


automerge/javascript/src/internal_state.ts
  11:20  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any

automerge/javascript/src/stable.ts
  113:3  error  Unnecessary semicolon  @typescript-eslint/no-extra-semi
  127:3  error  Unnecessary semicolon  @typescript-eslint/no-extra-semi

automerge/javascript/src/uuid.deno.ts
  11:31  error  Don't use `Function` as a type. The `Function` type accepts any function-like value.
It provides no type safety when calling the function, which can be a common source of bugs.
It also accepts things like class declarations, which will throw at runtime as they will not be called with `new`.
If you are expecting the function to accept certain arguments, you should explicitly define the function shape  @typescript-eslint/ban-types

automerge/javascript/src/uuid.ts
  9:31  error  Don't use `Function` as a type. The `Function` type accepts any function-like value.
It provides no type safety when calling the function, which can be a common source of bugs.
It also accepts things like class declarations, which will throw at runtime as they will not be called with `new`.
If you are expecting the function to accept certain arguments, you should explicitly define the function shape  @typescript-eslint/ban-types

✖ 5 problems (4 errors, 1 warning)
  2 errors and 0 warnings potentially fixable with the `--fix` option.
```

This PR fixes those errors. I plan to make this check as a PR check to make sure the code adheres to lint.