### PR TITLE
bigint support

### DIFF
--- a/javascript/src/proxies.ts
+++ b/javascript/src/proxies.ts
@@ -1,6 +1,8 @@
 /* eslint-disable  @typescript-eslint/no-explicit-any */
 import type { Automerge, ObjID, Prop } from "./wasm_types.js"
 
+const MAX_I64 = BigInt("9223372036854775807") // 2n ** 63n - 1n;
+
 import type {
   AutomergeValue,
   ScalarValue,
@@ -141,6 +143,12 @@ function import_value(
       }
     case "boolean":
       return [value, "boolean"]
+    case "bigint":
+      if (value > MAX_I64) {
+        return [value, "uint"]
+      } else {
+        return [value, "int"]
+      }
     case "number":
       if (Number.isInteger(value)) {
         return [value, "int"]

--- a/javascript/test/basic_test.ts
+++ b/javascript/test/basic_test.ts
@@ -851,4 +851,33 @@ describe("Automerge", () => {
     let save2 = Automerge.save(doc1)
     assert.deepEqual(save1, save2)
   })
+
+  it("it should be able to handle ints and floats at their limits", () => {
+    let imax = BigInt("9223372036854775807")
+    let imin = BigInt("-9223372036854775808")
+    let umax = BigInt("18446744073709551615")
+    let inf = Infinity
+    let ninf = -Infinity
+    let nan = NaN;
+    let base = { nan, inf, ninf, imax, imin, umax }
+    let doc1 = Automerge.from<any>(base)
+    assert.deepEqual(doc1, base)
+    let doc2 = Automerge.load<any>(Automerge.save(doc1));
+    assert.deepEqual(doc2, base)
+    let doc3 = Automerge.change(Automerge.init<any>(), d => {
+        d.imax = imax;
+        d.umax = umax;
+        d.imin = imin;
+        d.nan = nan;
+        d.inf = inf;
+        d.ninf = ninf;
+    })
+    assert.deepEqual(doc3, base)
+    assert.throws(() => {
+      let doc4 = Automerge.from<any>({ bad: umax + BigInt("1") })
+    }, /larger than/)
+    assert.throws(() => {
+      let doc4 = Automerge.from<any>({ bad: imin - BigInt("1") })
+    }, /smaller than/)
+  })
 })

--- a/rust/automerge-c/Cargo.toml
+++ b/rust/automerge-c/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.2.2"
 authors = ["Orion Henry <orion.henry@gmail.com>", "Jason Kankiewicz <jason.kankiewicz@gmail.com>"]
 edition = "2021"
 license = "MIT"
-rust-version = "1.73.0"
+rust-version = "1.80.0"
 
 [lib]
 name = "automerge_core"

--- a/rust/automerge-cli/Cargo.toml
+++ b/rust/automerge-cli/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 authors = ["Alex Good <alex@memoryandthought.me>"]
 edition = "2021"
 license = "MIT"
-rust-version = "1.73.0"
+rust-version = "1.80.0"
 
 [[bin]]
 name = "automerge"

--- a/rust/automerge-test/Cargo.toml
+++ b/rust/automerge-test/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.5.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/automerge/automerge"
-rust-version = "1.73.0"
+rust-version = "1.80.0"
 description = "Utilities for testing automerge libraries"
 
 [dependencies]

--- a/rust/automerge-wasm/Cargo.toml
+++ b/rust/automerge-wasm/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["wasm"]
 readme = "README.md"
 edition = "2021"
 license = "MIT"
-rust-version = "1.73.0"
+rust-version = "1.80.0"
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/rust/automerge/Cargo.toml
+++ b/rust/automerge/Cargo.toml
@@ -4,7 +4,7 @@ version = "1.0.0-beta.6"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/automerge/automerge"
-rust-version = "1.73.0"
+rust-version = "1.80.0"
 description = "A JSON-like data structure (a CRDT) that can be modified concurrently by different users, and merged again automatically"
 readme = "./README.md"
 

--- a/rust/automerge/src/op_set2/types.rs
+++ b/rust/automerge/src/op_set2/types.rs
@@ -373,16 +373,6 @@ impl<'a> ScalarValue<'a> {
             Self::Unknown { bytes, .. } => Some(bytes.clone()),
         }
     }
-
-    /*
-        pub(crate) fn as_i64(&self) -> i64 {
-            match self {
-                Self::Int(i) | Self::Counter(i) | Self::Timestamp(i) => *i,
-                Self::Uint(i) => *i as i64,
-                _ => 0,
-            }
-        }
-    */
 }
 
 // FIXME - this is a temporary fix - we ideally want
@@ -391,25 +381,6 @@ impl<'a> ScalarValue<'a> {
 
 impl crate::types::OpType {
     pub(crate) fn decompose(
-        self,
-    ) -> (
-        Action,
-        ScalarValue<'static>,
-        bool,
-        Option<Cow<'static, str>>,
-    ) {
-        let (a, v, x, m) = self.clone().decompose2();
-        let tmp = types::OpType::from_action_and_value(
-            a.into(),
-            v.clone().into(),
-            m.clone().map(|s| s.into()),
-            x,
-        );
-        assert_eq!(tmp, self);
-        (a, v, x, m)
-    }
-
-    pub(crate) fn decompose2(
         self,
     ) -> (
         Action,
@@ -434,21 +405,6 @@ impl crate::types::OpType {
             Self::MarkEnd(expand) => (Action::Mark, ScalarValue::Null, expand, None),
         }
     }
-
-    /*
-        pub(crate) fn to_raw(&self) -> Option<Cow<'_, [u8]>> {
-            match self {
-                Self::Put(v) => v.to_raw(),
-                Self::Increment(i) => {
-                    let mut out = Vec::new();
-                    leb128::write::signed(&mut out, *i).unwrap();
-                    Some(Cow::Owned(out))
-                }
-                Self::MarkBegin(_, crate::types::OldMarkData { value, .. }) => value.to_raw(),
-                _ => None,
-            }
-        }
-    */
 }
 
 impl crate::types::ScalarValue {

--- a/rust/automerge/src/types.rs
+++ b/rust/automerge/src/types.rs
@@ -238,37 +238,6 @@ pub enum OpType {
 }
 
 impl OpType {
-    /*
-        /// The index into the action array as specified in [1]
-        ///
-        /// [1]: https://alexjg.github.io/automerge-storage-docs/#action-array
-        pub(crate) fn action_index(&self) -> u64 {
-            match self {
-                Self::Make(ObjType::Map) => 0,
-                Self::Put(_) => 1,
-                Self::Make(ObjType::List) => 2,
-                Self::Delete => 3,
-                Self::Make(ObjType::Text) => 4,
-                Self::Increment(_) => 5,
-                Self::Make(ObjType::Table) => 6,
-                Self::MarkBegin(_, _) | Self::MarkEnd(_) => 7,
-            }
-        }
-
-    pub(crate) fn expand(&self) -> bool {
-        matches!(self, OpType::MarkBegin(true, _) | OpType::MarkEnd(true))
-    }
-
-    pub(crate) fn value(&self) -> Cow<'_, ScalarValue> {
-        match self {
-            OpType::Put(v) => Cow::Borrowed(v),
-            OpType::Increment(i) => Cow::Owned(ScalarValue::Int(*i)),
-            OpType::MarkBegin(_, OldMarkData { value, .. }) => Cow::Borrowed(value),
-            _ => Cow::Owned(ScalarValue::Null),
-        }
-    }
-    */
-
     pub(crate) fn validate_action_and_value(
         action: u64,
         value: &ScalarValue,
@@ -284,60 +253,6 @@ impl OpType {
             _ => Err(error::InvalidOpType::UnknownAction(action)),
         }
     }
-
-    pub(crate) fn from_action_and_value(
-        action: u64,
-        value: ScalarValue,
-        mark_name: Option<smol_str::SmolStr>,
-        expand: bool,
-    ) -> OpType {
-        match action {
-            0 => Self::Make(ObjType::Map),
-            1 => Self::Put(value),
-            2 => Self::Make(ObjType::List),
-            3 => Self::Delete,
-            4 => Self::Make(ObjType::Text),
-            5 => match value {
-                ScalarValue::Int(i) => Self::Increment(i),
-                ScalarValue::Uint(i) => Self::Increment(i as i64),
-                _ => unreachable!("validate_action_and_value returned NonNumericInc"),
-            },
-            6 => Self::Make(ObjType::Table),
-            7 => match mark_name {
-                Some(name) => Self::MarkBegin(expand, OldMarkData { name, value }),
-                None => Self::MarkEnd(expand),
-            },
-            _ => unreachable!("validate_action_and_value returned UnknownAction"),
-        }
-    }
-
-    /*
-        pub(crate) fn to_str(&self) -> &str {
-            if let OpType::Put(ScalarValue::Str(s)) = &self {
-                s
-            } else if self.is_mark() {
-                ""
-            } else {
-                "\u{fffc}"
-            }
-        }
-
-        pub(crate) fn mark_name(&self) -> Option<&str> {
-            if let OpType::MarkBegin(_, data) = self {
-                Some(&data.name)
-            } else {
-                None
-            }
-        }
-
-        pub(crate) fn is_mark(&self) -> bool {
-            matches!(&self, OpType::MarkBegin(_, _) | OpType::MarkEnd(_))
-        }
-
-        pub(crate) fn is_block(&self) -> bool {
-            &OpType::Make(ObjType::Map) == self
-        }
-    */
 }
 
 impl From<ObjType> for OpType {
@@ -397,17 +312,6 @@ impl Exportable for OpId {
         Export::Id(*self)
     }
 }
-
-/*
-impl Exportable for Key {
-    fn export(&self) -> Export {
-        match self {
-            Key::Map(p) => Export::Prop(*p),
-            Key::Seq(e) => e.export(),
-        }
-    }
-}
-*/
 
 impl From<ObjId> for OpId {
     fn from(o: ObjId) -> Self {


### PR DESCRIPTION
Added BigInt support to the wasm and js interface.  Also fixed some issues with NaN numbers.  Note: counters going over Number.MAX_SAFE_INT will do strnage things - there wasn't a simple way to fix this due to the Automerge.Counter wrapper class so I'm deferring to a later date.

