### PR TITLE
Cargo deny updates

### DIFF
--- a/rust/automerge-c/Cargo.toml
+++ b/rust/automerge-c/Cargo.toml
@@ -19,4 +19,4 @@ libc = "^0.2"
 smol_str = "0.2"
 
 [build-dependencies]
-cbindgen = "^0.24"
+cbindgen = "^0.27"

--- a/rust/automerge-wasm/Cargo.toml
+++ b/rust/automerge-wasm/Cargo.toml
@@ -32,7 +32,7 @@ uuid = { version = "^1.2.1", features=["v4", "js", "serde"] }
 serde-wasm-bindgen = "0.4.3"
 serde_bytes = "0.11.5"
 hex = "^0.4.3"
-itertools = "0.12.0"
+itertools = "0.13.0"
 thiserror = "^1.0.16"
 fxhash = "^0.2.1"
 

--- a/rust/automerge/Cargo.toml
+++ b/rust/automerge/Cargo.toml
@@ -18,7 +18,7 @@ hex = "^0.4.3"
 leb128 = "^0.2.5"
 sha2 = "^0.10.0"
 thiserror = "^1.0.16"
-itertools = "0.12.0"
+itertools = "0.13.0"
 flate2 = "^1.0.22"
 uuid = { version = "^1.2.1", features = ["v4", "serde"] }
 smol_str = { version = "0.2", features = ["serde"] }
@@ -47,7 +47,7 @@ serde_json = { version = "^1.0.73", features=["float_roundtrip"], default-featur
 maplit = { version = "^1.0" }
 criterion = "0.5"
 test-log = { version = "0.2.10", features = ["trace"], default-features = false}
-tracing-subscriber = { version = "0.3.9", features = ["fmt", "env-filter"] }
+tracing-subscriber = { version = "^0.3", features = ["fmt", "env-filter"] }
 automerge-test = { path = "../automerge-test" }
 prettytable = "0.10.0"
 

--- a/rust/automerge/Cargo.toml
+++ b/rust/automerge/Cargo.toml
@@ -45,7 +45,7 @@ pretty_assertions = "1.0.0"
 proptest = { version = "^1.0.0", default-features = false, features = ["std"] }
 serde_json = { version = "^1.0.73", features=["float_roundtrip"], default-features = true }
 maplit = { version = "^1.0" }
-criterion = "0.4.0"
+criterion = "0.5"
 test-log = { version = "0.2.10", features = ["trace"], default-features = false}
 tracing-subscriber = { version = "0.3.9", features = ["fmt", "env-filter"] }
 automerge-test = { path = "../automerge-test" }

--- a/rust/automerge/src/automerge.rs
+++ b/rust/automerge/src/automerge.rs
@@ -1330,7 +1330,7 @@ impl Automerge {
         clock: Option<Clock>,
     ) -> Result<Vec<Mark<'_>>, AutomergeError> {
         let obj = self.exid_to_obj(obj.as_ref())?;
-        let ops_by_key = self.ops().iter_ops(&obj.id).group_by(|o| o.elemid_or_key());
+        let ops_by_key = self.ops().iter_ops(&obj.id).chunk_by(|o| o.elemid_or_key());
         let mut index = 0;
         let mut marks = MarkStateMachine::default();
         let mut acc = MarkAccumulator::default();

--- a/rust/automerge/src/automerge/current_state.rs
+++ b/rust/automerge/src/automerge/current_state.rs
@@ -70,7 +70,7 @@ fn log_list_patches<'a, I: Iterator<Item = Op<'a>>>(
     obj: &ObjMeta,
     ops: I,
 ) {
-    let ops_by_key = ops.group_by(|o| o.elemid_or_key());
+    let ops_by_key = ops.chunk_by(|o| o.elemid_or_key());
     let mut len = 0;
     ops_by_key
         .into_iter()
@@ -130,7 +130,7 @@ fn log_map_patches<'a, I: Iterator<Item = Op<'a>>>(
     obj: &ObjMeta,
     ops: I,
 ) {
-    let ops_by_key = ops.group_by(|o| *o.key());
+    let ops_by_key = ops.chunk_by(|o| *o.key());
     ops_by_key
         .into_iter()
         .filter_map(log_map_key_patches)

--- a/rust/automerge/src/automerge/diff.rs
+++ b/rust/automerge/src/automerge/diff.rs
@@ -120,7 +120,7 @@ impl<'a> Patch<'a> {
 pub(crate) fn log_diff(doc: &Automerge, before: &Clock, after: &Clock, patch_log: &mut PatchLog) {
     for (obj, ops) in doc.ops().iter_objs() {
         let mut diff = RichTextDiff::new(doc);
-        let ops_by_key = ops.group_by(|o| o.as_op(doc.osd()).elemid_or_key());
+        let ops_by_key = ops.chunk_by(|o| o.as_op(doc.osd()).elemid_or_key());
         let diffs = ops_by_key.into_iter().filter_map(|(_key, key_ops)| {
             process(
                 key_ops.map(|i| i.as_op(doc.osd())),

--- a/rust/deny.toml
+++ b/rust/deny.toml
@@ -147,6 +147,10 @@ deny = [
 # Certain crates/versions that will be skipped when doing duplicate detection.
 skip = [
     { name = "heck", version = "0.5.0" },
+    { crate = "windows-sys@0.52", reason = "this is brought in by the clap dependency in automerge-cli, which is fine as we're not distributing that as a library" },
+    { crate = "regex-syntax@0.6.29", reason = "this is bought in by tracing-subscriber, which we only use in tests and the CLI" },
+    { crate = "regex-automata@0.1.10", reason = "this is bought in by tracing-subscriber, which we only use in tests and the CLI" },
+    { crate = "itertools@0.10.5", reason = "this is bought in by criterion, which we only use in benchmarks" },
 ]
 # Similarly to `skip` allows you to skip certain crates during duplicate 
 # detection. Unlike skip, it also includes the entire tree of transitive 

--- a/rust/deny.toml
+++ b/rust/deny.toml
@@ -62,9 +62,9 @@ ignore = [
 # [possible values: any SPDX 3.11 short identifier (+ optional exception)].
 allow = [
     "MIT",
-    "BSD-2-Clause",
     "Apache-2.0",
     "Apache-2.0 WITH LLVM-exception",
+    "MPL-2.0",
 ]
 # The confidence threshold for detecting a license from license text.
 # The higher the value, the more closely the license text must be to the
@@ -84,10 +84,6 @@ exceptions = [
     # these are needed by cbindgen and its dependancies
     # should be revied more fully before release
     { allow = ["MPL-2.0"], name = "cbindgen" },
-    { allow = ["BSD-3-Clause"], name = "instant" },
-
-    # we only use prettytable in tests
-    { allow = ["BSD-3-Clause"], name = "prettytable" },
 ]
 
 # Some crates don't have (easily) machine readable licensing information,
@@ -150,14 +146,6 @@ deny = [
 ]
 # Certain crates/versions that will be skipped when doing duplicate detection.
 skip = [
-    # redox_syscall has a dupliucate version included by prettytable
-    # which is only used in tests
-    { name = "redox_syscall", version = "0.2.16" },
-
-    # linux-raw-sys and rustix are duplicated due to transitive dependencies of
-    # cbindgen, which we only use at build time in automerge-c
-    { name = "linux-raw-sys", version = "0.3.8" },
-    { name = "rustix", version = "0.37.21" },
     { name = "heck", version = "0.5.0" },
 ]
 # Similarly to `skip` allows you to skip certain crates during duplicate 
@@ -165,10 +153,6 @@ skip = [
 # dependencies starting at the specified crate, up to a certain depth, which is
 # by default infinite
 skip-tree = [
-    # // We only ever use criterion in benchmarks
-    { name = "criterion", version = "0.4.0", depth=10},
-
-    { name = "windows-sys", version = "0.48.0" },
 ]
 
 # This section is considered when running `cargo deny check sources`.

--- a/rust/deny.toml
+++ b/rust/deny.toml
@@ -9,6 +9,7 @@
 # The values provided in this template are the default values that will be used
 # when any section or field is not specified in your own configuration
 
+[graph]
 # If 1 or more target triples (and optionally, target_features) are specified,
 # only the specified targets will be checked when running `cargo deny check`.
 # This means, if a particular package is only ever used as a target specific
@@ -36,12 +37,7 @@ db-path = "~/.cargo/advisory-db"
 # The url(s) of the advisory databases to use
 db-urls = ["https://github.com/rustsec/advisory-db"]
 # The lint level for security vulnerabilities
-vulnerability = "deny"
-# The lint level for unmaintained crates
-unmaintained = "warn"
-# The lint level for crates that have been yanked from their source registry
 yanked = "warn"
-notice = "warn"
 # A list of advisory IDs to ignore. Note that ignored advisories will still
 # output a note when they are encountered.
 ignore = [
@@ -61,8 +57,6 @@ ignore = [
 # More documentation for the licenses section can be found here:
 # https://embarkstudios.github.io/cargo-deny/checks/licenses/cfg.html
 [licenses]
-# The lint level for crates which do not have a detectable license
-unlicensed = "deny"
 # List of explictly allowed licenses
 # See https://spdx.org/licenses/ for list of possible licenses
 # [possible values: any SPDX 3.11 short identifier (+ optional exception)].
@@ -72,26 +66,6 @@ allow = [
     "Apache-2.0",
     "Apache-2.0 WITH LLVM-exception",
 ]
-# List of explictly disallowed licenses
-# See https://spdx.org/licenses/ for list of possible licenses
-# [possible values: any SPDX 3.11 short identifier (+ optional exception)].
-deny = [
-    #"Nokia",
-]
-# Lint level for licenses considered copyleft
-copyleft = "warn"
-# Blanket approval or denial for OSI-approved or FSF Free/Libre licenses
-# * both - The license will be approved if it is both OSI-approved *AND* FSF
-# * either - The license will be approved if it is either OSI-approved *OR* FSF
-# * osi-only - The license will be approved if is OSI-approved *AND NOT* FSF
-# * fsf-only - The license will be approved if is FSF *AND NOT* OSI-approved
-# * neither - This predicate is ignored and the default lint level is used
-allow-osi-fsf-free = "neither"
-# Lint level used when no other predicates are matched
-# 1. License isn't in the allow or deny lists
-# 2. License isn't copyleft
-# 3. License isn't OSI/FSF, or allow-osi-fsf-free = "neither"
-default = "deny"
 # The confidence threshold for detecting a license from license text.
 # The higher the value, the more closely the license text must be to the
 # canonical license text of a valid SPDX license file.

--- a/rust/edit-trace/Cargo.toml
+++ b/rust/edit-trace/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 [dependencies]
 automerge = { path = "../automerge" }
 criterion = "0.4.0"
-json = "0.12.4"
+jzon = "^0.12.5"
 rand = "^0.8"
 
 

--- a/rust/edit-trace/Cargo.toml
+++ b/rust/edit-trace/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT"
 
 [dependencies]
 automerge = { path = "../automerge" }
-criterion = "0.4.0"
+criterion = "^0.5"
 jzon = "^0.12.5"
 rand = "^0.8"
 

--- a/rust/edit-trace/benches/main.rs
+++ b/rust/edit-trace/benches/main.rs
@@ -41,7 +41,7 @@ fn load_trace_autotx(bytes: &[u8]) {
 
 fn bench(c: &mut Criterion) {
     let contents = fs::read_to_string("edits.json").expect("cannot read edits file");
-    let edits = json::parse(&contents).expect("cant parse edits");
+    let edits = jzon::parse(&contents).expect("cant parse edits");
     let mut commands = vec![];
     for i in 0..edits.len() {
         let pos: usize = edits[i][0].as_usize().unwrap();

--- a/rust/edit-trace/src/main.rs
+++ b/rust/edit-trace/src/main.rs
@@ -5,7 +5,7 @@ use std::time::Instant;
 
 fn main() -> Result<(), AutomergeError> {
     let contents = include_str!("../edits.json");
-    let edits = json::parse(contents).expect("cant parse edits");
+    let edits = jzon::parse(contents).expect("cant parse edits");
     let mut commands = vec![];
     for i in 0..edits.len() {
         let pos: usize = edits[i][0].as_usize().unwrap();


### PR DESCRIPTION
Various updates to move to the latest version of `cargo-deny`:

* Update `cbindgen` and `itertools` to remove duplicate dependencies in our depenency tree
* Switch from depending on `json` to `jzon` in the `edit-trace` crate as `json` is no longer maintained
* Modify the deny.toml config to remove deprecated keys