### PR TITLE
sync opt

### DIFF
--- a/rust/automerge/src/automerge.rs
+++ b/rust/automerge/src/automerge.rs
@@ -539,7 +539,7 @@ impl Automerge {
         Ok(f)
     }
 
-    fn get_changes_by_hashes(
+    pub(crate) fn get_changes_by_hashes(
         &self,
         hashes: Vec<ChangeHash>,
     ) -> Result<Vec<Change>, AutomergeError> {
@@ -1686,7 +1686,7 @@ impl Automerge {
         other.shared_heads == self.get_heads()
     }
 
-    fn has_change(&self, head: &ChangeHash) -> bool {
+    pub(crate) fn has_change(&self, head: &ChangeHash) -> bool {
         self.change_graph.has_change(head)
     }
 
@@ -1914,9 +1914,9 @@ impl ReadDoc for Automerge {
         let opid = self.exid_to_opid(obj)?;
         let typ = self.ops.object_type(&ObjId(opid));
         typ.ok_or_else(|| AutomergeError::InvalidObjId(obj.to_string()))
-        //Ok(typ)
     }
 
+    #[inline(never)]
     fn get_missing_deps(&self, heads: &[ChangeHash]) -> Vec<ChangeHash> {
         let in_queue: HashSet<_> = self.queue.iter().map(|change| change.hash()).collect();
         let mut missing = HashSet::new();

--- a/rust/automerge/src/sync/bloom.rs
+++ b/rust/automerge/src/sync/bloom.rs
@@ -107,6 +107,7 @@ impl BloomFilter {
             .map(|byte| byte & (1 << (probe & 7)))
     }
 
+    #[inline(never)]
     pub fn contains_hash(&self, hash: &ChangeHash) -> bool {
         if self.num_entries == 0 {
             false

--- a/rust/automerge/src/sync/message_builder.rs
+++ b/rust/automerge/src/sync/message_builder.rs
@@ -71,8 +71,4 @@ impl MessageBuilder {
             version: self.version,
         }
     }
-
-    pub(super) fn has_changes_to_send(&self) -> bool {
-        !self.changes.is_empty()
-    }
 }


### PR DESCRIPTION
Two big optimizations for sync

1. lots of the sync code was still requesting full changes when all it needed was hashes (2.2 -> 3.0) issue.  This has been fixed
2. found a bug where the send_whole doc was not triggering most of the time leading to much slower init sync

my test sync for 
 full -> full  went form 1600ms -> 17ms 
 full -> empty went from 3400ms -> 1600ms

