### PR TITLE
Add Automerge.stats

### DIFF
--- a/javascript/src/next_slim.ts
+++ b/javascript/src/next_slim.ts
@@ -139,6 +139,7 @@ export {
   hasHeads,
   topoHistoryTraversal,
   inspectChange,
+  stats,
 } from "./stable.js"
 
 export type InitOptions<T> = {

--- a/javascript/src/stable.ts
+++ b/javascript/src/stable.ts
@@ -1285,3 +1285,14 @@ export function inspectChange(
   const state = _state(doc)
   return state.handle.getDecodedChangeByHash(changeHash)
 }
+
+/**
+ * Return some internal statistics about the document
+ */
+export function stats(doc: Doc<unknown>): {
+  numChanges: number
+  numOps: number
+} {
+  const state = _state(doc)
+  return state.handle.stats()
+}

--- a/javascript/test/basic_test.ts
+++ b/javascript/test/basic_test.ts
@@ -879,4 +879,17 @@ describe("Automerge", () => {
       })
     })
   })
+
+  describe("the stats function", () => {
+    it("should return stats about the document", () => {
+      let doc = Automerge.init<{ a: number }>()
+      doc = Automerge.change(doc, d => (d.a = 1))
+      doc = Automerge.change(doc, d => (d.a = 2))
+      const stats = Automerge.stats(doc)
+      assert.deepStrictEqual(stats, {
+        numChanges: 2,
+        numOps: 2,
+      })
+    })
+  })
 })

--- a/rust/automerge-wasm/index.d.ts
+++ b/rust/automerge-wasm/index.d.ts
@@ -301,6 +301,8 @@ export class Automerge {
   applyAndReturnPatches<Doc>(obj: Doc, meta?: unknown): {value: Doc, patches: Patch[]};
 
   topoHistoryTraversal(): Hash[];
+
+  stats(): {numChanges: number, numOps: number};
 }
 
 export interface JsSyncState {

--- a/rust/automerge-wasm/src/lib.rs
+++ b/rust/automerge-wasm/src/lib.rs
@@ -1179,6 +1179,20 @@ impl Automerge {
             .collect::<Vec<_>>();
         AR::from(hashes).into()
     }
+
+    #[wasm_bindgen(js_name = stats)]
+    pub fn stats(&mut self) -> JsValue {
+        let stats = self.doc.stats();
+        let result = Object::new();
+        js_set(
+            &result,
+            "numChanges",
+            JsValue::from(stats.num_changes as usize),
+        )
+        .unwrap();
+        js_set(&result, "numOps", JsValue::from(stats.num_ops as usize)).unwrap();
+        result.into()
+    }
 }
 
 #[wasm_bindgen(js_name = create)]

--- a/rust/automerge-wasm/test/test.mts
+++ b/rust/automerge-wasm/test/test.mts
@@ -2387,4 +2387,16 @@ describe('Automerge', () => {
       ])
     })
   })
+
+  describe("the stats function", () => {
+    it("should return the number of changes and the number of ops", () => {
+      const doc = create()
+      doc.put("/", "foo", "bar")
+      doc.commit()
+      doc.put("/", "baz", "qux")
+      doc.commit()
+      const stats = doc.stats()
+      assert.deepStrictEqual(stats, { numChanges: 2, numOps: 2 })
+    })
+  })
 })

--- a/rust/automerge/src/autocommit.rs
+++ b/rust/automerge/src/autocommit.rs
@@ -830,6 +830,10 @@ impl ReadDoc for AutoCommit {
     fn get_change_by_hash(&self, hash: &ChangeHash) -> Option<&Change> {
         self.doc.get_change_by_hash(hash)
     }
+
+    fn stats(&self) -> crate::read::Stats {
+        self.doc.stats()
+    }
 }
 
 impl Transactable for AutoCommit {

--- a/rust/automerge/src/automerge.rs
+++ b/rust/automerge/src/automerge.rs
@@ -1949,6 +1949,13 @@ impl ReadDoc for Automerge {
             .get(hash)
             .and_then(|index| self.history.get(*index))
     }
+
+    fn stats(&self) -> crate::read::Stats {
+        crate::read::Stats {
+            num_changes: self.history.len() as u64,
+            num_ops: self.ops.len() as u64,
+        }
+    }
 }
 
 impl ReadDocInternal for Automerge {

--- a/rust/automerge/src/automerge/diff.rs
+++ b/rust/automerge/src/automerge/diff.rs
@@ -521,6 +521,10 @@ impl<'a, 'b> ReadDoc for ReadDocAt<'a, 'b> {
     ) -> Result<crate::hydrate::Value, crate::AutomergeError> {
         self.doc.hydrate_obj(obj.as_ref(), heads)
     }
+
+    fn stats(&self) -> crate::read::Stats {
+        self.doc.stats()
+    }
 }
 
 impl<'a, 'b> ReadDocInternal for ReadDocAt<'a, 'b> {

--- a/rust/automerge/src/read.rs
+++ b/rust/automerge/src/read.rs
@@ -259,9 +259,23 @@ pub trait ReadDoc {
 
     /// Get a change by its hash.
     fn get_change_by_hash(&self, hash: &ChangeHash) -> Option<&Change>;
+
+    /// Return some statistics about the document
+    fn stats(&self) -> Stats;
 }
 
 pub(crate) trait ReadDocInternal: ReadDoc {
     /// Produce a map from object ID to path for all visible objects in this doc
     fn live_obj_paths(&self) -> HashMap<ExId, Vec<(ExId, Prop)>>;
+}
+
+/// Statistics about the document
+///
+/// This is returned by [`ReadDoc::stats()`]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Stats {
+    /// The number of operations in the document
+    pub num_ops: u64,
+    /// The number of changes in the change graph for the document
+    pub num_changes: u64,
 }

--- a/rust/automerge/src/transaction/manual_transaction.rs
+++ b/rust/automerge/src/transaction/manual_transaction.rs
@@ -326,6 +326,10 @@ impl<'a> ReadDoc for Transaction<'a> {
     fn get_change_by_hash(&self, hash: &ChangeHash) -> Option<&crate::Change> {
         self.doc.get_change_by_hash(hash)
     }
+
+    fn stats(&self) -> crate::read::Stats {
+        self.doc.stats()
+    }
 }
 
 impl<'a> Transactable for Transaction<'a> {

--- a/rust/automerge/tests/test.rs
+++ b/rust/automerge/tests/test.rs
@@ -2264,3 +2264,15 @@ fn has_our_changes() {
     }
     assert!(right.has_our_changes(&right_to_left));
 }
+
+#[test]
+fn stats_smoke_test() {
+    let mut doc = AutoCommit::new();
+    doc.put(&automerge::ROOT, "a", 1).unwrap();
+    doc.commit();
+    doc.put(&automerge::ROOT, "b", 2).unwrap();
+    doc.commit();
+    let stats = doc.stats();
+    assert_eq!(stats.num_changes, 2);
+    assert_eq!(stats.num_ops, 2);
+}

--- a/rust/deny.toml
+++ b/rust/deny.toml
@@ -68,6 +68,7 @@ unlicensed = "deny"
 # [possible values: any SPDX 3.11 short identifier (+ optional exception)].
 allow = [
     "MIT",
+    "BSD-2-Clause",
     "Apache-2.0",
     "Apache-2.0 WITH LLVM-exception",
 ]


### PR DESCRIPTION
Problem: sometimes it is hard to know why performance is suffering for a given document. Often, the issue is that the document history is large, but it's not easy to examine this in a general manner.

Solution: Add a `Automerge.stats` function that returns a JSON object indicating the number of changes and the number of ops in the document.