### PR TITLE
automerge-wasm: Pin version of wasm-bindgen

### DIFF
--- a/rust/automerge-wasm/Cargo.toml
+++ b/rust/automerge-wasm/Cargo.toml
@@ -37,7 +37,7 @@ thiserror = "^1.0.16"
 fxhash = "^0.2.1"
 
 [dependencies.wasm-bindgen]
-version = "^0.2.95"
+version = "= 0.2.95"
 #features = ["std"]
 features = ["serde-serialize", "std"]
 


### PR DESCRIPTION
Problem: The wasm-bindgen dependency of automerge-wasm has to be exactly the same as the version of the CLI used to build the JavaScript package. The CI environment is pinned to a specific version in the Github actions workflow but the version of wasm-bindgen in the Cargo.toml file is not.  This means that when a new version of wasm-bindgen is released, the build fails because cargo automatically pulls the latest version of wasm-bindgen which is different to the version used in the CI environment.

Solution: Pin the version of wasm-bindgen in the Cargo.toml to the same version as in CI.