### PR TITLE
[#980] Documentation on how to build automerge-c docs is broken

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,8 @@ To build this codebase you will need:
 - `yarn`
 - `cmake`
 - `cmocka`
+- `doxygen`
+- `ninja`
 
 You will also need to install the following with `cargo install`
 

--- a/rust/automerge-c/README.md
+++ b/rust/automerge-c/README.md
@@ -5,6 +5,14 @@ for other language bindings that have good support for calling C functions.
 
 # Installing
 
+## Prerequisites
+
+* Cargo >= 1.71.0
+* CMake >= 3.25
+* CMocka >= 1.1.5
+* Doxygen >= 1.9.1
+* Ninja >= 1.10.1
+
 See the main README for instructions on getting your environment set up and then
 you can build the automerge-c library and install its constituent files within
 a root directory of your choosing (e.g. "/usr/local") like so:

--- a/rust/automerge-c/README.md
+++ b/rust/automerge-c/README.md
@@ -71,7 +71,7 @@ You can build and view the C API's HTML reference documentation like so:
 cmake -E make_directory automerge-c/build
 cmake -S automerge-c -B automerge-c/build
 cmake --build automerge-c/build --target automerge_docs
-firefox automerge-c/build/src/html/index.html
+firefox automerge-c/build/docs/html/index.html
 ```
 
 To get started quickly, look at the

--- a/rust/automerge-c/cmake/enum-string-functions-gen.cmake
+++ b/rust/automerge-c/cmake/enum-string-functions-gen.cmake
@@ -1,7 +1,7 @@
 # This CMake script is used to generate a header and a source file for utility
 # functions that convert the tags of generated enum types into strings and
 # strings into the tags of generated enum types.
-cmake_minimum_required(VERSION 3.23 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.25 FATAL_ERROR)
 
 # Seeks the starting line of the source enum's declaration.
 macro(seek_enum_mode)

--- a/rust/automerge-c/cmake/file-regex-replace.cmake
+++ b/rust/automerge-c/cmake/file-regex-replace.cmake
@@ -1,6 +1,6 @@
 # This CMake script is used to perform string substitutions within a generated
 # file.
-cmake_minimum_required(VERSION 3.23 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.25 FATAL_ERROR)
 
 if(NOT DEFINED MATCH_REGEX)
     message(FATAL_ERROR "Variable \"MATCH_REGEX\" is not defined.")

--- a/rust/automerge-c/cmake/file-touch.cmake
+++ b/rust/automerge-c/cmake/file-touch.cmake
@@ -1,6 +1,6 @@
 # This CMake script is used to force Cargo to regenerate the header file for the
 # core bindings after the out-of-source build directory has been cleaned.
-cmake_minimum_required(VERSION 3.23 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.25 FATAL_ERROR)
 
 if(NOT DEFINED CONDITION)
     message(FATAL_ERROR "Variable \"CONDITION\" is not defined.")

--- a/rust/automerge-c/docs/CMakeLists.txt
+++ b/rust/automerge-c/docs/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.23 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.25 FATAL_ERROR)
 
 find_package(Doxygen OPTIONAL_COMPONENTS dot)
 

--- a/rust/automerge-c/examples/CMakeLists.txt
+++ b/rust/automerge-c/examples/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.23 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.25 FATAL_ERROR)
 
 add_executable(
     ${LIBRARY_NAME}_quickstart

--- a/rust/automerge-c/test/CMakeLists.txt
+++ b/rust/automerge-c/test/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.23 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.25 FATAL_ERROR)
 
 find_package(cmocka CONFIG REQUIRED)
 


### PR DESCRIPTION
This PR fixes various documentation bugs related to building the reference documentation for the automerge-c library.

:eyes: @alexjg @msakrejda @orionz 