### PR TITLE
new feature "single-threaded" can be used to switch from Arc to Rc in…

### DIFF
--- a/rust/automerge/Cargo.toml
+++ b/rust/automerge/Cargo.toml
@@ -11,6 +11,7 @@ readme = "./README.md"
 [features]
 optree-visualisation = ["dot"]
 wasm = ["js-sys", "wasm-bindgen", "web-sys", "getrandom/wasm_js", "hexane/wasm"]
+single-threaded = []
 utf8-indexing = []
 utf16-indexing = []
 

--- a/rust/automerge/src/automerge/diff.rs
+++ b/rust/automerge/src/automerge/diff.rs
@@ -1,6 +1,5 @@
 use itertools::Itertools;
 use std::collections::HashSet;
-use std::sync::Arc;
 
 use crate::automerge::Automerge;
 use crate::hydrate;
@@ -10,7 +9,7 @@ use crate::{
     marks::{MarkSet, MarkStateMachine},
     op_set2::{DiffOp, Op, OpQuery, OpType, ScalarValue},
     patches::PatchLog,
-    types::{Clock, ObjId, SequenceType},
+    types::{Clock, ObjId, Shared, SequenceType},
     ObjType,
 };
 
@@ -114,16 +113,16 @@ fn resolve<'a>(
 
 #[derive(Debug, Clone)]
 enum Patch<'a> {
-    New(Winner<'a>, Option<Arc<MarkSet>>),
+    New(Winner<'a>, Option<Shared<MarkSet>>),
     Old {
         before: Winner<'a>,
         after: Winner<'a>,
-        marks: Option<Arc<MarkSet>>,
+        marks: Option<Shared<MarkSet>>,
     },
     Update {
         before: Winner<'a>,
         after: Winner<'a>,
-        marks: Option<Arc<MarkSet>>,
+        marks: Option<Shared<MarkSet>>,
     },
     Delete(Winner<'a>),
 }
@@ -340,13 +339,13 @@ pub(crate) struct RichTextDiff<'a> {
 }
 
 impl<'a> RichTextDiff<'a> {
-    pub(crate) fn current(&self) -> Option<Arc<MarkSet>> {
+    pub(crate) fn current(&self) -> Option<Shared<MarkSet>> {
         // do this without all the cloning - cache the result
         let b = self.before.current().cloned().unwrap_or_default();
         let a = self.after.current().cloned().unwrap_or_default();
         if a != b {
             let result = b.diff(&a);
-            Some(Arc::new(result))
+            Some(Shared::new(result))
         } else {
             None
         }

--- a/rust/automerge/src/lib.rs
+++ b/rust/automerge/src/lib.rs
@@ -306,7 +306,7 @@ pub use sequence_tree::SequenceTree;
 pub use storage::VerificationMode;
 pub use text_value::ConcreteTextValue;
 pub use transaction::BlockOrText;
-pub use types::{ActorId, ChangeHash, ObjType, OpType, ParseChangeHashError, Prop, TextEncoding};
+pub use types::{ActorId, ChangeHash, ObjType, OpType, ParseChangeHashError, Prop, Shared, TextEncoding};
 pub use value::{ScalarValue, Value};
 
 /// The object ID for the root map of a document

--- a/rust/automerge/src/op_set2/columns.rs
+++ b/rust/automerge/src/op_set2/columns.rs
@@ -572,7 +572,7 @@ impl Column {
 
     pub(crate) fn external(
         spec: ColumnSpec,
-        data: Arc<Vec<u8>>,
+        data: Shared<Vec<u8>>,
         range: Range<usize>,
         actors: &[ActorId],
     ) -> Result<Self, PackError> {

--- a/rust/automerge/src/op_set2/op_set.rs
+++ b/rust/automerge/src/op_set2/op_set.rs
@@ -6,7 +6,7 @@ use crate::storage::{columns::compression::Uncompressed, ColumnSpec, Document, R
 use crate::types;
 use crate::types::{
     ActorId, Clock, ElemId, Export, Exportable, ObjId, ObjMeta, ObjType, OpId, Prop, SequenceType,
-    TextEncoding,
+    Shared, TextEncoding,
 };
 use crate::AutomergeError;
 
@@ -21,7 +21,6 @@ use std::borrow::Cow;
 use std::cmp::Ordering;
 use std::num::NonZeroUsize;
 use std::ops::{Range, RangeBounds};
-use std::sync::Arc;
 
 mod found_op;
 mod index;
@@ -1162,7 +1161,7 @@ pub(crate) struct Parent {
 
 #[derive(Debug, Clone, PartialEq)]
 pub(crate) struct QueryNth {
-    pub(crate) marks: Option<Arc<MarkSet>>,
+    pub(crate) marks: Option<Shared<MarkSet>>,
     pub(crate) pos: usize,
     pub(crate) index: usize,
     pub(crate) elemid: ElemId,

--- a/rust/automerge/src/op_set2/op_set/elems.rs
+++ b/rust/automerge/src/op_set2/op_set/elems.rs
@@ -1,12 +1,11 @@
 use crate::{
     marks::{MarkSet, MarkStateMachine},
-    types::Clock,
+    types::{Clock, Shared},
 };
 
 use super::{Op, OpIter, OpQueryTerm, OpType};
 
 use std::fmt::Debug;
-use std::sync::Arc;
 
 #[derive(Clone, Debug)]
 pub(crate) struct ElemIter<'a, I: Iterator<Item = Op<'a>> + Clone> {
@@ -37,7 +36,7 @@ impl<'a, I: OpQueryTerm<'a> + Clone> OpQueryTerm<'a> for ElemIter<'a, I> {
         self.iter.get_opiter()
     }
 
-    fn get_marks(&self) -> Option<&Arc<MarkSet>> {
+    fn get_marks(&self) -> Option<&Shared<MarkSet>> {
         self.iter.get_marks()
     }
 }

--- a/rust/automerge/src/op_set2/op_set/marks.rs
+++ b/rust/automerge/src/op_set2/op_set/marks.rs
@@ -1,10 +1,10 @@
 use crate::marks::{MarkSet, MarkStateMachine};
+use crate::types::Shared;
 
 use super::{Action, MarkData, Op, OpQueryTerm};
 
 use std::fmt::Debug;
 use std::ops::Range;
-use std::sync::Arc;
 
 #[derive(Clone, Debug)]
 pub(crate) struct MarkIter<'a, I: Iterator<Item = Op<'a>> + Clone> {
@@ -41,7 +41,7 @@ impl<'a, I: Iterator<Item = Op<'a>> + Clone> Iterator for MarkIter<'a, I> {
 }
 
 impl<'a, I: OpQueryTerm<'a> + Clone> OpQueryTerm<'a> for MarkIter<'a, I> {
-    fn get_marks(&self) -> Option<&Arc<MarkSet>> {
+    fn get_marks(&self) -> Option<&Shared<MarkSet>> {
         self.marks.current()
     }
 
@@ -76,7 +76,7 @@ impl<'a, I: Iterator<Item = Op<'a>> + Clone> Iterator for NoMarkIter<'a, I> {
 }
 
 impl<'a, I: OpQueryTerm<'a> + Clone> OpQueryTerm<'a> for NoMarkIter<'a, I> {
-    fn get_marks(&self) -> Option<&Arc<MarkSet>> {
+    fn get_marks(&self) -> Option<&Shared<MarkSet>> {
         None
     }
 

--- a/rust/automerge/src/op_set2/op_set/op_query.rs
+++ b/rust/automerge/src/op_set2/op_set/op_query.rs
@@ -2,17 +2,16 @@ use super::visible::VisIter;
 use super::{DiffOpIter, MarkIter, NoMarkIter, Op, OpIter, OpSet, TopOpIter, VisibleOpIter};
 use crate::iter::tools::SkipIter;
 use crate::marks::MarkSet;
-use crate::types::Clock;
+use crate::types::{Clock, Shared};
 
 #[cfg(test)]
 use crate::iter::KeyOpIter;
 
 use std::fmt::Debug;
 use std::ops::Range;
-use std::sync::Arc;
 
 pub(crate) trait OpQueryTerm<'a>: Iterator<Item = Op<'a>> + Debug {
-    fn get_marks(&self) -> Option<&Arc<MarkSet>>;
+    fn get_marks(&self) -> Option<&Shared<MarkSet>>;
 
     fn range(&self) -> Range<usize>;
 }
@@ -50,7 +49,7 @@ pub(crate) trait OpQuery<'a>: OpQueryTerm<'a> + Clone {
 }
 
 impl<'a> OpQueryTerm<'a> for OpIter<'a> {
-    fn get_marks(&self) -> Option<&Arc<MarkSet>> {
+    fn get_marks(&self) -> Option<&Shared<MarkSet>> {
         None
     }
 

--- a/rust/automerge/src/op_set2/op_set/top_op.rs
+++ b/rust/automerge/src/op_set2/op_set/top_op.rs
@@ -1,10 +1,10 @@
 use crate::marks::MarkSet;
+use crate::types::Shared;
 
 use super::{Op, OpQueryTerm};
 
 use std::fmt::Debug;
 use std::ops::Range;
-use std::sync::Arc;
 
 #[derive(Clone, Debug)]
 pub(crate) struct TopOpIter<'a, I: Iterator<Item = Op<'a>>> {
@@ -41,7 +41,7 @@ impl<'a, I: Iterator<Item = Op<'a>>> Iterator for TopOpIter<'a, I> {
 }
 
 impl<'a, I: OpQueryTerm<'a>> OpQueryTerm<'a> for TopOpIter<'a, I> {
-    fn get_marks(&self) -> Option<&Arc<MarkSet>> {
+    fn get_marks(&self) -> Option<&Shared<MarkSet>> {
         self.iter.get_marks()
     }
     fn range(&self) -> Range<usize> {

--- a/rust/automerge/src/op_set2/op_set/visible.rs
+++ b/rust/automerge/src/op_set2/op_set/visible.rs
@@ -1,4 +1,4 @@
-use crate::{marks::MarkSet, types::Clock};
+use crate::{marks::MarkSet, types::{Clock, Shared}};
 
 use super::{ActionIter, Op, OpId, OpIdIter, OpQueryTerm, SuccIterIter};
 use crate::op_set2::op::SuccCursors;
@@ -9,7 +9,6 @@ use hexane::{BooleanCursor, ColumnDataIter};
 
 use std::fmt::Debug;
 use std::ops::Range;
-use std::sync::Arc;
 
 use crate::iter::tools::{Shiftable, Skipper};
 
@@ -280,7 +279,7 @@ impl Visibility<'_> {
 }
 
 impl<'a, I: OpQueryTerm<'a> + Clone> OpQueryTerm<'a> for VisibleOpIter<'a, I> {
-    fn get_marks(&self) -> Option<&Arc<MarkSet>> {
+    fn get_marks(&self) -> Option<&Shared<MarkSet>> {
         self.iter.get_marks()
     }
 

--- a/rust/automerge/src/op_set2/skip_list.rs
+++ b/rust/automerge/src/op_set2/skip_list.rs
@@ -2,7 +2,6 @@
 
 use fxhash::FxBuildHasher;
 //use im::HashMap;
-//use std::sync::Arc;
 use std::collections::HashMap;
 //use rand::rngs::ThreadRng;
 use rand::prelude::*;

--- a/rust/automerge/src/patches/patch_builder.rs
+++ b/rust/automerge/src/patches/patch_builder.rs
@@ -1,12 +1,11 @@
 use core::fmt::Debug;
 use std::collections::{BTreeMap, HashSet};
-use std::sync::Arc;
 
 use crate::exid::ExId;
 use crate::iter::SpanInternal;
 use crate::marks::MarkSet;
 use crate::text_value::ConcreteTextValue;
-use crate::types::{Clock, ObjId, ObjType};
+use crate::types::{Clock, ObjId, ObjType, Shared};
 use crate::{Automerge, Prop, TextEncoding, Value};
 
 use super::{Patch, PatchAction};
@@ -15,7 +14,7 @@ use crate::{marks::Mark, sequence_tree::SequenceTree};
 #[derive(Debug, Clone)]
 pub(crate) struct PatchBuilder<'a> {
     patches: Vec<Patch>,
-    last_mark_set: Option<Arc<MarkSet>>, // keep this around for a quick pointer equality test
+    last_mark_set: Option<Shared<MarkSet>>, // keep this around for a quick pointer equality test
     path_map: BTreeMap<ObjId, (Prop, ObjId)>,
     seen: HashSet<ObjId>,
     text_encoding: TextEncoding,
@@ -144,7 +143,7 @@ impl PatchBuilder<'_> {
         obj: ExId,
         index: usize,
         value: &str,
-        marks: Option<Arc<MarkSet>>,
+        marks: Option<Shared<MarkSet>>,
     ) {
         if let Some(PatchAction::SpliceText {
             index: tail_index,

--- a/rust/automerge/src/patches/patch_log.rs
+++ b/rust/automerge/src/patches/patch_log.rs
@@ -4,10 +4,9 @@ use crate::exid::ExId;
 use crate::hydrate::Value;
 use crate::marks::{MarkAccumulator, MarkSet};
 use crate::op_set2::PropRef;
-use crate::types::{ActorId, Clock, ObjId, ObjType, OpId, Prop, TextEncoding};
+use crate::types::{ActorId, Clock, ObjId, ObjType, OpId, Prop, Shared, TextEncoding};
 use crate::{ChangeHash, Patch};
 use std::collections::{BTreeMap, BTreeSet, HashSet};
-use std::sync::Arc;
 
 use super::PatchBuilder;
 
@@ -74,7 +73,7 @@ pub(crate) enum Event {
     Splice {
         index: usize,
         text: String,
-        marks: Option<Arc<MarkSet>>,
+        marks: Option<Shared<MarkSet>>,
     },
     Insert {
         index: usize,
@@ -317,7 +316,7 @@ impl PatchLog {
         obj: ObjId,
         index: usize,
         text: &str,
-        marks: Option<Arc<MarkSet>>,
+        marks: Option<Shared<MarkSet>>,
     ) {
         self.events.push((
             obj,
@@ -329,7 +328,7 @@ impl PatchLog {
         ))
     }
 
-    pub(crate) fn mark(&mut self, obj: ObjId, index: usize, len: usize, marks: &Arc<MarkSet>) {
+    pub(crate) fn mark(&mut self, obj: ObjId, index: usize, len: usize, marks: &Shared<MarkSet>) {
         if let Some((_, Event::Mark { marks: tail_marks })) = self.events.last_mut() {
             tail_marks.add(index, len, marks);
             return;

--- a/rust/automerge/src/transaction/inner.rs
+++ b/rust/automerge/src/transaction/inner.rs
@@ -2,7 +2,6 @@ use std::borrow::Cow;
 use std::collections::HashSet;
 use std::num::NonZeroU64;
 use std::ops::Range;
-use std::sync::Arc;
 
 use crate::change_graph::ChangeGraph;
 use unicode_segmentation::UnicodeSegmentation;
@@ -12,7 +11,7 @@ use crate::marks::{ExpandMark, Mark, MarkSet};
 use crate::op_set2::change::build_change;
 use crate::op_set2::{Op, OpSet, OpSetCheckpoint, PropRef, SuccInsert, TxOp};
 use crate::patches::PatchLog;
-use crate::types::{Clock, ElemId, ObjMeta, OpId, ScalarValue, SequenceType, TextEncoding};
+use crate::types::{Clock, ElemId, ObjMeta, OpId, ScalarValue, SequenceType, Shared, TextEncoding};
 use crate::Automerge;
 use crate::{AutomergeError, ObjType, OpType, ReadDoc};
 use crate::{Change, ChangeHash, Prop};
@@ -835,7 +834,7 @@ impl TransactionInner {
         encoding: TextEncoding,
         patch_log: &mut PatchLog,
         op: &TxOp,
-        marks: Option<Arc<MarkSet>>,
+        marks: Option<Shared<MarkSet>>,
     ) {
         let obj_typ = op.obj_type;
         let obj = op.bld.obj;

--- a/rust/automerge/src/types.rs
+++ b/rust/automerge/src/types.rs
@@ -888,6 +888,12 @@ impl From<Prop> for wasm_bindgen::JsValue {
     }
 }
 
+#[cfg(feature = "single-threaded")]
+pub type Shared<T> = std::rc::Rc<T>;
+
+#[cfg(not(feature = "single-threaded"))]
+pub type Shared<T> = std::sync::Arc<T>;
+
 #[cfg(test)]
 pub(crate) mod gen {
     //use super::{ChangeHash, ElemId, ObjType, OpId, OpType, ScalarValue, HASH_SIZE};


### PR DESCRIPTION
… strictly single threaded use cases.

Hello, in cases when automerge is surely be ran from a single-thread only, there is a performance benefit to use Rc instead of Arc.

 I just experimented with it in a single threaded environment when I have Rc all over the place and getting Marks from the spans just felt weird having suddenly an Arc to pass around. (Or having to try_unwrap() or copy it from an Arc to Rc).

I didn't measure how much performance it really brings, so I'm not super invested into this.. I guess it might also introduce the need of adaption to other packages that build on this? So anyway, just wondering what you think about this.

Maybe the naming of the feature is not the best, since someone might think it would start threads otherwise.. 