### PR TITLE
Don't show removed marks in AutoCommit::get_marks

### DIFF
--- a/rust/automerge/src/automerge.rs
+++ b/rust/automerge/src/automerge.rs
@@ -1727,6 +1727,7 @@ impl Automerge {
             .marks()
             .as_deref()
             .cloned()
+            .map(|m| m.without_unmarks())
             .unwrap_or_default();
         Ok(result)
     }

--- a/rust/automerge/src/marks.rs
+++ b/rust/automerge/src/marks.rs
@@ -153,6 +153,14 @@ impl MarkSet {
         }
         marks.current().cloned()
     }
+
+    /// Return this MarkSet without any marks which have a value of Null, i.e.
+    /// marks which have been removed.
+    pub(crate) fn without_unmarks(self) -> Self {
+        let mut marks = self.marks.clone();
+        marks.retain(|_, value| !matches!(value, ScalarValue::Null));
+        MarkSet { marks }
+    }
 }
 
 // FromIterator implementation for an iterator of (String, ScalarValue) tuples


### PR DESCRIPTION
Problem: The `AutoCommit::get_marks` call which returns the marks active for a particular index in the text returns a map from mark name to value. This map still contains marks that have been removed, just with their value set to `ScalarValue::Null`. This is inconsistent with the `marks` API and `spans` APIs which return the marks active for the whole sequence of text and do not include removed marks at all.

Solution: Update the `AutoCommit::get_marks` function to only return marks that are active for the given index.