### PR TITLE
Update flake and build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ To build this codebase you will need:
 - `yarn`
 - `cmake`
 - `cmocka`
+- `ninja`
 
 You will also need to install the following with `cargo install`
 

--- a/flake.lock
+++ b/flake.lock
@@ -1,27 +1,15 @@
 {
   "nodes": {
     "flake-utils": {
-      "locked": {
-        "lastModified": 1667395993,
-        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
-        "type": "github"
+      "inputs": {
+        "systems": "systems"
       },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "flake-utils_2": {
       "locked": {
-        "lastModified": 1659877975,
-        "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "c0e246b9b83f637f4681389ecabcb2681b4f3af0",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
         "type": "github"
       },
       "original": {
@@ -32,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1669542132,
-        "narHash": "sha256-DRlg++NJAwPh8io3ExBJdNW7Djs3plVI5jgYQ+iXAZQ=",
+        "lastModified": 1726062873,
+        "narHash": "sha256-IiA3jfbR7K/B5+9byVi9BZGWTD4VSbWe8VLpp9B/iYk=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "a115bb9bd56831941be3776c8a94005867f316a7",
+        "rev": "4f807e8940284ad7925ebd0a0993d2a1791acb2f",
         "type": "github"
       },
       "original": {
@@ -48,11 +36,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1665296151,
-        "narHash": "sha256-uOB0oxqxN9K7XGF1hcnY+PQnlQJ+3bP2vCn/+Ru/bbc=",
+        "lastModified": 1718428119,
+        "narHash": "sha256-WdWDpNaq6u1IPtxtYHHWpl5BmabtpmLnMAx0RdJ/vo8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "14ccaaedd95a488dd7ae142757884d8e125b3363",
+        "rev": "e6cea36f83499eb4e9cd184c8a8e823296b50ad5",
         "type": "github"
       },
       "original": {
@@ -71,20 +59,34 @@
     },
     "rust-overlay": {
       "inputs": {
-        "flake-utils": "flake-utils_2",
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1669775522,
-        "narHash": "sha256-6xxGArBqssX38DdHpDoPcPvB/e79uXyQBwpBcaO/BwY=",
+        "lastModified": 1726280639,
+        "narHash": "sha256-YfLRPlFZWrT2oRLNAoqf7G3+NnUTDdlIJk6tmBU7kXM=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "3158e47f6b85a288d12948aeb9a048e0ed4434d6",
+        "rev": "e9f8641c92f26fd1e076e705edb12147c384171d",
         "type": "github"
       },
       "original": {
         "owner": "oxalica",
         "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
         "type": "github"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -19,7 +19,7 @@
         overlays = [rust-overlay.overlays.default];
         inherit system;
       };
-      rust = pkgs.rust-bin.stable.latest.default;
+      rust = pkgs.rust-bin.selectLatestNightlyWith (toolchain: toolchain.default);
     in {
       formatter = pkgs.alejandra;
 
@@ -48,7 +48,7 @@
           cargo-deny
           crate2nix
           wasm-pack
-          pkgconfig
+          pkg-config
           openssl
           gnuplot
 
@@ -60,8 +60,8 @@
           cmake
           cmocka
           doxygen
+          ninja
 
-          rnix-lsp
           nixpkgs-fmt
         ];
       };

--- a/rust/automerge-c/Cargo.toml
+++ b/rust/automerge-c/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "automerge-c"
-version = "0.2.2"
+version = "0.3.0"
 authors = ["Orion Henry <orion.henry@gmail.com>", "Jason Kankiewicz <jason.kankiewicz@gmail.com>"]
 edition = "2021"
 license = "MIT"
@@ -19,4 +19,4 @@ libc = "^0.2"
 smol_str = "0.2"
 
 [build-dependencies]
-cbindgen = "^0.27"
+cbindgen = "^0.24"

--- a/rust/automerge-c/README.md
+++ b/rust/automerge-c/README.md
@@ -11,7 +11,7 @@ a root directory of your choosing (e.g. "/usr/local") like so:
 
 ```shell
 cmake -E make_directory automerge-c/build
-cmake -S automerge-c -B automerge-c/build
+cmake -S automerge-c -B automerge-c/build -G Ninja
 cmake --build automerge-c/build
 cmake --install automerge-c/build --prefix "/usr/local"
 ```


### PR DESCRIPTION
Since the build assumes nightly rust builds (by using the -Z flag), the rust overlay now selects the latest nightly version.

The other changes in the flake:
-  rnix-lsp is unmaintained and thus removed
- pkgconfig has been renamed

The changes to `rust/automerge-c/Cargo.toml` are somehow generated by the build step, I did not manually change the version number.

The build instructions are updated to use ninja as that was the only thing that worked for me. If this is undesirable, we can indicate that ninja is an alternative way to build.