### PR TITLE
Fix marks in spans not respecting heads

### DIFF
--- a/javascript/test/block_test.ts
+++ b/javascript/test/block_test.ts
@@ -251,4 +251,22 @@ describe("Automerge", () => {
       })
     })
   })
+
+  describe("when using Automerge.view", () => {
+    it("should show historical marks", () => {
+      let doc = Automerge.from({ text: "hello world" })
+      doc = Automerge.change(doc, d => {
+        Automerge.mark(d, ["text"], { start: 0, end: 5 }, "bold", true)
+      })
+      const headsBefore = Automerge.getHeads(doc)
+      doc = Automerge.change(doc, d => {
+        Automerge.mark(d, ["text"], { start: 5, end: 11 }, "italic", true)
+      })
+      const spans = Automerge.spans(Automerge.view(doc, headsBefore), ["text"])
+      assert.deepStrictEqual(spans, [
+        { type: "text", value: "hello", marks: { bold: true } },
+        { type: "text", value: " world" },
+      ])
+    })
+  })
 })

--- a/rust/automerge/src/iter/spans.rs
+++ b/rust/automerge/src/iter/spans.rs
@@ -161,7 +161,7 @@ where
             return Some(block);
         }
         for op in &mut self.iter {
-            if !(op.is_mark() || op.visible_at(self.clock.as_ref())) {
+            if !op.visible_or_mark(self.clock.as_ref()) {
                 continue;
             }
             let key = op.elemid_or_key();


### PR DESCRIPTION
Problem: the spans returned by `Automerge::spans` always rendered the "latest" marks in the document - i.e. the marks corresponding to the tips of the commit graph. This means that if you call `Automerge::spans_at(<some heads>)` (or, in JS,
`Automerge.spans(Automerge.view(doc, heads), <path>))` you get the correct block markers (the block markers as at the given heads), but incorrect marks (the marks as at the latest heads in the document). The reason this was happening is that in the spans iterator, which iterates over every op in the document, we correctly skip invisible ops when processing blocks, but not when processing marks.

Solution: correctly skip invisible ops when processing marks.