### PR TITLE
js: Fix indexOf not finding string elements

### DIFF
--- a/javascript/src/proxies.ts
+++ b/javascript/src/proxies.ts
@@ -557,11 +557,41 @@ function listMethods(target: Target) {
       return this
     },
 
-    indexOf(o: any, start = 0) {
+    indexOf(searchElement: any, start = 0) {
       const length = context.length(objectId)
       for (let i = start; i < length; i++) {
-        const value = context.getWithType(objectId, i)
-        if (value && (value[1] === o[OBJECT_ID] || value[1] === o)) {
+        const valueWithType = context.getWithType(objectId, i)
+        if (!valueWithType) {
+          continue
+        }
+
+        const [valType, value] = valueWithType
+
+        // Either the target element is an object, and we return if we have found
+        // the same object or it is a primitive value and we return if it matches
+        // the current value
+        const isObject = ["map", "list", "text"].includes(valType)
+
+        if (!isObject) {
+          // If the element is not an object, then check if the value is equal to the target
+          if (value === searchElement) {
+            return i
+          } else {
+            continue
+          }
+        }
+
+        // if it's an object, but the type of the search element is a string, then we
+        // need to check if the object is a text object with the same value as the search element
+        if (valType === "text" && typeof searchElement === "string") {
+          if (searchElement === valueAt(target, i)) {
+            return i
+          }
+        }
+
+        // The only possible match now is if the searchElement is an object already in the
+        // automerge document with the same object ID as the value
+        if (searchElement[OBJECT_ID] === value) {
           return i
         }
       }

--- a/javascript/test/proxies.ts
+++ b/javascript/test/proxies.ts
@@ -63,6 +63,25 @@ describe("Proxies", () => {
     })
   })
 
+  describe("List indexOf", () => {
+    let doc: Doc<DocType>
+    beforeEach(() => {
+      doc = from({ list: ["a", "b", "c"] })
+    })
+
+    it("should return the index of a value for a string in a list of strings", () => {
+      change(doc, d => {
+        assert.equal(d.list.indexOf("b"), 1)
+      })
+    })
+
+    it("should return -1 if the value is not found", () => {
+      change(doc, d => {
+        assert.equal(d.list.indexOf("d"), -1)
+      })
+    })
+  })
+
   describe("List splice", () => {
     it("should be able to remove a defined number of list entries", () => {
       doc = change(doc, d => {


### PR DESCRIPTION
Problem: the indexOf method which is exposed on lists inside of a `change` callback does not handle strings correctly. For example, this test

```
let doc = Automerge.from({list: ["a", "b", "c"]})
doc = Automerge.change(doc, d => {
    assert.equal(d.list.indexOf("b"), 1)
})
```

Will fail. The `indexOf` will return `-1`. The reason is that the elements of the list are represented as text objects but we compare them with native javascript strings inside `indexof`.

Solution: if the search element argument to `indexOf` is a string, check whether the candidate element is a text object and compare the search element to the reified text of the candidate element. I also commented the implementation as it was a little terse and hard to follow.