### PR TITLE
Interruptible load

### DIFF
--- a/javascript/src/implementation.ts
+++ b/javascript/src/implementation.ts
@@ -62,6 +62,8 @@ import type {
   Span,
   DecodedSyncMessage,
   UpdateSpansConfig,
+  AutomergeLoadState,
+  LoadStateResult,
 } from "./wasm_types.js"
 export type {
   ChangeMetadata,
@@ -113,6 +115,33 @@ import {
 export { applyPatch, applyPatches } from "./apply_patches.js"
 
 import { conflictAt } from "./conflicts.js"
+
+export class LoadState<T> {
+  private _state: AutomergeLoadState
+  private _opts: InitOptions<T>
+
+  constructor(state: AutomergeLoadState, opts: InitOptions<T>) {
+    this._state = state
+    this._opts = opts
+  }
+
+  step(): { done: false } | { done: true; doc: Doc<T> } {
+    const result = this._state.step()
+    if (result.done) {
+      const handle = result.value
+      handle.enableFreeze(!!this._opts.freeze)
+      registerDatatypes(handle)
+      const doc = handle.materialize("/", undefined, {
+        handle,
+        heads: undefined,
+        patchCallback: this._opts.patchCallback,
+      }) as Doc<T>
+      return { done: true, doc }
+    } else {
+      return { done: false }
+    }
+  }
+}
 
 /** Options passed to {@link change}, and {@link emptyChange}
  * @typeParam T - The type of value contained in the document
@@ -721,6 +750,25 @@ export function load<T>(
     patchCallback,
   }) as Doc<T>
   return doc
+}
+
+export function loadInterruptible<T>(
+  data: Uint8Array,
+  _opts?: ActorId | InitOptions<T>,
+): LoadState<T> {
+  const opts = importOpts(_opts)
+  const actor = opts.actor
+  const unchecked = opts.unchecked || false
+  const allowMissingDeps = opts.allowMissingChanges || false
+  const convertImmutableStringsToText =
+    opts.convertImmutableStringsToText || false
+  const state = ApiHandler.loadInterruptible(data, {
+    actor,
+    unchecked,
+    allowMissingDeps,
+    convertImmutableStringsToText,
+  })
+  return new LoadState(state, opts)
 }
 
 /**

--- a/javascript/src/low_level.ts
+++ b/javascript/src/low_level.ts
@@ -1,6 +1,7 @@
 import type {
   API,
   Automerge,
+  AutomergeLoadState,
   Change,
   DecodedChange,
   SyncMessage,
@@ -38,6 +39,9 @@ export const ApiHandler: API = {
   },
   load(data: Uint8Array, options?: LoadOptions): Automerge {
     throw new RangeError("Automerge.use() not called (load)")
+  },
+  loadInterruptible(data: Uint8Array, options?: LoadOptions): AutomergeLoadState {
+    throw new RangeError("Automerge.use() not called (loadInterruptible)")
   },
   encodeChange(change: ChangeToEncode): Change {
     throw new RangeError("Automerge.use() not called (encodeChange)")

--- a/javascript/test/interruptibleLoad.ts
+++ b/javascript/test/interruptibleLoad.ts
@@ -1,0 +1,39 @@
+import { default as assert } from "assert"
+import * as Automerge from "../src/entrypoints/fullfat_node.js"
+
+describe("loadInterruptible", () => {
+  it("should allow loading a document in steps", () => {
+    let doc = Automerge.from({ foo: "bar" })
+    for (let i = 0; i < 100; i++) {
+      doc = Automerge.change(doc, d => {
+        d.foo = "bar" + i
+      })
+    }
+    const saved = Automerge.save(doc)
+
+    let state = Automerge.loadInterruptible<any>(saved)
+    let result = state.step()
+    let steps = 0
+    while (!result.done) {
+      steps++
+      result = state.step()
+    }
+    // This assertion is a bit fragile but we know that the document
+    // will be loaded in chunks, so it should take at least 2 steps (one for
+    // the start, and then at least one chunk)
+    assert(steps > 0)
+    assert.deepEqual(result.doc, doc)
+  })
+
+  it("should handle options correctly", () => {
+    let doc = Automerge.from({ foo: "bar" }, { actor: "aaaaaa" })
+    const saved = Automerge.save(doc)
+
+    let state = Automerge.loadInterruptible<any>(saved, { actor: "bbbbbb" })
+    let result = state.step()
+    while (!result.done) {
+      result = state.step()
+    }
+    assert.equal(Automerge.getActorId(result.doc), "bbbbbb")
+  })
+})

--- a/rust/automerge-wasm/src/lib.rs
+++ b/rust/automerge-wasm/src/lib.rs
@@ -1891,8 +1891,9 @@ pub fn read_bundle(bundle: Uint8Array) -> Result<JsValue, error::ReadBundle> {
     let bundle_bytes = bundle.to_vec();
     let bundle = automerge::Bundle::try_from(bundle_bytes.as_slice())
         .map_err(|e| error::ReadBundle(e.to_string()))?;
+    let deps = bundle.deps().to_vec();
     let changes = bundle
-        .to_changes()
+        .into_changes()
         .map_err(|e| error::ReadBundle(e.to_string()))?;
     let js_changes = changes
         .iter()
@@ -1912,7 +1913,6 @@ pub fn read_bundle(bundle: Uint8Array) -> Result<JsValue, error::ReadBundle> {
     )
     .unwrap();
 
-    let deps = bundle.deps().to_vec();
     Reflect::set(&result, &("deps").into(), &JS::from(deps).0).unwrap();
     Ok(result.into())
 }

--- a/rust/automerge-wasm/src/lib.rs
+++ b/rust/automerge-wasm/src/lib.rs
@@ -41,6 +41,7 @@ use serde::ser::Serialize;
 use std::borrow::Cow;
 use std::collections::HashMap;
 use std::convert::TryInto;
+use std::pin::Pin;
 use wasm_bindgen::prelude::*;
 use wasm_bindgen::JsCast;
 
@@ -352,6 +353,13 @@ export type InitOptions = {
 
 export function create(options?: InitOptions): Automerge;
 export function load(data: Uint8Array, options?: LoadOptions): Automerge;
+export function loadInterruptible(data: Uint8Array, options?: LoadOptions): AutomergeLoadState;
+
+export type LoadStateResult = { done: false } | { done: true, value: Automerge };
+
+export interface AutomergeLoadState {
+    step(): LoadStateResult;
+}
 
 export interface JsSyncState {
   sharedHeads: Heads;
@@ -372,6 +380,7 @@ export interface DecodedBundle {
 export interface API {
   create(options?: InitOptions): Automerge;
   load(data: Uint8Array, options?: LoadOptions): Automerge;
+  loadInterruptible(data: Uint8Array, options?: LoadOptions): AutomergeLoadState;
   encodeChange(change: ChangeToEncode): Change;
   decodeChange(change: Change): DecodedChange;
   initSyncState(): SyncState;
@@ -1798,6 +1807,112 @@ pub fn wasm_release_info() -> JsValue {
     )
     .unwrap();
     result.into()
+}
+
+#[wasm_bindgen(js_name = loadInterruptible, skip_typescript)]
+pub fn load_interruptible(
+    data: Uint8Array,
+    options: JsValue,
+) -> Result<AutomergeLoadState, error::Load> {
+    let data = data.to_vec();
+    let actor = js_get(&options, "actor").ok().and_then(|a| a.as_string());
+    let actor = if let Some(s) = actor {
+        Some(automerge::ActorId::from(
+            hex::decode(s).map_err(error::BadActorId::from)?.to_vec(),
+        ))
+    } else {
+        None
+    };
+
+    let unchecked = js_get(&options, "unchecked")
+        .ok()
+        .and_then(|v1| v1.as_bool())
+        .unwrap_or(false);
+    let verification_mode = if unchecked {
+        VerificationMode::DontCheck
+    } else {
+        VerificationMode::Check
+    };
+    let allow_missing_deps = js_get(&options, "allowMissingDeps")
+        .ok()
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+    let on_partial_load = if allow_missing_deps {
+        OnPartialLoad::Ignore
+    } else {
+        OnPartialLoad::Error
+    };
+    let string_migration = if js_get(&options, "convertImmutableStringsToText")
+        .ok()
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false)
+    {
+        StringMigration::ConvertToText
+    } else {
+        StringMigration::NoMigration
+    };
+
+    let load_options = am::LoadOptions::new()
+        .on_partial_load(on_partial_load)
+        .verification_mode(verification_mode)
+        .migrate_strings(string_migration)
+        .text_encoding(TextEncoding::Utf16CodeUnit);
+
+    let data_pin: Pin<Box<[u8]>> = Pin::new(data.into_boxed_slice());
+    let data_ref: &'static [u8] = unsafe { std::mem::transmute(data_pin.as_ref().get_ref()) };
+
+    let inner = am::Automerge::load_interruptible(data_ref, load_options);
+
+    Ok(AutomergeLoadState {
+        inner: Some(inner),
+        data: data_pin,
+        actor,
+    })
+}
+
+#[wasm_bindgen]
+#[derive(Debug)]
+pub struct AutomergeLoadState {
+    inner: Option<am::LoadState<'static, 'static>>,
+    #[allow(dead_code)]
+    data: Pin<Box<[u8]>>,
+    actor: Option<am::ActorId>,
+}
+
+#[wasm_bindgen]
+impl AutomergeLoadState {
+    #[wasm_bindgen]
+    pub fn step(&mut self) -> Result<JsValue, JsValue> {
+        let inner = self
+            .inner
+            .take()
+            .ok_or_else(|| to_js_err("state consumed"))?;
+        match inner.step() {
+            Ok(am::StepResult::Loading(state)) => {
+                self.inner = Some(state);
+                let result = Object::new();
+                js_set(&result, "done", false)?;
+                Ok(result.into())
+            }
+            Ok(am::StepResult::Ready(doc)) => {
+                self.inner = None;
+                let mut doc: am::AutoCommit = doc.into();
+                if let Some(actor) = self.actor.take() {
+                    doc.set_actor(actor);
+                }
+                let result = Object::new();
+                js_set(&result, "done", true)?;
+                let am = Automerge {
+                    doc,
+                    freeze: false,
+                    external_types: HashMap::default(),
+                };
+                js_set(&result, "value", am)?;
+                Ok(result.into())
+            }
+            Err(e) => Err(error::Load::from(e).into()),
+        }
+    }
 }
 
 #[wasm_bindgen(js_name = encodeChange)]

--- a/rust/automerge/src/autocommit.rs
+++ b/rust/automerge/src/autocommit.rs
@@ -83,6 +83,20 @@ impl Default for AutoCommit {
     }
 }
 
+impl From<Automerge> for AutoCommit {
+    fn from(doc: Automerge) -> Self {
+        Self {
+            doc,
+            transaction: None,
+            patch_log: PatchLog::inactive(),
+            diff_cursor: Vec::new(),
+            diff_cache: None,
+            save_cursor: Vec::new(),
+            isolation: None,
+        }
+    }
+}
+
 impl AutoCommit {
     pub fn new() -> AutoCommit {
         AutoCommit::default()

--- a/rust/automerge/src/automerge.rs
+++ b/rust/automerge/src/automerge.rs
@@ -28,8 +28,8 @@ use crate::transaction::{
 };
 
 use crate::clock::{Clock, ClockRange};
-use crate::hydrate;
 use crate::types::{ActorId, ChangeHash, ObjId, ObjMeta, OpId, SequenceType, TextEncoding, Value};
+use crate::{hydrate, StepResult};
 use crate::{AutomergeError, Change, Cursor, ObjType, Prop};
 
 pub(crate) mod current_state;
@@ -84,11 +84,11 @@ pub enum StringMigration {
 
 #[derive(Debug)]
 pub struct LoadOptions<'a> {
-    on_partial_load: OnPartialLoad,
-    verification_mode: VerificationMode,
-    string_migration: StringMigration,
-    patch_log: Option<&'a mut PatchLog>,
-    text_encoding: TextEncoding,
+    pub(crate) on_partial_load: OnPartialLoad,
+    pub(crate) verification_mode: VerificationMode,
+    pub(crate) string_migration: StringMigration,
+    pub(crate) patch_log: Option<&'a mut PatchLog>,
+    pub(crate) text_encoding: TextEncoding,
 }
 
 impl<'a> LoadOptions<'a> {
@@ -739,6 +739,14 @@ impl Automerge {
         )
     }
 
+    #[tracing::instrument(skip(data))]
+    pub fn load_interruptible<'a, 'b>(
+        data: &'a [u8],
+        options: LoadOptions<'b>,
+    ) -> crate::storage::load::LoadState<'a, 'b> {
+        load::LoadState::new(options, data)
+    }
+
     /// Load a document, with options
     ///
     /// # Arguments
@@ -749,84 +757,13 @@ impl Automerge {
         data: &[u8],
         options: LoadOptions<'_>,
     ) -> Result<Self, AutomergeError> {
-        if data.is_empty() {
-            tracing::trace!("no data, initializing empty document");
-            return Ok(Self::new());
-        }
-        tracing::trace!("loading first chunk");
-        let (remaining, first_chunk) = storage::Chunk::parse(storage::parse::Input::new(data))
-            .map_err(|e| load::Error::Parse(Box::new(e)))?;
-        if !first_chunk.checksum_valid() {
-            return Err(load::Error::BadChecksum.into());
-        }
-
-        let mut changes = vec![];
-        let mut first_chunk_was_doc = false;
-        let mut am = match first_chunk {
-            storage::Chunk::Document(d) => {
-                tracing::trace!("first chunk is document chunk, inflating");
-                first_chunk_was_doc = true;
-                d.reconstruct(options.verification_mode, options.text_encoding)
-                    .map_err(|e| load::Error::InflateDocument(Box::new(e)))?
-            }
-            storage::Chunk::Change(stored_change) => {
-                tracing::trace!("first chunk is change chunk");
-                changes.push(
-                    Change::new_from_unverified(stored_change.into_owned(), None)
-                        .map_err(|e| load::Error::InvalidChangeColumns(Box::new(e)))?,
-                );
-                Self::new()
-            }
-            storage::Chunk::Bundle(bundle) => {
-                tracing::trace!("first chunk is change chunk");
-                let bundle = Bundle::new_from_unverified(bundle.into_owned())
-                    .map_err(|e| load::Error::InvalidBundleColumn(Box::new(e)))?;
-                let bundle_changes = bundle
-                    .to_changes()
-                    .map_err(|e| load::Error::InvalidBundleChange(Box::new(e)))?;
-                changes.extend(bundle_changes);
-                Self::new()
-            }
-            storage::Chunk::CompressedChange(stored_change, compressed) => {
-                tracing::trace!("first chunk is compressed change");
-                changes.push(
-                    Change::new_from_unverified(
-                        stored_change.into_owned(),
-                        Some(compressed.into_owned()),
-                    )
-                    .map_err(|e| load::Error::InvalidChangeColumns(Box::new(e)))?,
-                );
-                Self::new()
-            }
-        };
-        tracing::trace!("loading change chunks");
-        match load::load_changes(remaining.reset(), options.text_encoding, &am.change_graph) {
-            load::LoadedChanges::Complete(c) => {
-                am.apply_changes(changes.into_iter().chain(c))?;
-                // Only allow missing deps if the first chunk was a document chunk
-                // See https://github.com/automerge/automerge/pull/599#issuecomment-1549667472
-                if !am.queue.is_empty()
-                    && !first_chunk_was_doc
-                    && options.on_partial_load == OnPartialLoad::Error
-                {
-                    return Err(AutomergeError::MissingDeps);
-                }
-            }
-            load::LoadedChanges::Partial { error, .. } => {
-                if options.on_partial_load == OnPartialLoad::Error {
-                    return Err(error.into());
-                }
+        let mut state = Self::load_interruptible(data, options);
+        loop {
+            match state.step()? {
+                StepResult::Ready(doc) => return Ok(doc),
+                StepResult::Loading(l) => state = l,
             }
         }
-        if let StringMigration::ConvertToText = options.string_migration {
-            am.convert_scalar_strings_to_text()?;
-        }
-        if let Some(patch_log) = options.patch_log {
-            if patch_log.is_active() {
-                am.log_current_state(ObjMeta::root(), patch_log, true);
-            }
-        }
-        Ok(am)
     }
 
     /// Create the patches from a [`PatchLog`]
@@ -1693,7 +1630,7 @@ impl Automerge {
         }
     }
 
-    fn convert_scalar_strings_to_text(&mut self) -> Result<(), AutomergeError> {
+    pub(crate) fn convert_scalar_strings_to_text(&mut self) -> Result<(), AutomergeError> {
         struct Conversion {
             obj_id: ExId,
             prop: Prop,

--- a/rust/automerge/src/columnar/column_range/raw.rs
+++ b/rust/automerge/src/columnar/column_range/raw.rs
@@ -36,3 +36,9 @@ impl From<RawRange> for Range<usize> {
         r.0
     }
 }
+
+impl<'a> From<&'a RawRange> for Range<usize> {
+    fn from(r: &'a RawRange) -> Range<usize> {
+        r.0.clone()
+    }
+}

--- a/rust/automerge/src/lib.rs
+++ b/rust/automerge/src/lib.rs
@@ -305,7 +305,9 @@ pub use op_set2::{ChangeMetadata, Parent, Parents, ScalarValue as ScalarValueRef
 pub use patches::{Patch, PatchAction, PatchLog};
 pub use read::{ReadDoc, Stats};
 pub use sequence_tree::SequenceTree;
-pub use storage::{Bundle, BundleChange, BundleChangeIter, VerificationMode};
+pub use storage::{
+    Bundle, BundleChange, BundleChangeIter, LoadState, StepResult, VerificationMode,
+};
 pub use text_value::ConcreteTextValue;
 pub use transaction::BlockOrText;
 pub use types::{ActorId, ChangeHash, ObjType, OpType, ParseChangeHashError, Prop, TextEncoding};

--- a/rust/automerge/src/op_set2/change/collector.rs
+++ b/rust/automerge/src/op_set2/change/collector.rs
@@ -17,7 +17,6 @@ use crate::change_graph::{ChangeGraph, ChangeGraphCols};
 use crate::error::AutomergeError;
 use crate::op_set2::change::{write_change_ops, GetHash};
 use crate::op_set2::op_set::IndexBuilder;
-use crate::storage::bundle::BundleChange;
 use crate::storage::change::{Change as StoredChange, Verified};
 use crate::storage::load::change_collector::Error;
 use crate::storage::{ChunkType, Header};
@@ -37,24 +36,6 @@ pub(crate) struct IndexedChangeCollector<'a> {
 }
 
 impl<'a> IndexedChangeCollector<'a> {
-    pub(crate) fn process_ops(&mut self, op_set: &'a OpSet) -> Result<(), ReadOpError> {
-        let mut iter = op_set.iter();
-
-        while let Some(op) = iter.try_next()? {
-            let op_id = op.id;
-            let op_is_counter = op.is_counter();
-            let op_succ = op.succ();
-
-            self.process_op(op);
-
-            for id in op_succ {
-                self.index.process_succ(op_is_counter, id);
-                self.collector.process_succ(op_id, id);
-            }
-        }
-        Ok(())
-    }
-
     pub(crate) fn collect(self, op_set: &OpSet) -> Result<CollectedChanges, Error> {
         self.collector.collect(op_set)
     }
@@ -591,14 +572,6 @@ impl<'a> ChangeCollector<'a> {
         Ok(())
     }
 
-    pub(crate) fn from_bundle_changes(
-        changes: Vec<BundleChange<'a>>,
-        actors: &'a [ActorId],
-    ) -> ChangeCollector<'a> {
-        let changes = changes.into_iter().map(|c| c.into()).collect();
-        Self::from_change_meta(changes, actors)
-    }
-
     pub(crate) fn try_from_change_meta(
         mut changes: Vec<BuildChangeMetadata<'a>>,
         actors: &'a [ActorId],
@@ -728,7 +701,7 @@ impl<'a> ChangeCollector<'a> {
             r1,
             crate::storage::Bundle::for_hashes(op_set, change_graph, r1.iter().map(|c| c.hash()))
                 .unwrap()
-                .to_changes()
+                .into_changes()
                 .unwrap()
         );
         r1

--- a/rust/automerge/src/op_set2/columns.rs
+++ b/rust/automerge/src/op_set2/columns.rs
@@ -2,6 +2,7 @@ use super::meta::MetaCursor;
 use super::op::OpLike;
 use super::op_set::MarkIndexColumn;
 use super::types::{Action, ActionCursor, ActorCursor, ActorIdx, ScalarValue};
+use crate::op_set2::op_set::{SuccIterIter, ValueIter};
 use crate::storage::columns::compression::Uncompressed;
 use crate::storage::columns::ColumnId;
 use crate::storage::columns::{BadColumnLayout, Columns as ColumnFormat};
@@ -19,7 +20,7 @@ use std::fmt::Debug;
 use std::ops::Range;
 
 #[derive(Debug, Clone)]
-pub(super) struct Columns {
+pub(crate) struct Columns {
     pub(super) id_actor: ColumnData<ActorCursor>,
     pub(super) id_ctr: ColumnData<DeltaCursor>,
     pub(super) obj_actor: ColumnData<ActorCursor>,
@@ -37,6 +38,24 @@ pub(super) struct Columns {
     pub(super) mark_name: ColumnData<StrCursor>,
     pub(super) expand: ColumnData<BooleanCursor>,
     pub(super) index: Indexes,
+}
+
+impl Columns {
+    pub(crate) fn value_iter_range(&self, range: &Range<usize>) -> ValueIter<'_> {
+        let value_meta = self.value_meta.iter_range(range.clone());
+        let value_advance = value_meta.calculate_acc().as_usize();
+        let value_raw = self.value.raw_reader(value_advance);
+        ValueIter::new(value_meta, value_raw)
+    }
+
+    pub(crate) fn succ_iter_range(&self, range: &Range<usize>) -> SuccIterIter<'_> {
+        let succ_count = self.succ_count.iter_range(range.clone());
+        let succ_range = succ_count.calculate_acc().as_usize()..usize::MAX;
+        let succ_actor = self.succ_actor.iter_range(succ_range.clone());
+        let succ_counter = self.succ_ctr.iter_range(succ_range.clone());
+        let inc_values = self.index.inc.iter_range(succ_range);
+        SuccIterIter::new(succ_count, succ_actor, succ_counter, inc_values)
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/rust/automerge/src/op_set2/op_set.rs
+++ b/rust/automerge/src/op_set2/op_set.rs
@@ -46,8 +46,8 @@ pub(crate) use insert::InsertQuery;
 pub(crate) use mark_index::{MarkIndexBuilder, MarkIndexColumn};
 pub(crate) use marks::{MarkIter, NoMarkIter};
 pub(crate) use op_iter::{
-    ActionIter, ActionValueIter, CtrWalker, MarkInfoIter, ObjIdIter, OpIdIter, OpIter, ReadOpError,
-    SuccIterIter, SuccWalker, ValueIter,
+    ActionIter, ActionValueIter, CtrWalker, MarkInfoIter, ObjIdIter, OpIdIter, OpIter, OpIterState,
+    ReadOpError, SuccIterIter, SuccWalker, ValueIter,
 };
 pub(crate) use op_query::{OpQuery, OpQueryTerm};
 pub(crate) use top_op::TopOpIter;
@@ -106,7 +106,7 @@ impl OpSet {
     }
 
     pub(crate) fn index_builder(&self) -> IndexBuilder {
-        IndexBuilder::new(self, self.text_encoding)
+        IndexBuilder::new(&self.cols, self.text_encoding)
     }
 
     pub(crate) fn reset_top(&mut self, range: Range<usize>) {
@@ -355,10 +355,6 @@ impl OpSet {
 
     pub(crate) fn len(&self) -> usize {
         self.cols.len()
-    }
-
-    pub(crate) fn sub_len(&self) -> usize {
-        self.cols.sub_len()
     }
 
     pub(crate) fn seq_length(
@@ -939,7 +935,8 @@ impl OpSet {
         // FIXME - shouldn't need to clone bytes here (eventually)
         let data = doc.op_raw_bytes();
         let actors = doc.actors().to_vec();
-        Self::from_parts(doc.op_metadata.clone(), data, actors, text_encoding)
+        let cols = Columns::load(doc.op_metadata.as_map(), data, &actors)?;
+        Ok(Self::from_parts(cols, actors, text_encoding))
     }
 
     #[cfg(test)]
@@ -959,22 +956,17 @@ impl OpSet {
         }
     }
 
-    fn from_parts(
-        cols: RawColumns<Uncompressed>,
-        data: &[u8],
+    pub(crate) fn from_parts(
+        cols: Columns,
         actors: Vec<ActorId>,
         text_encoding: TextEncoding,
-    ) -> Result<Self, PackError> {
-        let cols = Columns::load(cols.as_map(), data, &actors)?;
-
-        let op_set = OpSet {
+    ) -> Self {
+        OpSet {
             actors,
             cols,
             obj_info: ObjIndex::default(),
             text_encoding,
-        };
-
-        Ok(op_set)
+        }
     }
 
     pub(crate) fn export(&self) -> (RawColumns<Uncompressed>, Vec<u8>) {

--- a/rust/automerge/src/op_set2/op_set.rs
+++ b/rust/automerge/src/op_set2/op_set.rs
@@ -3,6 +3,7 @@ use crate::clock::{Clock, ClockRange};
 use crate::exid::ExId;
 use crate::iter::tools::{MergeIter, SkipIter, SkipWrap};
 use crate::marks::{MarkSet, RichTextQueryState};
+use crate::op_set2::op_set::op_iter::{InsertIter, KeyIter};
 use crate::storage::columns::BadColumnLayout;
 use crate::storage::{columns::compression::Uncompressed, ColumnSpec, Document, RawColumns};
 use crate::types;
@@ -45,8 +46,8 @@ pub(crate) use insert::InsertQuery;
 pub(crate) use mark_index::{MarkIndexBuilder, MarkIndexColumn};
 pub(crate) use marks::{MarkIter, NoMarkIter};
 pub(crate) use op_iter::{
-    ActionIter, ActionValueIter, CtrWalker, InsertIter, KeyIter, MarkInfoIter, ObjIdIter, OpIdIter,
-    OpIter, ReadOpError, SuccIterIter, SuccWalker, ValueIter,
+    ActionIter, ActionValueIter, CtrWalker, MarkInfoIter, ObjIdIter, OpIdIter, OpIter, ReadOpError,
+    SuccIterIter, SuccWalker, ValueIter,
 };
 pub(crate) use op_query::{OpQuery, OpQueryTerm};
 pub(crate) use top_op::TopOpIter;
@@ -1040,9 +1041,6 @@ impl OpSet {
     }
 
     pub(crate) fn iter_range(&self, range: &Range<usize>) -> OpIter<'_> {
-        let value = self.value_iter_range(range);
-        let succ = self.succ_iter_range(range);
-
         OpIter {
             pos: range.start,
             id: self.id_iter_range(range),
@@ -1055,10 +1053,10 @@ impl OpSet {
                 self.cols.key_actor.iter_range(range.clone()),
                 self.cols.key_ctr.iter_range(range.clone()),
             ),
-            succ,
+            succ: self.cols.succ_iter_range(range),
             insert: InsertIter::new(self.cols.insert.iter_range(range.clone())),
             action: ActionIter::new(self.cols.action.iter_range(range.clone())),
-            value,
+            value: self.cols.value_iter_range(range),
             marks: self.mark_info_iter_range(range),
             range: range.clone(),
             op_set: self,

--- a/rust/automerge/src/op_set2/op_set/index.rs
+++ b/rust/automerge/src/op_set2/op_set/index.rs
@@ -1,5 +1,6 @@
+use crate::op_set2::columns::Columns;
 use crate::op_set2::op_set::{MarkIndexBuilder, MarkIndexColumn};
-use crate::op_set2::{ChangeOp, Op, OpBuilder, OpSet};
+use crate::op_set2::{ChangeOp, Op, OpBuilder};
 use crate::types::{ObjId, ObjType, OpId, SequenceType, TextEncoding};
 use hexane::{BooleanCursor, ColumnData, IntCursor, UIntCursor};
 use std::collections::HashMap;
@@ -98,14 +99,14 @@ pub(crate) struct Indexes {
 }
 
 impl IndexBuilder {
-    pub(crate) fn new(op_set: &OpSet, encoding: TextEncoding) -> Self {
+    pub(crate) fn new(cols: &Columns, encoding: TextEncoding) -> Self {
         Self {
             counters: HashMap::new(),
-            succ: Vec::with_capacity(op_set.len()),
-            top: Vec::with_capacity(op_set.len()),
-            widths: Vec::with_capacity(op_set.len()),
-            incs: Vec::with_capacity(op_set.sub_len()),
-            marks: Vec::with_capacity(op_set.len()),
+            succ: Vec::with_capacity(cols.len()),
+            top: Vec::with_capacity(cols.len()),
+            widths: Vec::with_capacity(cols.len()),
+            incs: Vec::with_capacity(cols.sub_len()),
+            marks: Vec::with_capacity(cols.len()),
             obj_info: ObjIndex::default(),
             last_flush: 0,
             text_encoding: encoding,

--- a/rust/automerge/src/storage.rs
+++ b/rust/automerge/src/storage.rs
@@ -9,7 +9,7 @@ pub(crate) mod load;
 pub(crate) mod parse;
 
 pub use bundle::{Bundle, BundleChange, BundleChangeIter};
-pub use load::VerificationMode;
+pub use load::{LoadState, StepResult, VerificationMode};
 
 pub(crate) use {
     bundle::{BundleMetadata, BundleStorage},

--- a/rust/automerge/src/storage/bundle/builder.rs
+++ b/rust/automerge/src/storage/bundle/builder.rs
@@ -707,26 +707,6 @@ struct OpIterInner<'a> {
     mark_name: CursorIter<'a, StrCursor>,
 }
 
-pub(crate) struct OpIter<'a> {
-    iter: OpIterUnverified<'a>,
-}
-
-impl<'a> OpIter<'a> {
-    pub(crate) fn new(columns: &RawColumns<compression::Uncompressed>, data: &'a [u8]) -> Self {
-        Self {
-            iter: OpIterUnverified::new(columns, data),
-        }
-    }
-}
-
-impl<'a> Iterator for OpIter<'a> {
-    type Item = OpBuilder<'a>;
-
-    fn next(&mut self) -> Option<OpBuilder<'a>> {
-        self.iter.next().map(|v| v.unwrap())
-    }
-}
-
 impl<'a> Iterator for OpIterUnverified<'a> {
     type Item = Result<OpBuilder<'a>, ParseError>;
 

--- a/rust/automerge/src/storage/bundle/loading_bundle.rs
+++ b/rust/automerge/src/storage/bundle/loading_bundle.rs
@@ -1,0 +1,290 @@
+use std::{borrow::Cow, marker::PhantomPinned, ops::Range, pin::Pin, ptr::NonNull};
+
+use crate::{
+    automerge::ChangeCollector,
+    op_set2::change::BuildChangeMetadata,
+    storage::{
+        bundle::{BundleChangeIterUnverified, OpIterUnverified, ParseError},
+        change::Unverified,
+        columns::compression::Uncompressed,
+        BundleStorage, Header, RawColumns,
+    },
+    ActorId, Change, ChangeHash, StepResult,
+};
+
+/// Pinned data that iterators and collectors will reference. Once pinned, this
+/// cannot move, which allows us to safely create iterators that reference it.
+struct LoadingBundleData<'a> {
+    bytes: Cow<'a, [u8]>,
+    #[allow(dead_code)]
+    header: Header,
+    deps: Vec<ChangeHash>,
+    actors: Vec<ActorId>,
+    ops_meta: RawColumns<Uncompressed>,
+    ops_data: Range<usize>,
+    changes_meta: RawColumns<Uncompressed>,
+    changes_data: Range<usize>,
+    /// Marker to opt out of `Unpin`, making `Pin` meaningful
+    _pin: PhantomPinned,
+}
+
+/// State for the loading phase.
+///
+/// # Safety
+///
+/// The iterators and collectors here reference memory in a sibling
+/// `Pin<Box<LoadingBundleData>>`. This is safe because:
+/// 1. The data is pinned and cannot move
+/// 2. This enum is dropped before the data (field ordering in `LoadingBundleChanges`)
+/// 3. We never expose the iterators outside this module
+enum LoadingState {
+    Changes {
+        iter: NonNull<BundleChangeIterUnverified<'static>>,
+        changes: Vec<BuildChangeMetadata<'static>>,
+        batch_size: Option<usize>,
+    },
+    Ops {
+        /// Option so we can take the iterator in step() without double-free on Drop
+        iter: Option<NonNull<OpIterUnverified<'static>>>,
+        /// Option so we can take the collector in step() without double-free on Drop.
+        /// Stored as NonNull to avoid transmuting references to 'static, which
+        /// violates miri's Stacked Borrows model.
+        collector: Option<NonNull<ChangeCollector<'static>>>,
+        batch_size: Option<usize>,
+    },
+    Done,
+}
+
+impl Drop for LoadingState {
+    fn drop(&mut self) {
+        match self {
+            LoadingState::Changes { iter, .. } => {
+                // SAFETY: iter was created via Box::into_raw
+                unsafe {
+                    drop(Box::from_raw(iter.as_ptr()));
+                }
+            }
+            LoadingState::Ops {
+                iter, collector, ..
+            } => {
+                // Free iterator if it hasn't been taken yet
+                if let Some(iter_ptr) = iter.take() {
+                    // SAFETY: iter was created via Box::into_raw and is never moved afterwards
+                    unsafe {
+                        drop(Box::from_raw(iter_ptr.as_ptr()));
+                    }
+                }
+                // Free collector if it hasn't been taken yet
+                if let Some(collector_ptr) = collector.take() {
+                    // SAFETY: collector was created via Box::into_raw and is never moved afterwards
+                    unsafe {
+                        drop(Box::from_raw(collector_ptr.as_ptr()));
+                    }
+                }
+            }
+            LoadingState::Done => {}
+        }
+    }
+}
+
+/// Interruptible bundle change loading state machine.
+///
+/// This struct uses pinning and raw pointers to safely store iterators
+/// alongside the data they reference.
+pub(crate) struct LoadingBundleChanges<'a> {
+    // IMPORTANT: Field order determines drop order.
+    // `state` contains iterators/collectors referencing `data`, so must be dropped first.
+    state: LoadingState,
+    data: Pin<Box<LoadingBundleData<'a>>>,
+}
+
+impl<'a> LoadingBundleChanges<'a> {
+    pub(super) fn new(
+        storage: BundleStorage<'a, Unverified>,
+        _ops_batch_size: Option<usize>,
+        change_batch_size: Option<usize>,
+    ) -> Self {
+        // Pin the data so its address is stable
+        let data = Box::pin(LoadingBundleData {
+            bytes: storage.bytes,
+            header: storage.header,
+            deps: storage.deps,
+            actors: storage.actors,
+            ops_meta: storage.ops_meta,
+            ops_data: storage.ops_data,
+            changes_meta: storage.changes_meta,
+            changes_data: storage.changes_data,
+            _pin: PhantomPinned,
+        });
+
+        // Create the change metadata iterator referencing the pinned data
+        // SAFETY: data is pinned and won't move. The 'static lifetime is a lie -
+        // the true lifetime is "until data is dropped" - but we guarantee the
+        // iterator is dropped first via field ordering.
+        let iter = unsafe {
+            let data_ref = data.as_ref().get_ref();
+            let change_data: &'static [u8] =
+                std::mem::transmute(&data_ref.bytes[data_ref.changes_data.clone()]);
+            let changes_meta: &'static RawColumns<Uncompressed> =
+                std::mem::transmute(&data_ref.changes_meta);
+
+            let iter = BundleChangeIterUnverified::new(changes_meta, change_data);
+            NonNull::new_unchecked(Box::into_raw(Box::new(iter)))
+        };
+
+        LoadingBundleChanges {
+            state: LoadingState::Changes {
+                iter,
+                changes: Vec::new(),
+                batch_size: change_batch_size,
+            },
+            data,
+        }
+    }
+
+    /// Create an op iterator referencing the pinned data.
+    ///
+    /// # Safety
+    ///
+    /// The returned iterator has a fake 'static lifetime but actually references
+    /// `self.data`. Caller must ensure the iterator is dropped before `self.data`.
+    unsafe fn create_op_iter(&self) -> NonNull<OpIterUnverified<'static>> {
+        let data_ref = self.data.as_ref().get_ref();
+        let ops_data: &'static [u8] =
+            std::mem::transmute(&data_ref.bytes[data_ref.ops_data.clone()]);
+        let ops_meta: &'static RawColumns<Uncompressed> = std::mem::transmute(&data_ref.ops_meta);
+
+        let iter = OpIterUnverified::new(ops_meta, ops_data);
+        NonNull::new_unchecked(Box::into_raw(Box::new(iter)))
+    }
+
+    /// Create a collector referencing the pinned actors data.
+    ///
+    /// # Safety
+    ///
+    /// The returned NonNull points to a heap-allocated ChangeCollector that
+    /// references `self.data.actors`. Caller must ensure the collector is
+    /// dropped (via Box::from_raw) before `self.data` is dropped.
+    unsafe fn create_collector(
+        &self,
+        changes: Vec<BuildChangeMetadata<'static>>,
+    ) -> NonNull<ChangeCollector<'static>> {
+        let data_ref = self.data.as_ref().get_ref();
+        // Create the collector with actual lifetime, then immediately box it.
+        // The NonNull erases the lifetime at the pointer level, avoiding the
+        // need to transmute references which violates Stacked Borrows.
+        let collector = ChangeCollector::from_change_meta(changes, &data_ref.actors);
+        // Transmute the collector to 'static. This is safe because:
+        // 1. The collector is immediately boxed and stored as a raw pointer
+        // 2. We guarantee via drop ordering that it's freed before actors
+        let collector: ChangeCollector<'static> = std::mem::transmute(collector);
+        NonNull::new_unchecked(Box::into_raw(Box::new(collector)))
+    }
+
+    pub(crate) fn step(mut self) -> Result<StepResult<Self, Vec<Change>>, ParseError> {
+        match &mut self.state {
+            LoadingState::Changes {
+                iter,
+                changes,
+                batch_size,
+            } => {
+                let mut iterations = 0;
+                // SAFETY: iter points to a valid, live iterator
+                let iter_ref = unsafe { iter.as_mut() };
+
+                for change_meta_result in iter_ref.by_ref() {
+                    // Verification happens here - we propagate any parse errors
+                    let change_meta = change_meta_result?;
+                    changes.push(change_meta.into());
+                    iterations += 1;
+                    if let Some(bs) = *batch_size {
+                        if iterations >= bs {
+                            return Ok(StepResult::Loading(self));
+                        }
+                    }
+                }
+
+                // Transition to Ops phase
+                let old_batch_size = *batch_size;
+
+                // Take ownership of changes before replacing state
+                let changes = std::mem::take(changes);
+
+                // Replace state to free the change iterator
+                let old_state = std::mem::replace(&mut self.state, LoadingState::Done);
+                drop(old_state);
+
+                // Create the collector and op iterator
+                // SAFETY: Both collector and iterator reference pinned data.
+                // They will be stored in self.state which is dropped before self.data.
+                let collector = unsafe { self.create_collector(changes) };
+                let op_iter = unsafe { self.create_op_iter() };
+
+                self.state = LoadingState::Ops {
+                    iter: Some(op_iter),
+                    collector: Some(collector),
+                    batch_size: old_batch_size,
+                };
+
+                Ok(StepResult::Loading(self))
+            }
+            LoadingState::Ops {
+                iter,
+                collector,
+                batch_size,
+            } => {
+                let mut iterations = 0;
+                // SAFETY: The only place we move or invalidate iter and
+                // collector is in this function after the iter_ref returns None
+                // when we drop them both and transition to a new state. That
+                // means that if iter and collector are Some (and we'll panic if
+                // they're not so we don't get UB) then they are valid
+                let iter_ref = unsafe { iter.as_mut().unwrap().as_mut() };
+                let collector_ref = unsafe { collector.as_mut().unwrap().as_mut() };
+
+                for op_result in iter_ref.by_ref() {
+                    // Verification happens here - we propagate any parse errors
+                    let op = op_result?;
+                    collector_ref.add(op);
+                    iterations += 1;
+                    if let Some(bs) = *batch_size {
+                        if iterations >= bs {
+                            return Ok(StepResult::Loading(self));
+                        }
+                    }
+                }
+
+                // Take ownership of iterator and collector before transitioning state.
+                // Using Option::take() means Drop won't try to free them again.
+                let iter_ptr = iter.take().unwrap();
+                let collector_ptr = collector.take().unwrap();
+
+                // Free the iterator
+                unsafe {
+                    drop(Box::from_raw(iter_ptr.as_ptr()));
+                }
+
+                // Free the collector
+                let collector = unsafe { *Box::from_raw(collector_ptr.as_ptr()) };
+
+                // Transition to Done
+                self.state = LoadingState::Done;
+
+                // Get references to deps and actors for unbundle
+                // SAFETY: We've freed the iterators, but collector still references actors.
+                // However, unbundle() consumes the collector and returns owned Changes,
+                // so after this call no references to the pinned data remain.
+                let data_ref = self.data.as_ref().get_ref();
+
+                let changes = collector
+                    .unbundle(&data_ref.actors, &data_ref.deps)
+                    .map_err(|e| ParseError::Unbundle(Box::new(e)))?;
+
+                Ok(StepResult::Ready(changes))
+            }
+            LoadingState::Done => {
+                panic!("step() called on completed LoadingBundleChanges");
+            }
+        }
+    }
+}

--- a/rust/automerge/src/storage/chunk.rs
+++ b/rust/automerge/src/storage/chunk.rs
@@ -121,6 +121,15 @@ impl<'a> Chunk<'a> {
             Self::Bundle(b) => b.checksum_valid(),
         }
     }
+
+    pub(crate) fn chunk_type(&self) -> ChunkType {
+        match self {
+            Self::Document(_) => ChunkType::Document,
+            Self::Change(_) => ChunkType::Change,
+            Self::CompressedChange(_, _) => ChunkType::Compressed,
+            Self::Bundle(_) => ChunkType::Bundle,
+        }
+    }
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]

--- a/rust/automerge/src/storage/document.rs
+++ b/rust/automerge/src/storage/document.rs
@@ -9,7 +9,7 @@ use crate::op_set2::change::{ChangeCollector, CollectedChanges, OutOfMemory};
 use crate::op_set2::{OpSet, ReadOpError};
 use crate::storage::columns::compression::Uncompressed;
 use crate::storage::ColumnSpec;
-use crate::{ActorId, Automerge, Change, ChangeHash, TextEncoding};
+use crate::{ActorId, Change, ChangeHash, TextEncoding};
 
 mod compression;
 
@@ -301,7 +301,7 @@ impl<'a> Document<'a> {
         &self.heads
     }
 
-    fn verify_changes(
+    pub(crate) fn verify_changes(
         &self,
         cc: &CollectedChanges,
         mode: VerificationMode,
@@ -317,36 +317,6 @@ impl<'a> Document<'a> {
         } else {
             Ok(())
         }
-    }
-
-    pub(crate) fn reconstruct(
-        &self,
-        mode: VerificationMode,
-        text_encoding: TextEncoding,
-    ) -> Result<Automerge, ReconstructError> {
-        let mut op_set = OpSet::load(self, text_encoding)?;
-        let change_cols = ChangeGraphCols::load(self)?;
-
-        let mut index = op_set.index_builder();
-
-        let change_collector = ChangeCollector::try_new(&change_cols, &op_set)?;
-        let mut change_collector = change_collector.with_index(&mut index);
-
-        change_collector.process_ops(&op_set)?;
-
-        let changes = change_collector.collect(&op_set)?;
-
-        self.verify_changes(&changes, mode)?;
-
-        op_set.set_indexes(index);
-
-        let change_graph = change_cols.finalize(&changes.changes);
-
-        debug_assert_eq!(changes.changes.len(), change_graph.len());
-
-        debug_assert!(op_set.validate_top_index());
-
-        Ok(Automerge::from_parts(op_set, change_graph))
     }
 
     pub(crate) fn reconstruct_changes(

--- a/rust/automerge/src/storage/load.rs
+++ b/rust/automerge/src/storage/load.rs
@@ -15,6 +15,9 @@ pub enum VerificationMode {
     DontCheck,
 }
 
+mod load_state;
+pub use load_state::{LoadState, StepResult};
+
 #[derive(Debug, thiserror::Error)]
 #[allow(unreachable_pub)]
 pub enum Error {
@@ -120,7 +123,7 @@ fn load_next_change<'a>(
             let bundle = Bundle::new_from_unverified(bundle.into_owned())
                 .map_err(|e| Error::InvalidBundleColumn(Box::new(e)))?;
             let bundle_changes = bundle
-                .to_changes()
+                .into_changes()
                 .map_err(|e| Error::InvalidBundleChange(Box::new(e)))?;
             changes.extend(bundle_changes);
         }

--- a/rust/automerge/src/storage/load/load_state.rs
+++ b/rust/automerge/src/storage/load/load_state.rs
@@ -1,0 +1,297 @@
+use crate::{
+    storage::{self, load::Error as LoadError, parse, Bundle, ChunkType},
+    types::ObjMeta,
+    Automerge, AutomergeError, Change, LoadOptions, OnPartialLoad, StringMigration,
+};
+
+mod collector_cell;
+mod load_doc_chunk;
+use load_doc_chunk::LoadingDocChunk;
+
+#[derive(Debug)]
+pub enum StepResult<S, O> {
+    Loading(S),
+    Ready(O),
+}
+
+#[derive(Debug)]
+pub struct LoadState<'a, 'b> {
+    options: LoadOptions<'b>,
+    first_chunk_type: Option<ChunkType>,
+    changes: Vec<Change>,
+    doc: Option<Automerge>,
+    phase: Phase<'a>,
+}
+
+enum Phase<'a> {
+    /// Looking at the byte stream for the next chunk header.
+    NextChunk { data: parse::Input<'a> },
+    /// Currently iterating ops within a document chunk. Boxed because the
+    /// loader is significantly larger than the other variants.
+    LoadingDoc(Box<LoadingDocPhase<'a>>),
+    /// Done parsing chunks; ready to assemble the document.
+    Finishing,
+}
+
+struct LoadingDocPhase<'a> {
+    loader: LoadingDocChunk<'a>,
+    remaining: parse::Input<'a>,
+}
+
+impl<'a> std::fmt::Debug for Phase<'a> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::NextChunk { .. } => write!(f, "NextChunk"),
+            Self::LoadingDoc(_) => write!(f, "LoadingDoc"),
+            Self::Finishing => write!(f, "Finishing"),
+        }
+    }
+}
+
+impl<'a, 'b> LoadState<'a, 'b> {
+    pub(crate) fn new(options: LoadOptions<'b>, data: &'a [u8]) -> Self {
+        Self {
+            options,
+            first_chunk_type: None,
+            changes: Vec::new(),
+            doc: None,
+            phase: Phase::NextChunk {
+                data: parse::Input::new(data),
+            },
+        }
+    }
+
+    pub fn step(mut self) -> Result<StepResult<Self, Automerge>, AutomergeError> {
+        match std::mem::replace(&mut self.phase, Phase::Finishing) {
+            Phase::Finishing => Ok(StepResult::Ready(self.finish()?)),
+            Phase::LoadingDoc(state) => self.step_loading_doc(state.loader, state.remaining),
+            Phase::NextChunk { data } => self.step_next_chunk(data),
+        }
+    }
+
+    fn step_next_chunk(
+        mut self,
+        data: parse::Input<'a>,
+    ) -> Result<StepResult<Self, Automerge>, AutomergeError> {
+        if data.is_empty() {
+            self.phase = Phase::Finishing;
+            return Ok(StepResult::Loading(self));
+        }
+
+        let is_first_chunk = self.first_chunk_type.is_none();
+        let (remaining, chunk) = match storage::Chunk::parse(data) {
+            Ok(c) => c,
+            Err(e) => {
+                if is_first_chunk || self.options.on_partial_load == OnPartialLoad::Error {
+                    return Err(LoadError::Parse(Box::new(e)).into());
+                }
+                self.phase = Phase::Finishing;
+                return Ok(StepResult::Loading(self));
+            }
+        };
+
+        if !chunk.checksum_valid() {
+            return Err(LoadError::BadChecksum.into());
+        }
+
+        let chunk_type = chunk.chunk_type();
+        if self.first_chunk_type.is_none() {
+            self.first_chunk_type = Some(chunk_type);
+        }
+        let remaining = remaining.reset();
+
+        let on_partial_load = self.options.on_partial_load;
+        match self.handle_chunk(chunk, is_first_chunk, remaining) {
+            Ok(()) => Ok(StepResult::Loading(self)),
+            Err(e) => {
+                if is_first_chunk || on_partial_load == OnPartialLoad::Error {
+                    Err(e.into())
+                } else {
+                    self.phase = Phase::Finishing;
+                    Ok(StepResult::Loading(self))
+                }
+            }
+        }
+    }
+
+    /// Process a freshly-parsed chunk header. For document chunks this kicks
+    /// off an interruptible sub-load; other chunk types are decoded eagerly
+    /// (they are small and unlikely to be a bottleneck).
+    fn handle_chunk(
+        &mut self,
+        chunk: storage::Chunk<'a>,
+        is_first_chunk: bool,
+        remaining: parse::Input<'a>,
+    ) -> Result<(), LoadError> {
+        match chunk {
+            storage::Chunk::Document(d) => {
+                tracing::trace!("loading document chunk");
+                if is_first_chunk {
+                    let loader = LoadingDocChunk::new(
+                        d,
+                        self.options.text_encoding,
+                        self.options.verification_mode,
+                    );
+                    self.phase = Phase::LoadingDoc(Box::new(LoadingDocPhase { loader, remaining }));
+                } else {
+                    if !self.change_graph_has_heads(d.heads()) {
+                        let new_changes = d
+                            .reconstruct_changes(self.options.text_encoding)
+                            .map_err(|e| LoadError::InflateDocument(Box::new(e)))?;
+                        self.changes.extend(new_changes);
+                    }
+                    self.phase = Phase::NextChunk { data: remaining };
+                }
+            }
+            storage::Chunk::Change(stored) => {
+                tracing::trace!("loading change chunk");
+                let change = Change::new_from_unverified(stored.into_owned(), None)
+                    .map_err(|e| LoadError::InvalidChangeColumns(Box::new(e)))?;
+                self.changes.push(change);
+                self.phase = Phase::NextChunk { data: remaining };
+            }
+            storage::Chunk::CompressedChange(stored, compressed) => {
+                tracing::trace!("loading compressed change chunk");
+                let change =
+                    Change::new_from_unverified(stored.into_owned(), Some(compressed.into_owned()))
+                        .map_err(|e| LoadError::InvalidChangeColumns(Box::new(e)))?;
+                self.changes.push(change);
+                self.phase = Phase::NextChunk { data: remaining };
+            }
+            storage::Chunk::Bundle(bundle) => {
+                tracing::trace!("loading bundle chunk");
+                let bundle = Bundle::new_from_unverified(bundle.into_owned())
+                    .map_err(|e| LoadError::InvalidBundleColumn(Box::new(e)))?;
+                let bundle_changes = bundle
+                    .into_changes()
+                    .map_err(|e| LoadError::InvalidBundleChange(Box::new(e)))?;
+                self.changes.extend(bundle_changes);
+                self.phase = Phase::NextChunk { data: remaining };
+            }
+        }
+        Ok(())
+    }
+
+    fn step_loading_doc(
+        mut self,
+        loader: LoadingDocChunk<'a>,
+        remaining: parse::Input<'a>,
+    ) -> Result<StepResult<Self, Automerge>, AutomergeError> {
+        match loader.step() {
+            Ok(StepResult::Loading(loader)) => {
+                self.phase = Phase::LoadingDoc(Box::new(LoadingDocPhase { loader, remaining }));
+                Ok(StepResult::Loading(self))
+            }
+            Ok(StepResult::Ready(doc)) => {
+                self.doc = Some(doc);
+                self.phase = Phase::NextChunk { data: remaining };
+                Ok(StepResult::Loading(self))
+            }
+            Err(e) => {
+                // We're inside the first chunk; partial loads aren't allowed
+                // here because there's no usable document yet.
+                Err(e.into())
+            }
+        }
+    }
+
+    fn change_graph_has_heads(&self, heads: &[crate::types::ChangeHash]) -> bool {
+        match &self.doc {
+            Some(doc) => heads.iter().all(|h| doc.change_graph.has_change(h)),
+            None => false,
+        }
+    }
+
+    fn finish(self) -> Result<Automerge, AutomergeError> {
+        let LoadState {
+            options,
+            first_chunk_type,
+            changes,
+            doc,
+            ..
+        } = self;
+        let mut doc = doc.unwrap_or_else(Automerge::new);
+        doc.apply_changes(changes)?;
+
+        if !doc.queue.is_empty()
+            && first_chunk_type != Some(ChunkType::Document)
+            && options.on_partial_load == OnPartialLoad::Error
+        {
+            return Err(AutomergeError::MissingDeps);
+        }
+
+        if let StringMigration::ConvertToText = options.string_migration {
+            doc.convert_scalar_strings_to_text()?;
+        }
+
+        if let Some(patch_log) = options.patch_log {
+            if patch_log.is_active() {
+                doc.log_current_state(ObjMeta::root(), patch_log, true);
+            }
+        }
+
+        Ok(doc)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{transaction::Transactable, AutoCommit, ObjType, ROOT};
+
+    fn build_big_doc() -> AutoCommit {
+        let mut doc = AutoCommit::new();
+        let list = doc.put_object(ROOT, "list", ObjType::List).unwrap();
+        for i in 0..2000 {
+            doc.insert(&list, i, i as i64).unwrap();
+        }
+        let text = doc.put_object(ROOT, "text", ObjType::Text).unwrap();
+        for i in 0..5 {
+            doc.splice_text(&text, 0, 0, &format!("chunk-{i}-"))
+                .unwrap();
+        }
+        doc
+    }
+
+    #[test]
+    fn step_loads_document_in_multiple_steps() {
+        let mut doc = build_big_doc();
+        let bytes = doc.save();
+
+        let mut state = LoadState::new(LoadOptions::new(), &bytes);
+        let mut steps = 0;
+        let loaded = loop {
+            match state.step().unwrap() {
+                StepResult::Loading(next) => {
+                    state = next;
+                    steps += 1;
+                }
+                StepResult::Ready(doc) => break doc,
+            }
+        };
+
+        // The document was built to have many more ops than the test
+        // `BATCH_SIZE`, so the doc-chunk loader has to suspend and resume the
+        // op iterator several times before finishing.
+        assert!(
+            steps > 8,
+            "expected mid-iteration suspends, only got {steps} steps"
+        );
+
+        let expected = Automerge::load(&bytes).unwrap();
+        assert_eq!(loaded.get_heads(), expected.get_heads());
+        assert_eq!(loaded.save(), expected.save());
+    }
+
+    #[test]
+    fn empty_input_produces_empty_doc() {
+        let mut state = LoadState::new(LoadOptions::new(), &[]);
+        let doc = loop {
+            match state.step().unwrap() {
+                StepResult::Loading(next) => state = next,
+                StepResult::Ready(doc) => break doc,
+            }
+        };
+        assert!(doc.get_heads().is_empty());
+    }
+}

--- a/rust/automerge/src/storage/load/load_state/collector_cell.rs
+++ b/rust/automerge/src/storage/load/load_state/collector_cell.rs
@@ -1,0 +1,123 @@
+//! Safe wrapper around the self-referential pairing of an
+//! [`IndexedChangeCollector`] with the data it borrows from.
+//!
+//! `IndexedChangeCollector<'a>` borrows from an [`OpSet`], a
+//! [`ChangeGraphCols`], and an [`IndexBuilder`]. To keep all of these alive
+//! together across yield points we need a self-referential struct. Rust's type
+//! system can't directly express self-references, so this module hides the
+//! required `unsafe` behind a closure-based API: callers never see the
+//! `'static` lifetime erasure used internally.
+//!
+//! All `unsafe` code in the interruptible loader lives here.
+
+use std::mem::ManuallyDrop;
+
+use crate::change_graph::ChangeGraphCols;
+use crate::op_set2::{change::collector::IndexedChangeCollector, op_set::IndexBuilder, OpSet};
+
+/// The owned data that an [`IndexedChangeCollector`] borrows from.
+pub(crate) struct CollectorOwner {
+    pub(crate) op_set: OpSet,
+    pub(crate) change_cols: ChangeGraphCols,
+    pub(crate) index_builder: IndexBuilder,
+}
+
+/// A live [`IndexedChangeCollector`] paired with the [`CollectorOwner`] it
+/// borrows from.
+///
+/// The owner sits in a `Box` so the addresses of its fields are stable; the
+/// collector's actual borrows point into that box. The collector is stored
+/// internally with its lifetime erased to `'static`; access is only ever via
+/// the closure-based methods below, which re-narrow the lifetime to a borrow
+/// tied to `&self` / `&mut self`.
+pub(crate) struct CollectorCell {
+    // Field declaration order matters for `Drop`. `collector` references
+    // `owner` and must be dropped first. Do not reorder these fields.
+    collector: ManuallyDrop<IndexedChangeCollector<'static>>,
+    owner: ManuallyDrop<Box<CollectorOwner>>,
+}
+
+impl CollectorCell {
+    /// Build a new cell from an owned [`CollectorOwner`] plus a constructor
+    /// closure. The closure is handed split borrows into the (now heap-pinned)
+    /// owner and returns the live collector.
+    pub(crate) fn try_new<E>(
+        owner: CollectorOwner,
+        build: impl for<'a> FnOnce(
+            &'a ChangeGraphCols,
+            &'a OpSet,
+            &'a mut IndexBuilder,
+        ) -> Result<IndexedChangeCollector<'a>, E>,
+    ) -> Result<Self, E> {
+        let mut owner = Box::new(owner);
+        let collector = {
+            let CollectorOwner {
+                op_set,
+                change_cols,
+                index_builder,
+            } = &mut *owner;
+            build(change_cols, op_set, index_builder)?
+        };
+        // SAFETY: `collector` borrows from `*owner`. `owner` lives in a `Box`,
+        // so its address is stable, and we own it for the lifetime of `self`.
+        // We erase the lifetime to `'static` purely for storage; every
+        // accessor below re-narrows it to a borrow tied to `&self` / `&mut
+        // self`. The `Drop` impl drops the collector before the owner.
+        let collector: IndexedChangeCollector<'static> = unsafe { std::mem::transmute(collector) };
+        Ok(Self {
+            collector: ManuallyDrop::new(collector),
+            owner: ManuallyDrop::new(owner),
+        })
+    }
+
+    /// Access the collector and owner together with mutually consistent
+    /// lifetimes. The HRTB on `f` prevents references from escaping.
+    pub(crate) fn with_mut<R>(
+        &mut self,
+        f: impl for<'a> FnOnce(&'a mut IndexedChangeCollector<'a>, &'a CollectorOwner) -> R,
+    ) -> R {
+        // SAFETY: re-narrow the stored `'static` lifetime to a borrow tied to
+        // `&mut self`. The collector borrows from `*self.owner`, which is
+        // shared-borrowed for the duration of `f`. The HRTB ensures the
+        // closure can't smuggle a reference out.
+        let collector: &mut IndexedChangeCollector<'_> =
+            unsafe { std::mem::transmute(&mut *self.collector) };
+        f(collector, &self.owner)
+    }
+
+    /// Consume the cell. Calls `f` with the live collector and a borrow of
+    /// the owner's [`OpSet`]; once `f` returns, hands back its result along
+    /// with the unboxed [`CollectorOwner`].
+    pub(crate) fn consume<R, E>(
+        self,
+        f: impl for<'a> FnOnce(IndexedChangeCollector<'a>, &'a OpSet) -> Result<R, E>,
+    ) -> Result<(R, CollectorOwner), E> {
+        // Suppress the normal `Drop` so we can take the fields out by value.
+        let mut this = ManuallyDrop::new(self);
+        // SAFETY: we never touch `this.collector` after this take.
+        let collector = unsafe { ManuallyDrop::take(&mut this.collector) };
+        // SAFETY: we never touch `this.owner` after this take.
+        let owner_box = unsafe { ManuallyDrop::take(&mut this.owner) };
+
+        // SAFETY: `collector` references `*owner_box`. The box stays alive on
+        // this stack frame until after `f` runs; the closure consumes the
+        // collector (or drops it if it panics), so by the time we unbox the
+        // owner the collector is gone. The HRTB on `f` prevents references
+        // from escaping.
+        let collector: IndexedChangeCollector<'_> = unsafe { std::mem::transmute(collector) };
+
+        let result = f(collector, &owner_box.op_set)?;
+        Ok((result, *owner_box))
+    }
+}
+
+impl Drop for CollectorCell {
+    fn drop(&mut self) {
+        // SAFETY: `collector` borrows from `*owner`, so we drop it first. We
+        // do not touch either field after dropping it.
+        unsafe {
+            ManuallyDrop::drop(&mut self.collector);
+            ManuallyDrop::drop(&mut self.owner);
+        }
+    }
+}

--- a/rust/automerge/src/storage/load/load_state/load_doc_chunk.rs
+++ b/rust/automerge/src/storage/load/load_state/load_doc_chunk.rs
@@ -1,0 +1,178 @@
+use crate::{
+    op_set2::{change::ChangeCollector, op_set::OpIterState},
+    storage::{
+        document::ReconstructError,
+        load::{Error as LoadError, VerificationMode},
+        Document,
+    },
+    Automerge, TextEncoding,
+};
+
+use super::collector_cell::{CollectorCell, CollectorOwner};
+use super::StepResult;
+
+#[cfg(test)]
+const BATCH_SIZE: usize = 250;
+#[cfg(not(test))]
+const BATCH_SIZE: usize = 100_000;
+
+/// Step-able loader for a single document chunk.
+///
+/// Owns the parsed [`Document`], plus a [`CollectorCell`] that bundles the
+/// `OpSet`, change-graph columns, index builder and a live change collector
+/// borrowing from them. Between [`step`](Self::step) calls the op iterator is
+/// suspended into an [`OpIterState`]; the collector stays live inside the
+/// cell.
+pub(crate) struct LoadingDocChunk<'a> {
+    encoding: TextEncoding,
+    verification_mode: VerificationMode,
+    doc: Document<'a>,
+    phase: Phase,
+}
+
+enum Phase {
+    NotStarted,
+    /// Iterating ops. Boxed because [`OpIterState`] is significantly larger
+    /// than the other variants.
+    Processing(Box<ProcessingPhase>),
+    /// Iteration complete; ready to collect changes. Boxed so this variant is
+    /// pointer-sized rather than the size of a [`CollectorCell`].
+    Finishing(Box<CollectorCell>),
+}
+
+struct ProcessingPhase {
+    cell: CollectorCell,
+    iter_state: OpIterState,
+}
+
+impl<'a> LoadingDocChunk<'a> {
+    pub(crate) fn new(
+        doc: Document<'a>,
+        encoding: TextEncoding,
+        verification_mode: VerificationMode,
+    ) -> Self {
+        Self {
+            encoding,
+            verification_mode,
+            doc,
+            phase: Phase::NotStarted,
+        }
+    }
+
+    pub(crate) fn step(mut self) -> Result<StepResult<Self, Automerge>, LoadError> {
+        let phase = std::mem::replace(&mut self.phase, Phase::NotStarted);
+        match phase {
+            Phase::NotStarted => {
+                let (cell, iter_state) = build(&self.doc, self.encoding)?;
+                self.phase = Phase::Processing(Box::new(ProcessingPhase { cell, iter_state }));
+                Ok(StepResult::Loading(self))
+            }
+            Phase::Processing(mut state) => {
+                let done = run_batch(&mut state.cell, &mut state.iter_state)?;
+                self.phase = if done {
+                    Phase::Finishing(Box::new(state.cell))
+                } else {
+                    Phase::Processing(state)
+                };
+                Ok(StepResult::Loading(self))
+            }
+            Phase::Finishing(cell) => Ok(StepResult::Ready(self.finish(*cell)?)),
+        }
+    }
+
+    fn finish(self, cell: CollectorCell) -> Result<Automerge, LoadError> {
+        let (changes, owner) = cell.consume(|collector, op_set| {
+            collector
+                .collect(op_set)
+                .map_err(|e| reconstruct_error(e.into()))
+        })?;
+
+        self.doc
+            .verify_changes(&changes, self.verification_mode)
+            .map_err(reconstruct_error)?;
+
+        let CollectorOwner {
+            mut op_set,
+            change_cols,
+            index_builder,
+        } = owner;
+
+        op_set.set_indexes(index_builder);
+
+        let change_graph = change_cols.finalize(&changes.changes);
+
+        debug_assert_eq!(changes.changes.len(), change_graph.len());
+        debug_assert!(op_set.validate_top_index());
+
+        Ok(Automerge::from_parts(op_set, change_graph))
+    }
+}
+
+fn build(
+    doc: &Document<'_>,
+    encoding: TextEncoding,
+) -> Result<(CollectorCell, OpIterState), LoadError> {
+    use crate::change_graph::ChangeGraphCols;
+    use crate::op_set2::OpSet;
+
+    let op_set = OpSet::load(doc, encoding).map_err(|e| reconstruct_error(e.into()))?;
+    let change_cols = ChangeGraphCols::load(doc).map_err(reconstruct_error)?;
+    let index_builder = op_set.index_builder();
+    // Initial iterator state: a fresh iter that hasn't advanced. The first
+    // `run_batch` will resume from position 0.
+    let iter_state = op_set.iter().suspend();
+
+    let owner = CollectorOwner {
+        op_set,
+        change_cols,
+        index_builder,
+    };
+    let cell = CollectorCell::try_new(owner, |change_cols, op_set, index_builder| {
+        let collector = ChangeCollector::try_new(change_cols, op_set)
+            .map_err(|e| reconstruct_error(e.into()))?;
+        Ok::<_, LoadError>(collector.with_index(index_builder))
+    })?;
+
+    Ok((cell, iter_state))
+}
+
+/// Run one batch of op iteration. Returns `true` when the iterator has been
+/// exhausted (the caller should advance to the finalization phase).
+fn run_batch(cell: &mut CollectorCell, iter_state: &mut OpIterState) -> Result<bool, LoadError> {
+    cell.with_mut(|collector, owner| {
+        let mut iter = iter_state
+            .try_resume(&owner.op_set)
+            .map_err(|e| LoadError::InflateDocument(Box::new(e)))?;
+
+        for _ in 0..BATCH_SIZE {
+            match iter
+                .try_next()
+                .map_err(|e| LoadError::InflateDocument(Box::new(e)))?
+            {
+                None => {
+                    *iter_state = iter.suspend();
+                    return Ok(true);
+                }
+                Some(op) => {
+                    let op_id = op.id;
+                    let op_is_counter = op.is_counter();
+                    let op_succ = op.succ();
+
+                    collector.process_op(op);
+
+                    for id in op_succ {
+                        collector.index.process_succ(op_is_counter, id);
+                        collector.collector.process_succ(op_id, id);
+                    }
+                }
+            }
+        }
+
+        *iter_state = iter.suspend();
+        Ok(false)
+    })
+}
+
+fn reconstruct_error(e: ReconstructError) -> LoadError {
+    LoadError::InflateDocument(Box::new(e))
+}

--- a/rust/hexane/src/rle.rs
+++ b/rust/hexane/src/rle.rs
@@ -446,7 +446,9 @@ impl<const B: usize, P: Packable + ?Sized, X: HasPos + HasAcc + SpanWeight<Slab>
                 }
                 count if *count < 0 => {
                     let (value_bytes, value) = P::unpack(data)?;
-                    assert!(-*count < slab.len() as i64);
+                    if -*count >= slab.len() as i64 {
+                        return Err(PackError::BadFormat);
+                    }
                     self.lit = Some(LitRunCursor::new(
                         self.offset + count_bytes,
                         *count,


### PR DESCRIPTION
This is a speculative attempt to make loading a document "interruptible" in the sense that rather than blocking the calling process forever, it does some small batch of work and then yields back to the caller. This allows for things like not blocking the UI for a minute when loading a giant document - which is nice.

This particular implementation is going down a particularly aggressive route where the granularity of work is very small. Internally most of the work we are doing is iterating over operations in columnar encoded chunks of ops. This PR allows a chunk of work to be as small as a single op. This is achieved by liberal use of unsafe code to suspend the state of the columnar iterators in hexane whilst we yield to the caller. I'm reasonably sure it's sound and running all the tests with `miri` passes, but still, it's a bunch of unsafe code, we should be sceptical.

A less aggressive version of this would be to make a single commit in the underlying document the unit of yielding. This would mean we wouldn't need to suspend iterators in the same way and we could probably achieve everything without `unsafe`, but we would also block on large individual commits.