### PR TITLE
js: freeze getConflicts return value outside of change callbacks

### DIFF
--- a/javascript/src/conflicts.ts
+++ b/javascript/src/conflicts.ts
@@ -1,13 +1,34 @@
 import { Counter, AutomergeValue } from "./types.js"
 import { mapProxy, listProxy } from "./proxies.js"
-import type { Automerge, Prop, ObjID } from "./wasm_types.js"
+import type { Automerge, Prop, ObjID, FullValue } from "./wasm_types.js"
 
 export type Conflicts = { [key: string]: AutomergeValue }
 
+/**
+ * The conflicting values at a particular property in an object
+ *
+ * The return value of this function is a map. The values of the map are the
+ * conflicting values and the keys are the op IDs which set those values. Most of
+ * the time all you care about is the values.
+ *
+ * One important note is that the return type of this function differs based on
+ * whether we are inside a change callback or not. Inside a change callback we
+ * return proxies, just like anywhere else in the document. This allows the user to
+ * make changes inside a conflicted value without being forced to first resolve the
+ * conflict. Outside of a change callback we return frozen POJOs.
+ *
+ * @param context The underlying automerge-wasm document
+ * @param objectId The object ID within which we are looking up conflicts
+ * @param prop The property inside the object which we are looking up conflicts for
+ * @param withinChangeCallback Whether we are inside a currently running change callback
+ *
+ * @returns A map from op ID to the value for that op ID
+ */
 export function conflictAt(
   context: Automerge,
   objectId: ObjID,
   prop: Prop,
+  withinChangeCallback: boolean,
 ): Conflicts | undefined {
   const values = context.getAll(objectId, prop)
   if (values.length <= 1) {
@@ -17,10 +38,18 @@ export function conflictAt(
   for (const fullVal of values) {
     switch (fullVal[0]) {
       case "map":
-        result[fullVal[1]] = mapProxy(context, fullVal[1], [prop])
+        if (withinChangeCallback) {
+          result[fullVal[1]] = mapProxy(context, fullVal[1], [prop])
+        } else {
+          result[fullVal[1]] = reifyFullValue(context, [fullVal[0], fullVal[1]])
+        }
         break
       case "list":
-        result[fullVal[1]] = listProxy(context, fullVal[1], [prop])
+        if (withinChangeCallback) {
+          result[fullVal[1]] = listProxy(context, fullVal[1], [prop])
+        } else {
+          result[fullVal[1]] = reifyFullValue(context, [fullVal[0], fullVal[1]])
+        }
         break
       case "text":
         result[fullVal[1]] = context.text(fullVal[1] as ObjID)
@@ -45,4 +74,49 @@ export function conflictAt(
     }
   }
   return result
+}
+
+function reifyFullValue(
+  context: Automerge,
+  fullValue: FullValue,
+): AutomergeValue {
+  switch (fullValue[0]) {
+    case "map":
+      const mapResult = {}
+      for (const key of context.keys(fullValue[1])) {
+        let subVal = context.getWithType(fullValue[1], key)
+        if (!subVal) {
+          throw new Error("unexpected null map value")
+        }
+        mapResult[key] = reifyFullValue(context, subVal)
+      }
+      return Object.freeze(mapResult)
+    case "list":
+      const listResult: AutomergeValue[] = []
+      const length = context.length(fullValue[1])
+      for (let i = 0; i < length; i++) {
+        let subVal = context.getWithType(fullValue[1], i)
+        if (!subVal) {
+          throw new Error("unexpected null list element")
+        }
+        listResult.push(reifyFullValue(context, subVal))
+      }
+      return Object.freeze(listResult) as AutomergeValue
+    case "text":
+      return context.text(fullValue[1])
+    case "str":
+    case "uint":
+    case "int":
+    case "f64":
+    case "boolean":
+    case "bytes":
+    case "null":
+      return fullValue[1]
+    case "counter":
+      return new Counter(fullValue[1]) as AutomergeValue
+    case "timestamp":
+      return new Date(fullValue[1]) as AutomergeValue
+    default:
+      throw RangeError(`datatype ${fullValue[0]} unimplemented`)
+  }
 }

--- a/javascript/src/implementation.ts
+++ b/javascript/src/implementation.ts
@@ -877,7 +877,8 @@ export function getConflicts<T>(
   const state = _state(doc, false)
   const objectId = _obj(doc)
   if (objectId != null) {
-    return conflictAt(state.handle, objectId, prop)
+    const withinChangeCallback = _is_proxy(doc)
+    return conflictAt(state.handle, objectId, prop, withinChangeCallback)
   } else {
     return undefined
   }

--- a/javascript/test/conflicts.ts
+++ b/javascript/test/conflicts.ts
@@ -1,0 +1,143 @@
+import * as assert from "assert"
+import * as Automerge from "../src/index.js"
+
+describe("conflicts", () => {
+  it("should not allow updating values inside a conflict outside of the change callback", () => {
+    // This test is basically checking that we don't accidentally return proxies
+    // which can modify the document when outside of a change callback
+
+    // Create a conflicted document
+    let doc = Automerge.from({ user: { name: "alice" } })
+    let doc2 = Automerge.clone(doc)
+    doc = Automerge.change(doc, d => {
+      d.user = { name: "bob" }
+    })
+    doc2 = Automerge.change(doc2, d => {
+      d.user = { name: "charlie" }
+    })
+    doc = Automerge.merge(doc, doc2)
+
+    // Load the conflicts
+    let conflicts = Automerge.getConflicts(doc, "user")
+    if (!conflicts || !(typeof conflicts === "object")) {
+      throw new Error("unable to get conflicts")
+    }
+
+    // Modify the conflicted objects returned from getConflicts
+    for (const value of Object.values(conflicts)) {
+      if (!value || !(typeof value === "object")) {
+        continue
+      }
+      if (Reflect.get(value, "name") === "bob") {
+        try {
+          Reflect.set(value, "name", "Attila")
+        } catch {}
+      }
+    }
+
+    // Make sure that the conflicts inside the document have not changed
+    conflicts = Automerge.getConflicts(doc, "user")
+    if (!conflicts || !(typeof conflicts === "object")) {
+      throw new Error("unable to get conflicst")
+    }
+    // We can't use assert.deepStrictEqual directly as it doesn't respect proxy traps
+    // so instead we get the names out of the conflicted objects, one of which will
+    // have changed in the Reflect.set call above if we did erroneously return proxies
+    // from getConflicts above
+    let names = Object.values(conflicts).map(c => {
+      if (!c || !(typeof c === "object")) {
+        throw new Error("conflict should be an object")
+      }
+      return Reflect.get(c, "name")
+    })
+    assert.deepStrictEqual(new Set(names), new Set(["charlie", "bob"]))
+  })
+
+  it("should allow updating  values inside a conflicted map", () => {
+    let doc = Automerge.from({ user: {} })
+    let doc2 = Automerge.clone(doc)
+    doc2 = Automerge.change(doc2, d => {
+      d.user = { name: "alice" }
+    })
+    let doc3 = Automerge.clone(doc)
+    doc3 = Automerge.change(doc3, d => {
+      d.user = { name: "charlie" }
+    })
+
+    doc = Automerge.change(doc, d => {
+      d.user = { name: "bob" }
+    })
+
+    doc = Automerge.merge(doc, doc2)
+    doc = Automerge.merge(doc, doc3)
+
+    let conflictsBefore = Automerge.getConflicts(doc, "user")
+    assert.deepStrictEqual(conflictsBefore, {
+      [`2@${Automerge.getActorId(doc)}`]: { name: "bob" },
+      [`2@${Automerge.getActorId(doc2)}`]: { name: "alice" },
+      [`2@${Automerge.getActorId(doc3)}`]: { name: "charlie" },
+    })
+
+    doc = Automerge.change(doc, d => {
+      let conflicts = Automerge.getConflicts(d, "user")
+      if (conflicts) {
+        for (const conflict of Object.values(conflicts)) {
+          if (conflict && typeof conflict === "object") {
+            conflict["name"] = "Attila"
+          }
+        }
+      }
+    })
+
+    let conflictsAfter = Automerge.getConflicts(doc, "user")
+    assert.deepStrictEqual(conflictsAfter, {
+      [`2@${Automerge.getActorId(doc)}`]: { name: "Attila" },
+      [`2@${Automerge.getActorId(doc2)}`]: { name: "Attila" },
+      [`2@${Automerge.getActorId(doc3)}`]: { name: "Attila" },
+    })
+  })
+
+  it("should allow updating  values inside a conflicted list", () => {
+    let doc = Automerge.from({ users: [{ name: "ignored" }] })
+    let doc2 = Automerge.clone(doc)
+    doc2 = Automerge.change(doc2, d => {
+      d.users[0] = { name: "alice" }
+    })
+    let doc3 = Automerge.clone(doc)
+    doc3 = Automerge.change(doc3, d => {
+      d.users[0] = { name: "charlie" }
+    })
+
+    doc = Automerge.change(doc, d => {
+      d.users[0] = { name: "bob" }
+    })
+
+    doc = Automerge.merge(doc, doc2)
+    doc = Automerge.merge(doc, doc3)
+
+    let conflictsBefore = Automerge.getConflicts(doc.users, 0)
+    assert.deepStrictEqual(conflictsBefore, {
+      [`11@${Automerge.getActorId(doc)}`]: { name: "bob" },
+      [`11@${Automerge.getActorId(doc2)}`]: { name: "alice" },
+      [`11@${Automerge.getActorId(doc3)}`]: { name: "charlie" },
+    })
+
+    doc = Automerge.change(doc, d => {
+      let conflicts = Automerge.getConflicts(d.users, 0)
+      if (conflicts) {
+        for (const conflict of Object.values(conflicts)) {
+          if (conflict && typeof conflict === "object") {
+            Reflect.set(conflict, "name", "Attila")
+          }
+        }
+      }
+    })
+
+    let conflictsAfter = Automerge.getConflicts(doc.users, 0)
+    assert.deepStrictEqual(conflictsAfter, {
+      [`11@${Automerge.getActorId(doc)}`]: { name: "Attila" },
+      [`11@${Automerge.getActorId(doc2)}`]: { name: "Attila" },
+      [`11@${Automerge.getActorId(doc3)}`]: { name: "Attila" },
+    })
+  })
+})


### PR DESCRIPTION
Problem: the getConflicts call returns proxies which allow users to modify the values inside conflicted values. This is great inside a change callback but outside of a change callback it allows modifications of a document by modifying the conflicted values. This is extremely confusing as it's entirely opposite to how the rest of the API works.

Solution: detect if we are inside a change callback in `getConflicts` and if we are not, return a frozen POJO object instead of a proxy. This is much more predictable. 

As a side benefit, this fixes some tests which recently started failing due to changes in the way `assert.deepStrictEqual` treats proxies in recent node versions.