### PR TITLE
Has our changes

### DIFF
--- a/javascript/HACKING.md
+++ b/javascript/HACKING.md
@@ -7,7 +7,7 @@ do two things:
 1. We compile the Rust code to WebAssembly with a thin JavaScript binding
    around it. This is implemented in the rust codebase in `../rust/automerge-wasm`
 2. We implement a higher level, more idiomatic JavaScript API which exposes the
-   automerge document as a POJO using JavaScript proxies. This is the code 
+   automerge document as a POJO using JavaScript proxies. This is the code
    implemented in this directory.
 
 Due to the complexity of WebAssembly loading we have to do some fiddly things
@@ -26,7 +26,7 @@ yarn run build
 yarn run test
 ```
 
-Any time you change the rust code in `../rust/*` you'll need to re-run the 
+Any time you change the rust code in `../rust/*` you'll need to re-run the
 `yarn run build` command.
 
 Read on to understand what the `build` step is doing.
@@ -107,20 +107,20 @@ different implementations of the same module for different environments.
 
 Our objective is to provide conditional exports which do the following:
 
-* If you are using a bundler which supports WebAssembly (e.g. Webpack) then
+- If you are using a bundler which supports WebAssembly (e.g. Webpack) then
   import the webassembly file as an ES module and allow the bundler to handle
   initializing it
-* If you are in node or a cloudflare worker, directly import the WebAssembly
+- If you are in node or a cloudflare worker, directly import the WebAssembly
   file as these platforms support WebAssembly as modules
-* Otherwise, provide an alternative import which allows you to load the
+- Otherwise, provide an alternative import which allows you to load the
   WebAssembly yourself.
 
 We need to do this in a manner which allows libraries to depend on automerge
-without forcing their users into any particular initialization strategy. We 
+without forcing their users into any particular initialization strategy. We
 can do this with conditional exports on the "." path.
 
 To allow the client to choose their own initialization strategy we also provide
-a `/slim` subpath export. This export only includes the javascript code and 
+a `/slim` subpath export. This export only includes the javascript code and
 allows the user to figure out how to load the WebAssembly themselves. This is
 also the path which libraries should depend on.
 
@@ -129,24 +129,24 @@ and it's types (this is mainly for convenience when importing types in
 typescript). This subpath export also needs to be conditional.
 
 In order to allow choosing initialization on the `/next` subpath we
-also expose a `/slim/next` subpath. Altogether then we have the following 
+also expose a `/slim/next` subpath. Altogether then we have the following
 subpaths:
 
 Finally, we also want to make it easy for the user to obtain the WebAssembly
 file from this package, so we expose two subpath exports, one which provides
-the WebAssembly file directly and another which exposes a base64 encoded 
+the WebAssembly file directly and another which exposes a base64 encoded
 version of it.
 
 Altogether then we have the following exports:
 
-* `/`: The full package with WebAssembly initialization
-* `/slim`: Only the JavaScript code, no WebAssembly initialization
-* `/next`: Only the "next" API and it's types, performs WebAssembly
+- `/`: The full package with WebAssembly initialization
+- `/slim`: Only the JavaScript code, no WebAssembly initialization
+- `/next`: Only the "next" API and it's types, performs WebAssembly
   initialization
-* `/slim/next`: Only the "next" API, no WebAssembly initialization
-* `/automerge.wasm`: The WebAssembly file
-* `/automerge.wasm.base64.js`: The WebAssembly file as a module with a single
-                               export which is a base64 encoded string
+- `/slim/next`: Only the "next" API, no WebAssembly initialization
+- `/automerge.wasm`: The WebAssembly file
+- `/automerge.wasm.base64.js`: The WebAssembly file as a module with a single
+  export which is a base64 encoded string
 
 These subpath exports are then mapped - using conditional exports - to platform
 specific files in the `src/entrypoints` directory. For example, here are the

--- a/javascript/scripts/build.mjs
+++ b/javascript/scripts/build.mjs
@@ -129,7 +129,6 @@ function copyAndFixupWasm(wasmBuildTarball) {
   const outputPath = path.join(jsProjectDir, "src", "wasm_bindgen_output")
   fs.rmSync(outputPath, { recursive: true, force: true })
 
-
   const automergeWasmPath = path.join(
     __dirname,
     "..",
@@ -169,13 +168,12 @@ function copyAndFixupWasm(wasmBuildTarball) {
     jsProjectDir,
     "src",
     "wasm_bindgen_output",
-    "workerd"
+    "workerd",
   )
-  fs.cpSync(
-    webOutputPath,
-    workerdOutputPath,
-    { recursive: true, dereference: true }
-  )
+  fs.cpSync(webOutputPath, workerdOutputPath, {
+    recursive: true,
+    dereference: true,
+  })
 
   console.log(
     "encoding the 'wasm' blob in the 'web' target into a base64 string",
@@ -252,7 +250,10 @@ function compileTypescript() {
     "copying wasm_bindgen_output directory to dist/mjs/wasm_bindgen_output",
   )
   fs.mkdirSync(mjsWasmDir, { recursive: true })
-  fs.cpSync(wasmBindgenSrcDir, mjsWasmDir, { recursive: true, dereference: true })
+  fs.cpSync(wasmBindgenSrcDir, mjsWasmDir, {
+    recursive: true,
+    dereference: true,
+  })
 
   fs.copyFileSync(
     path.join(jsProjectDir, "src", "wasm_types.d.ts"),
@@ -287,9 +288,7 @@ async function transpileCjs() {
   const iifeDir = path.join(distDir, "iife")
   await build({
     absWorkingDir: distDir,
-    entryPoints: [
-      `${inDir}/entrypoints/iife.js`,
-    ],
+    entryPoints: [`${inDir}/entrypoints/iife.js`],
     outdir: iifeDir,
     bundle: true,
     format: "iife",

--- a/javascript/src/low_level.ts
+++ b/javascript/src/low_level.ts
@@ -68,12 +68,12 @@ export const ApiHandler: API = {
 /* eslint-enable */
 
 /**
- * Initialize the wasm module 
+ * Initialize the wasm module
  *
  * @param wasmBlob - The wasm module as a Uint8Array, Request, Promise<Uint8Array> or string. If this argument is a string then it is assumed to be a URL and the library will attempt to fetch the wasm module from that URL.
  *
  * @remarks
- * If you are using the `/slim` subpath export then this function must be 
+ * If you are using the `/slim` subpath export then this function must be
  * called before any other functions in the library. If you are using any of
  * the other subpath exports then it will have already been called for you.
  */

--- a/javascript/src/next_slim.ts
+++ b/javascript/src/next_slim.ts
@@ -117,6 +117,7 @@ export {
   decodeSyncState,
   generateSyncMessage,
   receiveSyncMessage,
+  hasOurChanges,
   initSyncState,
   encodeChange,
   decodeChange,

--- a/javascript/src/stable.ts
+++ b/javascript/src/stable.ts
@@ -1096,6 +1096,22 @@ export function receiveSyncMessage<T>(
 }
 
 /**
+ * Check whether the replica represented by `remoteState` has all our changes
+ *
+ * @param doc - The doc to check whether the remote has changes for
+ * @param remoteState - The {@link SyncState} representing the peer we are talking to
+ *
+ * @group sync
+ *
+ * @returns true if the remote has all of our changes
+ */
+export function hasOurChanges<T>(doc: Doc<T>, remoteState: SyncState): boolean {
+  const state = _state(doc)
+  const syncState = ApiHandler.importSyncState(remoteState)
+  return state.handle.hasOurChanges(syncState)
+}
+
+/**
  * Create a new, blank {@link SyncState}
  *
  * When communicating with a peer for the first time use this to generate a new

--- a/javascript/test/sync_test.ts
+++ b/javascript/test/sync_test.ts
@@ -1091,4 +1091,46 @@ describe("Data sync protocol", () => {
       assert.deepStrictEqual(s1.sharedHeads, [c2, c8].sort())
     })
   })
+
+  it("should report whether the other end has our changes", () => {
+    let left = Automerge.from({ foo: "bar" })
+    let right = Automerge.from({ baz: "qux" })
+
+    let leftToRight = Automerge.initSyncState()
+    let rightToLeft = Automerge.initSyncState()
+
+    while (
+      !Automerge.hasOurChanges(left, leftToRight) &&
+      !Automerge.hasOurChanges(right, rightToLeft)
+    ) {
+      let quiet = true
+      let msg: Automerge.SyncMessage | null
+      ;[leftToRight, msg] = Automerge.generateSyncMessage(left, leftToRight)
+      if (msg) {
+        quiet = false
+        ;[right, rightToLeft] = Automerge.receiveSyncMessage(
+          right,
+          rightToLeft,
+          msg,
+        )
+      }
+      ;[rightToLeft, msg] = Automerge.generateSyncMessage(right, rightToLeft)
+      if (msg) {
+        quiet = false
+        ;[left, leftToRight] = Automerge.receiveSyncMessage(
+          left,
+          leftToRight,
+          msg,
+        )
+      }
+      if (quiet) {
+        throw new Error(
+          "no sync message generated but the sync states say we are not done",
+        )
+      }
+    }
+
+    assert.ok(Automerge.hasOurChanges(left, leftToRight))
+    assert.ok(Automerge.hasOurChanges(right, rightToLeft))
+  })
 })

--- a/rust/automerge-wasm/index.d.ts
+++ b/rust/automerge-wasm/index.d.ts
@@ -276,6 +276,7 @@ export class Automerge {
   // sync over network
   receiveSyncMessage(state: SyncState, message: SyncMessage): void;
   generateSyncMessage(state: SyncState): SyncMessage | null;
+  hasOurChanges(state: SyncState): boolean;
 
   // low level change functions
   applyChanges(changes: Change[]): void;

--- a/rust/automerge-wasm/src/lib.rs
+++ b/rust/automerge-wasm/src/lib.rs
@@ -1151,6 +1151,11 @@ impl Automerge {
             Ok(self.doc.text(obj)?)
         }
     }
+
+    #[wasm_bindgen(js_name = hasOurChanges)]
+    pub fn has_our_changes(&mut self, state: &mut SyncState) -> JsValue {
+        self.doc.has_our_changes(&state.0).into()
+    }
 }
 
 #[wasm_bindgen(js_name = create)]

--- a/rust/automerge/src/autocommit.rs
+++ b/rust/automerge/src/autocommit.rs
@@ -619,6 +619,12 @@ impl AutoCommit {
             diff::log_diff(&self.doc, &before_clock, &after_clock, &mut self.patch_log);
         }
     }
+
+    /// Whether the peer represented by `other` has all the changes we have
+    pub fn has_our_changes(&mut self, state: &crate::sync::State) -> bool {
+        self.ensure_transaction_closed();
+        self.doc.has_our_changes(state)
+    }
 }
 
 impl ReadDoc for AutoCommit {

--- a/rust/automerge/src/automerge.rs
+++ b/rust/automerge/src/automerge.rs
@@ -1709,6 +1709,11 @@ impl Automerge {
         }
         paths
     }
+
+    /// Whether the peer represented by `other` has all the changes we have
+    pub fn has_our_changes(&self, other: &crate::sync::State) -> bool {
+        other.shared_heads == self.get_heads()
+    }
 }
 
 impl ReadDoc for Automerge {

--- a/rust/automerge/tests/test.rs
+++ b/rust/automerge/tests/test.rs
@@ -3,8 +3,8 @@ use automerge::op_tree::B;
 use automerge::patches::TextRepresentation;
 use automerge::transaction::{CommitOptions, Transactable};
 use automerge::{
-    ActorId, AutoCommit, Automerge, AutomergeError, Change, ExpandedChange, ObjId, ObjType, Patch,
-    PatchAction, PatchLog, Prop, ReadDoc, ScalarValue, SequenceTree, Value, ROOT,
+    sync::SyncDoc, ActorId, AutoCommit, Automerge, AutomergeError, Change, ExpandedChange, ObjId,
+    ObjType, Patch, PatchAction, PatchLog, Prop, ReadDoc, ScalarValue, SequenceTree, Value, ROOT,
 };
 use std::fs;
 
@@ -2227,4 +2227,40 @@ fn allows_empty_keys_in_mappings() {
             "" => { 1 },
         }
     );
+}
+
+#[test]
+fn has_our_changes() {
+    let mut left = AutoCommit::new();
+    left.put(&automerge::ROOT, "a", 1).unwrap();
+
+    let mut right = AutoCommit::new();
+    right.put(&automerge::ROOT, "b", 2).unwrap();
+
+    let mut left_to_right = automerge::sync::State::new();
+    let mut right_to_left = automerge::sync::State::new();
+
+    assert!(!left.has_our_changes(&left_to_right));
+    assert!(!right.has_our_changes(&right_to_left));
+
+    while !left.has_our_changes(&left_to_right) || !right.has_our_changes(&right_to_left) {
+        let mut quiet = true;
+        if let Some(msg) = left.sync().generate_sync_message(&mut left_to_right) {
+            quiet = false;
+            right
+                .sync()
+                .receive_sync_message(&mut right_to_left, msg)
+                .unwrap();
+        }
+        if let Some(msg) = right.sync().generate_sync_message(&mut right_to_left) {
+            quiet = false;
+            left.sync()
+                .receive_sync_message(&mut left_to_right, msg)
+                .unwrap();
+        }
+        if quiet {
+            panic!("no messages sent but the sync state says we're not in sync");
+        }
+    }
+    assert!(right.has_our_changes(&right_to_left));
 }


### PR DESCRIPTION
Problem: it's often useful for the application to be able to tell
whether a remote peer has all the changes we have, but currently that
requires understanding the internal state of the automerge::sync::State
struct.

Solution: Add a method to Automerge and AutoCommit that returns true if
the replica represented by the sync state has all the changes we have.