### PR TITLE
Cleanup

### DIFF
--- a/rust/automerge/src/automerge.rs
+++ b/rust/automerge/src/automerge.rs
@@ -1218,7 +1218,7 @@ impl Automerge {
         let mut top_ops = self
             .ops()
             .iter_obj(&obj.id)
-            .visible(clock)
+            .visible_slow(clock)
             .top_ops()
             .marks();
 
@@ -1558,7 +1558,12 @@ impl Automerge {
         clock: Option<Clock>,
     ) -> Result<MarkSet, AutomergeError> {
         let obj = self.exid_to_obj(obj.as_ref())?;
-        let mut iter = self.ops.iter_obj(&obj.id).visible(clock).top_ops().marks();
+        let mut iter = self
+            .ops
+            .iter_obj(&obj.id)
+            .visible_slow(clock)
+            .top_ops()
+            .marks();
         iter.nth(index);
         match iter.get_marks() {
             Some(arc) => Ok(arc.as_ref().clone().without_unmarks()),
@@ -1576,7 +1581,7 @@ impl Automerge {
         for (obj, ops) in self.ops.iter_objs() {
             match obj.typ {
                 ObjType::Map | ObjType::List => {
-                    for op in ops.visible(None) {
+                    for op in ops.visible_slow(None) {
                         //if !op.visible() {
                         //    continue;
                         //}

--- a/rust/automerge/src/clock.rs
+++ b/rust/automerge/src/clock.rs
@@ -1,57 +1,57 @@
 use crate::types::OpId;
 
-use std::cmp::Ordering;
-
-#[derive(Default, Debug, Clone, Copy, PartialEq)]
-pub(crate) struct ClockData {
-    /// Maximum operation counter of the actor at the point in time.
-    pub(crate) max_op: u32,
-    /// Sequence number of the change from this actor.
-    pub(crate) seq: u32,
-}
-
-impl PartialOrd for ClockData {
-    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        Some(self.cmp(other))
-    }
-}
-
-impl Eq for ClockData {}
-
-impl Ord for ClockData {
-    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        self.max_op.cmp(&other.max_op)
-    }
-}
-
-impl ClockData {
-    pub(crate) fn new(max_op: u32, seq: u32) -> Self {
-        ClockData { max_op, seq }
-    }
-
-    fn max() -> Self {
-        ClockData {
-            max_op: u32::MAX,
-            seq: u32::MAX,
-        }
-    }
-}
+use std::num::NonZeroU32;
 
 #[derive(Default, Debug, Clone, PartialEq)]
-pub(crate) struct Clock(pub(crate) Vec<ClockData>);
+pub(crate) struct Clock(pub(crate) Vec<u32>);
 
-#[cfg(test)]
-impl PartialOrd for Clock {
-    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        if self.0 == other.0 {
-            Some(Ordering::Equal)
-        } else if self.is_greater(other) {
-            Some(Ordering::Greater)
-        } else if other.is_greater(self) {
-            Some(Ordering::Less)
+#[derive(Default, Debug, Clone, PartialEq)]
+pub(crate) struct SeqClock(pub(crate) Vec<Option<NonZeroU32>>);
+
+impl SeqClock {
+    pub(crate) fn iter(&self) -> impl Iterator<Item = (usize, Option<NonZeroU32>)> + '_ {
+        self.0.iter().copied().enumerate()
+    }
+
+    pub(crate) fn remove_actor(&mut self, idx: usize) {
+        self.0.remove(idx);
+    }
+
+    pub(crate) fn rewrite_with_new_actor(&mut self, idx: usize) {
+        self.0.insert(idx, None)
+    }
+
+    pub(crate) fn get_for_actor(&self, actor_index: &usize) -> Option<NonZeroU32> {
+        self.0.get(*actor_index).copied().flatten()
+    }
+
+    pub(crate) fn new(size: usize) -> Self {
+        Self(vec![None; size])
+    }
+
+    pub(crate) fn include(&mut self, actor_idx: usize, data: Option<u32>) -> bool {
+        if let Some(data) = data {
+            match self.0[actor_idx] {
+                None => {
+                    self.0[actor_idx] = NonZeroU32::try_from(data).ok();
+                    true
+                }
+                Some(old_data) if old_data.get() < data => {
+                    self.0[actor_idx] = NonZeroU32::try_from(data).ok();
+                    true
+                }
+                _ => false,
+            }
         } else {
-            // concurrent
-            None
+            false
+        }
+    }
+
+    pub(crate) fn merge(a: &mut Self, b: &Self) {
+        for (a, b) in std::iter::zip(a.0.iter_mut(), b.0.iter()) {
+            if *a < *b {
+                *a = *b;
+            }
         }
     }
 }
@@ -102,74 +102,65 @@ impl ClockRange {
 }
 
 impl Clock {
-    pub(crate) fn new(size: usize) -> Self {
-        //Self(vec![size; ClockData::new()])
-        Self(vec![ClockData::new(0, 0); size])
-    }
-
-    pub(crate) fn remove_actor(&mut self, idx: usize) {
-        self.0.remove(idx);
-    }
-
-    pub(crate) fn rewrite_with_new_actor(&mut self, idx: usize) {
-        self.0.insert(idx, ClockData::new(0, 0))
-    }
-
-    pub(crate) fn merge(a: &mut Self, b: &Self) {
-        for (a, b) in std::iter::zip(a.0.iter_mut(), b.0.iter()) {
-            if a.max_op < b.max_op {
-                *a = *b;
-            }
-        }
-    }
-
-    pub(crate) fn include(&mut self, actor_idx: usize, data: ClockData) -> bool {
-        match data.max_op.cmp(&self.0[actor_idx].max_op) {
-            Ordering::Less => {
-                // Nothing to do
-                false
-            }
-            Ordering::Equal => {
-                // This can occur if the actor has produced an empty change, their
-                // max_op won't have increased but their seq will have
-                self.0[actor_idx].seq = self.0[actor_idx].seq.max(data.seq);
-                true
-            }
-            Ordering::Greater => {
-                self.0[actor_idx] = data;
-                true
-            }
-        }
-    }
-
     pub(crate) fn isolate(&mut self, actor_index: usize) {
-        self.0[actor_index] = ClockData::max()
+        self.0[actor_index] = u32::MAX
     }
 
     pub(crate) fn covers(&self, id: &OpId) -> bool {
-        self.0[id.actor()].max_op as u64 >= id.counter()
+        self.0[id.actor()] as u64 >= id.counter()
     }
+}
 
-    pub(crate) fn get_for_actor(&self, actor_index: &usize) -> Option<&ClockData> {
-        self.0.get(*actor_index)
-    }
-
-    #[cfg(test)]
-    fn is_greater(&self, other: &Self) -> bool {
-        !std::iter::zip(self.0.iter(), other.0.iter()).any(|(a, b)| a.max_op < b.max_op)
+impl std::iter::FromIterator<Option<u32>> for Clock {
+    fn from_iter<I: IntoIterator<Item = Option<u32>>>(iter: I) -> Self {
+        Clock(iter.into_iter().map(|i| i.unwrap_or(0)).collect())
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::cmp::Ordering;
+
+    impl Clock {
+        pub(crate) fn new(size: usize) -> Self {
+            Self(vec![0; size])
+        }
+
+        pub(crate) fn include(&mut self, actor_idx: usize, data: u32) -> bool {
+            if data > self.0[actor_idx] {
+                self.0[actor_idx] = data;
+                true
+            } else {
+                false
+            }
+        }
+
+        fn is_greater(&self, other: &Self) -> bool {
+            !std::iter::zip(self.0.iter(), other.0.iter()).any(|(a, b)| a < b)
+        }
+    }
+
+    impl PartialOrd for Clock {
+        fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+            if self.0 == other.0 {
+                Some(Ordering::Equal)
+            } else if self.is_greater(other) {
+                Some(Ordering::Greater)
+            } else if other.is_greater(self) {
+                Some(Ordering::Less)
+            } else {
+                None
+            }
+        }
+    }
 
     #[test]
     fn covers() {
         let mut clock = Clock::new(4);
 
-        clock.include(1, ClockData { max_op: 20, seq: 1 });
-        clock.include(2, ClockData { max_op: 10, seq: 2 });
+        clock.include(1, 20);
+        clock.include(2, 10);
 
         assert!(clock.covers(&OpId::new(10, 1)));
         assert!(clock.covers(&OpId::new(20, 1)));
@@ -186,11 +177,11 @@ mod tests {
     #[test]
     fn comparison() {
         let mut base_clock = Clock::new(4);
-        base_clock.include(1, ClockData { max_op: 1, seq: 1 });
-        base_clock.include(2, ClockData { max_op: 1, seq: 1 });
+        base_clock.include(1, 1);
+        base_clock.include(2, 1);
 
         let mut after_clock = base_clock.clone();
-        after_clock.include(1, ClockData { max_op: 2, seq: 2 });
+        after_clock.include(1, 2);
 
         assert!(after_clock > base_clock);
         assert!(base_clock < after_clock);
@@ -198,7 +189,7 @@ mod tests {
         assert!(base_clock == base_clock);
 
         let mut new_actor_clock = base_clock.clone();
-        new_actor_clock.include(3, ClockData { max_op: 1, seq: 1 });
+        new_actor_clock.include(3, 1);
 
         assert_eq!(
             base_clock.partial_cmp(&new_actor_clock),

--- a/rust/automerge/src/op_set2/change/collector.rs
+++ b/rust/automerge/src/op_set2/change/collector.rs
@@ -363,7 +363,7 @@ impl<'a> ChangeCollector<'a> {
 
         let pred = self.preds.remove(&op.id).unwrap_or_default();
 
-        let op = op.build3(pred);
+        let op = op.build(pred);
 
         if let Some(index) = self.builders_index(op.id) {
             self.builders[index].add(op);
@@ -389,7 +389,7 @@ impl<'a> ChangeCollector<'a> {
         if let Some((obj, key)) = self.last.take() {
             for (id, pred) in &self.preds {
                 let op = Op::del(*id, obj, key.clone());
-                let op = op.build3(pred.to_vec());
+                let op = op.build(pred.to_vec());
                 if let Some(index) = self.builders_index(op.id) {
                     self.builders[index].add(op);
                 }

--- a/rust/automerge/src/op_set2/op.rs
+++ b/rust/automerge/src/op_set2/op.rs
@@ -1,8 +1,6 @@
 use super::hexane::{ColumnDataIter, DeltaCursor, IntCursor};
 use super::op_set::{MarkIndexBuilder, ObjInfo, OpSet, ResolvedAction};
-use super::types::{
-    Action, ActorCursor, ActorIdx, KeyRef, MarkData, OpType, PropRef, PropRef2, ScalarValue,
-};
+use super::types::{Action, ActorCursor, ActorIdx, KeyRef, MarkData, OpType, PropRef, ScalarValue};
 use super::{ValueMeta, ValueRef};
 
 use crate::clock::Clock;
@@ -60,17 +58,17 @@ pub(crate) struct ChangeOp {
 }
 
 impl ChangeOp {
-    pub(crate) fn prop2_static(&self) -> Option<PropRef2<'static>> {
+    pub(crate) fn prop_static(&self) -> Option<PropRef<'static>> {
         match &self.bld.key {
-            KeyRef::Map(s) => Some(PropRef2::Map(Cow::Owned(String::from(s.as_ref())))),
+            KeyRef::Map(s) => Some(PropRef::Map(Cow::Owned(String::from(s.as_ref())))),
             _ => None,
         }
     }
 
-    pub(crate) fn prop2(&self) -> Option<PropRef2<'_>> {
+    pub(crate) fn prop(&self) -> Option<PropRef<'_>> {
         match &self.bld.key {
-            KeyRef::Map(Cow::Owned(s)) => Some(PropRef2::Map(Cow::Borrowed(s))),
-            KeyRef::Map(Cow::Borrowed(s)) => Some(PropRef2::Map(Cow::Borrowed(s))),
+            KeyRef::Map(Cow::Owned(s)) => Some(PropRef::Map(Cow::Borrowed(s))),
+            KeyRef::Map(Cow::Borrowed(s)) => Some(PropRef::Map(Cow::Borrowed(s))),
             _ => None,
         }
     }
@@ -190,7 +188,7 @@ impl OpBuilder<'_> {
         match (self.action, &self.mark_name) {
             (Action::Mark, Some(name)) => {
                 let name = Cow::Owned(name.to_string());
-                let value = self.value.clone().into_owned2();
+                let value = self.value.clone().into_owned();
                 let data = MarkData { name, value };
                 Some(MarkIndexBuilder::Start(self.id, data))
             }
@@ -436,7 +434,7 @@ impl TxOp {
 
     pub(crate) fn prop(&self) -> PropRef<'_> {
         if let KeyRef::Map(s) = &self.bld.key {
-            PropRef::Map(s)
+            PropRef::Map(s.clone())
         } else {
             PropRef::Seq(self.index)
         }
@@ -930,7 +928,7 @@ impl<'a> Op<'a> {
         match (&self.action, &self.mark_name) {
             (Action::Mark, Some(name)) => {
                 let name = Cow::Owned(name.to_string());
-                let value = self.value.clone().into_owned2();
+                let value = self.value.clone().into_owned();
                 let data = MarkData { name, value };
                 Some(MarkIndexBuilder::Start(self.id, data))
             }
@@ -1117,7 +1115,7 @@ impl<'a> Op<'a> {
         self.action == Action::Mark
     }
 
-    pub(crate) fn build3(self, pred: Vec<OpId>) -> OpBuilder<'a> {
+    pub(crate) fn build(self, pred: Vec<OpId>) -> OpBuilder<'a> {
         OpBuilder {
             id: self.id,
             obj: self.obj,
@@ -1157,9 +1155,9 @@ impl<'a> Op<'a> {
         }
     }
 
-    pub(crate) fn prop2(&self) -> Option<PropRef2<'a>> {
+    pub(crate) fn prop(&self) -> Option<PropRef<'a>> {
         let key_str = self.key.key_str()?;
-        Some(PropRef2::Map(key_str))
+        Some(PropRef::Map(key_str))
     }
 }
 

--- a/rust/automerge/src/op_set2/op_set.rs
+++ b/rust/automerge/src/op_set2/op_set.rs
@@ -294,7 +294,7 @@ impl OpSet {
     }
 
     pub(crate) fn keys<'a>(&'a self, obj: &ObjId, clock: Option<Clock>) -> Keys<'a> {
-        let iter = self.iter_obj(obj).visible(clock).top_ops();
+        let iter = self.iter_obj(obj).visible_slow(clock).top_ops();
         Keys::new(self, iter)
     }
 
@@ -504,7 +504,7 @@ impl OpSet {
         let range = self.prop_range(obj, key);
         let iter = self.iter_range(&range);
         let end_pos = iter.end_pos();
-        let ops = iter.visible2(self, clock).collect::<Vec<_>>();
+        let ops = iter.visible(self, clock).collect::<Vec<_>>();
         assert_eq!(end_pos, range.end);
         OpsFound {
             index: 0,
@@ -605,7 +605,7 @@ impl OpSet {
         if iter.next().is_some() {
             let range = self.list_register_at_pos(tx_pos, range);
             let end_pos = range.end;
-            let ops = self.iter_range(&range).visible2(self, None).collect();
+            let ops = self.iter_range(&range).visible(self, None).collect();
             OpsFound {
                 index,
                 ops,
@@ -820,7 +820,7 @@ impl OpSet {
         obj: &ObjId,
         clock: Option<Clock>,
     ) -> TopOpIter<'a, VisibleOpIter<'a, OpIter<'a>>> {
-        self.iter_obj(obj).visible(clock).top_ops()
+        self.iter_obj(obj).visible_slow(clock).top_ops()
     }
 
     pub(crate) fn to_string<E: Exportable>(&self, id: E) -> String {
@@ -1772,7 +1772,7 @@ mod tests {
 
             let iter = opset.iter_obj(&ObjId(OpId::new(1, 1)));
             let ops = iter
-                .visible(None)
+                .visible_slow(None)
                 .key_ops()
                 .map(|n| n.collect::<Vec<_>>())
                 .collect::<Vec<_>>();
@@ -1787,7 +1787,7 @@ mod tests {
             assert!(key4.is_none());
 
             let iter = opset.iter_obj(&ObjId(OpId::new(1, 1)));
-            let ops = iter.visible(None).top_ops().collect::<Vec<_>>();
+            let ops = iter.visible_slow(None).top_ops().collect::<Vec<_>>();
             assert_eq!(&test_ops[2], &ops[0]);
             assert_eq!(&test_ops[5], &ops[1]);
             assert_eq!(&test_ops[7], &ops[2]);

--- a/rust/automerge/src/op_set2/op_set/op_query.rs
+++ b/rust/automerge/src/op_set2/op_set/op_query.rs
@@ -35,11 +35,11 @@ pub(crate) trait OpQuery<'a>: OpQueryTerm<'a> + Clone {
         KeyOpIter::new(self)
     }
 
-    fn visible(self, clock: Option<Clock>) -> VisibleOpIter<'a, Self> {
+    fn visible_slow(self, clock: Option<Clock>) -> VisibleOpIter<'a, Self> {
         VisibleOpIter::new(self, clock)
     }
 
-    fn visible2(self, op_set: &'a OpSet, clock: Option<&Clock>) -> FixCounters<'a, Self> {
+    fn visible(self, op_set: &'a OpSet, clock: Option<&Clock>) -> FixCounters<'a, Self> {
         let vis = VisIter::new(op_set, clock, self.range());
         FixCounters::new(SkipIter::new(self, vis), clock)
     }

--- a/rust/automerge/src/op_set2/types.rs
+++ b/rust/automerge/src/op_set2/types.rs
@@ -2,7 +2,7 @@ use std::borrow::Cow;
 
 use crate::error::AutomergeError;
 use crate::types;
-use crate::types::{ActorId, ChangeHash, ElemId, ObjType, Prop};
+use crate::types::{ActorId, ChangeHash, ElemId, ObjType};
 use crate::value;
 use crate::{hydrate, TextEncoding};
 
@@ -229,7 +229,7 @@ impl fmt::Display for ScalarValue<'_> {
 
 impl<'a> From<ScalarValue<'a>> for types::ScalarValue {
     fn from(s: ScalarValue<'a>) -> Self {
-        s.into_owned()
+        s.into_legacy()
     }
 }
 
@@ -283,7 +283,7 @@ impl<'a> ScalarValue<'a> {
         }
     }
 
-    pub(crate) fn into_owned(self) -> types::ScalarValue {
+    pub(crate) fn into_legacy(self) -> types::ScalarValue {
         match self {
             Self::Bytes(b) => types::ScalarValue::Bytes(b.to_vec()),
             Self::Str(s) => types::ScalarValue::Str(s.to_string().into()),
@@ -301,7 +301,7 @@ impl<'a> ScalarValue<'a> {
         }
     }
 
-    pub(crate) fn into_owned2(self) -> ScalarValue<'static> {
+    pub(crate) fn into_owned(self) -> ScalarValue<'static> {
         match self {
             Self::Bytes(b) => ScalarValue::Bytes(Cow::Owned(b.into_owned())),
             Self::Str(s) => ScalarValue::Str(Cow::Owned(s.into_owned())),
@@ -599,23 +599,8 @@ impl<'a> From<&'a str> for ScalarValue<'a> {
     }
 }
 
-#[derive(Clone, Debug, Copy, PartialEq)]
-pub(crate) enum PropRef<'a> {
-    Map(&'a str),
-    Seq(usize),
-}
-
-impl From<&PropRef<'_>> for Prop {
-    fn from(p: &PropRef<'_>) -> Prop {
-        match p {
-            PropRef::Map(s) => Prop::Map(s.to_string()),
-            PropRef::Seq(i) => Prop::Seq(*i),
-        }
-    }
-}
-
 #[derive(Clone, Debug, PartialEq)]
-pub(crate) enum PropRef2<'a> {
+pub(crate) enum PropRef<'a> {
     Map(Cow<'a, str>),
     Seq(usize),
 }
@@ -732,14 +717,14 @@ impl<'a> ValueRef<'a> {
     pub(crate) fn into_owned(self) -> ValueRef<'static> {
         match self {
             Self::Object(o) => ValueRef::Object(o),
-            Self::Scalar(s) => ValueRef::Scalar(s.into_owned2()),
+            Self::Scalar(s) => ValueRef::Scalar(s.into_owned()),
         }
     }
 
     pub fn into_value(self) -> value::Value<'static> {
         match self {
             Self::Object(o) => value::Value::Object(o),
-            Self::Scalar(s) => value::Value::Scalar(Cow::Owned(s.into_owned())),
+            Self::Scalar(s) => value::Value::Scalar(Cow::Owned(s.into_legacy())),
         }
     }
 

--- a/rust/automerge/src/patches/patch_log.rs
+++ b/rust/automerge/src/patches/patch_log.rs
@@ -212,9 +212,9 @@ impl PatchLog {
             .push((obj, Event::DeleteMap { key: key.into() }))
     }
 
-    pub(crate) fn increment2(&mut self, obj: ObjId, prop: PropRef<'_>, value: i64, id: OpId) {
+    pub(crate) fn increment(&mut self, obj: ObjId, prop: PropRef<'_>, value: i64, id: OpId) {
         match prop {
-            PropRef::Map(key) => self.increment_map(obj, key, value, id),
+            PropRef::Map(key) => self.increment_map(obj, &key, value, id),
             PropRef::Seq(index) => self.increment_seq(obj, index, value, id),
         }
     }
@@ -251,7 +251,7 @@ impl PatchLog {
         self.events.push((obj, Event::FlagConflictSeq { index }))
     }
 
-    pub(crate) fn put2(
+    pub(crate) fn put(
         &mut self,
         obj: ObjId,
         prop: PropRef<'_>,
@@ -261,7 +261,7 @@ impl PatchLog {
         expose: bool,
     ) {
         match prop {
-            PropRef::Map(key) => self.put_map(obj, key, value, id, conflict, expose),
+            PropRef::Map(key) => self.put_map(obj, &key, value, id, conflict, expose),
             PropRef::Seq(index) => self.put_seq(obj, index, value, id, conflict, expose),
         }
     }

--- a/rust/automerge/src/transaction/inner.rs
+++ b/rust/automerge/src/transaction/inner.rs
@@ -862,12 +862,12 @@ impl TransactionInner {
             } else if op.is_delete() {
                 match op.prop() {
                     PropRef::Seq(index) => patch_log.delete_seq(obj, index, 1),
-                    PropRef::Map(key) => patch_log.delete_map(obj, key),
+                    PropRef::Map(key) => patch_log.delete_map(obj, &key),
                 }
             } else if let Some(value) = op.get_increment_value() {
-                patch_log.increment2(obj, op.prop(), value, op.id());
+                patch_log.increment(obj, op.prop(), value, op.id());
             } else {
-                patch_log.put2(
+                patch_log.put(
                     obj,
                     op.prop(),
                     op.hydrate_value(encoding),


### PR DESCRIPTION
Done:

* Removed a bunch of v2 and v3 methods that didnt need to be that way
* Refactored Clock into SeqClock which only contains Seq Id and Clock which only contains max_op.  This makes debugging much easier to read as now Clock is just a Vec<u32>.  It also cuts the memory used by clock_cache by half which is signifigant.   Also this would have fixed the issue with empty changes had it been implemented sooner. 

Not Done:

* op_set2 -> op_set - this touches a lot of files and I'll wait till a time when a bunch of big PR's are not in flight 
* Remove types::ScalarValue and replace with op_set2::types::ScalarValue<'_> - perhaps overdue but changes the public interfaces a little.  Big enough of a change to be in its own PR.

