### PR TITLE
seek_ops_by_index would sometimes hit marks

### DIFF
--- a/rust/automerge/src/op_set2/change/batch.rs
+++ b/rust/automerge/src/op_set2/change/batch.rs
@@ -1195,9 +1195,6 @@ mod tests {
             .ok()
             .and_then(|s| s.parse::<u64>().ok())
             .unwrap_or_else(rand::random::<u64>);
-        // problem seed -> 3727965917273105553 - FIXME
-        // problem seed -> 15102432554960960582 - FIXME
-        // problem seed -> 7766005994852412174 - FIXME
         log!("SEED: {}", seed);
         SmallRng::seed_from_u64(seed)
     }

--- a/rust/automerge/src/op_set2/op_set.rs
+++ b/rust/automerge/src/op_set2/op_set.rs
@@ -453,12 +453,15 @@ impl OpSet {
         if let Some(tx) = iter.nth(index) {
             assert!(tx.acc >= obj_start);
             index = (tx.acc - obj_start).as_usize();
+            // TODO
+            // could use a SkipIter here
+            // could grab only needed fields and not all ops
             for op in self.iter_range(&(tx.pos..range.end)) {
                 if op.insert && !ops.is_empty() {
                     break;
                 }
                 end_pos = op.pos + 1;
-                if op.succ().len() == 0 {
+                if op.succ().len() == 0 && op.action != Action::Mark {
                     ops.push(op);
                 }
             }


### PR DESCRIPTION
Simple enough fix - optimized function wouldn't skip over marks after seeking to the starting location