### PR TITLE
add index to query insert, delete after multi-byte

### DIFF
--- a/rust/automerge-wasm/test/test.mts
+++ b/rust/automerge-wasm/test/test.mts
@@ -2486,13 +2486,13 @@ describe("Automerge", () => {
       assert.deepEqual(remote.length("/width2"), 14);
       assert.deepEqual(remote.length("/mixed"), 7);
 
-      // when indexing in the middle of a multibyte char it indexes at the char before
+      // when indexing in the middle of a multibyte char it indexes at the char after
       doc.splice("/width2", 4, 1, "X");
       mat = doc.applyPatches(mat);
       remote.loadIncremental(doc.saveIncremental());
       r_mat = remote.applyPatches(r_mat);
 
-      assert.deepEqual(mat.width2, "🐻AXA🐻🐻🐻🐻");
+      assert.deepEqual(mat.width2, "🐻A🐻X🐻🐻🐻🐻");
 
       assert.deepEqual(doc.length("/width1", heads1), 6);
       assert.deepEqual(doc.length("/width2", heads1), 12);
@@ -2558,19 +2558,18 @@ describe("Automerge", () => {
       assert.deepEqual(doc.text("/bad_text"), "ABBBBB\ufffcC");
       assert.deepEqual(doc.materialize("/bad_text"), "ABBBBB\ufffcC");
 
-      // deleting in the middle of a multi-byte character will delete the whole thing
+      // deleting in the middle of a multi-byte character will delete after 
       const doc1 = doc.fork();
       doc1.splice("/bad_text", 3, 3, "X");
-      assert.deepEqual(doc1.text("/bad_text"), "AX\ufffcC");
+      assert.deepEqual(doc1.text("/bad_text"), "ABBBBBX");
 
-      // deleting in the middle of a multi-byte character will delete the whole thing
-      // and characters past its end
+      // deleting in the middle of a multi-byte character will delete after
       const doc2 = doc.fork();
       doc2.splice("/bad_text", 3, 4, "X");
-      assert.deepEqual(doc2.text("/bad_text"), "AXC");
+      assert.deepEqual(doc2.text("/bad_text"), "ABBBBBX");
 
       const doc3 = doc.fork();
-      doc3.splice("/bad_text", 3, 5, "X");
+      doc3.splice("/bad_text", 1, 7, "X");
       assert.deepEqual(doc3.text("/bad_text"), "AX");
 
       // inserting in the middle of a mutli-bytes span inserts after

--- a/rust/automerge/src/lib.rs
+++ b/rust/automerge/src/lib.rs
@@ -274,7 +274,8 @@ pub mod hydrate;
 mod indexed_cache;
 pub mod iter;
 pub use iter::Span;
-mod legacy;
+#[doc(hidden)]
+pub mod legacy;
 pub mod marks;
 pub mod op_set2;
 pub mod patches;

--- a/rust/automerge/src/op_set2/columns.rs
+++ b/rust/automerge/src/op_set2/columns.rs
@@ -385,10 +385,11 @@ impl Columns {
         let mut value = self.value.raw_reader(0);
         let mut succ = self.succ_count.iter();
         let mut insert = self.insert.iter();
+        let mut text = self.index.text.iter();
         let mut vis = self.index.visible.iter();
         let mut top = self.index.top.iter();
         let mut pos = 0;
-        log!("::::: id       obj      key        elem     i v t act suc value");
+        log!("::::: id       obj      key        elem     i v t tx act suc value");
         loop {
             let id_a = fmt(id_a.next());
             let id_c = fmt(id_c.next());
@@ -396,6 +397,7 @@ impl Columns {
             let obj_c = fmt(obj_c.next());
             let act = fmt(act.next());
             let insert = fmt_bool(insert.next());
+            let text = fmt(text.next());
             let vis = fmt_bool(vis.next());
             let top = fmt_bool(top.next());
             let key_s = fmt(key_str.next());
@@ -413,7 +415,7 @@ impl Columns {
                 break;
             }
             log!(
-                "{:4}: {:8} {:8} {:10} {:8} {:1} {:1} {:1} {:3} {:1}   {}",
+                "{:4}: {:8} {:8} {:10} {:8} {:1} {:1} {:1} {:2} {:3} {:1}   {}",
                 pos,
                 format!("({}, {})", id_c, id_a),
                 format!("({}, {})", obj_c, obj_a),
@@ -422,6 +424,7 @@ impl Columns {
                 insert,
                 vis,
                 top,
+                text,
                 act,
                 succ,
                 v,

--- a/rust/automerge/src/op_set2/op_set.rs
+++ b/rust/automerge/src/op_set2/op_set.rs
@@ -413,11 +413,13 @@ impl OpSet {
     ) -> Option<QueryNth> {
         let range = self.scope_to_obj(obj);
         let mut iter = self.cols.index.text.iter_range(range.clone()).with_acc();
+        let start_acc = iter.acc().as_usize();
         let tx = iter.nth(index.get() - 1)?;
+        let current_acc = tx.acc.as_usize();
         let iter = self.iter_range(&(tx.pos..range.end));
         let marks = self.cols.index.mark.rich_text_at(tx.pos, None);
         let mut query = InsertQuery::new(iter, index.get(), encoding, None, marks);
-        query.resolve(index.get() - 1).ok()
+        query.resolve(current_acc - start_acc).ok()
     }
 
     pub(crate) fn query_insert_at_list(
@@ -1168,6 +1170,7 @@ pub(crate) struct Parent {
 pub(crate) struct QueryNth {
     pub(crate) marks: Option<Arc<MarkSet>>,
     pub(crate) pos: usize,
+    pub(crate) index: usize,
     pub(crate) elemid: ElemId,
 }
 

--- a/rust/automerge/src/op_set2/op_set/found_op.rs
+++ b/rust/automerge/src/op_set2/op_set/found_op.rs
@@ -50,6 +50,11 @@ impl<'a, I: OpQueryTerm<'a>> Iterator for OpsFoundIter<'a, I> {
                 _ => (),
             }
         }
-        self.found.take()
+        let found = self.found.take()?;
+        if found.ops.is_empty() {
+            None
+        } else {
+            Some(found)
+        }
     }
 }

--- a/rust/automerge/src/op_set2/op_set/insert.rs
+++ b/rust/automerge/src/op_set2/op_set/insert.rs
@@ -130,12 +130,14 @@ impl<'a> InsertQuery<'a> {
                 pos: loc.pos,
                 marks: MarkSet::from_query_state(&self.marks),
                 elemid: loc.cursor,
+                index,
             })
         } else if let Some(cursor) = self.last_visible_cursor {
             Ok(QueryNth {
                 pos: pos + 1,
                 marks: MarkSet::from_query_state(&self.marks),
                 elemid: cursor,
+                index,
             })
         } else {
             Err(AutomergeError::InvalidIndex(self.target))

--- a/rust/automerge/src/op_set2/op_set/op_iter.rs
+++ b/rust/automerge/src/op_set2/op_set/op_iter.rs
@@ -33,6 +33,7 @@ pub(crate) struct OpIter<'a> {
     pub(super) value: ValueIter<'a>,
     pub(super) marks: MarkInfoIter<'a>,
     pub(super) op_set: &'a OpSet,
+    pub(super) range: Range<usize>,
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/rust/automerge/src/transaction/inner.rs
+++ b/rust/automerge/src/transaction/inner.rs
@@ -582,47 +582,29 @@ impl TransactionInner {
 
         //let ex_obj = doc.ops().id_to_exid(obj.0);
         let encoding = splice_type.encoding(self.text_encoding);
-        // delete `del` items - performing the query for each one
-        let mut deleted: usize = 0;
-        while deleted < (del as usize) {
-            // TODO: could do this with a single custom query
 
-            let query = doc
-                .ops()
-                .seek_ops_by_index(&obj.id, index, encoding, self.scope.as_ref());
-
-            // if we delete in the middle of a multi-character
-            // move cursor back to the beginning and expand the del width
-            let adjusted_index = query.index;
-            if adjusted_index < index {
-                del += (index - adjusted_index) as isize;
-                index = adjusted_index;
+        // First check that the insertion point is not inside a multibyte character
+        // If it is, move the insertion point forwards to just after the multibyte
+        // character
+        let query = doc
+            .ops()
+            .seek_ops_by_index(&obj.id, index, encoding, self.scope.as_ref());
+        if query.index < index {
+            if let Some(op) = query.ops.last() {
+                // We're inside a multibyte character
+                if del > 0 {
+                    // if we are deleting, we insert before the multibyte character
+                    // then expand the deletion to cover the whole multibyte character
+                    del += (index - query.index) as isize;
+                    index = query.index;
+                } else {
+                    // We just move the insertion point to after the multibyte character
+                    index = query.index + op.width(encoding);
+                }
             }
-
-            let step = if let Some(op) = query.ops.last() {
-                op.width(encoding)
-            } else {
-                break;
-            };
-
-            let query_elemid = query.elemid().ok_or(AutomergeError::InvalidIndex(index))?;
-            let op = self.next_delete(obj, index, query_elemid, &query.ops);
-            let ops_pos = query
-                .ops
-                .iter()
-                .map(|o| o.add_succ(op.id(), None))
-                .collect::<Vec<_>>();
-
-            doc.ops_mut().add_succ(&ops_pos);
-
-            deleted += step;
-
-            self.pending.push(op);
         }
 
-        if deleted > 0 && patch_log.is_active() {
-            patch_log.delete_seq(obj.id, index, deleted);
-        }
+        let mut inserted_width = 0;
 
         // do the insert query for the first item and then
         // insert the remaining ops one after the other
@@ -630,6 +612,7 @@ impl TransactionInner {
             let query = doc
                 .ops()
                 .query_insert_at(&obj.id, index, encoding, self.scope.clone())?;
+
             let mut pos = query.pos;
             let mut elemid = query.elemid;
             let marks = query.marks;
@@ -639,6 +622,8 @@ impl TransactionInner {
 
             for v in &values {
                 let op = TxOp::insert_val(self.next_id(), obj, pos, v.clone(), elemid);
+
+                inserted_width += op.bld.width(encoding);
 
                 elemid = ElemId(op.id());
 
@@ -667,6 +652,50 @@ impl TransactionInner {
                 }
             }
         }
+
+        // delete `del` items - performing the query for each one
+        let delete_index = index + inserted_width;
+        let mut deleted: usize = 0;
+        while deleted < (del as usize) {
+            // TODO: could do this with a single custom query
+
+            let query =
+                doc.ops()
+                    .seek_ops_by_index(&obj.id, delete_index, encoding, self.scope.as_ref());
+
+            // if we delete in the middle of a multi-character
+            // move cursor back to the beginning and expand the del width
+            let adjusted_index = query.index;
+            if adjusted_index < delete_index {
+                del += (delete_index - adjusted_index) as isize;
+                index = adjusted_index;
+            }
+
+            let step = if let Some(op) = query.ops.last() {
+                op.width(encoding)
+            } else {
+                break;
+            };
+
+            let query_elemid = query.elemid().ok_or(AutomergeError::InvalidIndex(index))?;
+            let op = self.next_delete(obj, delete_index, query_elemid, &query.ops);
+            let ops_pos = query
+                .ops
+                .iter()
+                .map(|o| o.add_succ(op.id(), None))
+                .collect::<Vec<_>>();
+
+            doc.ops_mut().add_succ(&ops_pos);
+
+            deleted += step;
+
+            self.pending.push(op);
+        }
+
+        if deleted > 0 && patch_log.is_active() {
+            patch_log.delete_seq(obj.id, delete_index, deleted);
+        }
+
         Ok(())
     }
 


### PR DESCRIPTION
Added index the QueryNth, made delete in the middle of a multibyte behave the same way as an insert (move to after) and removed the extra query in splice inner.