### PR TITLE
make getCursor work with Automerge.view

### DIFF
--- a/javascript/src/next_slim.ts
+++ b/javascript/src/next_slim.ts
@@ -536,7 +536,7 @@ export function getCursor<T>(
   const state = _state(doc, false)
 
   try {
-    return state.handle.getCursor(objPath, index)
+    return state.handle.getCursor(objPath, index, state.heads)
   } catch (e) {
     throw new RangeError(`Cannot getCursor: ${e}`)
   }


### PR DESCRIPTION
Problem: The `getCursor(doc, path, number)` - which returns a stable identifier
for a given index into a text object - always resolved the index with
respect to the latest heads of the document. In particular, if you
passed the result of `Automerge.view` as the first argument to
`getCursor` and then attempted to get a cursor for an index which had
since been deleted then a `RangeError` was thrown.

Solution: Respect the heads of the document passed to `getCursor` when
resolving the index.