### PR TITLE
don't include a fallback path for the wasm

### DIFF
--- a/rust/automerge-wasm/package.json
+++ b/rust/automerge-wasm/package.json
@@ -39,7 +39,7 @@
     "buildall": "cross-env TARGET=nodejs yarn target && cross-env TARGET=bundler yarn target && cross-env TARGET=deno yarn target && TARGET=web yarn target && node -e \"require('fs').cpSync('./src/export-web-wasm.js', './web/index.js')\" && node ./fixup-node-cjs.mjs",
     "target": "rimraf ./$TARGET && yarn compile && yarn bindgen && yarn opt",
     "compile": "cargo build --target wasm32-unknown-unknown --profile $PROFILE",
-    "bindgen": "wasm-bindgen --no-typescript --weak-refs --target $TARGET --out-dir $TARGET ../target/wasm32-unknown-unknown/$TARGET_DIR/automerge_wasm.wasm",
+    "bindgen": "wasm-bindgen --omit-default-module-path --no-typescript --weak-refs --target $TARGET --out-dir $TARGET ../target/wasm32-unknown-unknown/$TARGET_DIR/automerge_wasm.wasm",
     "opt": "echo wasm-opt -O4 $TARGET/automerge_wasm_bg.wasm -o $TARGET/automerge_wasm_bg.wasm",
     "test": "mocha --loader=ts-node/esm test/**/*.mts"
   },


### PR DESCRIPTION

1. we don't care for a fallback path
2. this file is imported in the bundler entrypoint that shouldn't see the fallback path
3. vite and rspack (and maybe other?) bundlers see the `new URL(".wasm", import.meta.url)` output when the fallback path is there and include an extra .wasm in the assets. it's not actually any harm but it's ugly and makes people feel like they did something wrong

i've confirmed on my local machine that this stops the `new URL(".wasm", import.meta.url)` from being output, but i haven't been able to run the tests. it took me an hour just to get it to build and i dont have the emotional fortitude to tackle the tests, let's see what CI says