### PR TITLE
Fix bug with `update_text` at old heads

### DIFF
--- a/rust/automerge/src/text_diff.rs
+++ b/rust/automerge/src/text_diff.rs
@@ -18,7 +18,7 @@ pub(crate) fn myers_diff<'a, S: AsRef<str>>(
     text_obj: &ExId,
     new: S,
 ) -> Result<(), crate::AutomergeError> {
-    let old = doc.text(text_obj)?;
+    let old = doc.text_for(text_obj, tx.get_scope().clone())?;
     let new = new.as_ref();
     let old_graphemes = old.graphemes(true).collect::<Vec<&str>>();
     let new_graphemes = new.graphemes(true).collect::<Vec<&str>>();

--- a/rust/deny.toml
+++ b/rust/deny.toml
@@ -51,7 +51,7 @@ ignore = [
 # * Medium - CVSS Score 4.0 - 6.9
 # * High - CVSS Score 7.0 - 8.9
 # * Critical - CVSS Score 9.0 - 10.0
-#severity-threshold = 
+#severity-threshold =
 
 # This section is considered when running `cargo deny check licenses`
 # More documentation for the licenses section can be found here:
@@ -60,12 +60,7 @@ ignore = [
 # List of explictly allowed licenses
 # See https://spdx.org/licenses/ for list of possible licenses
 # [possible values: any SPDX 3.11 short identifier (+ optional exception)].
-allow = [
-    "MIT",
-    "Apache-2.0",
-    "Apache-2.0 WITH LLVM-exception",
-    "MPL-2.0",
-]
+allow = ["MIT", "Apache-2.0", "Apache-2.0 WITH LLVM-exception", "MPL-2.0"]
 # The confidence threshold for detecting a license from license text.
 # The higher the value, the more closely the license text must be to the
 # canonical license text of a valid SPDX license file.
@@ -101,8 +96,8 @@ exceptions = [
 # and the crate will be checked normally, which may produce warnings or errors
 # depending on the rest of your configuration
 #license-files = [
-    # Each entry is a crate relative path, and the (opaque) hash of its contents
-    #{ path = "LICENSE", hash = 0xbd0eed23 }
+# Each entry is a crate relative path, and the (opaque) hash of its contents
+#{ path = "LICENSE", hash = 0xbd0eed23 }
 #]
 
 [licenses.private]
@@ -131,8 +126,7 @@ wildcards = "allow"
 # * all - Both lowest-version and simplest-path are used
 highlight = "all"
 # List of crates that are allowed. Use with care!
-allow = [
-]
+allow = []
 # List of crates to deny
 deny = [
     # Each entry the name of a crate and a version range. If version is
@@ -146,17 +140,17 @@ deny = [
 # Certain crates/versions that will be skipped when doing duplicate detection.
 skip = [
     { name = "heck", version = "0.5.0" },
-    { crate = "windows-sys@0.52", reason = "this is brought in by the clap dependency in automerge-cli, which is fine as we're not distributing that as a library" },
     { crate = "regex-syntax@0.6.29", reason = "this is bought in by tracing-subscriber, which we only use in tests and the CLI" },
     { crate = "regex-automata@0.1.10", reason = "this is bought in by tracing-subscriber, which we only use in tests and the CLI" },
     { crate = "itertools@0.10.5", reason = "this is bought in by criterion, which we only use in benchmarks" },
+    { crate = "getrandom@0.3.1", reason = "this is bought in by cbindgen which is only in build" },
+    { crate = "wasi@0.13.3+wasi-0.2.2", reason = "this is bought in by cbindgens dependency on getrandom, which is only in build" },
 ]
-# Similarly to `skip` allows you to skip certain crates during duplicate 
-# detection. Unlike skip, it also includes the entire tree of transitive 
+# Similarly to `skip` allows you to skip certain crates during duplicate
+# detection. Unlike skip, it also includes the entire tree of transitive
 # dependencies starting at the specified crate, up to a certain depth, which is
 # by default infinite
-skip-tree = [
-]
+skip-tree = []
 
 # This section is considered when running `cargo deny check sources`.
 # More documentation about the 'sources' section can be found here:


### PR DESCRIPTION
`Transaction::update_text` implements a diff based method for modifying text in an automerge document. The method accepts a new string and performs a myers diff between the new string and the existing string in order to determine the changes that need to be made to the text.

Calling `update_text` from within a transaction that is based on non-current heads (such as within an `AutoCommit` on which you have called `AutoCommit::isolate`) would erroneously calculate the diff against the text from the latest heads, rather than the heads the transaction was based on. This commit fixes the issue by using the transaction heads to materialize the text to diff against.