### PR TITLE
rust: Pin to rustc 1.81

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -76,6 +76,7 @@ jobs:
           # Optional version of wasm-bindgen to install(eg. '0.2.83', 'latest')
           version: '0.2.95'
       - name: Install wasm32 target
+        working-directory: rust
         run: rustup target add wasm32-unknown-unknown
       - name: run tests
         run: ./scripts/ci/wasm_tests
@@ -95,6 +96,7 @@ jobs:
           # Optional version of wasm-bindgen to install(eg. '0.2.83', 'latest')
           version: '0.2.95'
       - name: Install wasm32 target
+        working-directory: rust
         run: rustup target add wasm32-unknown-unknown
       - name: run tests
         run: ./scripts/ci/js_tests

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,6 +20,7 @@ jobs:
           # Optional version of wasm-bindgen to install(eg. '0.2.83', 'latest')
           version: '0.2.95'
       - name: Install wasm32 target
+        working-directory: rust
         run: rustup target add wasm32-unknown-unknown
       - name: yarn install
         run: yarn install
@@ -51,6 +52,7 @@ jobs:
       - name: Install wasm-bindgen-cli
         run: cargo install wasm-bindgen-cli wasm-opt
       - name: Install wasm32 target
+        working-directory: rust
         run: rustup target add wasm32-unknown-unknown
       - name: yarn install
         run: yarn install

--- a/rust/rust-toolchain.toml
+++ b/rust/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "1.81"


### PR DESCRIPTION
Problem: due to an intersection of changes in LLVM and wasm-bindgen described here[1], compiling with rustc1 1.82.0 breaks the WebPack webassembly integration. It looks like wasm-bindgen plan to push a fix for this (despite it not really being their responsibility) but that's not in yet.

Solution: pin the compiler to 1.81 until the wasm-bindgen fix is int.

[1]:  https://github.com/rustwasm/wasm-bindgen/issues/4211