### PR TITLE
bugfix: don't emit patches for conflicts

### DIFF
--- a/rust/automerge/src/automerge.rs
+++ b/rust/automerge/src/automerge.rs
@@ -1641,7 +1641,7 @@ impl Automerge {
             if !visible_objs.contains(&obj.id) {
                 continue;
             }
-            for op in ops.visible(at.clone()) {
+            for op in ops.visible(at.clone()).top_ops() {
                 //if op.visible_at(at.as_ref()) {
                 if let OpType::Make(_) = op.op_type() {
                     visible_objs.insert(op.id.into());


### PR DESCRIPTION
Problem: in some scenarios it was possible for the patch logic to emit patches for elements of an object which were not actually visible. This would occur if both of these things happened:

* A change had been made to a conflicted object which was not the "winner" of the conflict
* The change was made in an interaction (e.g. a change callback, or a receive sync message) which generated a large number of patches (specifically more than 100)

In this case the patch logic would emit patches for the "loser" of the conflict, which would then be applied by the patch logic, resulting in garbled output.

The reason this was occurring is that if there are more than 100 patches to render the patch logic precomputes a cache of all the live objects in the document to avoid repeatedly traversing the document to render patch paths. This precomputation was using `OpSet::visible`, which returns _all the conflicting objects_ in the document. This meant that we considered patches to be visible even if they were a hidden conflict.

Solution: Use `OpSet::visible()::top_ops()` to scope the paths to the winners of the conflicts.
  
Fixes #951 