### PR TITLE
js: Update webpack packaging tests to webpack 5.99.0

### DIFF
--- a/javascript/packaging_tests/webpack_cjs_fullfat/package.json
+++ b/javascript/packaging_tests/webpack_cjs_fullfat/package.json
@@ -10,8 +10,8 @@
   "description": "",
   "devDependencies": {
     "html-webpack-plugin": "^5.6.0",
-    "webpack": "^5.92.0",
-    "webpack-cli": "^5.1.4",
-    "webpack-dev-server": "^5.0.4"
+    "webpack": "^5.99.0",
+    "webpack-cli": "^6.0.1",
+    "webpack-dev-server": "^5.2.1"
   }
 }

--- a/javascript/packaging_tests/webpack_cjs_fullfat_next/package.json
+++ b/javascript/packaging_tests/webpack_cjs_fullfat_next/package.json
@@ -10,8 +10,8 @@
   "description": "",
   "devDependencies": {
     "html-webpack-plugin": "^5.6.0",
-    "webpack": "^5.92.0",
-    "webpack-cli": "^5.1.4",
-    "webpack-dev-server": "^5.0.4"
+    "webpack": "^5.99.0",
+    "webpack-cli": "^6.0.1",
+    "webpack-dev-server": "^5.2.1"
   }
 }

--- a/javascript/packaging_tests/webpack_cjs_slim/package.json
+++ b/javascript/packaging_tests/webpack_cjs_slim/package.json
@@ -10,8 +10,8 @@
   "description": "",
   "devDependencies": {
     "html-webpack-plugin": "^5.6.0",
-    "webpack": "^5.92.0",
-    "webpack-cli": "^5.1.4",
-    "webpack-dev-server": "^5.0.4"
+    "webpack": "^5.99.0",
+    "webpack-cli": "^6.0.1",
+    "webpack-dev-server": "^5.2.1"
   }
 }

--- a/javascript/packaging_tests/webpack_cjs_slim_next/package.json
+++ b/javascript/packaging_tests/webpack_cjs_slim_next/package.json
@@ -10,8 +10,8 @@
   "description": "",
   "devDependencies": {
     "html-webpack-plugin": "^5.6.0",
-    "webpack": "^5.92.0",
-    "webpack-cli": "^5.1.4",
-    "webpack-dev-server": "^5.0.4"
+    "webpack": "^5.99.0",
+    "webpack-cli": "^6.0.1",
+    "webpack-dev-server": "^5.2.1"
   }
 }

--- a/javascript/packaging_tests/webpack_esm_fullfat/package.json
+++ b/javascript/packaging_tests/webpack_esm_fullfat/package.json
@@ -11,8 +11,8 @@
   "description": "",
   "devDependencies": {
     "html-webpack-plugin": "^5.6.0",
-    "webpack": "^5.92.0",
-    "webpack-cli": "^5.1.4",
-    "webpack-dev-server": "^5.0.4"
+    "webpack": "^5.99.0",
+    "webpack-cli": "^6.0.1",
+    "webpack-dev-server": "^5.2.1"
   }
 }

--- a/javascript/packaging_tests/webpack_esm_fullfat_next/package.json
+++ b/javascript/packaging_tests/webpack_esm_fullfat_next/package.json
@@ -11,8 +11,8 @@
   "description": "",
   "devDependencies": {
     "html-webpack-plugin": "^5.6.0",
-    "webpack": "^5.92.0",
-    "webpack-cli": "^5.1.4",
-    "webpack-dev-server": "^5.0.4"
+    "webpack": "^5.99.0",
+    "webpack-cli": "^6.0.1",
+    "webpack-dev-server": "^5.2.1"
   }
 }

--- a/javascript/packaging_tests/webpack_esm_slim/package.json
+++ b/javascript/packaging_tests/webpack_esm_slim/package.json
@@ -11,8 +11,8 @@
   "description": "",
   "devDependencies": {
     "html-webpack-plugin": "^5.6.0",
-    "webpack": "^5.92.0",
-    "webpack-cli": "^5.1.4",
-    "webpack-dev-server": "^5.0.4"
+    "webpack": "^5.99.0",
+    "webpack-cli": "^6.0.1",
+    "webpack-dev-server": "^5.2.1"
   }
 }

--- a/javascript/packaging_tests/webpack_esm_slim_next/package.json
+++ b/javascript/packaging_tests/webpack_esm_slim_next/package.json
@@ -11,8 +11,8 @@
   "description": "",
   "devDependencies": {
     "html-webpack-plugin": "^5.6.0",
-    "webpack": "^5.92.0",
-    "webpack-cli": "^5.1.4",
-    "webpack-dev-server": "^5.0.4"
+    "webpack": "^5.99.0",
+    "webpack-cli": "^6.0.1",
+    "webpack-dev-server": "^5.2.1"
   }
 }


### PR DESCRIPTION
Problem: when using rustc > 1.82 and webpack < 5.97.0 the wasm file generated by wasm-bindgen can't be loaded by webpack. This is tracked by an issue [1] in the wasm-bindgen repo and an issue [2] in the webpack repo. This meant that the packaging tests were failing.

Solution: upgrade the packaging tests to use webpack 5.99.0. This does mean that people using older versions of webpack will need to upgrade, but it's a patch version upgrade so shouldn't be too disruptive.

[1]: https://github.com/rustwasm/wasm-bindgen/issues/4211
[2]: https://github.com/webpack/webpack/issues/15566