### PR TITLE
rust: allow specifying text encoding at document creation

### DIFF
--- a/rust/automerge-wasm/src/lib.rs
+++ b/rust/automerge-wasm/src/lib.rs
@@ -32,6 +32,7 @@ use am::ScalarValue;
 use am::StringMigration;
 use am::VerificationMode;
 use automerge as am;
+use automerge::TextEncoding;
 use automerge::{sync::SyncDoc, AutoCommit, Change, Prop, ReadDoc, Value, ROOT};
 use js_sys::{Array, Function, Object, Uint8Array};
 use serde::ser::Serialize;
@@ -85,7 +86,9 @@ impl From<TextRepresentation> for am::patches::TextRepresentation {
     fn from(tr: TextRepresentation) -> Self {
         match tr {
             TextRepresentation::Array => am::patches::TextRepresentation::Array,
-            TextRepresentation::String => am::patches::TextRepresentation::String,
+            TextRepresentation::String => {
+                am::patches::TextRepresentation::String(TextEncoding::Utf16CodeUnit)
+            }
         }
     }
 }

--- a/rust/automerge/examples/watch.rs
+++ b/rust/automerge/examples/watch.rs
@@ -3,6 +3,7 @@ use automerge::transaction::CommitOptions;
 use automerge::transaction::Transactable;
 use automerge::Automerge;
 use automerge::AutomergeError;
+use automerge::TextEncoding;
 use automerge::ROOT;
 use automerge::{Patch, PatchAction, PatchLog};
 
@@ -12,7 +13,7 @@ fn main() {
     // a simple scalar change in the root object
     let mut result = doc
         .transact_and_log_patches_with::<_, _, AutomergeError, _>(
-            TextRepresentation::String,
+            TextRepresentation::String(TextEncoding::default()),
             |_result| CommitOptions::default(),
             |tx| {
                 tx.put(ROOT, "hello", "world").unwrap();
@@ -22,7 +23,9 @@ fn main() {
         .unwrap();
     get_changes(&doc, doc.make_patches(&mut result.patch_log));
 
-    let mut tx = doc.transaction_log_patches(PatchLog::active(TextRepresentation::String));
+    let mut tx = doc.transaction_log_patches(PatchLog::active(TextRepresentation::String(
+        TextEncoding::default(),
+    )));
     let map = tx
         .put_object(ROOT, "my new map", automerge::ObjType::Map)
         .unwrap();

--- a/rust/automerge/src/change.rs
+++ b/rust/automerge/src/change.rs
@@ -347,7 +347,7 @@ pub(crate) mod gen {
             gen::{gen_hash, gen_op},
             ObjId, OpId,
         },
-        ActorId,
+        ActorId, TextEncoding,
     };
     use proptest::prelude::*;
 
@@ -367,7 +367,7 @@ pub(crate) mod gen {
     ) -> impl Strategy<Value = (Vec<(ObjId, OpIdx)>, OpSetData)> {
         let mut all_actors = vec![this_actor];
         all_actors.extend(other_actors);
-        let mut osd = OpSetData::from_actors(all_actors);
+        let mut osd = OpSetData::from_actors(all_actors, TextEncoding::default());
         osd.props.cache("someprop".to_string());
         let root_id = ObjId::root();
         (0_u64..10)

--- a/rust/automerge/src/change_graph.rs
+++ b/rust/automerge/src/change_graph.rs
@@ -238,7 +238,7 @@ mod tests {
         op_set::OpSetData,
         storage::{change::ChangeBuilder, convert::op_as_actor_id},
         types::{Key, ObjId, OpBuilder, OpId},
-        ActorId,
+        ActorId, TextEncoding,
     };
 
     use super::*;
@@ -322,7 +322,7 @@ mod tests {
             num_new_ops: usize,
             parents: &[ChangeHash],
         ) -> ChangeHash {
-            let mut osd = OpSetData::from_actors(self.actors.clone());
+            let mut osd = OpSetData::from_actors(self.actors.clone(), TextEncoding::default());
             let key = osd.props.cache("key".to_string());
 
             let start_op = parents

--- a/rust/automerge/src/error.rs
+++ b/rust/automerge/src/error.rs
@@ -129,6 +129,8 @@ pub enum HydrateError {
     InvalidTextOp(PatchAction),
     #[error("invalid prop in patch: {0}")]
     ApplyInvalidProp(PatchAction),
+    #[error("invalid encoding for text value")]
+    InvalidEncoding,
 }
 
 #[derive(Error, Debug)]

--- a/rust/automerge/src/hydrate/list.rs
+++ b/rust/automerge/src/hydrate/list.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 
 use crate::exid::ExId;
+use crate::patches::TextRepresentation;
 use crate::types::Prop;
 use crate::{PatchAction, ScalarValue, SequenceTree};
 
@@ -35,24 +36,28 @@ impl List {
         self.len() == 0
     }
 
-    pub(crate) fn apply(&mut self, patch: PatchAction) -> Result<(), HydrateError> {
+    pub(crate) fn apply(
+        &mut self,
+        text_rep: TextRepresentation,
+        patch: PatchAction,
+    ) -> Result<(), HydrateError> {
         match patch {
             PatchAction::PutSeq {
                 index,
                 value,
                 conflict,
             } => {
+                let h_value = Value::new(value.0, text_rep);
                 *self
                     .0
                     .get_mut(index)
-                    .ok_or(HydrateError::InvalidIndex(index))? =
-                    ListValue::new(value.0.into(), conflict);
+                    .ok_or(HydrateError::InvalidIndex(index))? = ListValue::new(h_value, conflict);
                 Ok(())
             }
             PatchAction::Insert { index, values, .. } => {
                 for (n, value) in values.into_iter().enumerate() {
-                    self.0
-                        .insert(index + n, ListValue::new(value.0.clone().into(), value.2));
+                    let h_value = Value::new(value.0.clone(), text_rep);
+                    self.0.insert(index + n, ListValue::new(h_value, value.2));
                 }
                 Ok(())
             }

--- a/rust/automerge/src/hydrate/map.rs
+++ b/rust/automerge/src/hydrate/map.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 use std::ops::{Deref, DerefMut};
 
 use crate::exid::ExId;
+use crate::patches::TextRepresentation;
 use crate::types::Prop;
 use crate::{PatchAction, ScalarValue};
 
@@ -21,7 +22,11 @@ impl Map {
         self.0.iter()
     }
 
-    pub(crate) fn apply(&mut self, patch: PatchAction) -> Result<(), HydrateError> {
+    pub(crate) fn apply(
+        &mut self,
+        text_rep: TextRepresentation,
+        patch: PatchAction,
+    ) -> Result<(), HydrateError> {
         match patch {
             PatchAction::DeleteMap { key } => {
                 self.0.remove(&key);
@@ -32,8 +37,9 @@ impl Map {
                 value,
                 conflict,
             } => {
+                let h_value = Value::new(value.0, text_rep);
                 self.0
-                    .insert(key, MapValue::new(value.0.into(), value.1, conflict));
+                    .insert(key, MapValue::new(h_value, value.1, conflict));
                 Ok(())
             }
             PatchAction::Increment {

--- a/rust/automerge/src/hydrate/tests.rs
+++ b/rust/automerge/src/hydrate/tests.rs
@@ -1,12 +1,14 @@
+use text_value::ConcreteTextValue;
+
 use crate::exid::ExId;
 use crate::patches::TextRepresentation;
-use crate::text_value::TextValue;
 use crate::transaction::Transactable;
 use crate::*;
 
 #[test]
 fn simple_hydrate() -> Result<(), AutomergeError> {
-    let mut doc = AutoCommit::default().with_text_rep(TextRepresentation::String);
+    let mut doc =
+        AutoCommit::default().with_text_rep(TextRepresentation::String(TextEncoding::default()));
     let list = doc.put_object(&ObjId::Root, "list", ObjType::List)?;
     doc.insert(&list, 0, 5)?;
     doc.insert(&list, 1, 6)?;
@@ -22,7 +24,7 @@ fn simple_hydrate() -> Result<(), AutomergeError> {
         hydrated,
         hydrate_map!(
             "list" => hydrate_list!(5,6,7,"hello", ScalarValue::counter(100), hydrate_map!(), hydrate_list![]),
-            "text" => TextValue::new("hello world"),
+            "text" => ConcreteTextValue::new("hello world", TextRepresentation::String(TextEncoding::default())),
         ).into()
     );
     doc.splice_text(&text, 6, 0, "big bad ")?;
@@ -31,10 +33,10 @@ fn simple_hydrate() -> Result<(), AutomergeError> {
     let cursor = doc.diff_cursor().to_vec();
     let patches = doc.diff(&cursor, &heads);
     doc.update_diff_cursor();
-    hydrated.apply_patches(patches)?;
-    assert_eq!(
-        hydrated.as_map().unwrap().get("text"),
-        Some(&TextValue::new("hello big bad world").into())
-    );
+    hydrated.apply_patches(TextRepresentation::String(TextEncoding::default()), patches)?;
+    let hydrate::Value::Text(val) = &hydrated.as_map().unwrap().get("text").unwrap() else {
+        panic!("expected text");
+    };
+    assert_eq!(String::from(val), "hello big bad world".to_string(),);
     Ok(())
 }

--- a/rust/automerge/src/iter/spans.rs
+++ b/rust/automerge/src/iter/spans.rs
@@ -3,7 +3,7 @@ use crate::marks::{MarkSet, MarkStateMachine};
 //use crate::port::HasMetadata;
 use crate::op_set::Op;
 use crate::op_tree::{OpTreeIter, OpTreeOpIter};
-use crate::types::Clock;
+use crate::types::{Clock, TextEncoding};
 use crate::types::{Key, ListEncoding, ObjType, OpId, OpType};
 use crate::Automerge;
 
@@ -20,6 +20,7 @@ struct SpansState<'a> {
     text: String,
     block: Option<Op<'a>>,
     marks: MarkStateMachine<'a>,
+    text_encoding: TextEncoding,
 }
 
 #[derive(Debug)]
@@ -95,7 +96,7 @@ impl<'a> SpansState<'a> {
                     if let Some(next_marks) = self.next_marks.take() {
                         let mut result = None;
                         if next_marks == self.current_marks {
-                            self.len += op.width(ListEncoding::Text);
+                            self.len += op.width(ListEncoding::Text(self.text_encoding));
                         } else {
                             // only flush if the marks are actually changing. One situation where
                             // they might not change is if a zero length mark was encountered in
@@ -103,12 +104,12 @@ impl<'a> SpansState<'a> {
                             // would change `next_marks` to the empty span, and then back again.
                             result = self.flush();
                             self.current_marks = next_marks;
-                            self.len = op.width(ListEncoding::Text);
+                            self.len = op.width(ListEncoding::Text(self.text_encoding));
                         }
                         self.text.push_str(op.as_str());
                         result
                     } else {
-                        self.len += op.width(ListEncoding::Text);
+                        self.len += op.width(ListEncoding::Text(self.text_encoding));
                         self.text.push_str(op.as_str());
                         None
                     }
@@ -135,7 +136,7 @@ impl<'a> SpansState<'a> {
 
             Some(span)
         } else if let Some(block) = self.block.take() {
-            let width = block.width(ListEncoding::Text);
+            let width = block.width(ListEncoding::Text(self.text_encoding));
             let block = SpanInternal::Obj(*block.id(), self.index);
             self.index += width;
             Some(block)
@@ -154,7 +155,7 @@ where
 
     fn next(&mut self) -> Option<Self::Item> {
         if let Some(block) = self.state.block.take() {
-            let width = block.width(ListEncoding::Text);
+            let width = block.width(ListEncoding::Text(self.state.text_encoding));
             let block = SpanInternal::Obj(*block.id(), self.state.index);
             self.state.index += width;
             return Some(block);

--- a/rust/automerge/src/lib.rs
+++ b/rust/automerge/src/lib.rs
@@ -305,8 +305,9 @@ pub use patches::{Patch, PatchAction, PatchLog};
 pub use read::ReadDoc;
 pub use sequence_tree::SequenceTree;
 pub use storage::VerificationMode;
+pub use text_value::ConcreteTextValue;
 pub use transaction::BlockOrText;
-pub use types::{ActorId, ChangeHash, ObjType, OpType, ParseChangeHashError, Prop};
+pub use types::{ActorId, ChangeHash, ObjType, OpType, ParseChangeHashError, Prop, TextEncoding};
 pub use value::{ScalarValue, Value};
 
 /// The object ID for the root map of a document

--- a/rust/automerge/src/op_tree/iter.rs
+++ b/rust/automerge/src/op_tree/iter.rs
@@ -228,6 +228,7 @@ mod tests {
     use super::super::OpTreeInternal;
     use crate::op_set::{OpIdx, OpSetData};
     use crate::types::{Key, ObjType, OpBuilder, OpId, OpType, ScalarValue, ROOT};
+    use crate::TextEncoding;
     use proptest::prelude::*;
 
     #[derive(Clone)]
@@ -309,7 +310,7 @@ mod tests {
     impl Model {
         fn insert(&self, index: usize, next_op_counter: u64) -> Self {
             let mut actions = self.actions.clone();
-            let mut osd = OpSetData::default();
+            let mut osd = OpSetData::new(TextEncoding::default());
             let op = op(next_op_counter, &mut osd);
             actions.push(Action::Insert(index, op));
             let mut model = self.model.clone();
@@ -372,7 +373,7 @@ mod tests {
                 Model {
                     actions: Vec::new(),
                     model: Vec::new(),
-                    osd: OpSetData::default(),
+                    osd: OpSetData::new(TextEncoding::default()),
                 },
             ))
             .boxed();
@@ -394,7 +395,7 @@ mod tests {
     }
 
     fn make_optree(actions: &[Action], osd: &OpSetData) -> super::OpTreeInternal {
-        let mut optree = OpTreeInternal::new(ObjType::List);
+        let mut optree = OpTreeInternal::new(ObjType::List, TextEncoding::default());
         for action in actions {
             match action {
                 Action::Insert(index, idx) => {

--- a/rust/automerge/src/patches.rs
+++ b/rust/automerge/src/patches.rs
@@ -5,19 +5,36 @@ pub use patch::{Patch, PatchAction};
 pub(crate) use patch_builder::PatchBuilder;
 pub use patch_log::PatchLog;
 
-use crate::{types::ListEncoding, ObjType};
+use crate::{
+    types::{ListEncoding, TextEncoding},
+    ObjType,
+};
 
-#[derive(Default, Debug, Copy, Clone, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq)]
 pub enum TextRepresentation {
     Array,
-    #[default]
-    String,
+    String(TextEncoding),
+}
+
+impl From<ListEncoding> for TextRepresentation {
+    fn from(encoding: ListEncoding) -> Self {
+        match encoding {
+            ListEncoding::Text(encoding) => Self::String(encoding),
+            ListEncoding::List => Self::Array,
+        }
+    }
+}
+
+impl From<TextEncoding> for TextRepresentation {
+    fn from(value: TextEncoding) -> Self {
+        Self::String(value)
+    }
 }
 
 impl TextRepresentation {
     pub(crate) fn encoding(&self, typ: ObjType) -> ListEncoding {
         match (self, typ) {
-            (&Self::String, ObjType::Text) => ListEncoding::Text,
+            (&Self::String(encoding), ObjType::Text) => ListEncoding::Text(encoding),
             _ => ListEncoding::List,
         }
     }
@@ -27,6 +44,6 @@ impl TextRepresentation {
     }
 
     pub fn is_string(&self) -> bool {
-        matches!(self, TextRepresentation::String)
+        matches!(self, TextRepresentation::String(_))
     }
 }

--- a/rust/automerge/src/patches/patch.rs
+++ b/rust/automerge/src/patches/patch.rs
@@ -1,12 +1,12 @@
 use crate::{
     marks::{Mark, MarkSet},
+    text_value::ConcreteTextValue,
     ObjId, Prop, Value,
 };
 use core::fmt::Debug;
 use std::fmt;
 
 use crate::sequence_tree::SequenceTree;
-use crate::text_value::TextValue;
 
 /// A change to the current state of the document
 ///
@@ -58,7 +58,7 @@ pub enum PatchAction {
     SpliceText {
         index: usize,
         /// The text that was inserted
-        value: TextValue,
+        value: ConcreteTextValue,
         /// All marks currently active for this span of text
         marks: Option<MarkSet>,
     },

--- a/rust/automerge/src/read.rs
+++ b/rust/automerge/src/read.rs
@@ -6,7 +6,7 @@ use crate::{
     iter::{Keys, ListRange, MapRange, Spans, Values},
     marks::{Mark, MarkSet},
     parents::Parents,
-    Change, ChangeHash, Cursor, ObjType, Prop, Value,
+    Change, ChangeHash, Cursor, ObjType, Prop, TextEncoding, Value,
 };
 
 use std::{collections::HashMap, ops::RangeBounds};
@@ -284,6 +284,8 @@ pub trait ReadDoc {
 
     /// Return some statistics about the document
     fn stats(&self) -> Stats;
+
+    fn text_encoding(&self) -> TextEncoding;
 }
 
 pub(crate) trait ReadDocInternal: ReadDoc {

--- a/rust/automerge/src/storage/load.rs
+++ b/rust/automerge/src/storage/load.rs
@@ -3,6 +3,7 @@ use tracing::instrument;
 use crate::{
     change::Change,
     storage::{self, parse},
+    types::TextEncoding,
 };
 
 pub(crate) mod change_collector;
@@ -51,10 +52,13 @@ pub(crate) enum LoadedChanges<'a> {
 /// chunks are valid. This function returns a `LoadedChanges` which you can examine to determine if
 /// this is the case.
 #[instrument(skip(data))]
-pub(crate) fn load_changes<'a>(mut data: parse::Input<'a>) -> LoadedChanges<'a> {
+pub(crate) fn load_changes<'a>(
+    mut data: parse::Input<'a>,
+    text_encoding: TextEncoding,
+) -> LoadedChanges<'a> {
     let mut changes = Vec::new();
     while !data.is_empty() {
-        let remaining = match load_next_change(data, &mut changes) {
+        let remaining = match load_next_change(data, &mut changes, text_encoding) {
             Ok(d) => d,
             Err(e) => {
                 return LoadedChanges::Partial {
@@ -72,6 +76,7 @@ pub(crate) fn load_changes<'a>(mut data: parse::Input<'a>) -> LoadedChanges<'a> 
 fn load_next_change<'a>(
     data: parse::Input<'a>,
     changes: &mut Vec<Change>,
+    text_encoding: TextEncoding,
 ) -> Result<parse::Input<'a>, Error> {
     let (remaining, chunk) = storage::Chunk::parse(data).map_err(|e| Error::Parse(Box::new(e)))?;
     if !chunk.checksum_valid() {
@@ -80,7 +85,7 @@ fn load_next_change<'a>(
     match chunk {
         storage::Chunk::Document(d) => {
             tracing::trace!("loading document chunk");
-            let new_changes = reconstruct_opset(&d, VerificationMode::DontCheck)
+            let new_changes = reconstruct_opset(&d, VerificationMode::DontCheck, text_encoding)
                 .map_err(|e| Error::InflateDocument(Box::new(e)))?
                 .changes;
             changes.extend(new_changes);

--- a/rust/automerge/src/sync.rs
+++ b/rust/automerge/src/sync.rs
@@ -292,7 +292,7 @@ impl SyncDoc for Automerge {
         sync_state: &mut State,
         message: Message,
     ) -> Result<(), AutomergeError> {
-        let mut patch_log = PatchLog::inactive(TextRepresentation::default());
+        let mut patch_log = PatchLog::inactive(TextRepresentation::String(self.text_encoding()));
         self.receive_sync_message_inner(sync_state, message, &mut patch_log)
     }
 

--- a/rust/automerge/src/sync/v1_compat_test/mod.rs
+++ b/rust/automerge/src/sync/v1_compat_test/mod.rs
@@ -6,7 +6,7 @@ use serde::ser::SerializeMap;
 use std::collections::{HashMap, HashSet};
 
 use crate::{
-    patches::{PatchLog, TextRepresentation},
+    patches::PatchLog,
     storage::parse::Input,
     storage::{parse, Change as StoredChange, ReadChangeOpError},
     sync::SyncDoc,
@@ -120,7 +120,7 @@ impl Automerge {
         sync_state: &mut State,
         message: Message,
     ) -> Result<(), AutomergeError> {
-        let mut patch_log = PatchLog::inactive(TextRepresentation::default());
+        let mut patch_log = PatchLog::inactive(self.text_encoding().into());
         self.receive_sync_message_inner_v1(sync_state, message, &mut patch_log)
     }
 

--- a/rust/automerge/src/text_value.rs
+++ b/rust/automerge/src/text_value.rs
@@ -1,156 +1,328 @@
-use crate::sequence_tree::SequenceTree;
+use crate::{patches::TextRepresentation, sequence_tree::SequenceTree, TextEncoding};
 use cfg_if::cfg_if;
-use core::fmt::Debug;
 
 cfg_if! {
     if #[cfg(feature = "utf8-indexing")] {
-        #[derive(Clone, PartialEq, Default)]
-        pub struct TextValue(SequenceTree<u8>);
-
-        impl TextValue {
-            pub(crate) fn new(s: &str) -> Self {
-                let mut v = SequenceTree::new();
-                for ch in s.bytes() {
-                    v.push(ch)
-                }
-                Self(v)
-            }
-
-            pub(crate) fn splice(&mut self, index: usize, value: &str) {
-                for (n, ch) in value.bytes().enumerate() {
-                    self.0.insert(index + n, ch)
-                }
-            }
-
-            pub(crate) fn splice_text_value(&mut self, index: usize, value: &TextValue) {
-                for (n, ch) in value.chars().enumerate() {
-                    self.0.insert(index + n, ch)
-                }
-            }
-
-            pub fn make_string(&self) -> String {
-                let bytes: Vec<_> = self.0.iter().cloned().collect();
-                String::from_utf8_lossy(bytes.as_slice()).to_string()
-            }
-
-            pub(crate) fn width(s: &str) -> usize {
-                s.len()
-            }
-
-            pub(crate) fn chars(&self) -> impl Iterator<Item = u8> + '_ {
-                self.0.iter().cloned()
+        impl std::default::Default for TextEncoding {
+            fn default() -> Self {
+                Self::Utf8CodeUnit
             }
         }
     } else if #[cfg(feature = "utf16-indexing")] {
-        #[derive(Clone, PartialEq, Default)]
-        pub struct TextValue(SequenceTree<u16>);
-
-        impl TextValue {
-            pub(crate) fn new(s: &str) -> Self {
-                let mut v = SequenceTree::new();
-                for ch in s.encode_utf16() {
-                    v.push(ch)
-                }
-                Self(v)
-            }
-
-            pub(crate) fn splice(&mut self, index: usize, value: &str) {
-                for (n, ch) in value.encode_utf16().enumerate() {
-                    self.0.insert(index + n, ch)
-                }
-            }
-
-            pub(crate) fn splice_text_value(&mut self, index: usize, value: &TextValue) {
-                for (n, ch) in value.chars().enumerate() {
-                    self.0.insert(index + n, ch)
-                }
-            }
-
-            pub fn make_string(&self) -> String {
-                let bytes: Vec<_> = self.0.iter().cloned().collect();
-                String::from_utf16_lossy(bytes.as_slice())
-            }
-
-            pub(crate) fn width(s: &str) -> usize {
-                s.encode_utf16().count()
-            }
-
-            pub(crate) fn chars(&self) -> impl Iterator<Item = u16> + '_ {
-                self.0.iter().cloned()
+        impl std::default::Default for TextEncoding {
+            fn default() -> Self {
+                Self::Utf16CodeUnit
             }
         }
     } else {
-        #[derive(Clone, PartialEq, Default)]
-        pub struct TextValue(SequenceTree<char>);
-
-        impl TextValue {
-            pub(crate) fn new(s: &str) -> Self {
-                let mut v = SequenceTree::new();
-                for ch in s.chars() {
-                    v.push(ch)
-                }
-                Self(v)
-            }
-
-            pub(crate) fn splice(&mut self, index: usize, value: &str) {
-                for (n, ch) in value.chars().enumerate() {
-                    self.0.insert(index + n, ch)
-                }
-            }
-
-            pub(crate) fn splice_text_value(&mut self, index: usize, value: &TextValue) {
-                for (n, ch) in value.chars().enumerate() {
-                    self.0.insert(index + n, ch)
-                }
-            }
-
-            pub fn make_string(&self) -> String {
-                self.0.iter().collect()
-            }
-
-            pub(crate) fn width(s: &str) -> usize {
-                s.chars().count()
-            }
-
-            pub fn chars(&self) -> impl Iterator<Item = char> + '_ {
-                self.0.iter().cloned()
+        impl std::default::Default for TextEncoding {
+            fn default() -> Self {
+                Self::UnicodeCodePoint
             }
         }
     }
 }
 
-impl TextValue {
-    pub fn len(&self) -> usize {
+pub(crate) trait TextValue {
+    type Elem;
+    fn new(s: &str) -> Self;
+    fn splice(&mut self, index: usize, value: &str);
+    fn splice_text_value(&mut self, index: usize, value: &SequenceTree<Self::Elem>);
+    fn make_string(&self) -> String;
+    fn len(&self) -> usize;
+    fn remove(&mut self, index: usize);
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct Utf8(SequenceTree<u8>);
+
+impl TextValue for Utf8 {
+    type Elem = u8;
+    fn new(s: &str) -> Self {
+        let mut v = SequenceTree::new();
+        for ch in s.bytes() {
+            v.push(ch)
+        }
+        Self(v)
+    }
+
+    fn splice(&mut self, index: usize, value: &str) {
+        for (n, ch) in value.bytes().enumerate() {
+            self.0.insert(index + n, ch)
+        }
+    }
+
+    fn splice_text_value(&mut self, index: usize, value: &SequenceTree<Self::Elem>) {
+        for (n, ch) in value.iter().cloned().enumerate() {
+            self.0.insert(index + n, ch)
+        }
+    }
+
+    fn make_string(&self) -> String {
+        let bytes: Vec<_> = self.0.iter().cloned().collect();
+        String::from_utf8_lossy(bytes.as_slice()).to_string()
+    }
+
+    fn len(&self) -> usize {
         self.0.len()
     }
 
-    pub fn remove(&mut self, index: usize) {
+    fn remove(&mut self, index: usize) {
         self.0.remove(index);
     }
 }
 
-impl Debug for TextValue {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_tuple("TextValue")
-            .field(&self.make_string())
-            .finish()
+#[derive(Debug, Clone, PartialEq)]
+pub struct CodePoint(SequenceTree<char>);
+impl TextValue for CodePoint {
+    type Elem = char;
+
+    fn new(s: &str) -> Self {
+        let mut v = SequenceTree::new();
+        for ch in s.chars() {
+            v.push(ch)
+        }
+        Self(v)
+    }
+
+    fn splice(&mut self, index: usize, value: &str) {
+        for (n, ch) in value.chars().enumerate() {
+            self.0.insert(index + n, ch)
+        }
+    }
+
+    fn splice_text_value(&mut self, index: usize, value: &SequenceTree<char>) {
+        for (n, ch) in value.iter().copied().enumerate() {
+            self.0.insert(index + n, ch)
+        }
+    }
+
+    fn make_string(&self) -> String {
+        self.0.iter().collect()
+    }
+
+    fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    fn remove(&mut self, index: usize) {
+        self.0.remove(index);
     }
 }
 
-impl From<&str> for TextValue {
-    fn from(s: &str) -> Self {
-        TextValue::new(s)
+#[derive(Debug, Clone, PartialEq)]
+pub struct Utf16(SequenceTree<u16>);
+impl TextValue for Utf16 {
+    type Elem = u16;
+
+    fn new(s: &str) -> Self {
+        let mut v = SequenceTree::new();
+        for ch in s.encode_utf16() {
+            v.push(ch)
+        }
+        Self(v)
+    }
+
+    fn splice(&mut self, index: usize, value: &str) {
+        for (n, ch) in value.encode_utf16().enumerate() {
+            self.0.insert(index + n, ch)
+        }
+    }
+
+    fn splice_text_value(&mut self, index: usize, value: &SequenceTree<Self::Elem>) {
+        for (n, ch) in value.iter().copied().enumerate() {
+            self.0.insert(index + n, ch)
+        }
+    }
+
+    fn make_string(&self) -> String {
+        let bytes: Vec<_> = self.0.iter().cloned().collect();
+        String::from_utf16_lossy(bytes.as_slice())
+    }
+
+    fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    fn remove(&mut self, index: usize) {
+        self.0.remove(index);
     }
 }
 
-impl From<String> for TextValue {
-    fn from(s: String) -> Self {
-        TextValue::new(&s)
+#[derive(Debug, Clone, PartialEq)]
+pub struct List(SequenceTree<String>);
+
+impl TextValue for List {
+    type Elem = String;
+
+    fn new(s: &str) -> Self {
+        let mut v = SequenceTree::new();
+        for ch in s.chars() {
+            v.push(ch.to_string())
+        }
+        Self(v)
+    }
+
+    fn splice(&mut self, index: usize, value: &str) {
+        for (n, ch) in value.chars().enumerate() {
+            self.0.insert(index + n, ch.to_string())
+        }
+    }
+
+    fn splice_text_value(&mut self, index: usize, value: &SequenceTree<Self::Elem>) {
+        for (n, ch) in value.iter().cloned().enumerate() {
+            self.0.insert(index + n, ch)
+        }
+    }
+
+    fn make_string(&self) -> String {
+        self.0.iter().fold(String::new(), |acc, s| acc + s)
+    }
+
+    fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    fn remove(&mut self, index: usize) {
+        self.0.remove(index);
     }
 }
 
-impl From<&TextValue> for String {
-    fn from(s: &TextValue) -> Self {
-        s.make_string()
+#[derive(Debug, Clone, PartialEq)]
+pub struct Grapheme(SequenceTree<String>);
+
+impl TextValue for Grapheme {
+    type Elem = String;
+
+    fn new(s: &str) -> Self {
+        let mut v = SequenceTree::new();
+        for ch in unicode_segmentation::UnicodeSegmentation::graphemes(s, true) {
+            v.push(ch.to_string())
+        }
+        Self(v)
     }
+
+    fn splice(&mut self, index: usize, value: &str) {
+        for (n, ch) in unicode_segmentation::UnicodeSegmentation::graphemes(value, true).enumerate()
+        {
+            self.0.insert(index + n, ch.to_string())
+        }
+    }
+
+    fn splice_text_value(&mut self, index: usize, value: &SequenceTree<Self::Elem>) {
+        for (n, ch) in value.iter().cloned().enumerate() {
+            self.0.insert(index + n, ch)
+        }
+    }
+
+    fn make_string(&self) -> String {
+        self.0.iter().fold(String::new(), |acc, s| acc + s)
+    }
+
+    fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    fn remove(&mut self, index: usize) {
+        self.0.remove(index);
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum ConcreteTextValue {
+    Utf8CodeUnit(Utf8),
+    Utf16CodeUnit(Utf16),
+    CodePoint(CodePoint),
+    List(List),
+    Grapheme(Grapheme),
+}
+
+impl ConcreteTextValue {
+    pub fn new(s: &str, text_rep: TextRepresentation) -> Self {
+        match text_rep {
+            TextRepresentation::Array => Self::List(List::new(s)),
+            TextRepresentation::String(text_encoding) => match text_encoding {
+                TextEncoding::Utf8CodeUnit => Self::Utf8CodeUnit(Utf8::new(s)),
+                TextEncoding::Utf16CodeUnit => Self::Utf16CodeUnit(Utf16::new(s)),
+                TextEncoding::UnicodeCodePoint => Self::CodePoint(CodePoint::new(s)),
+                TextEncoding::GraphemeCluster => Self::Grapheme(Grapheme::new(s)),
+            },
+        }
+    }
+
+    pub fn make_string(&self) -> String {
+        match self {
+            Self::Utf8CodeUnit(u) => u.make_string(),
+            Self::Utf16CodeUnit(u) => u.make_string(),
+            Self::CodePoint(u) => u.make_string(),
+            Self::List(u) => u.make_string(),
+            Self::Grapheme(u) => u.make_string(),
+        }
+    }
+
+    pub(crate) fn splice_text_value(
+        &mut self,
+        index: usize,
+        other: &ConcreteTextValue,
+    ) -> Result<(), error::MismatchedEncoding> {
+        match (self, other) {
+            (ConcreteTextValue::Utf16CodeUnit(this), ConcreteTextValue::Utf16CodeUnit(other)) => {
+                this.splice_text_value(index, &other.0);
+                Ok(())
+            }
+            (ConcreteTextValue::Utf8CodeUnit(this), ConcreteTextValue::Utf8CodeUnit(other)) => {
+                this.splice_text_value(index, &other.0);
+                Ok(())
+            }
+            (ConcreteTextValue::CodePoint(this), ConcreteTextValue::CodePoint(other)) => {
+                this.splice_text_value(index, &other.0);
+                Ok(())
+            }
+            (ConcreteTextValue::List(this), ConcreteTextValue::List(other)) => {
+                this.splice_text_value(index, &other.0);
+                Ok(())
+            }
+            (ConcreteTextValue::Grapheme(this), ConcreteTextValue::Grapheme(other)) => {
+                this.splice_text_value(index, &other.0);
+                Ok(())
+            }
+            _ => Err(error::MismatchedEncoding),
+        }
+    }
+
+    pub(crate) fn splice(&mut self, index: usize, value: &str) {
+        match self {
+            Self::Utf8CodeUnit(u) => u.splice(index, value),
+            Self::Utf16CodeUnit(u) => u.splice(index, value),
+            Self::CodePoint(u) => u.splice(index, value),
+            Self::List(u) => u.splice(index, value),
+            Self::Grapheme(u) => u.splice(index, value),
+        }
+    }
+
+    pub(crate) fn len(&self) -> usize {
+        match self {
+            Self::Utf8CodeUnit(u) => u.len(),
+            Self::Utf16CodeUnit(u) => u.len(),
+            Self::CodePoint(u) => u.len(),
+            Self::List(u) => u.len(),
+            Self::Grapheme(u) => u.len(),
+        }
+    }
+
+    pub(crate) fn remove(&mut self, index: usize) {
+        match self {
+            Self::Utf8CodeUnit(u) => u.remove(index),
+            Self::Utf16CodeUnit(u) => u.remove(index),
+            Self::CodePoint(u) => u.remove(index),
+            Self::List(u) => u.remove(index),
+            Self::Grapheme(u) => u.remove(index),
+        }
+    }
+}
+
+pub(crate) mod error {
+    #[derive(Debug, thiserror::Error)]
+    #[error("mismatched encoding")]
+    pub(crate) struct MismatchedEncoding;
 }

--- a/rust/automerge/src/transaction/inner.rs
+++ b/rust/automerge/src/transaction/inner.rs
@@ -2,6 +2,8 @@ use std::collections::HashSet;
 use std::num::NonZeroU64;
 use std::sync::Arc;
 
+use unicode_segmentation::UnicodeSegmentation;
+
 use crate::exid::ExId;
 use crate::iter::{ListRangeItem, MapRangeItem};
 use crate::marks::{ExpandMark, Mark, MarkSet};
@@ -9,7 +11,7 @@ use crate::op_set::{ChangeOpIter, OpIdx, OpIdxRange};
 use crate::patches::{PatchLog, TextRepresentation};
 use crate::query::{self, OpIdSearch};
 use crate::storage::Change as StoredChange;
-use crate::types::{Clock, Key, ListEncoding, ObjMeta, OpId};
+use crate::types::{Clock, Key, ListEncoding, ObjMeta, OpId, TextEncoding};
 use crate::{op_tree::OpSetData, types::OpBuilder, Automerge, Change, ChangeHash, Prop};
 use crate::{AutomergeError, ObjType, OpType, ReadDoc, ScalarValue};
 
@@ -23,6 +25,7 @@ pub(crate) struct TransactionInner {
     deps: Vec<ChangeHash>,
     scope: Option<Clock>,
     idx_range: OpIdxRange,
+    text_encoding: TextEncoding,
 }
 
 /// Arguments required to create a new transaction
@@ -40,6 +43,8 @@ pub(crate) struct TransactionArgs {
     pub(crate) deps: Vec<ChangeHash>,
     /// The scope that should be visible to the transaction
     pub(crate) scope: Option<Clock>,
+    /// How text indices should be calculated
+    pub(crate) text_encoding: TextEncoding,
 }
 
 impl TransactionInner {
@@ -51,6 +56,7 @@ impl TransactionInner {
             idx_range,
             deps,
             scope,
+            text_encoding,
         }: TransactionArgs,
     ) -> Self {
         TransactionInner {
@@ -62,6 +68,7 @@ impl TransactionInner {
             idx_range,
             deps,
             scope,
+            text_encoding,
         }
     }
 
@@ -457,9 +464,14 @@ impl TransactionInner {
         action: OpType,
     ) -> Result<Option<OpIdx>, AutomergeError> {
         let osd = doc.osd();
+        let encoding = match obj.typ {
+            ObjType::List => ListEncoding::List,
+            ObjType::Text => patch_log.text_rep().encoding(obj.typ),
+            other => return Err(AutomergeError::InvalidOp(other)),
+        };
         let query = doc.ops().search(
             &obj.id,
-            query::Nth::new(index, ListEncoding::List, self.scope.clone(), osd),
+            query::Nth::new(index, encoding, self.scope.clone(), osd),
         );
 
         let id = self.next_id();
@@ -588,7 +600,15 @@ impl TransactionInner {
         if obj.typ != ObjType::Text {
             return Err(AutomergeError::InvalidOp(obj.typ));
         }
-        let values = text.chars().map(ScalarValue::from).collect();
+        let values = match doc.text_encoding() {
+            // Arguably we should do this for all text, rather than just the grapheme cluster encoding.
+            // However, at the time which I (Alex Good) am writing this code the existing implementation
+            // uses the unicode code points and the grapheme cluster text encoding is a new thing. I
+            // don't want to change the existing behaviour for the existing text encodings without a
+            // little more thought.
+            TextEncoding::GraphemeCluster => text.graphemes(true).map(ScalarValue::from).collect(),
+            _ => text.chars().map(ScalarValue::from).collect(),
+        };
         self.inner_splice(
             doc,
             patch_log,
@@ -624,7 +644,7 @@ impl TransactionInner {
         }
 
         //let ex_obj = doc.ops().id_to_exid(obj.0);
-        let encoding = splice_type.encoding();
+        let encoding = splice_type.encoding(self.text_encoding);
         // delete `del` items - performing the query for each one
         let mut deleted: usize = 0;
         while deleted < (del as usize) {
@@ -698,7 +718,7 @@ impl TransactionInner {
             if patch_log.is_active() {
                 match splice_type {
                     SpliceType::Text(text)
-                        if matches!(patch_log.text_rep(), TextRepresentation::String) =>
+                        if matches!(patch_log.text_rep(), TextRepresentation::String(_)) =>
                     {
                         patch_log.splice(obj.id, index, text, marks);
                     }
@@ -706,7 +726,9 @@ impl TransactionInner {
                         let mut opid = self.next_id().minus(values.len());
                         for (offset, v) in values.iter().enumerate() {
                             opid = opid.next();
-                            patch_log.insert(obj.id, index + offset, v.clone().into(), opid, false);
+                            let hydrated =
+                                crate::hydrate::Value::new(v.clone(), patch_log.text_rep());
+                            patch_log.insert(obj.id, index + offset, hydrated, opid, false);
                         }
                     }
                 }
@@ -922,12 +944,16 @@ impl TransactionInner {
                     match (obj.typ, prop) {
                         (ObjType::List, Prop::Seq(index)) => {
                             //let value = (op.value(), doc.ops().id_to_exid(op.id));
-                            patch_log.insert(obj.id, index, op.value().into(), *op.id(), false);
+                            let value =
+                                crate::hydrate::Value::new(op.value(), patch_log.text_rep());
+                            patch_log.insert(obj.id, index, value, *op.id(), false);
                         }
                         (ObjType::Text, Prop::Seq(index)) => {
                             if matches!(patch_log.text_rep(), TextRepresentation::Array) {
                                 //let value = (op.value(), doc.ops().id_to_exid(op.id));
-                                patch_log.insert(obj.id, index, op.value().into(), *op.id(), false);
+                                let value =
+                                    crate::hydrate::Value::new(op.value(), patch_log.text_rep());
+                                patch_log.insert(obj.id, index, value, *op.id(), false);
                             } else {
                                 patch_log.splice(obj.id, index, op.as_str(), marks);
                             }
@@ -943,7 +969,8 @@ impl TransactionInner {
             } else if let Some(value) = op.get_increment_value() {
                 patch_log.increment(obj.id, &prop, value, *op.id());
             } else {
-                patch_log.put(obj.id, &prop, op.value().into(), *op.id(), false, false);
+                let value = crate::hydrate::Value::new(op.value(), patch_log.text_rep());
+                patch_log.put(obj.id, &prop, value, *op.id(), false, false);
             }
         }
     }
@@ -1144,10 +1171,10 @@ enum SpliceType<'a> {
 }
 
 impl<'a> SpliceType<'a> {
-    fn encoding(&self) -> ListEncoding {
+    fn encoding(&self, text_encoding: TextEncoding) -> ListEncoding {
         match self {
             SpliceType::List => ListEncoding::List,
-            SpliceType::Text(_) => ListEncoding::Text,
+            SpliceType::Text(_) => ListEncoding::Text(text_encoding),
         }
     }
 }

--- a/rust/automerge/src/transaction/manual_transaction.rs
+++ b/rust/automerge/src/transaction/manual_transaction.rs
@@ -350,6 +350,10 @@ impl<'a> ReadDoc for Transaction<'a> {
     fn stats(&self) -> crate::read::Stats {
         self.doc.stats()
     }
+
+    fn text_encoding(&self) -> crate::TextEncoding {
+        self.doc.text_encoding()
+    }
 }
 
 impl<'a> Transactable for Transaction<'a> {

--- a/rust/automerge/src/types.rs
+++ b/rust/automerge/src/types.rs
@@ -592,21 +592,32 @@ impl ObjMeta {
     }
 }
 
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum TextEncoding {
+    UnicodeCodePoint,
+    Utf8CodeUnit,
+    Utf16CodeUnit,
+    GraphemeCluster,
+}
+
+impl TextEncoding {
+    pub(crate) fn width(&self, s: &str) -> usize {
+        match self {
+            Self::UnicodeCodePoint => s.chars().count(),
+            Self::Utf8CodeUnit => s.bytes().len(),
+            Self::Utf16CodeUnit => s.encode_utf16().count(),
+            Self::GraphemeCluster => {
+                unicode_segmentation::UnicodeSegmentation::graphemes(s, true).count()
+            }
+        }
+    }
+}
+
 #[derive(Default, Debug, Copy, Clone, PartialEq, Eq)]
 pub(crate) enum ListEncoding {
     #[default]
     List,
-    Text,
-}
-
-impl From<Option<ObjType>> for ListEncoding {
-    fn from(obj: Option<ObjType>) -> Self {
-        if obj == Some(ObjType::Text) {
-            ListEncoding::Text
-        } else {
-            ListEncoding::List
-        }
-    }
+    Text(TextEncoding),
 }
 
 #[derive(Debug, Clone, Copy, PartialOrd, Eq, PartialEq, Ord, Hash, Default)]

--- a/rust/automerge/tests/test.rs
+++ b/rust/automerge/tests/test.rs
@@ -2,6 +2,7 @@ use automerge::marks::{ExpandMark, Mark};
 use automerge::op_tree::B;
 use automerge::patches::TextRepresentation;
 use automerge::transaction::{CommitOptions, Transactable};
+use automerge::TextEncoding;
 use automerge::{
     sync::SyncDoc, ActorId, AutoCommit, Automerge, AutomergeError, Change, ExpandedChange, ObjId,
     ObjType, Patch, PatchAction, PatchLog, Prop, ReadDoc, ScalarValue, SequenceTree, Value, ROOT,
@@ -1576,7 +1577,7 @@ fn regression_insert_opid() {
 
     let change2 = doc.get_last_local_change().unwrap().clone();
     let mut new_doc = Automerge::new();
-    let mut patch_log = PatchLog::active(TextRepresentation::String);
+    let mut patch_log = PatchLog::active(TextRepresentation::String(TextEncoding::default()));
     new_doc
         .apply_changes_log_patches(vec![change1], &mut patch_log)
         .unwrap();
@@ -1665,7 +1666,7 @@ fn big_list() {
 
     let change2 = doc.get_last_local_change().unwrap().clone();
     let mut new_doc = Automerge::new();
-    let mut patch_log = PatchLog::active(TextRepresentation::String);
+    let mut patch_log = PatchLog::active(TextRepresentation::String(TextEncoding::default()));
     new_doc
         .apply_changes_log_patches(vec![change1], &mut patch_log)
         .unwrap();
@@ -2042,7 +2043,11 @@ fn large_patches_in_lists_are_correct() {
         .unwrap()
         .result;
     let heads_after = doc.get_heads();
-    let patches = doc.diff(&heads_before, &heads_after, TextRepresentation::String);
+    let patches = doc.diff(
+        &heads_before,
+        &heads_after,
+        TextRepresentation::String(TextEncoding::default()),
+    );
     let final_patch = patches.last().unwrap();
     assert_eq!(
         final_patch.path,

--- a/rust/automerge/tests/text.rs
+++ b/rust/automerge/tests/text.rs
@@ -5,8 +5,10 @@ use automerge::{
     iter::Span,
     marks::{ExpandMark, Mark},
     op_tree::B,
+    patches::TextRepresentation,
     transaction::Transactable,
-    ActorId, AutoCommit, ObjType, Patch, PatchAction, ReadDoc, ScalarValue, ROOT,
+    ActorId, AutoCommit, ConcreteTextValue, ObjType, Patch, PatchAction, ReadDoc, ScalarValue,
+    TextEncoding, ROOT,
 };
 use proptest::strategy::Strategy;
 use test_log::test;
@@ -214,7 +216,10 @@ fn local_patches_created_for_marks() {
             path: vec![(automerge::ROOT, "text".into())],
             action: PatchAction::SpliceText {
                 index: 0,
-                value: "the ".into(),
+                value: ConcreteTextValue::new(
+                    "the ",
+                    TextRepresentation::String(TextEncoding::default()),
+                ),
                 marks: Some(
                     vec![("bold".to_string(), ScalarValue::from(true))]
                         .into_iter()
@@ -227,7 +232,10 @@ fn local_patches_created_for_marks() {
             path: vec![(automerge::ROOT, "text".into())],
             action: PatchAction::SpliceText {
                 index: 4,
-                value: "quick ".into(),
+                value: ConcreteTextValue::new(
+                    "quick ",
+                    TextRepresentation::String(TextEncoding::default()),
+                ),
                 marks: Some(
                     vec![
                         ("bold".to_string(), ScalarValue::from(true)),
@@ -243,7 +251,10 @@ fn local_patches_created_for_marks() {
             path: vec![(automerge::ROOT, "text".into())],
             action: PatchAction::SpliceText {
                 index: 10,
-                value: "fox".into(),
+                value: ConcreteTextValue::new(
+                    "fox",
+                    TextRepresentation::String(TextEncoding::default()),
+                ),
                 marks: Some(
                     vec![
                         ("bold".to_string(), ScalarValue::from(true)),
@@ -263,7 +274,10 @@ fn local_patches_created_for_marks() {
             path: vec![(automerge::ROOT, "text".into())],
             action: PatchAction::SpliceText {
                 index: 13,
-                value: " jumps".into(),
+                value: ConcreteTextValue::new(
+                    " jumps",
+                    TextRepresentation::String(TextEncoding::default()),
+                ),
                 marks: Some(
                     vec![
                         ("bold".to_string(), ScalarValue::from(true)),
@@ -279,7 +293,10 @@ fn local_patches_created_for_marks() {
             path: vec![(automerge::ROOT, "text".into())],
             action: PatchAction::SpliceText {
                 index: 19,
-                value: " over the lazy dog".into(),
+                value: ConcreteTextValue::new(
+                    " over the lazy dog",
+                    TextRepresentation::String(TextEncoding::default()),
+                ),
                 marks: Some(
                     vec![("bold".to_string(), ScalarValue::from(true))]
                         .into_iter()

--- a/rust/automerge/tests/text_encoding.rs
+++ b/rust/automerge/tests/text_encoding.rs
@@ -1,0 +1,636 @@
+use std::borrow::Cow;
+
+// Test that looking up by index works across diferent ways of calculating
+// the index
+//
+// Places in the codebase where we use indexes for manipulating text:
+//
+// # Reading values
+//
+// - ReadDoc::length and ReadDoc::length_at
+// - ReadDoc::marks and ReadDoc::marks_at (via the Mark::start and Mark::end)
+//   fields
+// - ReadDoc::get_cursor
+// - ReadDoc::get and ReadDoc::get_at
+// - ReadDoc::get_all and ReadDoc::get_all_at
+//
+// # Writing values
+//
+// - Transactable::put
+// - Transactable::insert
+// - Transactable::delete
+// - Transactable::splice_text
+// - Transactable::mark
+// - Transactable::unmark
+// - Transactable::split_block
+//
+// # Patches
+//
+// - PatchAction::PutSeq
+// - PatchAction::Insert
+// - PatchAction::SpliceText
+// - PatchAction::Conflict
+// - PatchAction::DeleteSeq
+// - PatchAction::Mark
+//
+// The task here is to ensure that all these methods work correctly when
+// different ways of calculating the index are used. There are four different
+// ways of calculating indexes in a text object:
+//
+// - The unicode code point index within a stream of characters
+// - The UTF-8 code unit offset, i.e. the byte offset into a UTF-8 encoding of
+//   the text
+// - The UTF-16 code unit offset
+// - The grapheme cluster index
+use automerge::{
+    marks::{ExpandMark, Mark},
+    transaction::Transactable,
+    AutoCommit, ObjId, ObjType, ReadDoc, ScalarValue, Value, ROOT,
+};
+
+#[derive(Debug, PartialEq, Clone, Copy)]
+enum Encoding {
+    UnicodeCodePoint,
+    Utf8CodeUnit,
+    Utf16CodeUnit,
+    GraphemeCluster,
+}
+
+impl From<Encoding> for automerge::TextEncoding {
+    fn from(value: Encoding) -> Self {
+        match value {
+            Encoding::UnicodeCodePoint => automerge::TextEncoding::UnicodeCodePoint,
+            Encoding::Utf8CodeUnit => automerge::TextEncoding::Utf8CodeUnit,
+            Encoding::Utf16CodeUnit => automerge::TextEncoding::Utf16CodeUnit,
+            Encoding::GraphemeCluster => automerge::TextEncoding::GraphemeCluster,
+        }
+    }
+}
+
+impl std::fmt::Display for Encoding {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::UnicodeCodePoint => write!(f, "UnicodeCodePoint"),
+            Self::Utf8CodeUnit => write!(f, "Utf8CodeUnit"),
+            Self::Utf16CodeUnit => write!(f, "Utf16CodeUnit"),
+            Self::GraphemeCluster => write!(f, "GraphemeCluster"),
+        }
+    }
+}
+
+enum Expected<T> {
+    Always(T),
+    ByEncoding {
+        code_point: T,
+        utf8: T,
+        utf16: T,
+        grapheme: T,
+    },
+}
+
+impl<T: PartialEq + std::fmt::Debug> Expected<T> {
+    fn assert(&self, actual: &T, encoding: Encoding) {
+        match self {
+            Self::Always(t) => assert_eq!(actual, t, "failed for {}", encoding),
+            Self::ByEncoding {
+                code_point,
+                utf8,
+                utf16,
+                grapheme,
+            } => match encoding {
+                Encoding::UnicodeCodePoint => {
+                    assert_eq!(actual, code_point, "failed for {}", encoding)
+                }
+                Encoding::Utf8CodeUnit => assert_eq!(actual, utf8, "failed for {}", encoding),
+                Encoding::Utf16CodeUnit => assert_eq!(actual, utf16, "failed for {}", encoding),
+                Encoding::GraphemeCluster => {
+                    assert_eq!(actual, grapheme, "failed for {}", encoding)
+                }
+            },
+        }
+    }
+}
+
+struct Scenario<F, T> {
+    text: &'static str,
+    action: F,
+    expected: Expected<T>,
+}
+
+impl<F: Fn(&mut AutoCommit, &automerge::ObjId, Encoding) -> T, T: PartialEq + std::fmt::Debug>
+    Scenario<F, T>
+{
+    fn run(&self) {
+        for encoding in [
+            Encoding::UnicodeCodePoint,
+            Encoding::Utf8CodeUnit,
+            Encoding::Utf16CodeUnit,
+            Encoding::GraphemeCluster,
+        ] {
+            self.run_with_encoding(encoding);
+        }
+    }
+
+    fn run_with_encoding(&self, encoding: Encoding) {
+        let mut doc = AutoCommit::new_with_encoding(encoding.into());
+        let text = doc.put_object(ROOT, "text", ObjType::Text).unwrap();
+        doc.splice_text(&text, 0, 0, self.text).unwrap();
+        let result = (self.action)(&mut doc, &text, encoding);
+        self.expected.assert(&result, encoding);
+    }
+}
+
+impl<
+        F: Fn(&mut AutoCommit, &automerge::ObjId, Encoding) -> Result<T, String>,
+        T: PartialEq + std::fmt::Debug,
+    > Scenario<F, T>
+{
+    fn run_fallible(&self) {
+        for encoding in [
+            Encoding::UnicodeCodePoint,
+            Encoding::Utf8CodeUnit,
+            Encoding::Utf16CodeUnit,
+            Encoding::GraphemeCluster,
+        ] {
+            self.run_fallible_with_encoding(encoding);
+        }
+    }
+
+    fn run_fallible_with_encoding(&self, encoding: Encoding) {
+        let mut doc = AutoCommit::new_with_encoding(encoding.into());
+        let text = doc.put_object(ROOT, "text", ObjType::Text).unwrap();
+        doc.splice_text(&text, 0, 0, self.text).unwrap();
+        let result = (self.action)(&mut doc, &text, encoding);
+        match result {
+            Ok(result) => self.expected.assert(&result, encoding),
+            Err(e) => panic!("failed for {}: {}", encoding, e),
+        }
+    }
+}
+
+// All of the following tests use the 👩‍👩‍👧‍👦 emoji which is the following sequence of code points:
+//
+// - U+1F469 WOM
+// - U+200D ZWJ
+// - U+1F467 GIRL
+// - U+1f466 BOY
+//
+// This is a useful test case because it is:
+//
+// * A single grapheme cluster
+// * 7 code points
+// * 11 utf-16 code units
+// * 25 utf-8 code units
+
+#[test]
+fn length() {
+    Scenario {
+        text: "hello👩‍👩‍👧‍👦",
+        action: |doc: &mut AutoCommit, text: &ObjId, _encoding: Encoding| doc.length(text),
+        expected: Expected::ByEncoding {
+            code_point: 12,
+            utf8: 30,
+            utf16: 16,
+            grapheme: 6,
+        },
+    }
+    .run();
+}
+
+#[test]
+fn splice_text() {
+    Scenario {
+        text: "hello 👩‍👩‍👧‍👦 world",
+        action: |doc: &mut AutoCommit, text: &ObjId, encoding: Encoding| {
+            let insert_index = match encoding {
+                Encoding::UnicodeCodePoint => 14,
+                Encoding::Utf8CodeUnit => 32,
+                Encoding::Utf16CodeUnit => 18,
+                Encoding::GraphemeCluster => 8,
+            };
+            doc.splice_text(text, insert_index, 0, "beautiful ")
+                .unwrap();
+            doc.text(text).unwrap()
+        },
+        expected: Expected::Always("hello 👩‍👩‍👧‍👦 beautiful world".to_string()),
+    }
+    .run();
+}
+
+#[test]
+fn mark() {
+    Scenario {
+        text: "he👩‍👩‍👧‍👦llo",
+        action: |doc: &mut AutoCommit, text: &ObjId, encoding: Encoding| {
+            let end_index = match encoding {
+                Encoding::UnicodeCodePoint => 11,
+                Encoding::Utf8CodeUnit => 27,
+                Encoding::Utf16CodeUnit => 13,
+                Encoding::GraphemeCluster => 4,
+            };
+            let mark = Mark::new("bold".to_string(), true, 1, end_index);
+            doc.mark(text, mark, ExpandMark::Both).unwrap();
+            doc.marks(text)
+                .unwrap()
+                .into_iter()
+                .map(|m| (m.start, m.end))
+                .collect::<Vec<_>>()
+        },
+        expected: Expected::ByEncoding {
+            code_point: vec![(1, 11)],
+            utf8: vec![(1, 27)],
+            utf16: vec![(1, 13)],
+            grapheme: vec![(1, 4)],
+        },
+    }
+    .run()
+}
+
+#[test]
+fn unmark() {
+    Scenario {
+        text: "he👩‍👩‍👧‍👦llo",
+        action: |doc: &mut AutoCommit, text: &ObjId, encoding: Encoding| {
+            let end_index = match encoding {
+                Encoding::UnicodeCodePoint => 11,
+                Encoding::Utf8CodeUnit => 27,
+                Encoding::Utf16CodeUnit => 13,
+                Encoding::GraphemeCluster => 4,
+            };
+            let mark = Mark::new("bold".to_string(), true, 1, end_index);
+            doc.mark(text, mark, ExpandMark::Both).unwrap();
+            doc.unmark(text, "bold", 1, end_index, ExpandMark::Both)
+                .unwrap();
+            doc.marks(text)
+                .unwrap()
+                .into_iter()
+                .map(|m| (m.start, m.end))
+                .collect::<Vec<_>>()
+        },
+        expected: Expected::Always(Vec::new()),
+    }
+    .run()
+}
+
+#[test]
+fn cursors() {
+    // Get a cursor for the first 'l' in 'he👩‍👩‍👧‍👦llo', then insert a '👩‍👩‍👧‍👦' before
+    // the 'l' and lookup the index of the cursor afterwards.
+    Scenario {
+        text: "he👩‍👩‍👧‍👦llo",
+        action: |doc: &mut AutoCommit, text: &ObjId, encoding: Encoding| {
+            let cursor_index = match encoding {
+                Encoding::UnicodeCodePoint => 9,
+                Encoding::Utf8CodeUnit => 27,
+                Encoding::Utf16CodeUnit => 13,
+                Encoding::GraphemeCluster => 3,
+            };
+            let cursor = doc.get_cursor(text, cursor_index, None).unwrap();
+            doc.splice_text(text, 2, 0, "👩‍👩‍👧‍👦").unwrap();
+            doc.get_cursor_position(text, &cursor, None).unwrap()
+        },
+        expected: Expected::ByEncoding {
+            code_point: 16,
+            utf8: 52,
+            utf16: 24,
+            grapheme: 4,
+        },
+    }
+    .run()
+}
+
+#[test]
+fn get() {
+    Scenario {
+        text: "he👩‍👩‍👧‍👦lo",
+        action: |doc: &mut AutoCommit, text: &ObjId, encoding: Encoding| {
+            let index = match encoding {
+                Encoding::UnicodeCodePoint => 9,
+                Encoding::Utf8CodeUnit => 27,
+                Encoding::Utf16CodeUnit => 13,
+                Encoding::GraphemeCluster => 3,
+            };
+            match doc.get(text, index).unwrap() {
+                Some((Value::Scalar(s), _)) => match s.as_ref() {
+                    ScalarValue::Str(s) => Some(s.to_string()),
+                    _ => None,
+                },
+                _ => None,
+            }
+        },
+        expected: Expected::Always(Some("l".to_string())),
+    }
+    .run()
+}
+
+#[test]
+fn put() {
+    Scenario {
+        text: "he👩‍👩‍👧‍👦llo",
+        action: |doc: &mut AutoCommit, text: &ObjId, encoding: Encoding| {
+            let index = match encoding {
+                Encoding::UnicodeCodePoint => 9,
+                Encoding::Utf8CodeUnit => 27,
+                Encoding::Utf16CodeUnit => 13,
+                Encoding::GraphemeCluster => 3,
+            };
+            doc.put(text, index, "L").unwrap();
+            doc.text(text).unwrap()
+        },
+        expected: Expected::Always("he👩‍👩‍👧‍👦Llo".to_string()),
+    }
+    .run()
+}
+
+#[test]
+fn insert() {
+    Scenario {
+        text: "he👩‍👩‍👧‍👦llo",
+        action: |doc: &mut AutoCommit, text: &ObjId, encoding: Encoding| {
+            let index = match encoding {
+                Encoding::UnicodeCodePoint => 9,
+                Encoding::Utf8CodeUnit => 27,
+                Encoding::Utf16CodeUnit => 13,
+                Encoding::GraphemeCluster => 3,
+            };
+            doc.insert(text, index, "L").unwrap();
+            doc.text(text).unwrap()
+        },
+        expected: Expected::Always("he👩‍👩‍👧‍👦Lllo".to_string()),
+    }
+    .run()
+}
+
+#[test]
+fn delete() {
+    Scenario {
+        text: "he👩‍👩‍👧‍👦llo",
+        action: |doc: &mut AutoCommit, text: &ObjId, encoding: Encoding| {
+            let index = match encoding {
+                Encoding::UnicodeCodePoint => 9,
+                Encoding::Utf8CodeUnit => 27,
+                Encoding::Utf16CodeUnit => 13,
+                Encoding::GraphemeCluster => 3,
+            };
+            doc.delete(text, index).unwrap();
+            doc.text(text).unwrap()
+        },
+        expected: Expected::Always("he👩‍👩‍👧‍👦lo".to_string()),
+    }
+    .run()
+}
+
+#[test]
+fn split_block() {
+    Scenario {
+        text: "he👩‍👩‍👧‍👦llo",
+        action: |doc: &mut AutoCommit, text: &ObjId, encoding: Encoding| {
+            let index = match encoding {
+                Encoding::UnicodeCodePoint => 9,
+                Encoding::Utf8CodeUnit => 27,
+                Encoding::Utf16CodeUnit => 13,
+                Encoding::GraphemeCluster => 3,
+            };
+            doc.split_block(text, index).unwrap();
+            doc.spans(text)
+                .unwrap()
+                .filter_map(|s| match s {
+                    automerge::iter::Span::Text(val, _) => Some(val),
+                    automerge::iter::Span::Block(_) => None,
+                })
+                .collect::<Vec<_>>()
+        },
+        expected: Expected::Always(vec!["he👩‍👩‍👧‍👦".to_string(), "llo".to_string()]),
+    }
+    .run()
+}
+
+#[test]
+fn patch_put_seq() {
+    Scenario {
+        text: "he👩‍👩‍👧‍👦llo",
+        action: |doc: &mut AutoCommit, text: &ObjId, encoding: Encoding| {
+            let index = match encoding {
+                Encoding::UnicodeCodePoint => 9,
+                Encoding::Utf8CodeUnit => 27,
+                Encoding::Utf16CodeUnit => 13,
+                Encoding::GraphemeCluster => 3,
+            };
+            doc.update_diff_cursor();
+            doc.put(text, index, "L").unwrap();
+            let indexes = doc
+                .diff_incremental()
+                .into_iter()
+                .map(|p| match p {
+                    automerge::Patch {
+                        action: automerge::PatchAction::PutSeq { index, value, .. },
+                        ..
+                    } => {
+                        if value.0 == Value::Scalar(Cow::Owned(ScalarValue::Str("L".into()))) {
+                            Ok(index)
+                        } else {
+                            Err(format!("unexpected value {}", value.0).to_string())
+                        }
+                    }
+                    other => Err(format!("unexpected patch action {:?}", other).to_string()),
+                })
+                .collect::<Result<Vec<_>, _>>()?;
+            if indexes.len() != 1 {
+                return Err(format!("expected 1 patch, got {}", indexes.len()));
+            }
+            Ok(indexes[0])
+        },
+        expected: Expected::ByEncoding {
+            code_point: 9,
+            utf8: 27,
+            utf16: 13,
+            grapheme: 3,
+        },
+    }
+    .run_fallible()
+}
+
+#[test]
+fn patch_insert() {
+    Scenario {
+        text: "he👩‍👩‍👧‍👦llo",
+        action: |doc: &mut AutoCommit, text: &ObjId, encoding: Encoding| {
+            let index = match encoding {
+                Encoding::UnicodeCodePoint => 9,
+                Encoding::Utf8CodeUnit => 27,
+                Encoding::Utf16CodeUnit => 13,
+                Encoding::GraphemeCluster => 3,
+            };
+            doc.update_diff_cursor();
+            doc.insert(text, index, "L").unwrap();
+            let indexes = doc
+                .diff_incremental()
+                .into_iter()
+                .map(|p| match p {
+                    automerge::Patch {
+                        action: automerge::PatchAction::SpliceText { index, value, .. },
+                        ..
+                    } => {
+                        if value.make_string() != "L" {
+                            Err(format!("unexpected value {}", value.make_string()).to_string())
+                        } else {
+                            Ok(index)
+                        }
+                    }
+                    other => Err(format!("unexpected patch action {:?}", other).to_string()),
+                })
+                .collect::<Result<Vec<_>, _>>()?;
+            if indexes.len() != 1 {
+                return Err(format!("expected 1 patch, got {}", indexes.len()));
+            }
+            Ok(indexes[0])
+        },
+        expected: Expected::ByEncoding {
+            code_point: 9,
+            utf8: 27,
+            utf16: 13,
+            grapheme: 3,
+        },
+    }
+    .run_fallible()
+}
+
+#[test]
+fn patch_splice_text() {
+    Scenario {
+        text: "he👩‍👩‍👧‍👦llo",
+        action: |doc: &mut AutoCommit, text: &ObjId, encoding: Encoding| {
+            let index = match encoding {
+                Encoding::UnicodeCodePoint => 9,
+                Encoding::Utf8CodeUnit => 27,
+                Encoding::Utf16CodeUnit => 13,
+                Encoding::GraphemeCluster => 3,
+            };
+            doc.update_diff_cursor();
+            doc.splice_text(text, index, 0, "L").unwrap();
+            let indexes = doc
+                .diff_incremental()
+                .into_iter()
+                .map(|p| match p {
+                    automerge::Patch {
+                        action: automerge::PatchAction::SpliceText { index, value, .. },
+                        ..
+                    } => {
+                        if value.make_string() != "L" {
+                            Err(format!("unexpected value {}", value.make_string()).to_string())
+                        } else {
+                            Ok(index)
+                        }
+                    }
+                    other => Err(format!("unexpected patch action {:?}", other).to_string()),
+                })
+                .collect::<Result<Vec<_>, _>>()?;
+            if indexes.len() != 1 {
+                return Err(format!("expected 1 patch, got {}", indexes.len()));
+            }
+            Ok(indexes[0])
+        },
+        expected: Expected::ByEncoding {
+            code_point: 9,
+            utf8: 27,
+            utf16: 13,
+            grapheme: 3,
+        },
+    }
+    .run_fallible()
+}
+
+#[test]
+fn patch_delete() {
+    Scenario {
+        text: "he👩‍👩‍👧‍👦llo",
+        action: |doc: &mut AutoCommit, text: &ObjId, encoding: Encoding| {
+            let index = match encoding {
+                Encoding::UnicodeCodePoint => 9,
+                Encoding::Utf8CodeUnit => 27,
+                Encoding::Utf16CodeUnit => 13,
+                Encoding::GraphemeCluster => 3,
+            };
+            doc.update_diff_cursor();
+            doc.delete(text, index).unwrap();
+            let indexes = doc
+                .diff_incremental()
+                .into_iter()
+                .map(|p| match p {
+                    automerge::Patch {
+                        action: automerge::PatchAction::DeleteSeq { index, length, .. },
+                        ..
+                    } => {
+                        if length != 1 {
+                            Err(format!("unexpected length {}", length).to_string())
+                        } else {
+                            Ok(index)
+                        }
+                    }
+                    other => Err(format!("unexpected patch action {:?}", other).to_string()),
+                })
+                .collect::<Result<Vec<_>, _>>()?;
+            if indexes.len() != 1 {
+                return Err(format!("expected 1 patch, got {}", indexes.len()));
+            }
+            Ok(indexes[0])
+        },
+        expected: Expected::ByEncoding {
+            code_point: 9,
+            utf8: 27,
+            utf16: 13,
+            grapheme: 3,
+        },
+    }
+    .run_fallible()
+}
+
+#[test]
+fn patch_mark() {
+    Scenario {
+        text: "he👩‍👩‍👧‍👦llo",
+        action: |doc: &mut AutoCommit, text: &ObjId, encoding: Encoding| {
+            let end_index = match encoding {
+                Encoding::UnicodeCodePoint => 9,
+                Encoding::Utf8CodeUnit => 27,
+                Encoding::Utf16CodeUnit => 13,
+                Encoding::GraphemeCluster => 3,
+            };
+            let mark = Mark::new("bold".to_string(), true, 1, end_index);
+            doc.diff_incremental();
+            doc.mark(text, mark, ExpandMark::Both).unwrap();
+            let indexes = doc
+                .diff_incremental()
+                .into_iter()
+                .filter(|p| p.obj == *text)
+                .map(|p| match p {
+                    automerge::Patch {
+                        action: automerge::PatchAction::Mark { mut marks },
+                        ..
+                    } => {
+                        if marks.len() != 1 {
+                            return Err(format!("expected 1 mark, got {}", marks.len()));
+                        }
+                        let mark = marks.pop().unwrap();
+                        if mark.name() != "bold" {
+                            return Err(format!("unexpected mark name {}", mark.name()));
+                        }
+                        Ok((mark.start, mark.end))
+                    }
+                    other => Err(format!("unexpected patch action {:?}", other).to_string()),
+                })
+                .collect::<Result<Vec<_>, _>>()?;
+            if indexes.len() != 1 {
+                return Err(format!("expected 1 patch, got {}", indexes.len()));
+            }
+            Ok(indexes[0])
+        },
+        expected: Expected::ByEncoding {
+            code_point: (1, 9),
+            utf8: (1, 27),
+            utf16: (1, 13),
+            grapheme: (1, 3),
+        },
+    }
+    .run_fallible()
+}


### PR DESCRIPTION
Problem: when users perform operations like "insert at index <x> in text <y>" Automerge has to transform the index into a position in the OpSet. Different platforms prefer different encodings for text, so we need to know what encoding to use to translate the index the user has given us into a position in the OpSet. Currently this configuration is selected by compile time feature flags, but in some cases users don't know what encoding the platform they are targeting uses until runtime (this is the case for Rust code which is compiled to WASM, but not always used in a browser).

Solution: Make the text encoding a parameter at document creation.