### PR TITLE
rust: fix a bug where marks didn't cross block markers in spans

### DIFF
--- a/javascript/src/implementation.ts
+++ b/javascript/src/implementation.ts
@@ -1535,7 +1535,7 @@ export function updateSpans<T>(doc: Doc<T>, path: Prop[], newSpans: Span[]) {
   try {
     state.handle.updateSpans(objPath, newSpans)
   } catch (e) {
-    throw new RangeError(`Cannot updateBlock: ${e}`)
+    throw new RangeError(`Cannot updateSpans: ${e}`)
   }
 }
 


### PR DESCRIPTION
Problem: the `Automerge::spans` function didn't correctly report spans with marks which crossed block markers. This was quite fiddly to debug because the logic for emitting spans is a bit complex.

Solution: clean up the spans iterator a bit so it's clearer when we're emitting spans, then always keep track of the active marks so that when we emit a block marker we don't lose the state of marks which cross the block marker.