### PR TITLE
automerge-c: Expose Cursor API

### DIFF
--- a/rust/automerge-c/CMakeLists.txt
+++ b/rust/automerge-c/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.25 FATAL_ERROR)
 
-project(automerge-c VERSION 0.2.2
+project(automerge-c VERSION 0.3.0
                     LANGUAGES C
                     DESCRIPTION "C bindings for the Automerge Rust library.")
 

--- a/rust/automerge-c/CMakeLists.txt
+++ b/rust/automerge-c/CMakeLists.txt
@@ -160,6 +160,7 @@ add_custom_command(
         src/actor_id.rs
         src/byte_span.rs
         src/change.rs
+        src/cursor.rs
         src/doc.rs
         src/doc/list.rs
         src/doc/map.rs

--- a/rust/automerge-c/src/actor_id.rs
+++ b/rust/automerge-c/src/actor_id.rs
@@ -36,7 +36,7 @@ impl AMactorId {
         }
     }
 
-    pub fn as_hex_str(&self) -> AMbyteSpan {
+    fn to_str(&self) -> AMbyteSpan {
         let mut hex_str = self.hex_str.borrow_mut();
         match hex_str.as_mut() {
             None => {
@@ -187,7 +187,7 @@ pub unsafe extern "C" fn AMactorIdFromStr(value: AMbyteSpan) -> *mut AMresult {
 #[no_mangle]
 pub unsafe extern "C" fn AMactorIdStr(actor_id: *const AMactorId) -> AMbyteSpan {
     match actor_id.as_ref() {
-        Some(actor_id) => actor_id.as_hex_str(),
+        Some(actor_id) => actor_id.to_str(),
         None => Default::default(),
     }
 }

--- a/rust/automerge-c/src/byte_span.rs
+++ b/rust/automerge-c/src/byte_span.rs
@@ -117,7 +117,11 @@ impl From<&[u8]> for AMbyteSpan {
 
 impl From<&AMbyteSpan> for &[u8] {
     fn from(byte_span: &AMbyteSpan) -> Self {
-        unsafe { std::slice::from_raw_parts(byte_span.src, byte_span.count) }
+        return if byte_span.is_null() {
+            &[]
+        } else {
+            unsafe { std::slice::from_raw_parts(byte_span.src, byte_span.count) }
+        };
     }
 }
 

--- a/rust/automerge-c/src/change.rs
+++ b/rust/automerge-c/src/change.rs
@@ -31,14 +31,14 @@ impl AMchange {
         }
     }
 
-    pub fn message(&self) -> AMbyteSpan {
+    fn message(&self) -> AMbyteSpan {
         if let Some(message) = unsafe { (*self.body).message() } {
             return message.as_str().as_bytes().into();
         }
         Default::default()
     }
 
-    pub fn hash(&self) -> AMbyteSpan {
+    fn hash(&self) -> AMbyteSpan {
         let mut change_hash = self.change_hash.borrow_mut();
         if let Some(change_hash) = change_hash.as_ref() {
             change_hash.into()

--- a/rust/automerge-c/src/cursor.rs
+++ b/rust/automerge-c/src/cursor.rs
@@ -1,0 +1,168 @@
+use automerge as am;
+use std::cell::RefCell;
+
+use crate::byte_span::{to_str, AMbyteSpan};
+use crate::result::{to_result, AMresult};
+
+macro_rules! to_cursor {
+    ($handle:expr) => {{
+        match $handle.as_ref() {
+            Some(b) => b,
+            None => return AMresult::error("Invalid `AMcursor*`").into(),
+        }
+    }};
+}
+
+pub(crate) use to_cursor;
+
+/// \struct AMcursor
+/// \installed_headerfile
+/// \brief An identifier of a position within a list object or text object.
+///
+/// Example use cases:
+/// 1. Maintaining the contextual position of a user's cursor while merging
+///    remote changes.
+/// 2. Indexing a sentence within a text field.
+#[derive(PartialEq)]
+pub struct AMcursor {
+    body: am::Cursor,
+    bytes: RefCell<Option<Vec<u8>>>,
+    fmt_str: RefCell<Option<Box<str>>>,
+}
+
+impl AMcursor {
+    pub fn new(cursor: am::Cursor) -> Self {
+        Self {
+            body: cursor,
+            bytes: Default::default(),
+            fmt_str: Default::default(),
+        }
+    }
+
+    fn to_bytes(&self) -> AMbyteSpan {
+        let mut bytes = self.bytes.borrow_mut();
+        let vec = self.body.to_bytes();
+        let ptr = bytes.insert(vec);
+        AMbyteSpan {
+            src: ptr.as_ptr(),
+            count: ptr.len(),
+        }
+    }
+
+    fn to_str(&self) -> AMbyteSpan {
+        let mut fmt_str = self.fmt_str.borrow_mut();
+        let fmt_string = self.body.to_string();
+        fmt_str
+            .insert(fmt_string.into_boxed_str())
+            .as_bytes()
+            .into()
+    }
+}
+
+impl AsRef<am::Cursor> for AMcursor {
+    fn as_ref(&self) -> &am::Cursor {
+        &self.body
+    }
+}
+
+/// \memberof AMcursor
+/// \brief Gets the value of a cursor as an array of bytes.
+///
+/// \param[in] cursor A pointer to an `AMcursor` struct.
+/// \return An `AMbyteSpan` struct for an array of bytes.
+/// \pre \p cursor `!= NULL`
+/// \internal
+///
+/// # Safety
+/// cursor must be a valid pointer to an AMcursor
+#[no_mangle]
+pub unsafe extern "C" fn AMcursorBytes(cursor: *const AMcursor) -> AMbyteSpan {
+    match cursor.as_ref() {
+        Some(cursor) => cursor.to_bytes(),
+        None => Default::default(),
+    }
+}
+
+/// \memberof AMcursor
+/// \brief Tests the equality of two cursors.
+///
+/// \param[in] cursor1 A pointer to an `AMcursor` struct.
+/// \param[in] cursor2 A pointer to an `AMcursor` struct.
+/// \return `true` if \p cursor1 `==` \p cursor2 and `false` otherwise.
+/// \pre \p cursor1 `!= NULL`
+/// \pre \p cursor2 `!= NULL`
+/// \post `!(`\p cursor1 `&&` \p cursor2 `) -> false`
+/// \internal
+///
+/// #Safety
+/// cursor1 must be a valid pointer to an AMcursor
+/// cursor2 must be a valid pointer to an AMcursor
+#[no_mangle]
+pub unsafe extern "C" fn AMcursorEqual(cursor1: *const AMcursor, cursor2: *const AMcursor) -> bool {
+    match (cursor1.as_ref(), cursor2.as_ref()) {
+        (Some(cursor1), Some(cursor2)) => cursor1.as_ref() == cursor2.as_ref(),
+        (None, None) | (None, Some(_)) | (Some(_), None) => false,
+    }
+}
+
+/// \memberof AMcursor
+/// \brief Allocates a new cursor and initializes it from an array of
+///        bytes value.
+///
+/// \param[in] src A pointer to an array of bytes.
+/// \param[in] count The count of bytes to copy from the array pointed to by
+///                  \p src.
+/// \return A pointer to an `AMresult` struct with an `AM_VAL_TYPE_CURSOR` item.
+/// \pre \p src `!= NULL`
+/// \pre `sizeof(`\p src `) > 0`
+/// \pre \p count `<= sizeof(`\p src `)`
+/// \warning The returned `AMresult` struct pointer must be passed to
+///          `AMresultFree()` in order to avoid a memory leak.
+/// \internal
+///
+/// # Safety
+/// src must be a byte array of length `>= count`
+#[no_mangle]
+pub unsafe extern "C" fn AMcursorFromBytes(src: *const u8, count: usize) -> *mut AMresult {
+    if !src.is_null() {
+        let value = std::slice::from_raw_parts(src, count);
+        to_result(am::Cursor::try_from(value))
+    } else {
+        AMresult::error("Invalid uint8_t*").into()
+    }
+}
+
+/// \memberof AMcursor
+/// \brief Allocates a new cursor and initializes it from a UTF-8 string view
+///        value.
+///
+/// \param[in] value A UTF-8 string view as an `AMbyteSpan` struct.
+/// \return A pointer to an `AMresult` struct with an `AM_VAL_TYPE_CURSOR` item.
+/// \warning The returned `AMresult` struct pointer must be passed to
+///          `AMresultFree()` in order to avoid a memory leak.
+/// \internal
+///
+/// # Safety
+/// value.src must be a byte array of length >= value.count
+#[no_mangle]
+pub unsafe extern "C" fn AMcursorFromStr(value: AMbyteSpan) -> *mut AMresult {
+    to_result(am::Cursor::try_from(to_str!(value)))
+}
+
+/// \memberof AMcursor
+/// \brief Gets the value of a cursor as a UTF-8 string view.
+///
+/// \param[in] cursor A pointer to an `AMcursor` struct.
+/// \return A UTF-8 string view as an `AMbyteSpan` struct.
+/// \pre \p cursor `!= NULL`
+/// \internal
+///
+/// # Safety
+/// cursor must be a valid pointer to an AMcursor
+#[no_mangle]
+pub unsafe extern "C" fn AMcursorStr(cursor: *const AMcursor) -> AMbyteSpan {
+    match cursor.as_ref() {
+        Some(cursor) => cursor.to_str(),
+        None => Default::default(),
+    }
+}

--- a/rust/automerge-c/src/doc.rs
+++ b/rust/automerge-c/src/doc.rs
@@ -417,17 +417,11 @@ pub unsafe extern "C" fn AMgetCursor(
 ) -> *mut AMresult {
     let doc = to_doc!(doc);
     let obj_id = to_obj_id!(obj_id);
-    match heads.as_ref() {
-        None => {
-            return to_result(doc.get_cursor(obj_id, position, None));
-        }
+    return match heads.as_ref() {
+        None => to_result(doc.get_cursor(obj_id, position, None)),
         Some(heads) => match <Vec<am::ChangeHash>>::try_from(heads) {
-            Ok(heads) => {
-                return to_result(doc.get_cursor(obj_id, position, Some(heads.as_slice())));
-            }
-            Err(e) => {
-                return AMresult::error(&e.to_string()).into();
-            }
+            Ok(heads) => to_result(doc.get_cursor(obj_id, position, Some(heads.as_slice()))),
+            Err(e) => AMresult::error(&e.to_string()).into(),
         },
     };
 }
@@ -467,21 +461,13 @@ pub unsafe extern "C" fn AMgetCursorPosition(
     let doc = to_doc!(doc);
     let obj_id = to_obj_id!(obj_id);
     let cursor = to_cursor!(cursor);
-    match heads.as_ref() {
-        None => {
-            return to_result(doc.get_cursor_position(obj_id, cursor.as_ref(), None));
-        }
+    return match heads.as_ref() {
+        None => to_result(doc.get_cursor_position(obj_id, cursor.as_ref(), None)),
         Some(heads) => match <Vec<am::ChangeHash>>::try_from(heads) {
             Ok(heads) => {
-                return to_result(doc.get_cursor_position(
-                    obj_id,
-                    cursor.as_ref(),
-                    Some(heads.as_slice()),
-                ));
+                to_result(doc.get_cursor_position(obj_id, cursor.as_ref(), Some(heads.as_slice())))
             }
-            Err(e) => {
-                return AMresult::error(&e.to_string()).into();
-            }
+            Err(e) => AMresult::error(&e.to_string()).into(),
         },
     };
 }

--- a/rust/automerge-c/src/doc.rs
+++ b/rust/automerge-c/src/doc.rs
@@ -443,6 +443,9 @@ pub unsafe extern "C" fn AMgetCursor(
 ///                  items to select a historical object or `NULL` to select the
 ///                  current object.
 /// \return A pointer to an `AMresult` struct with an `AM_VAL_TYPE_UINT` item.
+///         For an `AM_OBJ_TYPE_TEXT` object, if `AUTOMERGE_C_UTF8` is defined
+///         then the item's value is in bytes but if `AUTOMERGE_C_UTF32` is
+///         defined then the item's value is in Unicode code points.
 /// \pre \p doc `!= NULL`
 /// \pre \p cursor `!= NULL`
 /// \warning The returned `AMresult` struct pointer must be passed to

--- a/rust/automerge-c/src/doc.rs
+++ b/rust/automerge-c/src/doc.rs
@@ -6,6 +6,7 @@ use std::ops::{Deref, DerefMut};
 
 use crate::actor_id::{to_actor_id, AMactorId};
 use crate::byte_span::{to_str, AMbyteSpan};
+use crate::cursor::{to_cursor, AMcursor};
 use crate::items::AMitems;
 use crate::obj::{to_obj_id, AMobjId, AMobjType};
 use crate::result::{to_result, AMresult};
@@ -39,7 +40,7 @@ impl AMdoc {
         Self(auto_commit)
     }
 
-    pub fn is_equal_to(&mut self, other: &mut Self) -> bool {
+    fn is_equal_to(&mut self, other: &mut Self) -> bool {
         self.document().get_heads() == other.document().get_heads()
     }
 }
@@ -384,6 +385,102 @@ pub unsafe extern "C" fn AMgetChangesAdded(doc1: *mut AMdoc, doc2: *mut AMdoc) -
     let doc1 = to_doc_mut!(doc1);
     let doc2 = to_doc_mut!(doc2);
     to_result(doc1.get_changes_added(doc2))
+}
+
+/// \memberof AMdoc
+/// \brief Gets an `AMcursor` i.e. a stable address for a position within a list
+///        object or text object.
+///
+/// \param[in] doc A pointer to an `AMdoc` struct.
+/// \param[in] obj_id A pointer to an `AMobjId` struct or `AM_ROOT`.
+/// \param[in] position The absolute position of the cursor.
+/// \param[in] heads A pointer to an `AMitems` struct with `AM_VAL_TYPE_CHANGE_HASH`
+///                  items to select a historical object or `NULL` to select the
+///                  current object.
+/// \return A pointer to an `AMresult` struct with an `AM_VAL_TYPE_CURSOR` item.
+/// \pre \p doc `!= NULL`
+/// \pre \p position `< AMobjSize(`\p doc, \p obj_id, \p heads `)`
+/// \warning The returned `AMresult` struct pointer must be passed to
+///          `AMresultFree()` in order to avoid a memory leak.
+/// \internal
+///
+/// # Safety
+/// doc must be a valid pointer to an AMdoc
+/// obj_id must be a valid pointer to an AMobjId or std::ptr::null()
+/// heads must be a valid pointer to an AMitems or std::ptr::null()
+#[no_mangle]
+pub unsafe extern "C" fn AMgetCursor(
+    doc: *const AMdoc,
+    obj_id: *const AMobjId,
+    position: usize,
+    heads: *const AMitems,
+) -> *mut AMresult {
+    let doc = to_doc!(doc);
+    let obj_id = to_obj_id!(obj_id);
+    match heads.as_ref() {
+        None => {
+            return to_result(doc.get_cursor(obj_id, position, None));
+        }
+        Some(heads) => match <Vec<am::ChangeHash>>::try_from(heads) {
+            Ok(heads) => {
+                return to_result(doc.get_cursor(obj_id, position, Some(heads.as_slice())));
+            }
+            Err(e) => {
+                return AMresult::error(&e.to_string()).into();
+            }
+        },
+    };
+}
+
+/// \memberof AMdoc
+/// \brief Gets the absolute position of an `AMcursor` within a list object or
+///        text object.
+///
+/// \param[in] doc A pointer to an `AMdoc` struct.
+/// \param[in] obj_id A pointer to an `AMobjId` struct or `AM_ROOT`.
+/// \param[in] cursor A pointer to an `AMcursor` struct.
+/// \param[in] heads A pointer to an `AMitems` struct with `AM_VAL_TYPE_CHANGE_HASH`
+///                  items to select a historical object or `NULL` to select the
+///                  current object.
+/// \return A pointer to an `AMresult` struct with an `AM_VAL_TYPE_UINT` item.
+/// \pre \p doc `!= NULL`
+/// \pre \p cursor `!= NULL`
+/// \warning The returned `AMresult` struct pointer must be passed to
+///          `AMresultFree()` in order to avoid a memory leak.
+/// \internal
+///
+/// # Safety
+/// doc must be a valid pointer to an AMdoc
+/// obj_id must be a valid pointer to an AMobjId or std::ptr::null()
+/// cursor must be a valid pointer to an AMcursor
+/// heads must be a valid pointer to an AMitems or std::ptr::null()
+#[no_mangle]
+pub unsafe extern "C" fn AMgetCursorPosition(
+    doc: *const AMdoc,
+    obj_id: *const AMobjId,
+    cursor: *const AMcursor,
+    heads: *const AMitems,
+) -> *mut AMresult {
+    let doc = to_doc!(doc);
+    let obj_id = to_obj_id!(obj_id);
+    let cursor = to_cursor!(cursor);
+    match heads.as_ref() {
+        None => {
+            return to_result(doc.get_cursor_position(obj_id, cursor.as_ref(), None));
+        }
+        Some(heads) => match <Vec<am::ChangeHash>>::try_from(heads) {
+            Ok(heads) => {
+                return to_result(doc.get_cursor_position(
+                    obj_id,
+                    cursor.as_ref(),
+                    Some(heads.as_slice()),
+                ));
+            }
+            Err(e) => {
+                return AMresult::error(&e.to_string()).into();
+            }
+        },
+    };
 }
 
 /// \memberof AMdoc

--- a/rust/automerge-c/src/doc/mark.rs
+++ b/rust/automerge-c/src/doc/mark.rs
@@ -35,7 +35,7 @@ pub(crate) use to_expand_mark;
 /// \enum AMmarkExpand
 /// \installed_headerfile
 /// \brief A mark's expansion mode for when bordering text is inserted.
-#[derive(PartialEq, Eq)]
+#[derive(Eq, PartialEq)]
 #[repr(C)]
 pub enum AMmarkExpand {
     /// Include text inserted at the end offset.
@@ -78,7 +78,8 @@ impl TryFrom<&AMmarkExpand> for ExpandMark {
 
 /// \struct AMmark
 /// \installed_headerfile
-/// \brief An association of out-of-bound information with a sequence.
+/// \brief An association of out-of-bound information with a list object or text
+///        object.
 pub struct AMmark<'a>(Mark<'a>);
 
 impl<'a> AMmark<'a> {
@@ -176,7 +177,8 @@ pub unsafe extern "C" fn AMmarkEnd(mark: *const AMmark) -> usize {
 /// \param[in] doc A pointer to an `AMdoc` struct.
 /// \param[in] obj_id A pointer to an `AMobjId` struct or `AM_ROOT`.
 /// \param[in] heads A pointer to an `AMitems` struct with `AM_VAL_TYPE_CHANGE_HASH`
-///                  items or `NULL`.
+///                  items to select a historical object or `NULL` to select the
+///                  current object.
 /// \return A pointer to an `AMresult` struct with `AM_VAL_TYPE_MARK` items.
 /// \pre \p doc `!= NULL`
 /// \warning The returned `AMresult` struct pointer must be passed to

--- a/rust/automerge-c/src/index.rs
+++ b/rust/automerge-c/src/index.rs
@@ -55,7 +55,7 @@ impl TryFrom<&AMindex> for usize {
 /// \enum AMidxType
 /// \installed_headerfile
 /// \brief The type of an item's index.
-#[derive(PartialEq, Eq)]
+#[derive(Eq, PartialEq)]
 #[repr(C)]
 pub enum AMidxType {
     /// The default tag, not a type signifier.

--- a/rust/automerge-c/src/items.rs
+++ b/rust/automerge-c/src/items.rs
@@ -30,7 +30,7 @@ impl Detail {
         }
     }
 
-    pub fn advance(&mut self, n: isize) {
+    fn advance(&mut self, n: isize) {
         if n == 0 {
             return;
         }
@@ -55,7 +55,7 @@ impl Detail {
         }
     }
 
-    pub fn get_index(&self) -> usize {
+    fn get_index(&self) -> usize {
         (self.offset
             + if self.offset < 0 {
                 self.len as isize
@@ -64,7 +64,7 @@ impl Detail {
             }) as usize
     }
 
-    pub fn next(&mut self, n: isize) -> Option<&mut AMitem> {
+    fn next(&mut self, n: isize) -> Option<&mut AMitem> {
         if self.is_stopped() {
             return None;
         }
@@ -75,12 +75,12 @@ impl Detail {
         Some(value)
     }
 
-    pub fn is_stopped(&self) -> bool {
+    fn is_stopped(&self) -> bool {
         let len = self.len as isize;
         self.offset < -len || self.offset == len
     }
 
-    pub fn prev(&mut self, n: isize) -> Option<&mut AMitem> {
+    fn prev(&mut self, n: isize) -> Option<&mut AMitem> {
         self.advance(-n);
         if self.is_stopped() {
             return None;
@@ -90,7 +90,7 @@ impl Detail {
         Some(&mut slice[self.get_index()])
     }
 
-    pub fn reversed(&self) -> Self {
+    fn reversed(&self) -> Self {
         Self {
             len: self.len,
             offset: -(self.offset + 1),
@@ -98,7 +98,7 @@ impl Detail {
         }
     }
 
-    pub fn rewound(&self) -> Self {
+    fn rewound(&self) -> Self {
         Self {
             len: self.len,
             offset: if self.offset < 0 { -1 } else { 0 },
@@ -139,27 +139,27 @@ impl<'a> AMitems<'a> {
         }
     }
 
-    pub fn advance(&mut self, n: isize) {
+    fn advance(&mut self, n: isize) {
         let detail = unsafe { &mut *(self.detail.as_mut_ptr() as *mut Detail) };
         detail.advance(n);
     }
 
-    pub fn len(&self) -> usize {
+    fn len(&self) -> usize {
         let detail = unsafe { &*(self.detail.as_ptr() as *const Detail) };
         detail.len
     }
 
-    pub fn next(&mut self, n: isize) -> Option<&mut AMitem> {
+    fn next(&mut self, n: isize) -> Option<&mut AMitem> {
         let detail = unsafe { &mut *(self.detail.as_mut_ptr() as *mut Detail) };
         detail.next(n)
     }
 
-    pub fn prev(&mut self, n: isize) -> Option<&mut AMitem> {
+    fn prev(&mut self, n: isize) -> Option<&mut AMitem> {
         let detail = unsafe { &mut *(self.detail.as_mut_ptr() as *mut Detail) };
         detail.prev(n)
     }
 
-    pub fn reversed(&self) -> Self {
+    fn reversed(&self) -> Self {
         let detail = unsafe { &*(self.detail.as_ptr() as *const Detail) };
         Self {
             detail: detail.reversed().into(),
@@ -167,7 +167,7 @@ impl<'a> AMitems<'a> {
         }
     }
 
-    pub fn rewound(&self) -> Self {
+    fn rewound(&self) -> Self {
         let detail = unsafe { &*(self.detail.as_ptr() as *const Detail) };
         Self {
             detail: detail.rewound().into(),

--- a/rust/automerge-c/src/lib.rs
+++ b/rust/automerge-c/src/lib.rs
@@ -1,6 +1,7 @@
 mod actor_id;
 mod byte_span;
 mod change;
+mod cursor;
 mod doc;
 mod index;
 mod item;
@@ -8,5 +9,3 @@ mod items;
 mod obj;
 mod result;
 mod sync;
-
-// include!(concat!(env!("OUT_DIR"), "/enum_string_functions.rs"));

--- a/rust/automerge-c/src/obj.rs
+++ b/rust/automerge-c/src/obj.rs
@@ -45,7 +45,7 @@ impl AMobjId {
         }
     }
 
-    pub fn actor_id(&self) -> *const AMactorId {
+    fn actor_id(&self) -> *const AMactorId {
         let mut c_actor_id = self.c_actor_id.borrow_mut();
         match c_actor_id.as_mut() {
             None => {
@@ -165,7 +165,7 @@ pub unsafe extern "C" fn AMobjIdIndex(obj_id: *const AMobjId) -> usize {
 /// \enum AMobjType
 /// \installed_headerfile
 /// \brief The type of an object.
-#[derive(PartialEq, Eq)]
+#[derive(Eq, PartialEq)]
 #[repr(C)]
 pub enum AMobjType {
     /// The default tag, not a type signifier.

--- a/rust/automerge-c/src/result.rs
+++ b/rust/automerge-c/src/result.rs
@@ -223,6 +223,15 @@ impl From<Result<am::Change, am::LoadChangeError>> for AMresult {
     }
 }
 
+impl From<Result<am::Cursor, am::AutomergeError>> for AMresult {
+    fn from(maybe: Result<am::Cursor, am::AutomergeError>) -> Self {
+        match maybe {
+            Ok(cursor) => Self::item(cursor.into()),
+            Err(e) => Self::error(&e.to_string()),
+        }
+    }
+}
+
 impl From<(Result<am::ObjId, am::AutomergeError>, &str, am::ObjType)> for AMresult {
     fn from(
         (maybe, key, obj_type): (Result<am::ObjId, am::AutomergeError>, &str, am::ObjType),
@@ -501,7 +510,7 @@ pub fn to_result<R: Into<AMresult>>(r: R) -> *mut AMresult {
 /// \enum AMstatus
 /// \installed_headerfile
 /// \brief The status of an API call.
-#[derive(PartialEq, Eq)]
+#[derive(Eq, PartialEq)]
 #[repr(C)]
 pub enum AMstatus {
     /// Success.

--- a/rust/automerge-c/src/sync/state.rs
+++ b/rust/automerge-c/src/sync/state.rs
@@ -177,6 +177,7 @@ pub unsafe extern "C" fn AMsyncStateLastSentHeads(sync_state: *const AMsyncState
 /// \pre \p has_value `!= NULL`
 /// \warning The returned `AMresult` struct pointer must be passed to
 ///          `AMresultFree()` in order to avoid a memory leak.
+/// \internal
 ///
 /// # Safety
 /// sync_state must be a valid pointer to an AMsyncState

--- a/rust/automerge-c/test/CMakeLists.txt
+++ b/rust/automerge-c/test/CMakeLists.txt
@@ -8,6 +8,7 @@ add_executable(
         base_state.c
         byte_span_tests.c
         cmocka_utils.c
+        cursor_tests.c
         enum_string_tests.c
         doc_state.c
         doc_tests.c
@@ -19,6 +20,7 @@ add_executable(
         mark_tests.c
         str_utils.c
         ported_wasm/basic_tests.c
+        ported_wasm/cursor_tests.c
         ported_wasm/suite.c
         ported_wasm/sync_tests.c
 )

--- a/rust/automerge-c/test/actor_id_tests.c
+++ b/rust/automerge-c/test/actor_id_tests.c
@@ -26,31 +26,31 @@ typedef struct {
     AMstack* stack;
     /** An actor ID as a hexadecimal string. */
     AMbyteSpan str;
-} DocState;
+} TestState;
 
-static int group_setup(void** state) {
-    DocState* doc_state = test_calloc(1, sizeof(DocState));
-    doc_state->str = AMstr("000102030405060708090a0b0c0d0e0f");
-    doc_state->count = doc_state->str.count / 2;
-    doc_state->src = test_calloc(doc_state->count, sizeof(uint8_t));
-    hex_to_bytes(doc_state->str.src, doc_state->src, doc_state->count);
-    *state = doc_state;
+static int setup(void** state) {
+    TestState* test_state = test_calloc(1, sizeof(TestState));
+    test_state->str = AMstr("000102030405060708090a0b0c0d0e0f");
+    test_state->count = test_state->str.count / 2;
+    test_state->src = test_calloc(test_state->count, sizeof(uint8_t));
+    hex_to_bytes(test_state->str.src, test_state->src, test_state->count);
+    *state = test_state;
     return 0;
 }
 
-static int group_teardown(void** state) {
-    DocState* doc_state = *state;
-    test_free(doc_state->src);
-    AMstackFree(&doc_state->stack);
-    test_free(doc_state);
+static int teardown(void** state) {
+    TestState* test_state = *state;
+    test_free(test_state->src);
+    AMstackFree(&test_state->stack);
+    test_free(test_state);
     return 0;
 }
 
 static void test_AMactorIdFromBytes(void** state) {
-    DocState* doc_state = *state;
-    AMstack** stack_ptr = &doc_state->stack;
+    TestState* test_state = *state;
+    AMstack** stack_ptr = &test_state->stack;
     /* Non-empty string. */
-    AMresult* result = AMstackResult(stack_ptr, AMactorIdFromBytes(doc_state->src, doc_state->count), NULL, NULL);
+    AMresult* result = AMstackResult(stack_ptr, AMactorIdFromBytes(test_state->src, test_state->count), NULL, NULL);
     if (AMresultStatus(result) != AM_STATUS_OK) {
         fail_msg_view("%s", AMresultError(result));
     }
@@ -60,25 +60,25 @@ static void test_AMactorIdFromBytes(void** state) {
     AMactorId const* actor_id;
     assert_true(AMitemToActorId(item, &actor_id));
     AMbyteSpan const bytes = AMactorIdBytes(actor_id);
-    assert_int_equal(bytes.count, doc_state->count);
-    assert_memory_equal(bytes.src, doc_state->src, bytes.count);
+    assert_int_equal(bytes.count, test_state->count);
+    assert_memory_equal(bytes.src, test_state->src, bytes.count);
     /* Empty array. */
     /** \todo Find out if this is intentionally allowed. */
-    result = AMstackResult(stack_ptr, AMactorIdFromBytes(doc_state->src, 0), NULL, NULL);
+    result = AMstackResult(stack_ptr, AMactorIdFromBytes(test_state->src, 0), NULL, NULL);
     if (AMresultStatus(result) != AM_STATUS_OK) {
         fail_msg_view("%s", AMresultError(result));
     }
     /* NULL array. */
-    result = AMstackResult(stack_ptr, AMactorIdFromBytes(NULL, doc_state->count), NULL, NULL);
+    result = AMstackResult(stack_ptr, AMactorIdFromBytes(NULL, test_state->count), NULL, NULL);
     if (AMresultStatus(result) == AM_STATUS_OK) {
-        fail_msg("AMactorId from NULL.");
+        fail_msg("`AMactorId` from `NULL`.");
     }
 }
 
 static void test_AMactorIdFromStr(void** state) {
-    DocState* doc_state = *state;
-    AMstack** stack_ptr = &doc_state->stack;
-    AMresult* result = AMstackResult(stack_ptr, AMactorIdFromStr(doc_state->str), NULL, NULL);
+    TestState* test_state = *state;
+    AMstack** stack_ptr = &test_state->stack;
+    AMresult* result = AMstackResult(stack_ptr, AMactorIdFromStr(test_state->str), NULL, NULL);
     if (AMresultStatus(result) != AM_STATUS_OK) {
         fail_msg_view("%s", AMresultError(result));
     }
@@ -89,18 +89,18 @@ static void test_AMactorIdFromStr(void** state) {
     AMactorId const* actor_id;
     assert_true(AMitemToActorId(item, &actor_id));
     AMbyteSpan const bytes = AMactorIdBytes(actor_id);
-    assert_int_equal(bytes.count, doc_state->count);
-    assert_memory_equal(bytes.src, doc_state->src, bytes.count);
+    assert_int_equal(bytes.count, test_state->count);
+    assert_memory_equal(bytes.src, test_state->src, bytes.count);
     /* The bytes should've been encoded as an identical hexadecimal string. */
     assert_true(AMitemToActorId(item, &actor_id));
     AMbyteSpan const str = AMactorIdStr(actor_id);
-    assert_int_equal(str.count, doc_state->str.count);
-    assert_memory_equal(str.src, doc_state->str.src, str.count);
+    assert_int_equal(str.count, test_state->str.count);
+    assert_memory_equal(str.src, test_state->str.src, str.count);
 }
 
 static void test_AMactorIdInit(void** state) {
-    DocState* doc_state = *state;
-    AMstack** stack_ptr = &doc_state->stack;
+    TestState* test_state = *state;
+    AMstack** stack_ptr = &test_state->stack;
     AMresult* prior_result = NULL;
     AMbyteSpan prior_bytes = {NULL, 0};
     AMbyteSpan prior_str = {NULL, 0};
@@ -136,5 +136,5 @@ int run_actor_id_tests(void) {
         cmocka_unit_test(test_AMactorIdInit),
     };
 
-    return cmocka_run_group_tests(tests, group_setup, group_teardown);
+    return cmocka_run_group_tests(tests, setup, teardown);
 }

--- a/rust/automerge-c/test/cursor_tests.c
+++ b/rust/automerge-c/test/cursor_tests.c
@@ -1,0 +1,263 @@
+#include <setjmp.h>
+#include <stdarg.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+/* third-party */
+#include <cmocka.h>
+
+/* local */
+#include <automerge-c/automerge.h>
+#include <automerge-c/utils/stack_callback_data.h>
+#include "cmocka_utils.h"
+#include "doc_state.h"
+
+typedef struct {
+    DocState* doc_state;
+    AMobjId const* text;
+} TestState;
+
+static int setup(void** state) {
+    /* let mut doc = Automerge::new();                                                                                */
+    TestState* test_state = test_calloc(1, sizeof(TestState));
+    setup_doc((void**)&test_state->doc_state);
+    AMstack** stack_ptr = &test_state->doc_state->base_state->stack;
+    /* let mut tx = doc.transaction();
+       let text = tx.put_object(ROOT, "text", ObjType::Text)?;                                                        */
+    test_state->text = AMitemObjId(
+        AMstackItem(stack_ptr, AMmapPutObject(test_state->doc_state->doc, AM_ROOT, AMstr("text"), AM_OBJ_TYPE_TEXT),
+                    cmocka_cb, AMexpect(AM_VAL_TYPE_OBJ_TYPE)));
+    /* tx.commit();                                                                                                   */
+    AMstackItem(NULL, AMcommit(test_state->doc_state->doc, AMstr(NULL), NULL), cmocka_cb,
+                AMexpect(AM_VAL_TYPE_CHANGE_HASH));
+    /* let mut tx = doc.transaction();
+       tx.splice_text(&text, 0, 0, "hello world")?;                                                                   */
+    AMstackItem(NULL, AMspliceText(test_state->doc_state->doc, test_state->text, 0, 0, AMstr("hello world")), cmocka_cb,
+                AMexpect(AM_VAL_TYPE_VOID));
+    /* tx.commit();                                                                                                   */
+    AMstackItem(NULL, AMcommit(test_state->doc_state->doc, AMstr(NULL), NULL), cmocka_cb,
+                AMexpect(AM_VAL_TYPE_CHANGE_HASH));
+    /* let mut tx = doc.transaction();
+       tx.splice_text(&text, 6, 0, "big bad ")?;                                                                      */
+    AMstackItem(NULL, AMspliceText(test_state->doc_state->doc, test_state->text, 6, 0, AMstr("big bad ")), cmocka_cb,
+                AMexpect(AM_VAL_TYPE_VOID));
+    /* tx.commit();                                                                                                   */
+    AMstackItem(NULL, AMcommit(test_state->doc_state->doc, AMstr(NULL), NULL), cmocka_cb,
+                AMexpect(AM_VAL_TYPE_CHANGE_HASH));
+    *state = test_state;
+    return 0;
+}
+
+static int teardown(void** state) {
+    TestState* test_state = *state;
+    teardown_doc((void**)&test_state->doc_state);
+    test_free(test_state);
+    return 0;
+}
+
+static void test_AMgetCursor(void** state) {
+    TestState* test_state = *state;
+    AMstack** stack_ptr = &test_state->doc_state->base_state->stack;
+    /* // simple cursor test + serialization
+       let cursor0 = doc.get_cursor(&text, 0, None).unwrap();                                                         */
+    AMcursor const* cursor0;
+    assert_true(
+        AMitemToCursor(AMstackItem(stack_ptr, AMgetCursor(test_state->doc_state->doc, test_state->text, 0, NULL),
+                                   cmocka_cb, AMexpect(AM_VAL_TYPE_CURSOR)),
+                       &cursor0));
+    /* let cursor0_str = cursor0.to_string();                                                                         */
+    AMbyteSpan const cursor0_str = AMcursorStr(cursor0);
+    assert_int_not_equal(cursor0_str.count, 0);
+    assert_non_null(cursor0_str.src);
+    /* let cursor0_bytes = cursor0.to_bytes();                                                                        */
+    AMbyteSpan const cursor0_bytes = AMcursorBytes(cursor0);
+    assert_int_not_equal(cursor0_bytes.count, 0);
+    assert_non_null(cursor0_bytes.src);
+    /* let pos0 = doc.get_cursor_position(&text, &cursor0, None).unwrap();                                            */
+    size_t pos0;
+    assert_true(AMitemToUint(
+        AMstackItem(stack_ptr, AMgetCursorPosition(test_state->doc_state->doc, test_state->text, cursor0, NULL),
+                    cmocka_cb, AMexpect(AM_VAL_TYPE_UINT)),
+        &pos0));
+    /* assert_eq!(pos0, 0);                                                                                           */
+    assert_int_equal(pos0, 0);
+    /* assert_eq!(Cursor::try_from(cursor0_str).unwrap(), cursor0);                                                   */
+    AMcursor const* cursor0_deserialized;
+    assert_true(
+        AMitemToCursor(AMstackItem(stack_ptr, AMcursorFromStr(cursor0_str), cmocka_cb, AMexpect(AM_VAL_TYPE_CURSOR)),
+                       &cursor0_deserialized));
+    assert_true(AMcursorEqual(cursor0_deserialized, cursor0));
+    /* assert_eq!(Cursor::try_from(cursor0_bytes).unwrap(), cursor0);                                                 */
+    assert_true(AMitemToCursor(AMstackItem(stack_ptr, AMcursorFromBytes(cursor0_bytes.src, cursor0_bytes.count),
+                                           cmocka_cb, AMexpect(AM_VAL_TYPE_CURSOR)),
+                               &cursor0_deserialized));
+    assert_true(AMcursorEqual(cursor0_deserialized, cursor0));
+}
+
+static void test_AMgetCursorPosition(void** state) {
+    TestState* test_state = *state;
+    AMstack** stack_ptr = &test_state->doc_state->base_state->stack;
+    /* // simple cursor test + serialization
+       let cursor1 = doc.get_cursor(&text, 6, None).unwrap();                                                         */
+    AMcursor const* cursor1;
+    assert_true(
+        AMitemToCursor(AMstackItem(stack_ptr, AMgetCursor(test_state->doc_state->doc, test_state->text, 6, NULL),
+                                   cmocka_cb, AMexpect(AM_VAL_TYPE_CURSOR)),
+                       &cursor1));
+    /* let cursor1_str = cursor1.to_string();                                                                         */
+    AMbyteSpan const cursor1_str = AMcursorStr(cursor1);
+    assert_int_not_equal(cursor1_str.count, 0);
+    assert_non_null(cursor1_str.src);
+    /* let cursor1_bytes = cursor1.to_bytes();                                                                        */
+    AMbyteSpan const cursor1_bytes = AMcursorBytes(cursor1);
+    assert_int_not_equal(cursor1_bytes.count, 0);
+    assert_non_null(cursor1_bytes.src);
+    /* let pos1 = doc.get_cursor_position(&text, &cursor1, None).unwrap();                                            */
+    size_t pos1;
+    assert_true(AMitemToUint(
+        AMstackItem(stack_ptr, AMgetCursorPosition(test_state->doc_state->doc, test_state->text, cursor1, NULL),
+                    cmocka_cb, AMexpect(AM_VAL_TYPE_UINT)),
+        &pos1));
+    /* assert_eq!(pos1, 6);                                                                                           */
+    assert_int_equal(pos1, 6);
+    /* assert_eq!(Cursor::try_from(cursor1_str).unwrap(), cursor1);                                                   */
+    AMcursor const* cursor1_deserialized;
+    assert_true(
+        AMitemToCursor(AMstackItem(stack_ptr, AMcursorFromStr(cursor1_str), cmocka_cb, AMexpect(AM_VAL_TYPE_CURSOR)),
+                       &cursor1_deserialized));
+    assert_true(AMcursorEqual(cursor1_deserialized, cursor1));
+    /* assert_eq!(Cursor::try_from(cursor1_bytes).unwrap(), cursor1);                                                 */
+    assert_true(AMitemToCursor(AMstackItem(stack_ptr, AMcursorFromBytes(cursor1_bytes.src, cursor1_bytes.count),
+                                           cmocka_cb, AMexpect(AM_VAL_TYPE_CURSOR)),
+                               &cursor1_deserialized));
+    assert_true(AMcursorEqual(cursor1_deserialized, cursor1));
+    /*
+       let heads0 = doc.get_heads();                                                                                  */
+    AMitems const heads0 =
+        AMstackItems(stack_ptr, AMgetHeads(test_state->doc_state->doc), cmocka_cb, AMexpect(AM_VAL_TYPE_CHANGE_HASH));
+    /*
+       let mut tx = doc.transaction();
+       tx.splice_text(&text, 3, 6, " new text ")?;                                                                    */
+    AMstackItem(NULL, AMspliceText(test_state->doc_state->doc, test_state->text, 3, 6, AMstr(" new text ")), cmocka_cb,
+                AMexpect(AM_VAL_TYPE_VOID));
+    /* tx.commit();                                                                                                   */
+    AMstackItem(NULL, AMcommit(test_state->doc_state->doc, AMstr(NULL), NULL), cmocka_cb,
+                AMexpect(AM_VAL_TYPE_CHANGE_HASH));
+    /*
+       // confirm the cursor changed position after an edit
+       let pos2 = doc.get_cursor_position(&text, &cursor1, None).unwrap();                                            */
+    size_t pos2;
+    assert_true(AMitemToUint(
+        AMstackItem(stack_ptr, AMgetCursorPosition(test_state->doc_state->doc, test_state->text, cursor1, NULL),
+                    cmocka_cb, AMexpect(AM_VAL_TYPE_UINT)),
+        &pos2));
+    /* assert_eq !(pos2, 13);  // -3 deleted & +10 inserted before cursor                                             */
+    assert_int_equal(pos2, 13);
+    /*
+       // confirm the cursor can still be read at the old position
+       let pos3 = doc.get_cursor_position(&text, &cursor1, Some(&heads0)).unwrap();                                   */
+    size_t pos3;
+    assert_true(AMitemToUint(
+        AMstackItem(stack_ptr, AMgetCursorPosition(test_state->doc_state->doc, test_state->text, cursor1, &heads0),
+                    cmocka_cb, AMexpect(AM_VAL_TYPE_UINT)),
+        &pos3));
+    /* assert_eq !(pos3, 6);  // back to the old heads                                                                */
+    assert_int_equal(pos3, 6);
+}
+
+static void test_AMcursorFromBytes_failure(void** state) {
+    TestState* test_state = *state;
+    AMstack** stack_ptr = &test_state->doc_state->base_state->stack;
+    /* // confirm cursor load errors
+       assert_eq!(
+        Cursor::try_from(vec![0u8, 3u8, 10u8].as_slice()),
+        Err(AutomergeError::InvalidCursorFormat)
+    );                                                                                                                */
+    uint8_t const BYTES[3] = {0, 3, 10};
+    AMresult* result = AMstackResult(stack_ptr, AMcursorFromBytes(BYTES, 3), NULL, NULL);
+    if (AMresultStatus(result) == AM_STATUS_OK) {
+        fail_msg("`AMcursor` from invalid array of bytes");
+    }
+}
+
+static void test_AMcursorFromStr_failure(void** state) {
+    TestState* test_state = *state;
+    AMstack** stack_ptr = &test_state->doc_state->base_state->stack;
+    /* assert_eq!(
+        Cursor::try_from("notacursor"),
+        Err(AutomergeError::InvalidCursorFormat)
+    );                                                                                                                */
+    AMresult* result = AMstackResult(stack_ptr, AMcursorFromStr(AMstr("notacursor")), NULL, NULL);
+    if (AMresultStatus(result) == AM_STATUS_OK) {
+        fail_msg("`AMcursor` from invalid UTF-8 string");
+    }
+}
+
+static void test_AMgetCursorPosition_failure(void** state) {
+    TestState* test_state = *state;
+    AMstack** stack_ptr = &test_state->doc_state->base_state->stack;
+    /* // confirm behavior of a invalid cursor
+       let bad_cursor = Cursor::try_from("10@aabbcc00").unwrap();                                                     */
+    AMcursor const* bad_cursor;
+    assert_true(AMitemToCursor(
+        AMstackItem(stack_ptr, AMcursorFromStr(AMstr("10@aabbcc00")), cmocka_cb, AMexpect(AM_VAL_TYPE_CURSOR)),
+        &bad_cursor));
+    /* assert_eq!(
+           doc.get_cursor_position(&text, &bad_cursor, None),
+           Err(AutomergeError::InvalidCursor(bad_cursor))
+       );                                                                                                             */
+    AMresult* result = AMstackResult(
+        stack_ptr, AMgetCursorPosition(test_state->doc_state->doc, test_state->text, bad_cursor, NULL), NULL, NULL);
+    if (AMresultStatus(result) == AM_STATUS_OK) {
+        fail_msg("position from invalid `AMcursor`");
+    }
+}
+
+static void test_AMgetCursor_failure(void** state) {
+    TestState* test_state = *state;
+    AMstack** stack_ptr = &test_state->doc_state->base_state->stack;
+    AMitems const heads0 =
+        AMstackItems(stack_ptr, AMgetHeads(test_state->doc_state->doc), cmocka_cb, AMexpect(AM_VAL_TYPE_CHANGE_HASH));
+    AMstackItem(NULL, AMspliceText(test_state->doc_state->doc, test_state->text, 3, 6, AMstr(" new text ")), cmocka_cb,
+                AMexpect(AM_VAL_TYPE_VOID));
+    AMstackItem(NULL, AMcommit(test_state->doc_state->doc, AMstr(NULL), NULL), cmocka_cb,
+                AMexpect(AM_VAL_TYPE_CHANGE_HASH));
+    /* // cursors created after heads are invalid
+       let cursor3 = doc.get_cursor(&text, 6, None).unwrap();                                                         */
+    AMcursor const* cursor3;
+    assert_true(
+        AMitemToCursor(AMstackItem(stack_ptr, AMgetCursor(test_state->doc_state->doc, test_state->text, 6, NULL),
+                                   cmocka_cb, AMexpect(AM_VAL_TYPE_CURSOR)),
+                       &cursor3));
+    /* let pos4 = doc.get_cursor_position(&text, &cursor3, None).unwrap();                                            */
+    size_t pos4;
+    assert_true(AMitemToUint(
+        AMstackItem(stack_ptr, AMgetCursorPosition(test_state->doc_state->doc, test_state->text, cursor3, NULL),
+                    cmocka_cb, AMexpect(AM_VAL_TYPE_UINT)),
+        &pos4));
+    /* assert_eq!(pos4, 6);                                                                                           */
+    assert_int_equal(pos4, 6);
+    /* assert_eq!(
+           doc.get_cursor_position(&text, &cursor3, Some(&heads0)),
+           Err(AutomergeError::InvalidCursor(cursor3))
+    );                                                                                                                */
+    AMresult* result = AMstackResult(
+        stack_ptr, AMgetCursorPosition(test_state->doc_state->doc, test_state->text, cursor3, &heads0), NULL, NULL);
+    if (AMresultStatus(result) == AM_STATUS_OK) {
+        fail_msg("`AMcursor` from invalid heads");
+    }
+}
+
+int run_cursor_tests(void) {
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test(test_AMgetCursor),
+        cmocka_unit_test(test_AMgetCursorPosition),
+        cmocka_unit_test(test_AMcursorFromBytes_failure),
+        cmocka_unit_test(test_AMcursorFromStr_failure),
+        cmocka_unit_test(test_AMgetCursorPosition_failure),
+        cmocka_unit_test(test_AMgetCursor_failure),
+    };
+
+    return cmocka_run_group_tests(tests, setup, teardown);
+}

--- a/rust/automerge-c/test/main.c
+++ b/rust/automerge-c/test/main.c
@@ -10,6 +10,8 @@ extern int run_actor_id_tests(void);
 
 extern int run_byte_span_tests(void);
 
+extern int run_cursor_tests(void);
+
 extern int run_doc_tests(void);
 
 extern int run_enum_string_tests(void);
@@ -25,6 +27,7 @@ extern int run_mark_tests(void);
 extern int run_ported_wasm_suite(void);
 
 int main(void) {
-    return (run_actor_id_tests() + run_byte_span_tests() + run_doc_tests() + run_enum_string_tests() +
-            run_item_tests() + run_list_tests() + run_map_tests() + run_mark_tests() + run_ported_wasm_suite());
+    return run_actor_id_tests() + run_byte_span_tests() + run_cursor_tests() + run_doc_tests() +
+           run_enum_string_tests() + run_item_tests() + run_list_tests() + run_map_tests() + run_mark_tests() +
+           run_ported_wasm_suite();
 }

--- a/rust/automerge-c/test/ported_wasm/cursor_tests.c
+++ b/rust/automerge-c/test/ported_wasm/cursor_tests.c
@@ -1,0 +1,108 @@
+#include <setjmp.h>
+#include <stdarg.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+/* third-party */
+#include <cmocka.h>
+
+/* local */
+#include <automerge-c/automerge.h>
+#include <automerge-c/utils/stack_callback_data.h>
+#include "../base_state.h"
+#include "../cmocka_utils.h"
+
+/**
+ * \brief should be able to make a cursor from a position in a text document, then use it
+ */
+static void test_make_cursor_from_position_and_use_it(void** state) {
+    BaseState* base_state = *state;
+    AMstack** stack_ptr = &base_state->stack;
+    /* let doc1 = create();                                                                                           */
+    AMdoc* doc1;
+    assert_true(AMitemToDoc(AMstackItem(stack_ptr, AMcreate(NULL), cmocka_cb, AMexpect(AM_VAL_TYPE_DOC)), &doc1));
+    /* doc1.putObject("/", "text", "the sly fox jumped over the lazy dog");                                           */
+    AMobjId const* const text =
+        AMitemObjId(AMstackItem(stack_ptr, AMmapPutObject(doc1, AM_ROOT, AMstr("text"), AM_OBJ_TYPE_TEXT), cmocka_cb,
+                                AMexpect(AM_VAL_TYPE_OBJ_TYPE)));
+    AMstackItem(NULL, AMspliceText(doc1, text, 0, 0, AMstr("the sly fox jumped over the lazy dog")), cmocka_cb,
+                AMexpect(AM_VAL_TYPE_VOID));
+    /* let heads1 = doc1.getHeads();                                                                                  */
+    AMitems const heads1 = AMstackItems(stack_ptr, AMgetHeads(doc1), cmocka_cb, AMexpect(AM_VAL_TYPE_CHANGE_HASH));
+    /*
+       // get a cursor at a position
+       let cursor = doc1.getCursor("/text", 12);                                                                      */
+    AMcursor const* cursor;
+    assert_true(AMitemToCursor(
+        AMstackItem(stack_ptr, AMgetCursor(doc1, text, 12, NULL), cmocka_cb, AMexpect(AM_VAL_TYPE_CURSOR)), &cursor));
+    /* let index1 = doc1.getCursorPosition("/text", cursor);                                                          */
+    size_t index1;
+    assert_true(AMitemToUint(
+        AMstackItem(stack_ptr, AMgetCursorPosition(doc1, text, cursor, NULL), cmocka_cb, AMexpect(AM_VAL_TYPE_UINT)),
+        &index1));
+    /* assert.deepStrictEqual(index1, 12);                                                                            */
+    assert_int_equal(index1, 12);
+    /*
+       // modifying the text changes the cursor position
+       doc1.splice("/text",0,3,"Has the");                                                                            */
+    AMstackItem(NULL, AMspliceText(doc1, text, 0, 3, AMstr("Has the")), cmocka_cb, AMexpect(AM_VAL_TYPE_VOID));
+    /* assert.deepStrictEqual(doc1.text("/text"), "Has the sly fox jumped over the lazy dog");                        */
+    AMbyteSpan str;
+    assert_true(
+        AMitemToStr(AMstackItem(stack_ptr, AMtext(doc1, text, NULL), cmocka_cb, AMexpect(AM_VAL_TYPE_STR)), &str));
+    assert_int_equal(str.count, strlen("Has the sly fox jumped over the lazy dog"));
+    assert_memory_equal(str.src, "Has the sly fox jumped over the lazy dog", str.count);
+    /* let index2 = doc1.getCursorPosition("/text", cursor);                                                          */
+    size_t index2;
+    assert_true(AMitemToUint(
+        AMstackItem(stack_ptr, AMgetCursorPosition(doc1, text, cursor, NULL), cmocka_cb, AMexpect(AM_VAL_TYPE_UINT)),
+        &index2));
+    /* assert.deepStrictEqual(index2, 16);                                                                            */
+    assert_int_equal(index2, 16);
+    /*
+       // get the cursor position at heads
+       let index3 = doc1.getCursorPosition("/text", cursor, heads1);                                                  */
+    size_t index3;
+    assert_true(AMitemToUint(
+        AMstackItem(stack_ptr, AMgetCursorPosition(doc1, text, cursor, &heads1), cmocka_cb, AMexpect(AM_VAL_TYPE_UINT)),
+        &index3));
+    /* assert.deepStrictEqual(index1, index3);                                                                        */
+    assert_int_equal(index1, index3);
+    /*
+       // get a cursor at heads
+       let cursor2 = doc1.getCursor("/text", 12, heads1);                                                             */
+    AMcursor const* cursor2;
+    assert_true(AMitemToCursor(
+        AMstackItem(stack_ptr, AMgetCursor(doc1, text, 12, &heads1), cmocka_cb, AMexpect(AM_VAL_TYPE_CURSOR)),
+        &cursor2));
+    /* let cursor3 = doc1.getCursor("/text", 16);                                                                     */
+    AMcursor const* cursor3;
+    assert_true(AMitemToCursor(
+        AMstackItem(stack_ptr, AMgetCursor(doc1, text, 16, NULL), cmocka_cb, AMexpect(AM_VAL_TYPE_CURSOR)), &cursor3));
+    /* assert.deepStrictEqual(cursor, cursor2);                                                                       */
+    assert_true(AMcursorEqual(cursor, cursor2));
+    /* assert.deepStrictEqual(cursor, cursor3);                                                                       */
+    assert_true(AMcursorEqual(cursor, cursor3));
+    /*
+       // cursor works at the heads
+       let cursor4 = doc1.getCursor("/text", 0);                                                                      */
+    AMcursor* cursor4;
+    assert_true(AMitemToCursor(
+        AMstackItem(stack_ptr, AMgetCursor(doc1, text, 0, NULL), cmocka_cb, AMexpect(AM_VAL_TYPE_CURSOR)), &cursor4));
+    /* let index4 = doc1.getCursorPosition("/text", cursor4);                                                         */
+    size_t index4;
+    assert_true(AMitemToUint(
+        AMstackItem(stack_ptr, AMgetCursorPosition(doc1, text, cursor4, NULL), cmocka_cb, AMexpect(AM_VAL_TYPE_UINT)),
+        &index4));
+    /* assert.deepStrictEqual(index4, 0);                                                                             */
+    assert_int_equal(index4, 0);
+}
+
+int run_ported_wasm_cursor_tests(void) {
+    const struct CMUnitTest tests[] = {
+        cmocka_unit_test_setup_teardown(test_make_cursor_from_position_and_use_it, setup_base, teardown_base)};
+
+    return cmocka_run_group_tests(tests, NULL, NULL);
+}

--- a/rust/automerge-c/test/ported_wasm/suite.c
+++ b/rust/automerge-c/test/ported_wasm/suite.c
@@ -8,8 +8,10 @@
 
 extern int run_ported_wasm_basic_tests(void);
 
+extern int run_ported_wasm_cursor_tests(void);
+
 extern int run_ported_wasm_sync_tests(void);
 
 int run_ported_wasm_suite(void) {
-    return (run_ported_wasm_basic_tests() + run_ported_wasm_sync_tests());
+    return run_ported_wasm_basic_tests() + run_ported_wasm_cursor_tests() + run_ported_wasm_sync_tests();
 }

--- a/rust/automerge-c/test/ported_wasm/sync_tests.c
+++ b/rust/automerge-c/test/ported_wasm/sync_tests.c
@@ -66,10 +66,12 @@ static void sync(AMdoc* a, AMdoc* b, AMsyncState* a_sync_state, AMsyncState* b_s
                 AMitemToSyncMessage(item, &a2b_msg);
                 AMstackResult(NULL, AMreceiveSyncMessage(b, b_sync_state, a2b_msg), cmocka_cb,
                               AMexpect(AM_VAL_TYPE_VOID));
-            } break;
-            case AM_VAL_TYPE_VOID:
+                break;
+            }
+            case AM_VAL_TYPE_VOID: {
                 a2b_msg = NULL;
                 break;
+            }
         }
         item = AMresultItem(b2a_msg_result);
         switch (AMitemValType(item)) {
@@ -77,10 +79,12 @@ static void sync(AMdoc* a, AMdoc* b, AMsyncState* a_sync_state, AMsyncState* b_s
                 AMitemToSyncMessage(item, &b2a_msg);
                 AMstackResult(NULL, AMreceiveSyncMessage(a, a_sync_state, b2a_msg), cmocka_cb,
                               AMexpect(AM_VAL_TYPE_VOID));
-            } break;
-            case AM_VAL_TYPE_VOID:
+                break;
+            }
+            case AM_VAL_TYPE_VOID: {
                 b2a_msg = NULL;
                 break;
+            }
         }
         if (++iter > MAX_ITER) {
             fail_msg(
@@ -98,140 +102,172 @@ static time_t const TIME_0 = 0;
  */
 static void test_should_send_a_sync_message_implying_no_local_data(void** state) {
     /* const doc = create()
-       const s1 = initSyncState()                                            */
+       const s1 = initSyncState()                                                                                     */
     TestState* test_state = *state;
     AMstack** stack_ptr = &test_state->base_state->stack;
     /* const m1 = doc.generateSyncMessage(s1)
-       if (m1 === null) { throw new RangeError("message should not be null") }
-       const message: DecodedSyncMessage = decodeSyncMessage(m1)             */
+       if (m1 === null) { throw new RangeError("message should not be null") }                                        */
     AMsyncMessage const* m1;
     assert_true(AMitemToSyncMessage(AMstackItem(stack_ptr, AMgenerateSyncMessage(test_state->n1, test_state->s1),
                                                 cmocka_cb, AMexpect(AM_VAL_TYPE_SYNC_MESSAGE)),
                                     &m1));
-    /* assert.deepStrictEqual(message.heads, [])                             */
+    /* const message: DecodedSyncMessage = decodeSyncMessage(m1)
+       assert.deepStrictEqual(message.heads, [])                                                                      */
     AMitems heads = AMstackItems(stack_ptr, AMsyncMessageHeads(m1), cmocka_cb, AMexpect(AM_VAL_TYPE_CHANGE_HASH));
     assert_int_equal(AMitemsSize(&heads), 0);
-    /* assert.deepStrictEqual(message.need, [])                              */
+    /* assert.deepStrictEqual(message.need, [])                                                                       */
     AMitems needs = AMstackItems(stack_ptr, AMsyncMessageNeeds(m1), cmocka_cb, AMexpect(AM_VAL_TYPE_CHANGE_HASH));
     assert_int_equal(AMitemsSize(&needs), 0);
-    /* assert.deepStrictEqual(message.have.length, 1)                        */
+    /* assert.deepStrictEqual(message.have.length, 1)                                                                 */
     AMitems haves = AMstackItems(stack_ptr, AMsyncMessageHaves(m1), cmocka_cb, AMexpect(AM_VAL_TYPE_SYNC_HAVE));
     assert_int_equal(AMitemsSize(&haves), 1);
-    /* assert.deepStrictEqual(message.have[0].lastSync, [])                  */
+    /* assert.deepStrictEqual(message.have[0].lastSync, [])                                                           */
     AMsyncHave const* have0;
     assert_true(AMitemToSyncHave(AMitemsNext(&haves, 1), &have0));
     AMitems last_sync =
         AMstackItems(stack_ptr, AMsyncHaveLastSync(have0), cmocka_cb, AMexpect(AM_VAL_TYPE_CHANGE_HASH));
     assert_int_equal(AMitemsSize(&last_sync), 0);
     /* assert.deepStrictEqual(message.have[0].bloom.byteLength, 0)
-       assert.deepStrictEqual(message.changes, [])                           */
-    AMitems changes = AMstackItems(stack_ptr, AMsyncMessageChanges(m1), cmocka_cb, AMexpect(AM_VAL_TYPE_CHANGE));
-    assert_int_equal(AMitemsSize(&changes), 0);
+       assert.deepStrictEqual(message.changes, [])                                                                    */
 }
 
 /**
- * \brief should not reply if we have no data as well
+ * \brief should not reply if we have no data as well after the first round
  */
-static void test_should_not_reply_if_we_have_no_data_as_well(void** state) {
+static void test_should_not_reply_if_we_have_no_data_as_well_after_the_first_round(void** state) {
     /* const n1 = create(), n2 = create()
-       const s1 = initSyncState(), s2 = initSyncState()                      */
+       const s1 = initSyncState(), s2 = initSyncState()                                                               */
     TestState* test_state = *state;
     AMstack** stack_ptr = &test_state->base_state->stack;
-    /* const m1 = n1.generateSyncMessage(s1)
-       if (m1 === null) { throw new RangeError("message should not be null")  */
+    /* let m1 = n1.generateSyncMessage(s1)
+       if (m1 === null) { throw new RangeError("message should not be null") }                                        */
     AMsyncMessage const* m1;
     assert_true(AMitemToSyncMessage(AMstackItem(stack_ptr, AMgenerateSyncMessage(test_state->n1, test_state->s1),
                                                 cmocka_cb, AMexpect(AM_VAL_TYPE_SYNC_MESSAGE)),
                                     &m1));
-    /* n2.receiveSyncMessage(s2, m1)                                         */
+    /* n2.receiveSyncMessage(s2, m1)                                                                                  */
     AMstackItem(NULL, AMreceiveSyncMessage(test_state->n2, test_state->s2, m1), cmocka_cb, AMexpect(AM_VAL_TYPE_VOID));
-    /* const m2 = n2.generateSyncMessage(s2)
-       assert.deepStrictEqual(m2, null)                                      */
-    AMstackItem(NULL, AMgenerateSyncMessage(test_state->n2, test_state->s2), cmocka_cb, AMexpect(AM_VAL_TYPE_VOID));
+    /* let m2 = n2.generateSyncMessage(s2)
+       // We should always send a message on the first round to advertise our heads
+       assert.notStrictEqual(m2, null)                                                                                */
+    AMsyncMessage const* m2;
+    assert_true(AMitemToSyncMessage(AMstackItem(stack_ptr, AMgenerateSyncMessage(test_state->n2, test_state->s2),
+                                                cmocka_cb, AMexpect(AM_VAL_TYPE_SYNC_MESSAGE)),
+                                    &m2));
+    /* n2.receiveSyncMessage(s2, m2!)                                                                                 */
+    AMstackItem(NULL, AMreceiveSyncMessage(test_state->n2, test_state->s2, m2), cmocka_cb, AMexpect(AM_VAL_TYPE_VOID));
+    /*
+       // now make a change on n1 so we generate another sync message to send
+       n1.put("_root", "x", 1)                                                                                        */
+    AMstackItem(NULL, AMmapPutInt(test_state->n1, AM_ROOT, AMstr("x"), 1), cmocka_cb, AMexpect(AM_VAL_TYPE_VOID));
+    /* m1 = n1.generateSyncMessage(s1)                                                                                */
+    assert_true(AMitemToSyncMessage(AMstackItem(stack_ptr, AMgenerateSyncMessage(test_state->n1, test_state->s1),
+                                                cmocka_cb, AMexpect(AM_VAL_TYPE_SYNC_MESSAGE)),
+                                    &m1));
+    /* n2.receiveSyncMessage(s2, m2!)                                                                                 */
+    AMstackItem(NULL, AMreceiveSyncMessage(test_state->n2, test_state->s2, m2), cmocka_cb, AMexpect(AM_VAL_TYPE_VOID));
+    /*
+       m2 = n2.generateSyncMessage(s2)
+       assert.deepStrictEqual(m2, null)                                                                               */
+    assert_false(AMitemToSyncMessage(AMstackItem(stack_ptr, AMgenerateSyncMessage(test_state->n2, test_state->s2),
+                                                 cmocka_cb, AMexpect(AM_VAL_TYPE_VOID)),
+                                     &m2));
 }
 
 /**
- * \brief repos with equal heads do not need a reply message
+ * \brief repos with equal heads do not need a reply message after the first
+ *        round
  */
-static void test_repos_with_equal_heads_do_not_need_a_reply_message(void** state) {
+static void test_repos_with_equal_heads_do_not_need_a_reply_message_after_the_first_round(void** state) {
     /* const n1 = create(), n2 = create()
-       const s1 = initSyncState(), s2 = initSyncState()                      */
+       const s1 = initSyncState(), s2 = initSyncState()                                                               */
     TestState* test_state = *state;
     AMstack** stack_ptr = &test_state->base_state->stack;
-    /*                                                                       */
-    /* make two nodes with the same changes */
-    /* const list = n1.putObject("_root", "n", [])                           */
+    /*
+       // make two nodes with the same changes
+       const list = n1.putObject("_root", "n", [])                                                                    */
     AMobjId const* const list =
         AMitemObjId(AMstackItem(stack_ptr, AMmapPutObject(test_state->n1, AM_ROOT, AMstr("n"), AM_OBJ_TYPE_LIST),
                                 cmocka_cb, AMexpect(AM_VAL_TYPE_OBJ_TYPE)));
-    /* n1.commit("", 0)                                                      */
+    /* n1.commit("", 0)                                                                                               */
     AMstackItem(NULL, AMcommit(test_state->n1, AMstr(""), &TIME_0), cmocka_cb, AMexpect(AM_VAL_TYPE_CHANGE_HASH));
-    /* for (let i = 0; i < 10; i++) {                                        */
+    /* for (let i = 0; i < 10; i++) {                                                                                 */
     for (size_t i = 0; i != 10; ++i) {
-        /* n1.insert(list, i, i)                                             */
+        /* n1.insert(list, i, i)                                                                                      */
         AMstackItem(NULL, AMlistPutUint(test_state->n1, list, i, true, i), cmocka_cb, AMexpect(AM_VAL_TYPE_VOID));
-        /* n1.commit("", 0)                                                  */
+        /* n1.commit("", 0)                                                                                           */
         AMstackItem(NULL, AMcommit(test_state->n1, AMstr(""), &TIME_0), cmocka_cb, AMexpect(AM_VAL_TYPE_CHANGE_HASH));
-        /* { */
+        /* }                                                                                                          */
     }
-    /* n2.applyChanges(n1.getChanges([]))                                    */
+    /* n2.applyChanges(n1.getChanges([]))                                                                             */
     AMitems const items =
         AMstackItems(stack_ptr, AMgetChanges(test_state->n1, NULL), cmocka_cb, AMexpect(AM_VAL_TYPE_CHANGE));
     AMstackItem(NULL, AMapplyChanges(test_state->n2, &items), cmocka_cb, AMexpect(AM_VAL_TYPE_VOID));
-    /* assert.deepStrictEqual(n1.materialize(), n2.materialize())            */
+    /* assert.deepStrictEqual(n1.materialize(), n2.materialize())                                                     */
     assert_true(AMequal(test_state->n1, test_state->n2));
-    /*                                                                       */
-    /* generate a naive sync message */
-    /* const m1 = n1.generateSyncMessage(s1)
-       if (m1 === null) { throw new RangeError("message should not be null")  */
+    /*
+       // generate a naive sync message
+       let m1 = n1.generateSyncMessage(s1)
+       if (m1 === null) { throw new RangeError("message should not be null") }                                        */
     AMsyncMessage const* m1;
     assert_true(AMitemToSyncMessage(AMstackItem(stack_ptr, AMgenerateSyncMessage(test_state->n1, test_state->s1),
                                                 cmocka_cb, AMexpect(AM_VAL_TYPE_SYNC_MESSAGE)),
                                     &m1));
-    /* assert.deepStrictEqual(s1.lastSentHeads, n1.getHeads())               */
+    /* assert.deepStrictEqual(s1.lastSentHeads, n1.getHeads())                                                        */
     AMitems const last_sent_heads =
         AMstackItems(stack_ptr, AMsyncStateLastSentHeads(test_state->s1), cmocka_cb, AMexpect(AM_VAL_TYPE_CHANGE_HASH));
     AMitems const heads =
         AMstackItems(stack_ptr, AMgetHeads(test_state->n1), cmocka_cb, AMexpect(AM_VAL_TYPE_CHANGE_HASH));
     assert_true(AMitemsEqual(&last_sent_heads, &heads));
-    /*                                                                       */
-    /* heads are equal so this message should be null */
-    /* n2.receiveSyncMessage(s2, m1)                                         */
+    /*
+       // process the first response (which is always generated so we know the other ends heads)
+       n2.receiveSyncMessage(s2, m1)                                                                                  */
     AMstackItem(NULL, AMreceiveSyncMessage(test_state->n2, test_state->s2, m1), cmocka_cb, AMexpect(AM_VAL_TYPE_VOID));
-    /* const m2 = n2.generateSyncMessage(s2)
-       assert.strictEqual(m2, null)                                          */
-    AMstackItem(stack_ptr, AMgenerateSyncMessage(test_state->n2, test_state->s2), cmocka_cb,
-                AMexpect(AM_VAL_TYPE_VOID));
+    /* const m2 = n2.generateSyncMessage(s2)                                                                          */
+    AMsyncMessage const* m2;
+    assert_true(AMitemToSyncMessage(AMstackItem(stack_ptr, AMgenerateSyncMessage(test_state->n2, test_state->s2),
+                                                cmocka_cb, AMexpect(AM_VAL_TYPE_SYNC_MESSAGE)),
+                                    &m2));
+    /* n1.receiveSyncMessage(s1, m2!)                                                                                 */
+    AMstackItem(NULL, AMreceiveSyncMessage(test_state->n1, test_state->s1, m2), cmocka_cb, AMexpect(AM_VAL_TYPE_VOID));
+    /*
+       // heads are equal so this message should be null
+       m1 = n1.generateSyncMessage(s2)
+       assert.strictEqual(m1, null)                                                                                   */
+    assert_false(AMitemToSyncMessage(AMstackItem(stack_ptr, AMgenerateSyncMessage(test_state->n1, test_state->s2),
+                                                 cmocka_cb, AMexpect(AM_VAL_TYPE_VOID)),
+                                     &m1));
 }
 
 /**
  * \brief n1 should offer all changes to n2 when starting from nothing
  */
 static void test_n1_should_offer_all_changes_to_n2_when_starting_from_nothing(void** state) {
-    /* const n1 = create(), n2 = create()                                    */
+    /* const n1 = create(), n2 = create()                                                                             */
     TestState* test_state = *state;
     AMstack** stack_ptr = &test_state->base_state->stack;
-    /* make changes for n1 that n2 should request */
-    /* const list = n1.putObject("_root", "n", [])                           */
+    /*
+       // make changes for n1 that n2 should request
+       const list = n1.putObject("_root", "n", [])                                                                    */
     AMobjId const* const list =
         AMitemObjId(AMstackItem(stack_ptr, AMmapPutObject(test_state->n1, AM_ROOT, AMstr("n"), AM_OBJ_TYPE_LIST),
                                 cmocka_cb, AMexpect(AM_VAL_TYPE_OBJ_TYPE)));
-    /* n1.commit("", 0)                                                      */
+    /* n1.commit("", 0)                                                                                               */
     AMstackItem(NULL, AMcommit(test_state->n1, AMstr(""), &TIME_0), cmocka_cb, AMexpect(AM_VAL_TYPE_CHANGE_HASH));
-    /* for (let i = 0; i < 10; i++) {                                        */
+    /* for (let i = 0; i < 10; i++) {                                                                                 */
     for (size_t i = 0; i != 10; ++i) {
-        /* n1.insert(list, i, i)                                             */
+        /* n1.insert(list, i, i)                                                                                      */
         AMstackItem(NULL, AMlistPutUint(test_state->n1, list, i, true, i), cmocka_cb, AMexpect(AM_VAL_TYPE_VOID));
-        /* n1.commit("", 0)                                                  */
+        /* n1.commit("", 0)                                                                                           */
         AMstackItem(NULL, AMcommit(test_state->n1, AMstr(""), &TIME_0), cmocka_cb, AMexpect(AM_VAL_TYPE_CHANGE_HASH));
-        /* { */
+        /* }                                                                                                          */
     }
-    /*                                                                       */
-    /* assert.notDeepStrictEqual(n1.materialize(), n2.materialize())         */
+    /*
+       assert.notDeepStrictEqual(n1.materialize(), n2.materialize())                                                  */
     assert_false(AMequal(test_state->n1, test_state->n2));
-    /* sync(n1, n2)                                                          */
+    /* sync(n1, n2)                                                                                                   */
     sync(test_state->n1, test_state->n2, test_state->s1, test_state->s2);
-    /* assert.deepStrictEqual(n1.materialize(), n2.materialize())            */
+    /* assert.deepStrictEqual(n1.materialize(), n2.materialize())                                                     */
     assert_true(AMequal(test_state->n1, test_state->n2));
 }
 
@@ -239,30 +275,31 @@ static void test_n1_should_offer_all_changes_to_n2_when_starting_from_nothing(vo
  * \brief should sync peers where one has commits the other does not
  */
 static void test_should_sync_peers_where_one_has_commits_the_other_does_not(void** state) {
-    /* const n1 = create(), n2 = create()                                    */
+    /* const n1 = create(), n2 = create()                                                                             */
     TestState* test_state = *state;
     AMstack** stack_ptr = &test_state->base_state->stack;
-    /* make changes for n1 that n2 should request */
-    /* const list = n1.putObject("_root", "n", [])                           */
+    /*
+       // make changes for n1 that n2 should request
+       const list = n1.putObject("_root", "n", [])                                                                    */
     AMobjId const* const list =
         AMitemObjId(AMstackItem(stack_ptr, AMmapPutObject(test_state->n1, AM_ROOT, AMstr("n"), AM_OBJ_TYPE_LIST),
                                 cmocka_cb, AMexpect(AM_VAL_TYPE_OBJ_TYPE)));
-    /* n1.commit("", 0)                                                      */
+    /* n1.commit("", 0)                                                                                               */
     AMstackItem(NULL, AMcommit(test_state->n1, AMstr(""), &TIME_0), cmocka_cb, AMexpect(AM_VAL_TYPE_CHANGE_HASH));
-    /* for (let i = 0; i < 10; i++) {                                        */
+    /* for (let i = 0; i < 10; i++) {                                                                                 */
     for (size_t i = 0; i != 10; ++i) {
-        /* n1.insert(list, i, i)                                             */
+        /* n1.insert(list, i, i)                                                                                      */
         AMstackItem(NULL, AMlistPutUint(test_state->n1, list, i, true, i), cmocka_cb, AMexpect(AM_VAL_TYPE_VOID));
-        /* n1.commit("", 0)                                                  */
+        /* n1.commit("", 0)                                                                                           */
         AMstackItem(NULL, AMcommit(test_state->n1, AMstr(""), &TIME_0), cmocka_cb, AMexpect(AM_VAL_TYPE_CHANGE_HASH));
-        /* { */
+        /* }                                                                                                          */
     }
-    /*                                                                       */
-    /* assert.notDeepStrictEqual(n1.materialize(), n2.materialize())         */
+    /*
+       assert.notDeepStrictEqual(n1.materialize(), n2.materialize())                                                  */
     assert_false(AMequal(test_state->n1, test_state->n2));
-    /* sync(n1, n2)                                                          */
+    /* sync(n1, n2)                                                                                                   */
     sync(test_state->n1, test_state->n2, test_state->s1, test_state->s2);
-    /* assert.deepStrictEqual(n1.materialize(), n2.materialize())            */
+    /* assert.deepStrictEqual(n1.materialize(), n2.materialize())                                                     */
     assert_true(AMequal(test_state->n1, test_state->n2));
 }
 
@@ -270,38 +307,40 @@ static void test_should_sync_peers_where_one_has_commits_the_other_does_not(void
  * \brief should work with prior sync state
  */
 static void test_should_work_with_prior_sync_state(void** state) {
-    /* create & synchronize two nodes */
-    /* const n1 = create(), n2 = create()
-       const s1 = initSyncState(), s2 = initSyncState()                      */
+    /* // create & synchronize two nodes
+       const n1 = create(), n2 = create()
+       const s1 = initSyncState(), s2 = initSyncState()                                                               */
     TestState* test_state = *state;
     AMstack** stack_ptr = &test_state->base_state->stack;
-    /*                                                                       */
-    /* for (let i = 0; i < 5; i++) {                                         */
+    /*
+       for (let i = 0; i < 5; i++) {                                                                                  */
     for (size_t i = 0; i != 5; ++i) {
-        /* n1.put("_root", "x", i)                                           */
+        /* n1.put("_root", "x", i)                                                                                    */
         AMstackItem(NULL, AMmapPutUint(test_state->n1, AM_ROOT, AMstr("x"), i), cmocka_cb, AMexpect(AM_VAL_TYPE_VOID));
-        /* n1.commit("", 0)                                                  */
+        /* n1.commit("", 0)                                                                                           */
         AMstackItem(NULL, AMcommit(test_state->n1, AMstr(""), &TIME_0), cmocka_cb, AMexpect(AM_VAL_TYPE_CHANGE_HASH));
-        /* { */
+        /* }                                                                                                          */
     }
-    /*                                                                       */
+    /*
+       sync(n1, n2, s1, s2)
+                                                                                                                      */
     sync(test_state->n1, test_state->n2, test_state->s1, test_state->s2);
-    /*                                                                       */
-    /* modify the first node further */
-    /* for (let i = 5; i < 10; i++) {                                        */
+    /*
+       // modify the first node further
+       for (let i = 5; i < 10; i++) {                                                                                 */
     for (size_t i = 5; i != 10; ++i) {
-        /* n1.put("_root", "x", i)                                           */
+        /* n1.put("_root", "x", i)                                                                                    */
         AMstackItem(NULL, AMmapPutUint(test_state->n1, AM_ROOT, AMstr("x"), i), cmocka_cb, AMexpect(AM_VAL_TYPE_VOID));
-        /* n1.commit("", 0)                                                  */
+        /* n1.commit("", 0)                                                                                           */
         AMstackItem(NULL, AMcommit(test_state->n1, AMstr(""), &TIME_0), cmocka_cb, AMexpect(AM_VAL_TYPE_CHANGE_HASH));
-        /* { */
+        /* }                                                                                                          */
     }
-    /*                                                                       */
-    /* assert.notDeepStrictEqual(n1.materialize(), n2.materialize())         */
+    /*
+       assert.notDeepStrictEqual(n1.materialize(), n2.materialize())                                                  */
     assert_false(AMequal(test_state->n1, test_state->n2));
-    /* sync(n1, n2, s1, s2)                                                  */
+    /* sync(n1, n2, s1, s2)                                                                                           */
     sync(test_state->n1, test_state->n2, test_state->s1, test_state->s2);
-    /* assert.deepStrictEqual(n1.materialize(), n2.materialize())            */
+    /* assert.deepStrictEqual(n1.materialize(), n2.materialize())                                                     */
     assert_true(AMequal(test_state->n1, test_state->n2));
 }
 
@@ -309,9 +348,9 @@ static void test_should_work_with_prior_sync_state(void** state) {
  * \brief should not generate messages once synced
  */
 static void test_should_not_generate_messages_once_synced(void** state) {
-    /* create & synchronize two nodes */
-    /* const n1 = create('abc123'), n2 = create('def456')
-       const s1 = initSyncState(), s2 = initSyncState()                      */
+    /* // create & synchronize two nodes
+       const n1 = create({ actor: 'abc123'}), n2 = create({ actor: 'def456'})
+       const s1 = initSyncState(), s2 = initSyncState()                                                               */
     TestState* test_state = *state;
     AMstack** stack_ptr = &test_state->base_state->stack;
     AMactorId const* actor_id;
@@ -323,95 +362,90 @@ static void test_should_not_generate_messages_once_synced(void** state) {
         AMstackItem(stack_ptr, AMactorIdFromStr(AMstr("def456")), cmocka_cb, AMexpect(AM_VAL_TYPE_ACTOR_ID)),
         &actor_id));
     AMstackItem(NULL, AMsetActorId(test_state->n2, actor_id), cmocka_cb, AMexpect(AM_VAL_TYPE_VOID));
-    /*                                                                       */
-    /* let message, patch
-       for (let i = 0; i < 5; i++) {                                         */
+    /*
+       let message                                                                                                    */
+    AMsyncMessage const* message = NULL;
+    /* for (let i = 0; i < 5; i++) {                                                                                  */
     for (size_t i = 0; i != 5; ++i) {
-        /* n1.put("_root", "x", i)                                           */
+        /* n1.put("_root", "x", i)                                                                                    */
         AMstackItem(NULL, AMmapPutUint(test_state->n1, AM_ROOT, AMstr("x"), i), cmocka_cb, AMexpect(AM_VAL_TYPE_VOID));
-        /* n1.commit("", 0)                                                  */
+        /* n1.commit("", 0)                                                                                           */
         AMstackItem(NULL, AMcommit(test_state->n1, AMstr(""), &TIME_0), cmocka_cb, AMexpect(AM_VAL_TYPE_CHANGE_HASH));
-        /* { */
+        /* }                                                                                                          */
     }
-    /* for (let i = 0; i < 5; i++) {                                         */
+    /* for (let i = 0; i < 5; i++) {                                                                                  */
     for (size_t i = 0; i != 5; ++i) {
-        /* n2.put("_root", "y", i)                                           */
+        /* n2.put("_root", "y", i)                                                                                    */
         AMstackItem(NULL, AMmapPutUint(test_state->n2, AM_ROOT, AMstr("y"), i), cmocka_cb, AMexpect(AM_VAL_TYPE_VOID));
-        /* n2.commit("", 0)                                                  */
+        /* n2.commit("", 0)                                                                                           */
         AMstackItem(NULL, AMcommit(test_state->n2, AMstr(""), &TIME_0), cmocka_cb, AMexpect(AM_VAL_TYPE_CHANGE_HASH));
-        /* { */
+        /* }                                                                                                          */
     }
-    /*                                                                       */
-    /* n1 reports what it has */
-    /* message = n1.generateSyncMessage(s1)
-       if (message === null) { throw new RangeError("message should not be
-       null")  */
-    AMsyncMessage const* message;
+    /*
+       // n1 reports what it has
+       message = n1.generateSyncMessage(s1)
+       if (message === null) { throw new RangeError("message should not be null") }                                   */
     assert_true(AMitemToSyncMessage(AMstackItem(stack_ptr, AMgenerateSyncMessage(test_state->n1, test_state->s1),
                                                 cmocka_cb, AMexpect(AM_VAL_TYPE_SYNC_MESSAGE)),
                                     &message));
-    /*                                                                       */
-    /* n2 receives that message and sends changes along with what it has */
-    /* n2.receiveSyncMessage(s2, message)                                    */
+    /*
+       // n2 receives that message and sends changes along with what it has
+       n2.receiveSyncMessage(s2, message)                                                                             */
     AMstackItem(NULL, AMreceiveSyncMessage(test_state->n2, test_state->s2, message), cmocka_cb,
                 AMexpect(AM_VAL_TYPE_VOID));
     /* message = n2.generateSyncMessage(s2)
-       if (message === null) { throw new RangeError("message should not be
-       null")  */
+       if (message === null) { throw new RangeError("message should not be null") }                                   */
     assert_true(AMitemToSyncMessage(AMstackItem(stack_ptr, AMgenerateSyncMessage(test_state->n2, test_state->s2),
                                                 cmocka_cb, AMexpect(AM_VAL_TYPE_SYNC_MESSAGE)),
                                     &message));
-    AMitems message_changes =
-        AMstackItems(stack_ptr, AMsyncMessageChanges(message), cmocka_cb, AMexpect(AM_VAL_TYPE_CHANGE));
-    assert_int_equal(AMitemsSize(&message_changes), 5);
-    /*                                                                       */
-    /* n1 receives the changes and replies with the changes it now knows that
-     * n2 needs */
-    /* n1.receiveSyncMessage(s1, message)                                    */
-    AMstackItem(NULL, AMreceiveSyncMessage(test_state->n1, test_state->s1, message), cmocka_cb,
-                AMexpect(AM_VAL_TYPE_VOID));
-    /* message = n2.generateSyncMessage(s2)
-       if (message === null) { throw new RangeError("message should not be
-       null")  */
-    assert_true(AMitemToSyncMessage(AMstackItem(stack_ptr, AMgenerateSyncMessage(test_state->n1, test_state->s1),
-                                                cmocka_cb, AMexpect(AM_VAL_TYPE_SYNC_MESSAGE)),
-                                    &message));
-    message_changes = AMstackItems(stack_ptr, AMsyncMessageChanges(message), cmocka_cb, AMexpect(AM_VAL_TYPE_CHANGE));
-    assert_int_equal(AMitemsSize(&message_changes), 5);
-    /*                                                                       */
-    /* n2 applies the changes and sends confirmation ending the exchange */
-    /* n2.receiveSyncMessage(s2, message)                                    */
-    AMstackItem(NULL, AMreceiveSyncMessage(test_state->n2, test_state->s2, message), cmocka_cb,
-                AMexpect(AM_VAL_TYPE_VOID));
-    /* message = n2.generateSyncMessage(s2)
-       if (message === null) { throw new RangeError("message should not be
-       null")  */
-    assert_true(AMitemToSyncMessage(AMstackItem(stack_ptr, AMgenerateSyncMessage(test_state->n2, test_state->s2),
-                                                cmocka_cb, AMexpect(AM_VAL_TYPE_SYNC_MESSAGE)),
-                                    &message));
-    /*                                                                       */
-    /* n1 receives the message and has nothing more to say */
-    /* n1.receiveSyncMessage(s1, message)                                    */
+    /* assert(decodeSyncMessage(message).changes.length > 0)
+       //assert.deepStrictEqual(patch, null) // no changes arrived
+
+       // n1 receives the changes and replies with the changes it now knows that n2 needs
+       n1.receiveSyncMessage(s1, message)                                                                             */
     AMstackItem(NULL, AMreceiveSyncMessage(test_state->n1, test_state->s1, message), cmocka_cb,
                 AMexpect(AM_VAL_TYPE_VOID));
     /* message = n1.generateSyncMessage(s1)
-       assert.deepStrictEqual(message, null)                                 */
+       if (message == null) { throw new RangeError("message should not be null") }                                    */
+    assert_true(AMitemToSyncMessage(AMstackItem(stack_ptr, AMgenerateSyncMessage(test_state->n1, test_state->s1),
+                                                cmocka_cb, AMexpect(AM_VAL_TYPE_SYNC_MESSAGE)),
+                                    &message));
+    /* assert(decodeSyncMessage(message).changes.length > 0)
+
+       // n2 applies the changes and sends confirmation ending the exchange
+       n2.receiveSyncMessage(s2, message)                                                                             */
+    AMstackItem(NULL, AMreceiveSyncMessage(test_state->n2, test_state->s2, message), cmocka_cb,
+                AMexpect(AM_VAL_TYPE_VOID));
+    /* message = n2.generateSyncMessage(s2)
+       if (message === null) { throw new RangeError("message should not be null") }                                   */
+    assert_true(AMitemToSyncMessage(AMstackItem(stack_ptr, AMgenerateSyncMessage(test_state->n2, test_state->s2),
+                                                cmocka_cb, AMexpect(AM_VAL_TYPE_SYNC_MESSAGE)),
+                                    &message));
+    /*
+       // n1 receives the message and has nothing more to say
+       n1.receiveSyncMessage(s1, message)                                                                             */
+    AMstackItem(NULL, AMreceiveSyncMessage(test_state->n1, test_state->s1, message), cmocka_cb,
+                AMexpect(AM_VAL_TYPE_VOID));
+    /* message = n1.generateSyncMessage(s1)
+       assert.deepStrictEqual(message, null)
+       //assert.deepStrictEqual(patch, null) // no changes arrived                                                    */
     AMstackItem(NULL, AMgenerateSyncMessage(test_state->n1, test_state->s1), cmocka_cb, AMexpect(AM_VAL_TYPE_VOID));
-    /* //assert.deepStrictEqual(patch, null) // no changes arrived           */
-    /*                                                                       */
-    /* n2 also has nothing left to say */
-    /* message = n2.generateSyncMessage(s2)
-       assert.deepStrictEqual(message, null)                                 */
-    AMstackItem(NULL, AMgenerateSyncMessage(test_state->n2, test_state->s2), cmocka_cb, AMexpect(AM_VAL_TYPE_VOID));
+    /*
+       // n2 also has nothing left to say
+       message = n2.generateSyncMessage(s2)
+       assert.deepStrictEqual(message, null)                                                                          */
+    assert_false(AMitemToSyncMessage(
+        AMstackItem(NULL, AMgenerateSyncMessage(test_state->n2, test_state->s2), cmocka_cb, AMexpect(AM_VAL_TYPE_VOID)),
+        &message));
 }
 
 /**
  * \brief should allow simultaneous messages during synchronization
  */
 static void test_should_allow_simultaneous_messages_during_synchronization(void** state) {
-    /* create & synchronize two nodes */
-    /* const n1 = create('abc123'), n2 = create('def456')
-       const s1 = initSyncState(), s2 = initSyncState()                      */
+    /* // create & synchronize two nodes
+       const n1 = create({ actor: 'abc123'}), n2 = create({ actor: 'def456'})
+       const s1 = initSyncState(), s2 = initSyncState()                                                               */
     TestState* test_state = *state;
     AMstack** stack_ptr = &test_state->base_state->stack;
     AMactorId const* actor_id;
@@ -423,53 +457,48 @@ static void test_should_allow_simultaneous_messages_during_synchronization(void*
         AMstackItem(stack_ptr, AMactorIdFromStr(AMstr("def456")), cmocka_cb, AMexpect(AM_VAL_TYPE_ACTOR_ID)),
         &actor_id));
     AMstackItem(NULL, AMsetActorId(test_state->n2, actor_id), cmocka_cb, AMexpect(AM_VAL_TYPE_VOID));
-    /*                                                                       */
-    /*  for (let i = 0; i < 5; i++) {                                        */
+    /*
+       for (let i = 0; i < 5; i++) {                                                                                  */
     for (size_t i = 0; i != 5; ++i) {
-        /* n1.put("_root", "x", i)                                           */
+        /* n1.put("_root", "x", i)                                                                                    */
         AMstackItem(NULL, AMmapPutUint(test_state->n1, AM_ROOT, AMstr("x"), i), cmocka_cb, AMexpect(AM_VAL_TYPE_VOID));
-        /* n1.commit("", 0)                                                  */
+        /* n1.commit("", 0)                                                                                           */
         AMstackItem(NULL, AMcommit(test_state->n1, AMstr(""), &TIME_0), cmocka_cb, AMexpect(AM_VAL_TYPE_CHANGE_HASH));
-        /* { */
+        /* }                                                                                                          */
     }
-    /* for (let i = 0; i < 5; i++) {                                         */
+    /* for (let i = 0; i < 5; i++) {                                                                                  */
     for (size_t i = 0; i != 5; ++i) {
-        /* n2.put("_root", "y", i)                                           */
+        /* n2.put("_root", "y", i)                                                                                    */
         AMstackItem(NULL, AMmapPutUint(test_state->n2, AM_ROOT, AMstr("y"), i), cmocka_cb, AMexpect(AM_VAL_TYPE_VOID));
-        /* n2.commit("", 0)                                                  */
+        /* n2.commit("", 0)                                                                                           */
         AMstackItem(NULL, AMcommit(test_state->n2, AMstr(""), &TIME_0), cmocka_cb, AMexpect(AM_VAL_TYPE_CHANGE_HASH));
-        /* { */
+        /* }                                                                                                          */
     }
-    /* const head1 = n1.getHeads()[0], head2 = n2.getHeads()[0]              */
+    /*
+       const head1 = n1.getHeads()[0], head2 = n2.getHeads()[0]                                                       */
     AMitems heads1 = AMstackItems(stack_ptr, AMgetHeads(test_state->n1), cmocka_cb, AMexpect(AM_VAL_TYPE_CHANGE_HASH));
     AMbyteSpan head1;
     assert_true(AMitemToChangeHash(AMitemsNext(&heads1, 1), &head1));
     AMitems heads2 = AMstackItems(stack_ptr, AMgetHeads(test_state->n2), cmocka_cb, AMexpect(AM_VAL_TYPE_CHANGE_HASH));
     AMbyteSpan head2;
     assert_true(AMitemToChangeHash(AMitemsNext(&heads2, 1), &head2));
-    /*                                                                       */
-    /* both sides report what they have but have no shared peer state */
-    /* let msg1to2, msg2to1
-       msg1to2 = n1.generateSyncMessage(s1)
-       if (msg1to2 === null) { throw new RangeError("message should not be
-       null")  */
+    /*
+       // both sides report what they have but have no shared peer state
+       let msg1to2, msg2to1                                                                                           */
     AMsyncMessage const* msg1to2;
+    AMsyncMessage const* msg2to1;
+    /* msg1to2 = n1.generateSyncMessage(s1)
+       msg2to1 = n2.generateSyncMessage(s2)
+       if (msg1to2 === null) { throw new RangeError("message should not be null") }
+       if (msg2to1 === null) { throw new RangeError("message should not be null") }                                   */
     assert_true(AMitemToSyncMessage(AMstackItem(stack_ptr, AMgenerateSyncMessage(test_state->n1, test_state->s1),
                                                 cmocka_cb, AMexpect(AM_VAL_TYPE_SYNC_MESSAGE)),
                                     &msg1to2));
-    /* msg2to1 = n2.generateSyncMessage(s2)
-       if (msg2to1 === null) { throw new RangeError("message should not be
-       null")  */
-    AMsyncMessage const* msg2to1;
     assert_true(AMitemToSyncMessage(AMstackItem(stack_ptr, AMgenerateSyncMessage(test_state->n2, test_state->s2),
                                                 cmocka_cb, AMexpect(AM_VAL_TYPE_SYNC_MESSAGE)),
                                     &msg2to1));
-    /* assert.deepStrictEqual(decodeSyncMessage(msg1to2).changes.length, 0)  */
-    AMitems msg1to2_changes =
-        AMstackItems(stack_ptr, AMsyncMessageChanges(msg1to2), cmocka_cb, AMexpect(AM_VAL_TYPE_CHANGE));
-    assert_int_equal(AMitemsSize(&msg1to2_changes), 0);
-    /* assert.deepStrictEqual(decodeSyncMessage(msg1to2).have[0].lastSync.length,
-     * 0 */
+    /* assert.deepStrictEqual(decodeSyncMessage(msg1to2).changes.length, 0)
+       assert.deepStrictEqual(decodeSyncMessage(msg1to2).have[0].lastSync.length, 0)                                  */
     AMitems msg1to2_haves =
         AMstackItems(stack_ptr, AMsyncMessageHaves(msg1to2), cmocka_cb, AMexpect(AM_VAL_TYPE_SYNC_HAVE));
     AMsyncHave const* msg1to2_have;
@@ -477,12 +506,8 @@ static void test_should_allow_simultaneous_messages_during_synchronization(void*
     AMitems msg1to2_last_sync =
         AMstackItems(stack_ptr, AMsyncHaveLastSync(msg1to2_have), cmocka_cb, AMexpect(AM_VAL_TYPE_CHANGE_HASH));
     assert_int_equal(AMitemsSize(&msg1to2_last_sync), 0);
-    /* assert.deepStrictEqual(decodeSyncMessage(msg2to1).changes.length, 0)  */
-    AMitems msg2to1_changes =
-        AMstackItems(stack_ptr, AMsyncMessageChanges(msg2to1), cmocka_cb, AMexpect(AM_VAL_TYPE_CHANGE));
-    assert_int_equal(AMitemsSize(&msg2to1_changes), 0);
-    /* assert.deepStrictEqual(decodeSyncMessage(msg2to1).have[0].lastSync.length,
-     * 0 */
+    /* assert.deepStrictEqual(decodeSyncMessage(msg2to1).changes.length, 0)
+       assert.deepStrictEqual(decodeSyncMessage(msg2to1).have[0].lastSync.length, 0)                                  */
     AMitems msg2to1_haves =
         AMstackItems(stack_ptr, AMsyncMessageHaves(msg2to1), cmocka_cb, AMexpect(AM_VAL_TYPE_SYNC_HAVE));
     AMsyncHave const* msg2to1_have;
@@ -490,47 +515,40 @@ static void test_should_allow_simultaneous_messages_during_synchronization(void*
     AMitems msg2to1_last_sync =
         AMstackItems(stack_ptr, AMsyncHaveLastSync(msg2to1_have), cmocka_cb, AMexpect(AM_VAL_TYPE_CHANGE_HASH));
     assert_int_equal(AMitemsSize(&msg2to1_last_sync), 0);
-    /*                                                                       */
-    /* n1 and n2 receive that message and update sync state but make no patc */
-    /* n1.receiveSyncMessage(s1, msg2to1)                                    */
+    /*
+       // n1 and n2 receive that message and update sync state but make no patch
+       n1.receiveSyncMessage(s1, msg2to1)                                                                             */
     AMstackItem(NULL, AMreceiveSyncMessage(test_state->n1, test_state->s1, msg2to1), cmocka_cb,
                 AMexpect(AM_VAL_TYPE_VOID));
-    /* n2.receiveSyncMessage(s2, msg1to2)                                    */
+    /* n2.receiveSyncMessage(s2, msg1to2)                                                                             */
     AMstackItem(NULL, AMreceiveSyncMessage(test_state->n2, test_state->s2, msg1to2), cmocka_cb,
                 AMexpect(AM_VAL_TYPE_VOID));
-    /*                                                                       */
-    /* now both reply with their local changes that the other lacks
-     * (standard warning that 1% of the time this will result in a "needs"
-     * message) */
-    /* msg1to2 = n1.generateSyncMessage(s1)
-       if (msg1to2 === null) { throw new RangeError("message should not be
-       null")  */
+    /*
+       // now both reply with their local changes the other lacks
+       // (standard warning that 1% of the time this will result in a "need" message)
+       msg1to2 = n1.generateSyncMessage(s1)
+       if (msg1to2 === null) { throw new RangeError("message should not be null") }                                   */
     assert_true(AMitemToSyncMessage(AMstackItem(stack_ptr, AMgenerateSyncMessage(test_state->n1, test_state->s1),
                                                 cmocka_cb, AMexpect(AM_VAL_TYPE_SYNC_MESSAGE)),
                                     &msg1to2));
-    /* assert.deepStrictEqual(decodeSyncMessage(msg1to2).changes.length, 5)  */
-    msg1to2_changes = AMstackItems(stack_ptr, AMsyncMessageChanges(msg1to2), cmocka_cb, AMexpect(AM_VAL_TYPE_CHANGE));
-    assert_int_equal(AMitemsSize(&msg1to2_changes), 5);
-    /* msg2to1 = n2.generateSyncMessage(s2)
-       if (msg2to1 === null) { throw new RangeError("message should not be
-       null")  */
+    /* assert(decodeSyncMessage(msg1to2).changes.length > 0)
+       msg2to1 = n2.generateSyncMessage(s2)
+       if (msg2to1 === null) { throw new RangeError("message should not be null") }                                   */
     assert_true(AMitemToSyncMessage(AMstackItem(stack_ptr, AMgenerateSyncMessage(test_state->n2, test_state->s2),
                                                 cmocka_cb, AMexpect(AM_VAL_TYPE_SYNC_MESSAGE)),
                                     &msg2to1));
-    /* assert.deepStrictEqual(decodeSyncMessage(msg2to1).changes.length, 5)  */
-    msg2to1_changes = AMstackItems(stack_ptr, AMsyncMessageChanges(msg2to1), cmocka_cb, AMexpect(AM_VAL_TYPE_CHANGE));
-    assert_int_equal(AMitemsSize(&msg2to1_changes), 5);
-    /*                                                                       */
-    /* both should now apply the changes and update the frontend */
-    /* n1.receiveSyncMessage(s1, msg2to1)                                    */
+    /* assert(decodeSyncMessage(msg2to1).changes.length > 0)
+
+       // both should now apply the changes and update the frontend
+       n1.receiveSyncMessage(s1, msg2to1)                                                                             */
     AMstackItem(NULL, AMreceiveSyncMessage(test_state->n1, test_state->s1, msg2to1), cmocka_cb,
                 AMexpect(AM_VAL_TYPE_VOID));
-    /* assert.deepStrictEqual(n1.getMissingDeps(), [])                       */
+    /* assert.deepStrictEqual(n1.getMissingDeps(), [])                                                                */
     AMitems missing_deps =
         AMstackItems(stack_ptr, AMgetMissingDeps(test_state->n1, NULL), cmocka_cb, AMexpect(AM_VAL_TYPE_CHANGE_HASH));
     assert_int_equal(AMitemsSize(&missing_deps), 0);
     /* //assert.notDeepStrictEqual(patch1, null)
-       assert.deepStrictEqual(n1.materialize(), { x: 4, y: 4 })              */
+       assert.deepStrictEqual(n1.materialize(), { x: 4, y: 4 })                                                       */
     uint64_t uint;
     assert_true(AMitemToUint(AMstackItem(stack_ptr, AMmapGet(test_state->n1, AM_ROOT, AMstr("x"), NULL), cmocka_cb,
                                          AMexpect(AM_VAL_TYPE_UINT)),
@@ -540,16 +558,16 @@ static void test_should_allow_simultaneous_messages_during_synchronization(void*
                                          AMexpect(AM_VAL_TYPE_UINT)),
                              &uint));
     assert_int_equal(uint, 4);
-    /*                                                                       */
-    /* n2.receiveSyncMessage(s2, msg1to2)                                    */
+    /*
+       n2.receiveSyncMessage(s2, msg1to2)                                                                             */
     AMstackItem(NULL, AMreceiveSyncMessage(test_state->n2, test_state->s2, msg1to2), cmocka_cb,
                 AMexpect(AM_VAL_TYPE_VOID));
-    /* assert.deepStrictEqual(n2.getMissingDeps(), [])                       */
+    /* assert.deepStrictEqual(n2.getMissingDeps(), [])                                                                */
     missing_deps =
         AMstackItems(stack_ptr, AMgetMissingDeps(test_state->n2, NULL), cmocka_cb, AMexpect(AM_VAL_TYPE_CHANGE_HASH));
     assert_int_equal(AMitemsSize(&missing_deps), 0);
     /* //assert.notDeepStrictEqual(patch2, null)
-       assert.deepStrictEqual(n2.materialize(), { x: 4, y: 4 })              */
+       assert.deepStrictEqual(n2.materialize(), { x: 4, y: 4 })                                                       */
     assert_true(AMitemToUint(AMstackItem(stack_ptr, AMmapGet(test_state->n2, AM_ROOT, AMstr("x"), NULL), cmocka_cb,
                                          AMexpect(AM_VAL_TYPE_UINT)),
                              &uint));
@@ -558,36 +576,29 @@ static void test_should_allow_simultaneous_messages_during_synchronization(void*
                                          AMexpect(AM_VAL_TYPE_UINT)),
                              &uint));
     assert_int_equal(uint, 4);
-    /*                                                                       */
-    /* The response acknowledges the changes received and sends no further
-     * changes */
-    /* msg1to2 = n1.generateSyncMessage(s1)
-       if (msg1to2 === null) { throw new RangeError("message should not be
-       null")  */
+    /*
+       // The response acknowledges the changes received and sends no further changes
+       msg1to2 = n1.generateSyncMessage(s1)
+       if (msg1to2 === null) { throw new RangeError("message should not be null") }                                   */
     assert_true(AMitemToSyncMessage(AMstackItem(stack_ptr, AMgenerateSyncMessage(test_state->n1, test_state->s1),
                                                 cmocka_cb, AMexpect(AM_VAL_TYPE_SYNC_MESSAGE)),
                                     &msg1to2));
-    /* assert.deepStrictEqual(decodeSyncMessage(msg1to2).changes.length, 0)  */
-    msg1to2_changes = AMstackItems(stack_ptr, AMsyncMessageChanges(msg1to2), cmocka_cb, AMexpect(AM_VAL_TYPE_CHANGE));
-    assert_int_equal(AMitemsSize(&msg1to2_changes), 0);
-    /* msg2to1 = n2.generateSyncMessage(s2)
-       if (msg2to1 === null) { throw new RangeError("message should not be
-       null")  */
+    /* assert.deepStrictEqual(decodeSyncMessage(msg1to2).changes.length, 0)
+       msg2to1 = n2.generateSyncMessage(s2)
+       if (msg2to1 === null) { throw new RangeError("message should not be null") }                                   */
     assert_true(AMitemToSyncMessage(AMstackItem(stack_ptr, AMgenerateSyncMessage(test_state->n2, test_state->s2),
                                                 cmocka_cb, AMexpect(AM_VAL_TYPE_SYNC_MESSAGE)),
                                     &msg2to1));
-    /* assert.deepStrictEqual(decodeSyncMessage(msg2to1).changes.length, 0)  */
-    msg2to1_changes = AMstackItems(stack_ptr, AMsyncMessageChanges(msg2to1), cmocka_cb, AMexpect(AM_VAL_TYPE_CHANGE));
-    assert_int_equal(AMitemsSize(&msg2to1_changes), 0);
-    /*                                                                       */
-    /* After receiving acknowledgements, their shared heads should be equal  */
-    /* n1.receiveSyncMessage(s1, msg2to1)                                    */
+    /* assert.deepStrictEqual(decodeSyncMessage(msg2to1).changes.length, 0)
+
+       // After receiving acknowledgements, their shared heads should be equal
+       n1.receiveSyncMessage(s1, msg2to1)                                                                             */
     AMstackItem(NULL, AMreceiveSyncMessage(test_state->n1, test_state->s1, msg2to1), cmocka_cb,
                 AMexpect(AM_VAL_TYPE_VOID));
-    /* n2.receiveSyncMessage(s2, msg1to2)                                    */
+    /* n2.receiveSyncMessage(s2, msg1to2)                                                                             */
     AMstackItem(NULL, AMreceiveSyncMessage(test_state->n2, test_state->s2, msg1to2), cmocka_cb,
                 AMexpect(AM_VAL_TYPE_VOID));
-    /* assert.deepStrictEqual(s1.sharedHeads, [head1, head2].sort())         */
+    /* assert.deepStrictEqual(s1.sharedHeads, [head1, head2].sort())                                                  */
     AMitems s1_shared_heads =
         AMstackItems(stack_ptr, AMsyncStateSharedHeads(test_state->s1), cmocka_cb, AMexpect(AM_VAL_TYPE_CHANGE_HASH));
     AMbyteSpan s1_shared_change_hash;
@@ -595,7 +606,7 @@ static void test_should_allow_simultaneous_messages_during_synchronization(void*
     assert_memory_equal(s1_shared_change_hash.src, head1.src, head1.count);
     assert_true(AMitemToChangeHash(AMitemsNext(&s1_shared_heads, 1), &s1_shared_change_hash));
     assert_memory_equal(s1_shared_change_hash.src, head2.src, head2.count);
-    /* assert.deepStrictEqual(s2.sharedHeads, [head1, head2].sort())         */
+    /* assert.deepStrictEqual(s2.sharedHeads, [head1, head2].sort())                                                  */
     AMitems s2_shared_heads =
         AMstackItems(stack_ptr, AMsyncStateSharedHeads(test_state->s2), cmocka_cb, AMexpect(AM_VAL_TYPE_CHANGE_HASH));
     AMbyteSpan s2_shared_change_hash;
@@ -604,28 +615,29 @@ static void test_should_allow_simultaneous_messages_during_synchronization(void*
     assert_true(AMitemToChangeHash(AMitemsNext(&s2_shared_heads, 1), &s2_shared_change_hash));
     assert_memory_equal(s2_shared_change_hash.src, head2.src, head2.count);
     /* //assert.deepStrictEqual(patch1, null)
-       //assert.deepStrictEqual(patch2, null)                                */
-    /*                                                                       */
-    /* We're in sync, no more messages required */
-    /* msg1to2 = n1.generateSyncMessage(s1)
-       assert.deepStrictEqual(msg1to2, null)                                 */
-    AMstackItem(NULL, AMgenerateSyncMessage(test_state->n1, test_state->s1), cmocka_cb, AMexpect(AM_VAL_TYPE_VOID));
-    /* msg2to1 = n2.generateSyncMessage(s2)
-       assert.deepStrictEqual(msg2to1, null)                                 */
-    AMstackItem(NULL, AMgenerateSyncMessage(test_state->n2, test_state->s2), cmocka_cb, AMexpect(AM_VAL_TYPE_VOID));
-    /*                                                                       */
-    /* If we make one more change and start another sync then its lastSync
-     * should be updated */
-    /* n1.put("_root", "x", 5)                                               */
+       //assert.deepStrictEqual(patch2, null)
+
+       // We're in sync, no more messages required
+       msg1to2 = n1.generateSyncMessage(s1)
+       msg2to1 = n2.generateSyncMessage(s2)
+       assert.deepStrictEqual(msg1to2, null)
+       assert.deepStrictEqual(msg2to1, null)                                                                          */
+    assert_false(AMitemToSyncMessage(AMstackItem(stack_ptr, AMgenerateSyncMessage(test_state->n1, test_state->s1),
+                                                 cmocka_cb, AMexpect(AM_VAL_TYPE_VOID)),
+                                     &msg1to2));
+    assert_false(AMitemToSyncMessage(AMstackItem(stack_ptr, AMgenerateSyncMessage(test_state->n2, test_state->s2),
+                                                 cmocka_cb, AMexpect(AM_VAL_TYPE_VOID)),
+                                     &msg2to1));
+    /*
+       // If we make one more change and start another sync then its lastSync should be updated
+       n1.put("_root", "x", 5)                                                                                        */
     AMstackItem(NULL, AMmapPutUint(test_state->n1, AM_ROOT, AMstr("x"), 5), cmocka_cb, AMexpect(AM_VAL_TYPE_VOID));
     /* msg1to2 = n1.generateSyncMessage(s1)
-       if (msg1to2 === null) { throw new RangeError("message should not be
-       null")  */
+       if (msg1to2 === null) { throw new RangeError("message should not be null") }                                   */
     assert_true(AMitemToSyncMessage(AMstackItem(stack_ptr, AMgenerateSyncMessage(test_state->n1, test_state->s1),
                                                 cmocka_cb, AMexpect(AM_VAL_TYPE_SYNC_MESSAGE)),
                                     &msg1to2));
-    /* assert.deepStrictEqual(decodeSyncMessage(msg1to2).have[0].lastSync,
-     * [head1, head2].sort( */
+    /* assert.deepStrictEqual(decodeSyncMessage(msg1to2).have[0].lastSync, [head1, head2].sort())                     */
     msg1to2_haves = AMstackItems(stack_ptr, AMsyncMessageHaves(msg1to2), cmocka_cb, AMexpect(AM_VAL_TYPE_SYNC_HAVE));
     assert_true(AMitemToSyncHave(AMitemsNext(&msg1to2_haves, 1), &msg1to2_have));
     msg1to2_last_sync =
@@ -643,108 +655,98 @@ static void test_should_allow_simultaneous_messages_during_synchronization(void*
  * \brief should assume sent changes were received until we hear otherwise
  */
 static void test_should_assume_sent_changes_were_received_until_we_hear_otherwise(void** state) {
-    /* const n1 = create('01234567'), n2 = create('89abcdef')
-       const s1 = initSyncState(), s2 = initSyncState()                      */
+    /* const n1 = create({ actor: '01234567'}), n2 = create({ actor: '89abcdef'})
+       const s1 = initSyncState(), s2 = initSyncState()                                                               */
     TestState* test_state = *state;
     AMstack** stack_ptr = &test_state->base_state->stack;
-    /* let message = null                                                    */
-    /*                                                                       */
-    /* const items = n1.putObject("_root", "items", [])                      */
+    /* let message = null
+
+       const items = n1.putObject("_root", "items", [])                                                               */
     AMobjId const* const items =
         AMitemObjId(AMstackItem(stack_ptr, AMmapPutObject(test_state->n1, AM_ROOT, AMstr("items"), AM_OBJ_TYPE_LIST),
                                 cmocka_cb, AMexpect(AM_VAL_TYPE_OBJ_TYPE)));
-    /* n1.commit("", 0)                                                      */
+    /* n1.commit("", 0)                                                                                               */
     AMstackItem(NULL, AMcommit(test_state->n1, AMstr(""), &TIME_0), cmocka_cb, AMexpect(AM_VAL_TYPE_CHANGE_HASH));
-    /*                                                                       */
-    /* sync(n1, n2, s1, s2)                                                  */
+    /*
+       sync(n1, n2, s1, s2)                                                                                           */
     sync(test_state->n1, test_state->n2, test_state->s1, test_state->s2);
-    /*                                                                       */
-    /* n1.push(items, "x")                                                   */
+    /*
+       n1.push(items, "x")                                                                                            */
     AMstackItem(NULL, AMlistPutStr(test_state->n1, items, SIZE_MAX, true, AMstr("x")), cmocka_cb,
                 AMexpect(AM_VAL_TYPE_VOID));
-    /* n1.commit("", 0)                                                      */
+    /* n1.commit("", 0)                                                                                               */
     AMstackItem(NULL, AMcommit(test_state->n1, AMstr(""), &TIME_0), cmocka_cb, AMexpect(AM_VAL_TYPE_CHANGE_HASH));
     /* message = n1.generateSyncMessage(s1)
-      if (message === null) { throw new RangeError("message should not be null")
-    */
+      if (message === null) { throw new RangeError("message should not be null") }                                    */
     AMsyncMessage const* message;
     assert_true(AMitemToSyncMessage(AMstackItem(stack_ptr, AMgenerateSyncMessage(test_state->n1, test_state->s1),
                                                 cmocka_cb, AMexpect(AM_VAL_TYPE_SYNC_MESSAGE)),
                                     &message));
-    /* assert.deepStrictEqual(decodeSyncMessage(message).changes.length, 1)  */
-    AMitems message_changes =
-        AMstackItems(stack_ptr, AMsyncMessageChanges(message), cmocka_cb, AMexpect(AM_VAL_TYPE_CHANGE));
-    assert_int_equal(AMitemsSize(&message_changes), 1);
-    /*                                                                       */
-    /* n1.push(items, "y")                                                   */
+    /* assert.deepStrictEqual(decodeSyncMessage(message).changes.length, 1)
+
+       n1.push(items, "y")                                                                                            */
     AMstackItem(NULL, AMlistPutStr(test_state->n1, items, SIZE_MAX, true, AMstr("y")), cmocka_cb,
                 AMexpect(AM_VAL_TYPE_VOID));
-    /* n1.commit("", 0)                                                      */
+    /* n1.commit("", 0)                                                                                               */
     AMstackItem(NULL, AMcommit(test_state->n1, AMstr(""), &TIME_0), cmocka_cb, AMexpect(AM_VAL_TYPE_CHANGE_HASH));
     /* message = n1.generateSyncMessage(s1)
-       if (message === null) { throw new RangeError("message should not be
-       null")  */
+       if (message === null) { throw new RangeError("message should not be null") }                                   */
     assert_true(AMitemToSyncMessage(AMstackItem(stack_ptr, AMgenerateSyncMessage(test_state->n1, test_state->s1),
                                                 cmocka_cb, AMexpect(AM_VAL_TYPE_SYNC_MESSAGE)),
                                     &message));
-    /* assert.deepStrictEqual(decodeSyncMessage(message).changes.length, 1)  */
-    message_changes = AMstackItems(stack_ptr, AMsyncMessageChanges(message), cmocka_cb, AMexpect(AM_VAL_TYPE_CHANGE));
-    assert_int_equal(AMitemsSize(&message_changes), 1);
-    /*                                                                       */
-    /* n1.push(items, "z")                                                   */
+    /* assert.deepStrictEqual(decodeSyncMessage(message).changes.length, 1)
+
+       n1.push(items, "z")                                                                                            */
     AMstackItem(NULL, AMlistPutStr(test_state->n1, items, SIZE_MAX, true, AMstr("z")), cmocka_cb,
                 AMexpect(AM_VAL_TYPE_VOID));
-    /* n1.commit("", 0)                                                      */
+    /* n1.commit("", 0)                                                                                               */
     AMstackItem(NULL, AMcommit(test_state->n1, AMstr(""), &TIME_0), cmocka_cb, AMexpect(AM_VAL_TYPE_CHANGE_HASH));
-    /*                                                                       */
-    /* message = n1.generateSyncMessage(s1)
-       if (message === null) { throw new RangeError("message should not be
-       null")  */
+    /*
+       message = n1.generateSyncMessage(s1)
+       if (message === null) { throw new RangeError("message should not be null") }                                   */
     assert_true(AMitemToSyncMessage(AMstackItem(stack_ptr, AMgenerateSyncMessage(test_state->n1, test_state->s1),
                                                 cmocka_cb, AMexpect(AM_VAL_TYPE_SYNC_MESSAGE)),
                                     &message));
-    /* assert.deepStrictEqual(decodeSyncMessage(message).changes.length, 1)  */
-    message_changes = AMstackItems(stack_ptr, AMsyncMessageChanges(message), cmocka_cb, AMexpect(AM_VAL_TYPE_CHANGE));
-    assert_int_equal(AMitemsSize(&message_changes), 1);
+    /* assert.deepStrictEqual(decodeSyncMessage(message).changes.length, 1)                                           */
 }
 
 /**
  * \brief should work regardless of who initiates the exchange
  */
 static void test_should_work_regardless_of_who_initiates_the_exchange(void** state) {
-    /* create & synchronize two nodes */
-    /* const n1 = create(), n2 = create()
-      const s1 = initSyncState(), s2 = initSyncState()                       */
+    /* // create & synchronize two nodes
+       const n1 = create(), n2 = create()
+       const s1 = initSyncState(), s2 = initSyncState()                                                               */
     TestState* test_state = *state;
     AMstack** stack_ptr = &test_state->base_state->stack;
-    /*                                                                       */
-    /* for (let i = 0; i < 5; i++) {                                         */
+    /*
+       for (let i = 0; i < 5; i++) {                                                                                  */
     for (size_t i = 0; i != 5; ++i) {
-        /* n1.put("_root", "x", i)                                           */
+        /* n1.put("_root", "x", i)                                                                                    */
         AMstackItem(NULL, AMmapPutUint(test_state->n1, AM_ROOT, AMstr("x"), i), cmocka_cb, AMexpect(AM_VAL_TYPE_VOID));
-        /* n1.commit("", 0)                                                  */
+        /* n1.commit("", 0)                                                                                           */
         AMstackItem(NULL, AMcommit(test_state->n1, AMstr(""), &TIME_0), cmocka_cb, AMexpect(AM_VAL_TYPE_CHANGE_HASH));
-        /* { */
+        /* }                                                                                                          */
     }
-    /*                                                                       */
-    /* sync(n1, n2, s1, s2)                                                  */
+    /*
+       sync(n1, n2, s1, s2)                                                                                           */
     sync(test_state->n1, test_state->n2, test_state->s1, test_state->s2);
-    /*                                                                       */
-    /* modify the first node further */
-    /* for (let i = 5; i < 10; i++) {                                        */
+    /*
+       // modify the first node further
+       for (let i = 5; i < 10; i++) {                                                                                 */
     for (size_t i = 5; i != 10; ++i) {
-        /* n1.put("_root", "x", i)                                           */
+        /* n1.put("_root", "x", i)                                                                                    */
         AMstackItem(NULL, AMmapPutUint(test_state->n1, AM_ROOT, AMstr("x"), i), cmocka_cb, AMexpect(AM_VAL_TYPE_VOID));
-        /* n1.commit("", 0)                                                  */
+        /* n1.commit("", 0)                                                                                           */
         AMstackItem(NULL, AMcommit(test_state->n1, AMstr(""), &TIME_0), cmocka_cb, AMexpect(AM_VAL_TYPE_CHANGE_HASH));
-        /* { */
+        /* }                                                                                                          */
     }
-    /*                                                                       */
-    /* assert.notDeepStrictEqual(n1.materialize(), n2.materialize())         */
+    /*
+       assert.notDeepStrictEqual(n1.materialize(), n2.materialize())                                                  */
     assert_false(AMequal(test_state->n1, test_state->n2));
-    /* sync(n1, n2, s1, s2)                                                  */
+    /* sync(n1, n2, s1, s2)                                                                                           */
     sync(test_state->n1, test_state->n2, test_state->s1, test_state->s2);
-    /* assert.deepStrictEqual(n1.materialize(), n2.materialize())            */
+    /* assert.deepStrictEqual(n1.materialize(), n2.materialize())                                                     */
     assert_true(AMequal(test_state->n1, test_state->n2));
 }
 
@@ -752,57 +754,56 @@ static void test_should_work_regardless_of_who_initiates_the_exchange(void** sta
  * \brief should work without prior sync state
  */
 static void test_should_work_without_prior_sync_state(void** state) {
-    /* Scenario:                                                            ,--
-     * c10 <-- c11 <-- c12 <-- c13 <-- c14 c0 <-- c1 <-- c2 <-- c3 <-- c4 <-- c5
-     * <-- c6 <-- c7 <-- c8 <-- c9 <-+
-     *                                                                      `--
-     * c15 <-- c16 <-- c17 lastSync is undefined. */
-    /*                                                                       */
-    /* create two peers both with divergent commits */
-    /* const n1 = create('01234567'), n2 = create('89abcdef')
-       const s1 = initSyncState(), s2 = initSyncState()                      */
+    /* // Scenario:                                                            ,-- c10 <-- c11 <-- c12 <-- c13 <-- c14
+       // c0 <-- c1 <-- c2 <-- c3 <-- c4 <-- c5 <-- c6 <-- c7 <-- c8 <-- c9 <-+
+       //                                                                      `-- c15 <-- c16 <-- c17
+       // lastSync is undefined.
+
+       // create two peers both with divergent commits
+       const n1 = create({ actor: '01234567'}), n2 = create({ actor: '89abcdef'})
+       //const s1 = initSyncState(), s2 = initSyncState()                                                             */
     TestState* test_state = *state;
     AMstack** stack_ptr = &test_state->base_state->stack;
-    /*                                                                       */
-    /* for (let i = 0; i < 10; i++) {                                        */
+    /*
+       for (let i = 0; i < 10; i++) {                                                                                 */
     for (size_t i = 0; i != 10; ++i) {
-        /* n1.put("_root", "x", i)                                           */
+        /* n1.put("_root", "x", i)                                                                                    */
         AMstackItem(NULL, AMmapPutUint(test_state->n1, AM_ROOT, AMstr("x"), i), cmocka_cb, AMexpect(AM_VAL_TYPE_VOID));
-        /* n1.commit("", 0)                                                  */
+        /* n1.commit("", 0)                                                                                           */
         AMstackItem(NULL, AMcommit(test_state->n1, AMstr(""), &TIME_0), cmocka_cb, AMexpect(AM_VAL_TYPE_CHANGE_HASH));
-        /* { */
+        /* }                                                                                                          */
     }
-    /*                                                                       */
-    /* sync(n1, n2)                                                          */
+    /*
+       sync(n1, n2)                                                                                                   */
     sync(test_state->n1, test_state->n2, test_state->s1, test_state->s2);
-    /*                                                                       */
-    /* for (let i = 10; i < 15; i++) {                                       */
+    /*
+       for (let i = 10; i < 15; i++) {                                                                                */
     for (size_t i = 10; i != 15; ++i) {
-        /* n1.put("_root", "x", i)                                           */
+        /* n1.put("_root", "x", i)                                                                                    */
         AMstackItem(NULL, AMmapPutUint(test_state->n1, AM_ROOT, AMstr("x"), i), cmocka_cb, AMexpect(AM_VAL_TYPE_VOID));
-        /* n1.commit("", 0)                                                  */
+        /* n1.commit("", 0)                                                                                           */
         AMstackItem(NULL, AMcommit(test_state->n1, AMstr(""), &TIME_0), cmocka_cb, AMexpect(AM_VAL_TYPE_CHANGE_HASH));
-        /* { */
+        /* }                                                                                                          */
     }
-    /*                                                                       */
-    /* for (let i = 15; i < 18; i++) {                                       */
+    /*
+       for (let i = 15; i < 18; i++) {                                                                                */
     for (size_t i = 15; i != 18; ++i) {
-        /* n2.put("_root", "x", i)                                           */
+        /* n2.put("_root", "x", i)                                                                                    */
         AMstackItem(NULL, AMmapPutUint(test_state->n2, AM_ROOT, AMstr("x"), i), cmocka_cb, AMexpect(AM_VAL_TYPE_VOID));
-        /* n2.commit("", 0)                                                  */
+        /* n2.commit("", 0)                                                                                           */
         AMstackItem(NULL, AMcommit(test_state->n2, AMstr(""), &TIME_0), cmocka_cb, AMexpect(AM_VAL_TYPE_CHANGE_HASH));
-        /* { */
+        /* }                                                                                                          */
     }
-    /*                                                                       */
-    /* assert.notDeepStrictEqual(n1.materialize(), n2.materialize())         */
+    /*
+       assert.notDeepStrictEqual(n1.materialize(), n2.materialize())                                                  */
     assert_false(AMequal(test_state->n1, test_state->n2));
-    /* sync(n1, n2)                                                          */
+    /* sync(n1, n2)                                                                                                   */
     sync(test_state->n1, test_state->n2, test_state->s1, test_state->s2);
-    /* assert.deepStrictEqual(n1.getHeads(), n2.getHeads())                  */
+    /* assert.deepStrictEqual(n1.getHeads(), n2.getHeads())                                                           */
     AMitems heads1 = AMstackItems(stack_ptr, AMgetHeads(test_state->n1), cmocka_cb, AMexpect(AM_VAL_TYPE_CHANGE_HASH));
     AMitems heads2 = AMstackItems(stack_ptr, AMgetHeads(test_state->n2), cmocka_cb, AMexpect(AM_VAL_TYPE_CHANGE_HASH));
     assert_true(AMitemsEqual(&heads1, &heads2));
-    /* assert.deepStrictEqual(n1.materialize(), n2.materialize())            */
+    /* assert.deepStrictEqual(n1.materialize(), n2.materialize())                                                     */
     assert_true(AMequal(test_state->n1, test_state->n2));
 }
 
@@ -810,49 +811,47 @@ static void test_should_work_without_prior_sync_state(void** state) {
  * \brief should work with prior sync state
  */
 static void test_should_work_with_prior_sync_state_2(void** state) {
-    /* Scenario:
-     *                                                                      ,--
-     * c10 <-- c11 <-- c12 <-- c13 <-- c14 c0 <-- c1 <-- c2 <-- c3 <-- c4 <-- c5
-     * <-- c6 <-- c7 <-- c8 <-- c9 <-+
-     *                                                                      `--
-     * c15 <-- c16 <-- c17 lastSync is c9. */
-    /*                                                                       */
-    /* create two peers both with divergent commits */
-    /* const n1 = create('01234567'), n2 = create('89abcdef')
-       let s1 = initSyncState(), s2 = initSyncState()                        */
+    /* // Scenario:                                                            ,-- c10 <-- c11 <-- c12 <-- c13 <-- c14
+       // c0 <-- c1 <-- c2 <-- c3 <-- c4 <-- c5 <-- c6 <-- c7 <-- c8 <-- c9 <-+
+       //                                                                      `-- c15 <-- c16 <-- c17
+       // lastSync is c9.
+
+       // create two peers both with divergent commits
+       const n1 = create({ actor: '01234567'}), n2 = create({ actor: '89abcdef'})
+       let s1 = initSyncState(), s2 = initSyncState()                                                                 */
     TestState* test_state = *state;
     AMstack** stack_ptr = &test_state->base_state->stack;
-    /*                                                                       */
-    /* for (let i = 0; i < 10; i++) {                                        */
+    /*
+       for (let i = 0; i < 10; i++) {                                                                                 */
     for (size_t i = 0; i != 10; ++i) {
-        /* n1.put("_root", "x", i)                                           */
+        /* n1.put("_root", "x", i)                                                                                    */
         AMstackItem(NULL, AMmapPutUint(test_state->n1, AM_ROOT, AMstr("x"), i), cmocka_cb, AMexpect(AM_VAL_TYPE_VOID));
-        /* n1.commit("", 0)                                                  */
+        /* n1.commit("", 0)                                                                                           */
         AMstackItem(NULL, AMcommit(test_state->n1, AMstr(""), &TIME_0), cmocka_cb, AMexpect(AM_VAL_TYPE_CHANGE_HASH));
-        /* { */
+        /* }                                                                                                          */
     }
-    /*                                                                       */
-    /* sync(n1, n2, s1, s2)                                                  */
+    /*
+       sync(n1, n2, s1, s2)                                                                                           */
     sync(test_state->n1, test_state->n2, test_state->s1, test_state->s2);
-    /*                                                                       */
-    /* for (let i = 10; i < 15; i++) {                                       */
+    /*
+       for (let i = 10; i < 15; i++) {                                                                                */
     for (size_t i = 10; i != 15; ++i) {
-        /* n1.put("_root", "x", i)                                           */
+        /* n1.put("_root", "x", i)                                                                                    */
         AMstackItem(NULL, AMmapPutUint(test_state->n1, AM_ROOT, AMstr("x"), i), cmocka_cb, AMexpect(AM_VAL_TYPE_VOID));
-        /* n1.commit("", 0)                                                  */
+        /* n1.commit("", 0)                                                                                           */
         AMstackItem(NULL, AMcommit(test_state->n1, AMstr(""), &TIME_0), cmocka_cb, AMexpect(AM_VAL_TYPE_CHANGE_HASH));
-        /* { */
+        /* }                                                                                                          */
     }
-    /* for (let i = 15; i < 18; i++) {                                       */
+    /* for (let i = 15; i < 18; i++) {                                                                                */
     for (size_t i = 15; i != 18; ++i) {
-        /* n2.put("_root", "x", i)                                           */
+        /* n2.put("_root", "x", i)                                                                                    */
         AMstackItem(NULL, AMmapPutUint(test_state->n2, AM_ROOT, AMstr("x"), i), cmocka_cb, AMexpect(AM_VAL_TYPE_VOID));
-        /* n2.commit("", 0)                                                  */
+        /* n2.commit("", 0)                                                                                           */
         AMstackItem(NULL, AMcommit(test_state->n2, AMstr(""), &TIME_0), cmocka_cb, AMexpect(AM_VAL_TYPE_CHANGE_HASH));
-        /* { */
+        /* }                                                                                                          */
     }
-    /*                                                                       */
-    /* s1 = decodeSyncState(encodeSyncState(s1))                             */
+    /*
+       s1 = decodeSyncState(encodeSyncState(s1))                                                                      */
     AMbyteSpan encoded;
     assert_true(AMitemToBytes(
         AMstackItem(stack_ptr, AMsyncStateEncode(test_state->s1), cmocka_cb, AMexpect(AM_VAL_TYPE_BYTES)), &encoded));
@@ -860,23 +859,23 @@ static void test_should_work_with_prior_sync_state_2(void** state) {
     assert_true(AMitemToSyncState(AMstackItem(stack_ptr, AMsyncStateDecode(encoded.src, encoded.count), cmocka_cb,
                                               AMexpect(AM_VAL_TYPE_SYNC_STATE)),
                                   &s1));
-    /* s2 = decodeSyncState(encodeSyncState(s2))                             */
+    /* s2 = decodeSyncState(encodeSyncState(s2))                                                                      */
     assert_true(AMitemToBytes(
         AMstackItem(stack_ptr, AMsyncStateEncode(test_state->s2), cmocka_cb, AMexpect(AM_VAL_TYPE_BYTES)), &encoded));
     AMsyncState* s2;
     assert_true(AMitemToSyncState(AMstackItem(stack_ptr, AMsyncStateDecode(encoded.src, encoded.count), cmocka_cb,
                                               AMexpect(AM_VAL_TYPE_SYNC_STATE)),
                                   &s2));
-    /*                                                                       */
-    /* assert.notDeepStrictEqual(n1.materialize(), n2.materialize())         */
+    /*
+       assert.notDeepStrictEqual(n1.materialize(), n2.materialize())                                                  */
     assert_false(AMequal(test_state->n1, test_state->n2));
-    /* sync(n1, n2, s1, s2)                                                  */
+    /* sync(n1, n2, s1, s2)                                                                                           */
     sync(test_state->n1, test_state->n2, s1, s2);
-    /* assert.deepStrictEqual(n1.getHeads(), n2.getHeads())                  */
+    /* assert.deepStrictEqual(n1.getHeads(), n2.getHeads())                                                           */
     AMitems heads1 = AMstackItems(stack_ptr, AMgetHeads(test_state->n1), cmocka_cb, AMexpect(AM_VAL_TYPE_CHANGE_HASH));
     AMitems heads2 = AMstackItems(stack_ptr, AMgetHeads(test_state->n2), cmocka_cb, AMexpect(AM_VAL_TYPE_CHANGE_HASH));
     assert_true(AMitemsEqual(&heads1, &heads2));
-    /* assert.deepStrictEqual(n1.materialize(), n2.materialize())            */
+    /* assert.deepStrictEqual(n1.materialize(), n2.materialize())                                                     */
     assert_true(AMequal(test_state->n1, test_state->n2));
 }
 
@@ -884,29 +883,29 @@ static void test_should_work_with_prior_sync_state_2(void** state) {
  * \brief should ensure non-empty state after sync
  */
 static void test_should_ensure_non_empty_state_after_sync(void** state) {
-    /* const n1 = create('01234567'), n2 = create('89abcdef')
-       const s1 = initSyncState(), s2 = initSyncState()                      */
+    /* const n1 = create({ actor: '01234567'}), n2 = create({ actor: '89abcdef'})
+       const s1 = initSyncState(), s2 = initSyncState()                                                               */
     TestState* test_state = *state;
     AMstack** stack_ptr = &test_state->base_state->stack;
-    /*                                                                       */
-    /* for (let i = 0; i < 3; i++) {                                         */
+    /*
+       for (let i = 0; i < 3; i++) {                                                                                  */
     for (size_t i = 0; i != 3; ++i) {
-        /* n1.put("_root", "x", i)                                           */
+        /* n1.put("_root", "x", i)                                                                                    */
         AMstackItem(NULL, AMmapPutUint(test_state->n1, AM_ROOT, AMstr("x"), i), cmocka_cb, AMexpect(AM_VAL_TYPE_VOID));
-        /* n1.commit("", 0)                                                  */
+        /* n1.commit("", 0)                                                                                           */
         AMstackItem(NULL, AMcommit(test_state->n1, AMstr(""), &TIME_0), cmocka_cb, AMexpect(AM_VAL_TYPE_CHANGE_HASH));
-        /* { */
+        /* }                                                                                                          */
     }
-    /*                                                                       */
-    /* sync(n1, n2, s1, s2)                                                  */
+    /*
+       sync(n1, n2, s1, s2)                                                                                           */
     sync(test_state->n1, test_state->n2, test_state->s1, test_state->s2);
-    /*                                                                       */
-    /* assert.deepStrictEqual(s1.sharedHeads, n1.getHeads())                 */
+    /*
+       assert.deepStrictEqual(s1.sharedHeads, n1.getHeads())                                                          */
     AMitems heads1 = AMstackItems(stack_ptr, AMgetHeads(test_state->n1), cmocka_cb, AMexpect(AM_VAL_TYPE_CHANGE_HASH));
     AMitems shared_heads1 =
         AMstackItems(stack_ptr, AMsyncStateSharedHeads(test_state->s1), cmocka_cb, AMexpect(AM_VAL_TYPE_CHANGE_HASH));
     assert_true(AMitemsEqual(&shared_heads1, &heads1));
-    /* assert.deepStrictEqual(s2.sharedHeads, n1.getHeads())                 */
+    /* assert.deepStrictEqual(s2.sharedHeads, n1.getHeads())                                                          */
     AMitems shared_heads2 =
         AMstackItems(stack_ptr, AMsyncStateSharedHeads(test_state->s2), cmocka_cb, AMexpect(AM_VAL_TYPE_CHANGE_HASH));
     assert_true(AMitemsEqual(&shared_heads2, &heads1));
@@ -916,34 +915,33 @@ static void test_should_ensure_non_empty_state_after_sync(void** state) {
  * \brief should re-sync after one node crashed with data loss
  */
 static void test_should_resync_after_one_node_crashed_with_data_loss(void** state) {
-    /* Scenario:     (r)                  (n2)                 (n1)
-     * c0 <-- c1 <-- c2 <-- c3 <-- c4 <-- c5 <-- c6 <-- c7 <-- c8
-     * n2 has changes {c0, c1, c2}, n1's lastSync is c5, and n2's lastSync
-     * is c2
-     * we want to successfully sync (n1) with (r), even though (n1) believes
-     * it's talking to (n2) */
-    /* const n1 = create('01234567'), n2 = create('89abcdef')
+    /* // Scenario:     (r)                  (n2)                 (n1)
+       // c0 <-- c1 <-- c2 <-- c3 <-- c4 <-- c5 <-- c6 <-- c7 <-- c8
+       // n2 has changes {c0, c1, c2}, n1's lastSync is c5, and n2's lastSync is c2.
+       // we want to successfully sync (n1) with (r), even though (n1) believes it's talking to (n2)
+       const n1 = create({ actor: '01234567'}), n2 = create({ actor: '89abcdef'})
        let s1 = initSyncState()
-       const s2 = initSyncState()                                            */
+       const s2 = initSyncState()                                                                                     */
     TestState* test_state = *state;
     AMstack** stack_ptr = &test_state->base_state->stack;
-    /*                                                                       */
-    /* n1 makes three changes, which we sync to n2 */
-    /* for (let i = 0; i < 3; i++) {                                         */
+    /*
+       // n1 makes three changes, which we sync to n2
+       for (let i = 0; i < 3; i++) {                                                                                  */
     for (size_t i = 0; i != 3; ++i) {
-        /* n1.put("_root", "x", i)                                           */
+        /* n1.put("_root", "x", i)                                                                                    */
         AMstackItem(NULL, AMmapPutUint(test_state->n1, AM_ROOT, AMstr("x"), i), cmocka_cb, AMexpect(AM_VAL_TYPE_VOID));
-        /* n1.commit("", 0)                                                  */
+        /* n1.commit("", 0)                                                                                           */
         AMstackItem(NULL, AMcommit(test_state->n1, AMstr(""), &TIME_0), cmocka_cb, AMexpect(AM_VAL_TYPE_CHANGE_HASH));
-        /* { */
+        /* }                                                                                                          */
     }
-    /*                                                                       */
+    /*
+       sync(n1, n2, s1, s2)                                                                                           */
     sync(test_state->n1, test_state->n2, test_state->s1, test_state->s2);
-    /*                                                                       */
-    /* save a copy of n2 as "r" to simulate recovering from a crash */
-    /* let r
+    /*
+       // save a copy of n2 as "r" to simulate recovering from a crash
+       let r
        let rSyncState
-       ;[r, rSyncState] = [n2.clone(), s2.clone()]                           */
+       ;[r, rSyncState] = [n2.clone(), s2.clone()]                                                                    */
     AMdoc* r;
     assert_true(AMitemToDoc(AMstackItem(stack_ptr, AMclone(test_state->n2), cmocka_cb, AMexpect(AM_VAL_TYPE_DOC)), &r));
     AMbyteSpan encoded_s2;
@@ -954,40 +952,39 @@ static void test_should_resync_after_one_node_crashed_with_data_loss(void** stat
     assert_true(AMitemToSyncState(AMstackItem(stack_ptr, AMsyncStateDecode(encoded_s2.src, encoded_s2.count), cmocka_cb,
                                               AMexpect(AM_VAL_TYPE_SYNC_STATE)),
                                   &sync_state_r));
-    /*                                                                       */
-    /* sync another few commits */
-    /* for (let i = 3; i < 6; i++) {                                         */
+    /*
+       // sync another few commits
+       for (let i = 3; i < 6; i++) {                                                                                  */
     for (size_t i = 3; i != 6; ++i) {
-        /* n1.put("_root", "x", i)                                           */
+        /* n1.put("_root", "x", i)                                                                                    */
         AMstackItem(NULL, AMmapPutUint(test_state->n1, AM_ROOT, AMstr("x"), i), cmocka_cb, AMexpect(AM_VAL_TYPE_VOID));
-        /* n1.commit("", 0)                                                  */
+        /* n1.commit("", 0)                                                                                           */
         AMstackItem(NULL, AMcommit(test_state->n1, AMstr(""), &TIME_0), cmocka_cb, AMexpect(AM_VAL_TYPE_CHANGE_HASH));
-        /* { */
+        /* }                                                                                                          */
     }
-    /*                                                                       */
-    /* sync(n1, n2, s1, s2)                                                  */
+    /*
+       sync(n1, n2, s1, s2)                                                                                           */
     sync(test_state->n1, test_state->n2, test_state->s1, test_state->s2);
-    /*                                                                       */
-    /* everyone should be on the same page here */
-    /* assert.deepStrictEqual(n1.getHeads(), n2.getHeads())                  */
+    /*
+       // everyone should be on the same page here
+       assert.deepStrictEqual(n1.getHeads(), n2.getHeads())                                                           */
     AMitems heads1 = AMstackItems(stack_ptr, AMgetHeads(test_state->n1), cmocka_cb, AMexpect(AM_VAL_TYPE_CHANGE_HASH));
     AMitems heads2 = AMstackItems(stack_ptr, AMgetHeads(test_state->n2), cmocka_cb, AMexpect(AM_VAL_TYPE_CHANGE_HASH));
     assert_true(AMitemsEqual(&heads1, &heads2));
-    /* assert.deepStrictEqual(n1.materialize(), n2.materialize())            */
+    /* assert.deepStrictEqual(n1.materialize(), n2.materialize())                                                     */
     assert_true(AMequal(test_state->n1, test_state->n2));
-    /*                                                                       */
-    /* now make a few more changes and then attempt to sync the fully
-     * up-to-date n1 with with the confused r */
-    /* for (let i = 6; i < 9; i++) {                                         */
+    /*
+       // now make a few more changes and then attempt to sync the fully up-to-date n1 with with the confused r
+       for (let i = 6; i < 9; i++) {                                                                                  */
     for (size_t i = 6; i != 9; ++i) {
-        /* n1.put("_root", "x", i)                                           */
+        /* n1.put("_root", "x", i)                                                                                    */
         AMstackItem(NULL, AMmapPutUint(test_state->n1, AM_ROOT, AMstr("x"), i), cmocka_cb, AMexpect(AM_VAL_TYPE_VOID));
-        /* n1.commit("", 0)                                                  */
+        /* n1.commit("", 0)                                                                                           */
         AMstackItem(NULL, AMcommit(test_state->n1, AMstr(""), &TIME_0), cmocka_cb, AMexpect(AM_VAL_TYPE_CHANGE_HASH));
-        /* { */
+        /* }                                                                                                          */
     }
-    /*                                                                       */
-    /* s1 = decodeSyncState(encodeSyncState(s1))                             */
+    /*
+       s1 = decodeSyncState(encodeSyncState(s1))                                                                      */
     AMbyteSpan encoded_s1;
     assert_true(
         AMitemToBytes(AMstackItem(stack_ptr, AMsyncStateEncode(test_state->s1), cmocka_cb, AMexpect(AM_VAL_TYPE_BYTES)),
@@ -996,71 +993,72 @@ static void test_should_resync_after_one_node_crashed_with_data_loss(void** stat
     assert_true(AMitemToSyncState(AMstackItem(stack_ptr, AMsyncStateDecode(encoded_s1.src, encoded_s1.count), cmocka_cb,
                                               AMexpect(AM_VAL_TYPE_SYNC_STATE)),
                                   &s1));
-    /* rSyncState = decodeSyncState(encodeSyncState(rSyncState))             */
+    /* rSyncState = decodeSyncState(encodeSyncState(rSyncState))                                                      */
     AMbyteSpan encoded_r;
     assert_true(AMitemToBytes(
         AMstackItem(stack_ptr, AMsyncStateEncode(sync_state_r), cmocka_cb, AMexpect(AM_VAL_TYPE_BYTES)), &encoded_r));
     assert_true(AMitemToSyncState(AMstackItem(stack_ptr, AMsyncStateDecode(encoded_r.src, encoded_r.count), cmocka_cb,
                                               AMexpect(AM_VAL_TYPE_SYNC_STATE)),
                                   &sync_state_r));
-    /*                                                                       */
-    /* assert.notDeepStrictEqual(n1.getHeads(), r.getHeads())                */
+    /*
+       assert.notDeepStrictEqual(n1.getHeads(), r.getHeads())                                                         */
     heads1 = AMstackItems(stack_ptr, AMgetHeads(test_state->n1), cmocka_cb, AMexpect(AM_VAL_TYPE_CHANGE_HASH));
     AMitems heads_r = AMstackItems(stack_ptr, AMgetHeads(r), cmocka_cb, AMexpect(AM_VAL_TYPE_CHANGE_HASH));
     assert_false(AMitemsEqual(&heads1, &heads_r));
-    /* assert.notDeepStrictEqual(n1.materialize(), r.materialize())          */
+    /* assert.notDeepStrictEqual(n1.materialize(), r.materialize())                                                   */
     assert_false(AMequal(test_state->n1, r));
-    /* assert.deepStrictEqual(n1.materialize(), { x: 8 })                    */
+    /* assert.deepStrictEqual(n1.materialize(), { x: 8 })                                                             */
     uint64_t uint;
     assert_true(AMitemToUint(AMstackItem(stack_ptr, AMmapGet(test_state->n1, AM_ROOT, AMstr("x"), NULL), cmocka_cb,
                                          AMexpect(AM_VAL_TYPE_UINT)),
                              &uint));
     assert_int_equal(uint, 8);
-    /* assert.deepStrictEqual(r.materialize(), { x: 2 })                     */
+    /* assert.deepStrictEqual(r.materialize(), { x: 2 })                                                              */
     assert_true(AMitemToUint(
         AMstackItem(stack_ptr, AMmapGet(r, AM_ROOT, AMstr("x"), NULL), cmocka_cb, AMexpect(AM_VAL_TYPE_UINT)), &uint));
     assert_int_equal(uint, 2);
-    /* sync(n1, r, s1, rSyncState)                                           */
+    /* sync(n1, r, s1, rSyncState)                                                                                    */
     sync(test_state->n1, r, test_state->s1, sync_state_r);
-    /* assert.deepStrictEqual(n1.getHeads(), r.getHeads())                   */
+    /* assert.deepStrictEqual(n1.getHeads(), r.getHeads())                                                            */
     heads1 = AMstackItems(stack_ptr, AMgetHeads(test_state->n1), cmocka_cb, AMexpect(AM_VAL_TYPE_CHANGE_HASH));
     heads_r = AMstackItems(stack_ptr, AMgetHeads(r), cmocka_cb, AMexpect(AM_VAL_TYPE_CHANGE_HASH));
     assert_true(AMitemsEqual(&heads1, &heads_r));
-    /* assert.deepStrictEqual(n1.materialize(), r.materialize())             */
+    /* assert.deepStrictEqual(n1.materialize(), r.materialize())                                                      */
     assert_true(AMequal(test_state->n1, r));
+    /* r = null                                                                                                       */
+    r = NULL;
 }
 
 /**
- * \brief should re-sync after one node experiences data loss without
- * disconnecting
+ * \brief should re-sync after one node experiences data loss without disconnecting
  */
 static void test_should_resync_after_one_node_experiences_data_loss_without_disconnecting(void** state) {
-    /* const n1 = create('01234567'), n2 = create('89abcdef')
-       const s1 = initSyncState(), s2 = initSyncState()                      */
+    /* const n1 = create({ actor: '01234567'}), n2 = create({ actor: '89abcdef'})
+       const s1 = initSyncState(), s2 = initSyncState()                                                               */
     TestState* test_state = *state;
     AMstack** stack_ptr = &test_state->base_state->stack;
-    /*                                                                       */
-    /* n1 makes three changes which we sync to n2 */
-    /* for (let i = 0; i < 3; i++) {                                         */
+    /*
+       // n1 makes three changes, which we sync to n2
+       for (let i = 0; i < 3; i++) {                                                                                  */
     for (size_t i = 0; i != 3; ++i) {
-        /* n1.put("_root", "x", i)                                           */
+        /* n1.put("_root", "x", i)                                                                                    */
         AMstackItem(NULL, AMmapPutUint(test_state->n1, AM_ROOT, AMstr("x"), i), cmocka_cb, AMexpect(AM_VAL_TYPE_VOID));
-        /* n1.commit("", 0)                                                  */
+        /* n1.commit("", 0)                                                                                           */
         AMstackItem(NULL, AMcommit(test_state->n1, AMstr(""), &TIME_0), cmocka_cb, AMexpect(AM_VAL_TYPE_CHANGE_HASH));
-        /* { */
+        /* }                                                                                                          */
     }
-    /*                                                                       */
-    /* sync(n1, n2, s1, s2)                                                  */
+    /*
+       sync(n1, n2, s1, s2)                                                                                           */
     sync(test_state->n1, test_state->n2, test_state->s1, test_state->s2);
-    /*                                                                       */
-    /* assert.deepStrictEqual(n1.getHeads(), n2.getHeads())                  */
+    /*
+       assert.deepStrictEqual(n1.getHeads(), n2.getHeads())                                                           */
     AMitems heads1 = AMstackItems(stack_ptr, AMgetHeads(test_state->n1), cmocka_cb, AMexpect(AM_VAL_TYPE_CHANGE_HASH));
     AMitems heads2 = AMstackItems(stack_ptr, AMgetHeads(test_state->n2), cmocka_cb, AMexpect(AM_VAL_TYPE_CHANGE_HASH));
     assert_true(AMitemsEqual(&heads1, &heads2));
-    /* assert.deepStrictEqual(n1.materialize(), n2.materialize())            */
+    /* assert.deepStrictEqual(n1.materialize(), n2.materialize())                                                     */
     assert_true(AMequal(test_state->n1, test_state->n2));
-    /*                                                                       */
-    /* const n2AfterDataLoss = create('89abcdef')                            */
+    /*
+       const n2AfterDataLoss = create({ actor: '89abcdef'})                                                           */
     AMactorId const* actor_id;
     assert_true(AMitemToActorId(
         AMstackItem(stack_ptr, AMactorIdFromStr(AMstr("89abcdef")), cmocka_cb, AMexpect(AM_VAL_TYPE_ACTOR_ID)),
@@ -1068,20 +1066,19 @@ static void test_should_resync_after_one_node_experiences_data_loss_without_disc
     AMdoc* n2_after_data_loss;
     assert_true(AMitemToDoc(AMstackItem(stack_ptr, AMcreate(actor_id), cmocka_cb, AMexpect(AM_VAL_TYPE_DOC)),
                             &n2_after_data_loss));
-    /*                                                                       */
-    /* "n2" now has no data, but n1 still thinks it does. Note we don't do
-     * decodeSyncState(encodeSyncState(s1)) in order to simulate data loss
-     * without disconnecting */
-    /* sync(n1, n2AfterDataLoss, s1, initSyncState())                        */
+    /*
+       // "n2" now has no data, but n1 still thinks it does. Note we don't do
+       // decodeSyncState(encodeSyncState(s1)) in order to simulate data loss without disconnecting
+       sync(n1, n2AfterDataLoss, s1, initSyncState())                                                                 */
     AMsyncState* s2_after_data_loss;
     assert_true(AMitemToSyncState(
         AMstackItem(stack_ptr, AMsyncStateInit(), cmocka_cb, AMexpect(AM_VAL_TYPE_SYNC_STATE)), &s2_after_data_loss));
     sync(test_state->n1, n2_after_data_loss, test_state->s1, s2_after_data_loss);
-    /* assert.deepStrictEqual(n1.getHeads(), n2.getHeads())                  */
+    /* assert.deepStrictEqual(n1.getHeads(), n2.getHeads())                                                           */
     heads1 = AMstackItems(stack_ptr, AMgetHeads(test_state->n1), cmocka_cb, AMexpect(AM_VAL_TYPE_CHANGE_HASH));
     heads2 = AMstackItems(stack_ptr, AMgetHeads(test_state->n2), cmocka_cb, AMexpect(AM_VAL_TYPE_CHANGE_HASH));
     assert_true(AMitemsEqual(&heads1, &heads2));
-    /* assert.deepStrictEqual(n1.materialize(), n2.materialize())            */
+    /* assert.deepStrictEqual(n1.materialize(), n2.materialize())                                                     */
     assert_true(AMequal(test_state->n1, test_state->n2));
 }
 
@@ -1089,8 +1086,7 @@ static void test_should_resync_after_one_node_experiences_data_loss_without_disc
  * \brief should handle changes concurrent to the last sync heads
  */
 static void test_should_handle_changes_concurrrent_to_the_last_sync_heads(void** state) {
-    /* const n1 = create('01234567'), n2 = create('89abcdef'), n3 =
-     * create('fedcba98' */
+    /* const n1 = create({ actor: '01234567'}), n2 = create({ actor: '89abcdef'}), n3 = create({ actor: 'fedcba98'})  */
     TestState* test_state = *state;
     AMstack** stack_ptr = &test_state->base_state->stack;
     AMactorId const* actor_id;
@@ -1099,8 +1095,7 @@ static void test_should_handle_changes_concurrrent_to_the_last_sync_heads(void**
         &actor_id));
     AMdoc* n3;
     assert_true(AMitemToDoc(AMstackItem(stack_ptr, AMcreate(actor_id), cmocka_cb, AMexpect(AM_VAL_TYPE_DOC)), &n3));
-    /* const s12 = initSyncState(), s21 = initSyncState(), s23 =
-     * initSyncState(), s32 = initSyncState( */
+    /* const s12 = initSyncState(), s21 = initSyncState(), s23 = initSyncState(), s32 = initSyncState()               */
     AMsyncState* s12 = test_state->s1;
     AMsyncState* s21 = test_state->s2;
     AMsyncState* s23;
@@ -1109,53 +1104,56 @@ static void test_should_handle_changes_concurrrent_to_the_last_sync_heads(void**
     AMsyncState* s32;
     assert_true(AMitemToSyncState(
         AMstackItem(stack_ptr, AMsyncStateInit(), cmocka_cb, AMexpect(AM_VAL_TYPE_SYNC_STATE)), &s32));
-    /*                                                                       */
-    /* Change 1 is known to all three nodes */
-    /* //n1 = Automerge.change(n1, {time: 0}, doc => doc.x = 1)              */
-    /* n1.put("_root", "x", 1); n1.commit("", 0)                             */
+    /*
+       // Change 1 is known to all three nodes
+       //n1 = Automerge.change(n1, {time: 0}, doc => doc.x = 1)
+       n1.put("_root", "x", 1); n1.commit("", 0)                                                                      */
     AMstackItem(NULL, AMmapPutUint(test_state->n1, AM_ROOT, AMstr("x"), 1), cmocka_cb, AMexpect(AM_VAL_TYPE_VOID));
     AMstackItem(NULL, AMcommit(test_state->n1, AMstr(""), &TIME_0), cmocka_cb, AMexpect(AM_VAL_TYPE_CHANGE_HASH));
-    /*                                                                       */
-    /* sync(n1, n2, s12, s21)                                                */
+    /*
+       sync(n1, n2, s12, s21)                                                                                         */
     sync(test_state->n1, test_state->n2, s12, s21);
-    /* sync(n2, n3, s23, s32)                                                */
+    /* sync(n2, n3, s23, s32)                                                                                         */
     sync(test_state->n2, n3, s23, s32);
-    /*                                                                       */
-    /* Change 2 is known to n1 and n2 */
-    /* n1.put("_root", "x", 2); n1.commit("", 0)                             */
+    /*
+       // Change 2 is known to n1 and n2
+       n1.put("_root", "x", 2); n1.commit("", 0)                                                                      */
     AMstackItem(NULL, AMmapPutUint(test_state->n1, AM_ROOT, AMstr("x"), 2), cmocka_cb, AMexpect(AM_VAL_TYPE_VOID));
     AMstackItem(NULL, AMcommit(test_state->n1, AMstr(""), &TIME_0), cmocka_cb, AMexpect(AM_VAL_TYPE_CHANGE_HASH));
-    /*                                                                       */
-    /* sync(n1, n2, s12, s21)                                                */
+    /*
+       sync(n1, n2, s12, s21)                                                                                         */
     sync(test_state->n1, test_state->n2, s12, s21);
-    /*                                                                       */
-    /* Each of the three nodes makes one change (changes 3, 4, 5) */
-    /* n1.put("_root", "x", 3); n1.commit("", 0)                             */
+    /*
+       // Each of the three nodes makes one change (changes 3, 4, 5)
+       n1.put("_root", "x", 3); n1.commit("", 0)                                                                      */
     AMstackItem(NULL, AMmapPutUint(test_state->n1, AM_ROOT, AMstr("x"), 3), cmocka_cb, AMexpect(AM_VAL_TYPE_VOID));
     AMstackItem(NULL, AMcommit(test_state->n1, AMstr(""), &TIME_0), cmocka_cb, AMexpect(AM_VAL_TYPE_CHANGE_HASH));
-    /* n2.put("_root", "x", 4); n2.commit("", 0)                             */
+    /* n2.put("_root", "x", 4); n2.commit("", 0)                                                                      */
     AMstackItem(NULL, AMmapPutUint(test_state->n2, AM_ROOT, AMstr("x"), 4), cmocka_cb, AMexpect(AM_VAL_TYPE_VOID));
     AMstackItem(NULL, AMcommit(test_state->n2, AMstr(""), &TIME_0), cmocka_cb, AMexpect(AM_VAL_TYPE_CHANGE_HASH));
-    /* n3.put("_root", "x", 5); n3.commit("", 0)                             */
+    /* n3.put("_root", "x", 5); n3.commit("", 0)                                                                      */
     AMstackItem(NULL, AMmapPutUint(n3, AM_ROOT, AMstr("x"), 5), cmocka_cb, AMexpect(AM_VAL_TYPE_VOID));
     AMstackItem(NULL, AMcommit(n3, AMstr(""), &TIME_0), cmocka_cb, AMexpect(AM_VAL_TYPE_CHANGE_HASH));
-    /*                                                                       */
-    /* Apply n3's latest change to n2. */
-    /* let change = n3.getLastLocalChange()
-       if (change === null) throw new RangeError("no local change")          */
+    /*
+       // Apply n3's latest change to n2. If running in Node, turn the Uint8Array into a Buffer, to
+       // simulate transmission over a network (see https://github.com/automerge/automerge/pull/362)
+       let change = n3.getLastLocalChange()
+       if (change === null) throw new RangeError("no local change")                                                   */
     AMitems changes = AMstackItems(stack_ptr, AMgetLastLocalChange(n3), cmocka_cb, AMexpect(AM_VAL_TYPE_CHANGE));
-    /* n2.applyChanges([change])                                             */
+    /* //ts-ignore
+       if (typeof Buffer === 'function') change = Buffer.from(change)
+       if (change === undefined) { throw new RangeError("last local change failed") }
+       n2.applyChanges([change])                                                                                      */
     AMstackItem(NULL, AMapplyChanges(test_state->n2, &changes), cmocka_cb, AMexpect(AM_VAL_TYPE_VOID));
-    /*                                                                       */
-    /* Now sync n1 and n2. n3's change is concurrent to n1 and n2's last sync
-     * heads */
-    /* sync(n1, n2, s12, s21)                                                */
+    /*
+       // Now sync n1 and n2. n3's change is concurrent to n1 and n2's last sync heads
+       sync(n1, n2, s12, s21)                                                                                         */
     sync(test_state->n1, test_state->n2, s12, s21);
-    /* assert.deepStrictEqual(n1.getHeads(), n2.getHeads())                  */
+    /* assert.deepStrictEqual(n1.getHeads(), n2.getHeads())                                                           */
     AMitems heads1 = AMstackItems(stack_ptr, AMgetHeads(test_state->n1), cmocka_cb, AMexpect(AM_VAL_TYPE_CHANGE_HASH));
     AMitems heads2 = AMstackItems(stack_ptr, AMgetHeads(test_state->n2), cmocka_cb, AMexpect(AM_VAL_TYPE_CHANGE_HASH));
     assert_true(AMitemsEqual(&heads1, &heads2));
-    /* assert.deepStrictEqual(n1.materialize(), n2.materialize())            */
+    /* assert.deepStrictEqual(n1.materialize(), n2.materialize())                                                     */
     assert_true(AMequal(test_state->n1, test_state->n2));
 }
 
@@ -1163,8 +1161,7 @@ static void test_should_handle_changes_concurrrent_to_the_last_sync_heads(void**
  * \brief should handle histories with lots of branching and merging
  */
 static void test_should_handle_histories_with_lots_of_branching_and_merging(void** state) {
-    /* const n1 = create('01234567'), n2 = create('89abcdef'), n3 =
-       create('fedcba98') const s1 = initSyncState(), s2 = initSyncState() */
+    /* const n1 = create({ actor: '01234567'}), n2 = create({ actor: '89abcdef'}), n3 = create({ actor: 'fedcba98'})  */
     TestState* test_state = *state;
     AMstack** stack_ptr = &test_state->base_state->stack;
     AMactorId const* actor_id;
@@ -1173,89 +1170,90 @@ static void test_should_handle_histories_with_lots_of_branching_and_merging(void
         &actor_id));
     AMdoc* n3;
     assert_true(AMitemToDoc(AMstackItem(stack_ptr, AMcreate(actor_id), cmocka_cb, AMexpect(AM_VAL_TYPE_DOC)), &n3));
-    /* n1.put("_root", "x", 0); n1.commit("", 0)                             */
+    /* n1.put("_root", "x", 0); n1.commit("", 0)                                                                      */
     AMstackItem(NULL, AMmapPutUint(test_state->n1, AM_ROOT, AMstr("x"), 0), cmocka_cb, AMexpect(AM_VAL_TYPE_VOID));
     AMstackItem(NULL, AMcommit(test_state->n1, AMstr(""), &TIME_0), cmocka_cb, AMexpect(AM_VAL_TYPE_CHANGE_HASH));
-    /* let change1 = n1.getLastLocalChange()
-       if (change1 === null) throw new RangeError("no local change")         */
+    /* const change1 = n1.getLastLocalChange()
+       if (change1 === null) throw new RangeError("no local change")                                                  */
     AMitems change1 =
         AMstackItems(stack_ptr, AMgetLastLocalChange(test_state->n1), cmocka_cb, AMexpect(AM_VAL_TYPE_CHANGE));
-    /* n2.applyChanges([change1])                                            */
+    /* n2.applyChanges([change1])                                                                                     */
     AMstackItem(NULL, AMapplyChanges(test_state->n2, &change1), cmocka_cb, AMexpect(AM_VAL_TYPE_VOID));
-    /* let change2 = n1.getLastLocalChange()
-       if (change2 === null) throw new RangeError("no local change")         */
+    /* const change2 = n1.getLastLocalChange()
+       if (change2 === null) throw new RangeError("no local change")                                                  */
     AMitems change2 =
         AMstackItems(stack_ptr, AMgetLastLocalChange(test_state->n1), cmocka_cb, AMexpect(AM_VAL_TYPE_CHANGE));
-    /* n3.applyChanges([change2])                                            */
+    /* n3.applyChanges([change2])                                                                                     */
     AMstackItem(NULL, AMapplyChanges(n3, &change2), cmocka_cb, AMexpect(AM_VAL_TYPE_VOID));
-    /* n3.put("_root", "x", 1); n3.commit("", 0)                             */
+    /* n3.put("_root", "x", 1); n3.commit("", 0)                                                                      */
     AMstackItem(NULL, AMmapPutUint(n3, AM_ROOT, AMstr("x"), 1), cmocka_cb, AMexpect(AM_VAL_TYPE_VOID));
     AMstackItem(NULL, AMcommit(n3, AMstr(""), &TIME_0), cmocka_cb, AMexpect(AM_VAL_TYPE_CHANGE_HASH));
-    /*                                                                       */
-    /*        - n1c1 <------ n1c2 <------ n1c3 <-- etc. <-- n1c20 <------ n1c21
-     *       /          \/           \/                              \/
-     *      /           /\           /\                              /\
-     * c0 <---- n2c1 <------ n2c2 <------ n2c3 <-- etc. <-- n2c20 <------ n2c21
-     *      \                                                          /
-     *       ---------------------------------------------- n3c1 <-----
-     */
-    /* for (let i = 1; i < 20; i++) {                                        */
+    /*
+       //        - n1c1 <------ n1c2 <------ n1c3 <-- etc. <-- n1c20 <------ n1c21
+       //       /          \/           \/                              \/
+       //      /           /\           /\                              /\
+       // c0 <---- n2c1 <------ n2c2 <------ n2c3 <-- etc. <-- n2c20 <------ n2c21
+       //      \                                                          /
+       //       ---------------------------------------------- n3c1 <-----
+       for (let i = 1; i < 20; i++) {                                                                                 */
     for (size_t i = 1; i != 20; ++i) {
-        /* n1.put("_root", "n1", i); n1.commit("", 0)                        */
+        /* n1.put("_root", "n1", i); n1.commit("", 0)                                                                 */
         AMstackItem(NULL, AMmapPutUint(test_state->n1, AM_ROOT, AMstr("n1"), i), cmocka_cb, AMexpect(AM_VAL_TYPE_VOID));
         AMstackItem(NULL, AMcommit(test_state->n1, AMstr(""), &TIME_0), cmocka_cb, AMexpect(AM_VAL_TYPE_CHANGE_HASH));
-        /* n2.put("_root", "n2", i); n2.commit("", 0)                        */
+        /* n2.put("_root", "n2", i); n2.commit("", 0)                                                                 */
         AMstackItem(NULL, AMmapPutUint(test_state->n2, AM_ROOT, AMstr("n2"), i), cmocka_cb, AMexpect(AM_VAL_TYPE_VOID));
         AMstackItem(NULL, AMcommit(test_state->n2, AMstr(""), &TIME_0), cmocka_cb, AMexpect(AM_VAL_TYPE_CHANGE_HASH));
         /* const change1 = n1.getLastLocalChange()
-           if (change1 === null) throw new RangeError("no local change")     */
+           if (change1 === null) throw new RangeError("no local change")                                              */
         AMitems change1 =
             AMstackItems(stack_ptr, AMgetLastLocalChange(test_state->n1), cmocka_cb, AMexpect(AM_VAL_TYPE_CHANGE));
         /* const change2 = n2.getLastLocalChange()
-           if (change2 === null) throw new RangeError("no local change")     */
+           if (change2 === null) throw new RangeError("no local change")                                              */
         AMitems change2 =
             AMstackItems(stack_ptr, AMgetLastLocalChange(test_state->n2), cmocka_cb, AMexpect(AM_VAL_TYPE_CHANGE));
-        /* n1.applyChanges([change2])                                        */
+        /* n1.applyChanges([change2])                                                                                 */
         AMstackItem(NULL, AMapplyChanges(test_state->n1, &change2), cmocka_cb, AMexpect(AM_VAL_TYPE_VOID));
-        /* n2.applyChanges([change1])                                        */
+        /* n2.applyChanges([change1])                                                                                 */
         AMstackItem(NULL, AMapplyChanges(test_state->n2, &change1), cmocka_cb, AMexpect(AM_VAL_TYPE_VOID));
-        /* { */
+        /* }                                                                                                          */
     }
-    /*                                                                       */
-    /* sync(n1, n2, s1, s2)                                                  */
+    /*
+       const s1 = initSyncState(), s2 = initSyncState()
+       sync(n1, n2, s1, s2)                                                                                           */
     sync(test_state->n1, test_state->n2, test_state->s1, test_state->s2);
-    /*                                                                       */
-    /* Having n3's last change concurrent to the last sync heads forces us into
-     * the slower code path */
-    /* const change3 = n2.getLastLocalChange()
-       if (change3 === null) throw new RangeError("no local change")         */
+    /*
+       // Having n3's last change concurrent to the last sync heads forces us into the slower code path
+       const change3 = n2.getLastLocalChange()
+       if (change3 === null) throw new RangeError("no local change")                                                  */
     AMitems change3 = AMstackItems(stack_ptr, AMgetLastLocalChange(n3), cmocka_cb, AMexpect(AM_VAL_TYPE_CHANGE));
-    /* n2.applyChanges([change3])                                            */
+    /* n2.applyChanges([change3])                                                                                     */
     AMstackItem(NULL, AMapplyChanges(test_state->n2, &change3), cmocka_cb, AMexpect(AM_VAL_TYPE_VOID));
-    /* n1.put("_root", "n1", "final"); n1.commit("", 0)                      */
+    /* n1.put("_root", "n1", "final"); n1.commit("", 0)                                                               */
     AMstackItem(NULL, AMmapPutStr(test_state->n1, AM_ROOT, AMstr("n1"), AMstr("final")), cmocka_cb,
                 AMexpect(AM_VAL_TYPE_VOID));
     AMstackItem(NULL, AMcommit(test_state->n1, AMstr(""), &TIME_0), cmocka_cb, AMexpect(AM_VAL_TYPE_CHANGE_HASH));
-    /* n2.put("_root", "n2", "final"); n2.commit("", 0)                      */
+    /* n2.put("_root", "n2", "final"); n2.commit("", 0)                                                               */
     AMstackItem(NULL, AMmapPutStr(test_state->n2, AM_ROOT, AMstr("n2"), AMstr("final")), cmocka_cb,
                 AMexpect(AM_VAL_TYPE_VOID));
     AMstackItem(NULL, AMcommit(test_state->n2, AMstr(""), &TIME_0), cmocka_cb, AMexpect(AM_VAL_TYPE_CHANGE_HASH));
-    /*                                                                       */
-    /* sync(n1, n2, s1, s2)                                                  */
+    /*
+       sync(n1, n2, s1, s2)                                                                                           */
     sync(test_state->n1, test_state->n2, test_state->s1, test_state->s2);
-    /* assert.deepStrictEqual(n1.getHeads(), n2.getHeads())                  */
+    /* assert.deepStrictEqual(n1.getHeads(), n2.getHeads())                                                           */
     AMitems heads1 = AMstackItems(stack_ptr, AMgetHeads(test_state->n1), cmocka_cb, AMexpect(AM_VAL_TYPE_CHANGE_HASH));
     AMitems heads2 = AMstackItems(stack_ptr, AMgetHeads(test_state->n2), cmocka_cb, AMexpect(AM_VAL_TYPE_CHANGE_HASH));
     assert_true(AMitemsEqual(&heads1, &heads2));
-    /* assert.deepStrictEqual(n1.materialize(), n2.materialize())            */
+    /* assert.deepStrictEqual(n1.materialize(), n2.materialize())                                                     */
     assert_true(AMequal(test_state->n1, test_state->n2));
 }
 
 int run_ported_wasm_sync_tests(void) {
     const struct CMUnitTest tests[] = {
         cmocka_unit_test_setup_teardown(test_should_send_a_sync_message_implying_no_local_data, setup, teardown),
-        cmocka_unit_test_setup_teardown(test_should_not_reply_if_we_have_no_data_as_well, setup, teardown),
-        cmocka_unit_test_setup_teardown(test_repos_with_equal_heads_do_not_need_a_reply_message, setup, teardown),
+        cmocka_unit_test_setup_teardown(test_should_not_reply_if_we_have_no_data_as_well_after_the_first_round, setup,
+                                        teardown),
+        cmocka_unit_test_setup_teardown(test_repos_with_equal_heads_do_not_need_a_reply_message_after_the_first_round,
+                                        setup, teardown),
         cmocka_unit_test_setup_teardown(test_n1_should_offer_all_changes_to_n2_when_starting_from_nothing, setup,
                                         teardown),
         cmocka_unit_test_setup_teardown(test_should_sync_peers_where_one_has_commits_the_other_does_not, setup,

--- a/rust/automerge/src/cursor.rs
+++ b/rust/automerge/src/cursor.rs
@@ -46,6 +46,7 @@ impl Cursor {
         let actor = s[(n + 1)..].try_into().ok()?;
         Some(Cursor { ctr, actor })
     }
+
     pub fn to_bytes(&self) -> Vec<u8> {
         // The serialized format is
         //


### PR DESCRIPTION
@alexjg, I've finally exposed the Cursor API to C programs.

In order to make the full unit test suite pass again, I also included the changes from PR #885 that I authored.

@heckj can either rebase PR #885 onto main after this PR is approved or he can open a new PR for his changes. 