### PR TITLE
Introducing Automerge Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 [![latest docs](https://img.shields.io/badge/docs-latest-informational)](https://docs.rs/automerge/latest/automerge)
 [![ci](https://github.com/automerge/automerge/actions/workflows/ci.yaml/badge.svg)](https://github.com/automerge/automerge/actions/workflows/ci.yaml)
 [![docs](https://github.com/automerge/automerge/actions/workflows/docs.yaml/badge.svg)](https://github.com/automerge/automerge/actions/workflows/docs.yaml)
+[![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20Automerge%20Guru-006BFF)](https://gurubase.io/g/automerge)
 
 Automerge is a library which provides fast implementations of several different
 CRDTs, a compact compression format for these CRDTs, and a sync protocol for


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [Automerge Guru](https://gurubase.io/g/automerge) to Gurubase. Automerge Guru uses the data from this repo and data from the [docs](https://automerge.org) to answer questions by leveraging the LLM.

In this PR, I showcased the "Automerge Guru", which highlights that Automerge now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable Automerge Guru in Gurubase, just let me know that's totally fine.
