### PR TITLE
rust: Add ReadDoc::view_at

### DIFF
--- a/rust/automerge/src/autocommit.rs
+++ b/rust/automerge/src/autocommit.rs
@@ -682,6 +682,13 @@ impl AutoCommit {
 }
 
 impl ReadDoc for AutoCommit {
+    type ViewAt<'a> = crate::view_at::AutomergeAt<'a>;
+
+    fn view_at(&self, heads: &[ChangeHash]) -> Result<Self::ViewAt<'_>, crate::error::ViewAtError> {
+        // Note: view_at ignores isolation and operates on the full document
+        crate::view_at::AutomergeAt::new(&self.doc, heads)
+    }
+
     fn parents<O: AsRef<ExId>>(&self, obj: O) -> Result<Parents<'_>, AutomergeError> {
         self.doc.parents_for(obj.as_ref(), self.get_scope(None))
     }

--- a/rust/automerge/src/automerge.rs
+++ b/rust/automerge/src/automerge.rs
@@ -1664,6 +1664,12 @@ impl Automerge {
 }
 
 impl ReadDoc for Automerge {
+    type ViewAt<'a> = crate::view_at::AutomergeAt<'a>;
+
+    fn view_at(&self, heads: &[ChangeHash]) -> Result<Self::ViewAt<'_>, crate::error::ViewAtError> {
+        crate::view_at::AutomergeAt::new(self, heads)
+    }
+
     fn parents<O: AsRef<ExId>>(&self, obj: O) -> Result<Parents<'_>, AutomergeError> {
         self.parents_for(obj.as_ref(), None)
     }

--- a/rust/automerge/src/error.rs
+++ b/rust/automerge/src/error.rs
@@ -153,3 +153,11 @@ pub enum UpdateObjectError {
     #[error(transparent)]
     Automerge(#[from] AutomergeError),
 }
+
+/// Error returned when [`crate::ReadDoc::view_at`] is called with invalid heads.
+#[derive(Error, Debug, Clone, PartialEq, Eq)]
+#[error("change hash not found in document: {missing}")]
+pub struct ViewAtError {
+    /// The change hash that was not found in the document.
+    pub missing: ChangeHash,
+}

--- a/rust/automerge/src/lib.rs
+++ b/rust/automerge/src/lib.rs
@@ -288,6 +288,7 @@ mod text_value;
 pub mod transaction;
 mod types;
 mod value;
+mod view_at;
 
 pub use crate::automerge::{Automerge, LoadOptions, OnPartialLoad, SaveOptions, StringMigration};
 pub use autocommit::AutoCommit;
@@ -297,6 +298,7 @@ pub use cursor::{Cursor, CursorPosition, MoveCursor, OpCursor};
 pub use error::AutomergeError;
 pub use error::InvalidActorId;
 pub use error::InvalidChangeHashSlice;
+pub use error::ViewAtError;
 pub use exid::{ExId as ObjId, ObjIdFromBytesError};
 pub use legacy::Change as ExpandedChange;
 pub use op_set2::{ChangeMetadata, Parent, Parents, ScalarValue as ScalarValueRef, ValueRef};
@@ -308,6 +310,7 @@ pub use text_value::ConcreteTextValue;
 pub use transaction::BlockOrText;
 pub use types::{ActorId, ChangeHash, ObjType, OpType, ParseChangeHashError, Prop, TextEncoding};
 pub use value::{ScalarValue, Value};
+pub use view_at::AutomergeAt;
 
 /// The object ID for the root map of a document
 pub const ROOT: ObjId = ObjId::Root;

--- a/rust/automerge/src/transaction/manual_transaction.rs
+++ b/rust/automerge/src/transaction/manual_transaction.rs
@@ -130,6 +130,18 @@ impl Transaction<'_> {
 }
 
 impl ReadDoc for Transaction<'_> {
+    type ViewAt<'a>
+        = crate::view_at::AutomergeAt<'a>
+    where
+        Self: 'a;
+
+    fn view_at(&self, heads: &[ChangeHash]) -> Result<Self::ViewAt<'_>, crate::error::ViewAtError> {
+        // Note: view_at sees the document state, not uncommitted transaction changes, which
+        // is fine, because view_at requires heads, which means uncommitted transaction changes
+        // are not relevant to the view at the specified heads.
+        crate::view_at::AutomergeAt::new(self.doc, heads)
+    }
+
     fn keys<O: AsRef<ExId>>(&self, obj: O) -> Keys<'_> {
         self.doc.keys_for(obj.as_ref(), self.get_scope(None))
     }

--- a/rust/automerge/src/view_at.rs
+++ b/rust/automerge/src/view_at.rs
@@ -1,0 +1,337 @@
+use std::ops::RangeBounds;
+
+use crate::clock::Clock;
+use crate::cursor::{CursorPosition, MoveCursor};
+use crate::error::{AutomergeError, ViewAtError};
+use crate::exid::ExId;
+use crate::iter::{DocIter, Keys, ListRange, MapRange, Spans, Values};
+use crate::marks::{Mark, MarkSet};
+use crate::op_set2::Parents;
+use crate::Automerge;
+use crate::Change;
+use crate::ChangeHash;
+use crate::Cursor;
+use crate::ObjType;
+use crate::Prop;
+use crate::ReadDoc;
+use crate::TextEncoding;
+use crate::Value;
+use crate::{hydrate, ROOT};
+
+/// A view of an [`Automerge`] document at a specific point in history.
+///
+/// This type implements [`ReadDoc`], allowing you to use all the normal read
+/// methods.
+///
+/// Create a view using [`ReadDoc::view_at`]:
+///
+/// ```
+/// use automerge::{AutoCommit, ReadDoc, ROOT};
+/// use automerge::transaction::Transactable;
+///
+/// let mut doc = AutoCommit::new();
+/// doc.put(&ROOT, "key", "value1").unwrap();
+/// let heads1 = doc.get_heads();
+///
+/// doc.put(&ROOT, "key", "value2").unwrap();
+///
+/// // View the document at the earlier point in history
+/// let view = doc.view_at(&heads1).unwrap();
+/// let (value, _) = view.get(&ROOT, "key").unwrap().unwrap();
+/// // value is "value1", not "value2"
+/// ```
+#[derive(Debug, Clone)]
+pub struct AutomergeAt<'a> {
+    pub(crate) doc: &'a Automerge,
+    pub(crate) clock: Clock,
+    pub(crate) heads: Vec<ChangeHash>,
+}
+
+impl<'a> AutomergeAt<'a> {
+    /// Create a new view of the document at the given heads.
+    ///
+    /// Returns an error if any of the heads do not exist in the document.
+    pub(crate) fn new(doc: &'a Automerge, heads: &[ChangeHash]) -> Result<Self, ViewAtError> {
+        // Validate all heads exist
+        for hash in heads {
+            if !doc.has_change(hash) {
+                return Err(ViewAtError { missing: *hash });
+            }
+        }
+
+        let clock = doc.clock_at(heads);
+        Ok(Self {
+            doc,
+            clock,
+            heads: heads.to_vec(),
+        })
+    }
+
+    /// Get a reference to the underlying document.
+    pub fn doc(&self) -> &Automerge {
+        self.doc
+    }
+
+    /// Get the heads this view is at.
+    pub fn heads(&self) -> &[ChangeHash] {
+        &self.heads
+    }
+}
+
+impl ReadDoc for AutomergeAt<'_> {
+    type ViewAt<'a>
+        = AutomergeAt<'a>
+    where
+        Self: 'a;
+
+    fn view_at(&self, heads: &[ChangeHash]) -> Result<Self::ViewAt<'_>, ViewAtError> {
+        AutomergeAt::new(self.doc, heads)
+    }
+
+    fn parents<O: AsRef<ExId>>(&self, obj: O) -> Result<Parents<'_>, AutomergeError> {
+        self.doc.parents_for(obj.as_ref(), Some(self.clock.clone()))
+    }
+
+    fn parents_at<O: AsRef<ExId>>(
+        &self,
+        obj: O,
+        heads: &[ChangeHash],
+    ) -> Result<Parents<'_>, AutomergeError> {
+        let clock = self.doc.clock_at(heads);
+        self.doc.parents_for(obj.as_ref(), Some(clock))
+    }
+
+    fn keys<O: AsRef<ExId>>(&self, obj: O) -> Keys<'_> {
+        self.doc.keys_for(obj.as_ref(), Some(self.clock.clone()))
+    }
+
+    fn keys_at<O: AsRef<ExId>>(&self, obj: O, heads: &[ChangeHash]) -> Keys<'_> {
+        let clock = self.doc.clock_at(heads);
+        self.doc.keys_for(obj.as_ref(), Some(clock))
+    }
+
+    fn iter_at<O: AsRef<ExId>>(&self, obj: O, heads: Option<&[ChangeHash]>) -> DocIter<'_> {
+        let clock = heads
+            .map(|h| self.doc.clock_at(h))
+            .unwrap_or_else(|| self.clock.clone());
+        self.doc.iter_for(obj.as_ref(), Some(clock))
+    }
+
+    fn iter(&self) -> DocIter<'_> {
+        self.doc.iter_for(&ROOT, Some(self.clock.clone()))
+    }
+
+    fn map_range<'a, O: AsRef<ExId>, R: RangeBounds<String> + 'a>(
+        &'a self,
+        obj: O,
+        range: R,
+    ) -> MapRange<'a> {
+        self.doc
+            .map_range_for(obj.as_ref(), range, Some(self.clock.clone()))
+    }
+
+    fn map_range_at<'a, O: AsRef<ExId>, R: RangeBounds<String> + 'a>(
+        &'a self,
+        obj: O,
+        range: R,
+        heads: &[ChangeHash],
+    ) -> MapRange<'a> {
+        let clock = self.doc.clock_at(heads);
+        self.doc.map_range_for(obj.as_ref(), range, Some(clock))
+    }
+
+    fn list_range<O: AsRef<ExId>, R: RangeBounds<usize>>(&self, obj: O, range: R) -> ListRange<'_> {
+        self.doc
+            .list_range_for(obj.as_ref(), range, Some(self.clock.clone()))
+    }
+
+    fn list_range_at<O: AsRef<ExId>, R: RangeBounds<usize>>(
+        &self,
+        obj: O,
+        range: R,
+        heads: &[ChangeHash],
+    ) -> ListRange<'_> {
+        let clock = self.doc.clock_at(heads);
+        self.doc.list_range_for(obj.as_ref(), range, Some(clock))
+    }
+
+    fn values<O: AsRef<ExId>>(&self, obj: O) -> Values<'_> {
+        self.doc.values_for(obj.as_ref(), Some(self.clock.clone()))
+    }
+
+    fn values_at<O: AsRef<ExId>>(&self, obj: O, heads: &[ChangeHash]) -> Values<'_> {
+        let clock = self.doc.clock_at(heads);
+        self.doc.values_for(obj.as_ref(), Some(clock))
+    }
+
+    fn length<O: AsRef<ExId>>(&self, obj: O) -> usize {
+        self.doc.length_for(obj.as_ref(), Some(self.clock.clone()))
+    }
+
+    fn length_at<O: AsRef<ExId>>(&self, obj: O, heads: &[ChangeHash]) -> usize {
+        let clock = self.doc.clock_at(heads);
+        self.doc.length_for(obj.as_ref(), Some(clock))
+    }
+
+    fn object_type<O: AsRef<ExId>>(&self, obj: O) -> Result<ObjType, AutomergeError> {
+        self.doc.object_type(obj)
+    }
+
+    fn marks<O: AsRef<ExId>>(&self, obj: O) -> Result<Vec<Mark>, AutomergeError> {
+        self.doc.marks_for(obj.as_ref(), Some(self.clock.clone()))
+    }
+
+    fn marks_at<O: AsRef<ExId>>(
+        &self,
+        obj: O,
+        heads: &[ChangeHash],
+    ) -> Result<Vec<Mark>, AutomergeError> {
+        let clock = self.doc.clock_at(heads);
+        self.doc.marks_for(obj.as_ref(), Some(clock))
+    }
+
+    fn get_marks<O: AsRef<ExId>>(
+        &self,
+        obj: O,
+        index: usize,
+        heads: Option<&[ChangeHash]>,
+    ) -> Result<MarkSet, AutomergeError> {
+        let clock = heads
+            .map(|h| self.doc.clock_at(h))
+            .unwrap_or_else(|| self.clock.clone());
+        self.doc.get_marks_for(obj.as_ref(), index, Some(clock))
+    }
+
+    fn text<O: AsRef<ExId>>(&self, obj: O) -> Result<String, AutomergeError> {
+        self.doc.text_for(obj.as_ref(), Some(self.clock.clone()))
+    }
+
+    fn text_at<O: AsRef<ExId>>(
+        &self,
+        obj: O,
+        heads: &[ChangeHash],
+    ) -> Result<String, AutomergeError> {
+        let clock = self.doc.clock_at(heads);
+        self.doc.text_for(obj.as_ref(), Some(clock))
+    }
+
+    fn spans<O: AsRef<ExId>>(&self, obj: O) -> Result<Spans<'_>, AutomergeError> {
+        self.doc.spans_for(obj.as_ref(), Some(self.clock.clone()))
+    }
+
+    fn spans_at<O: AsRef<ExId>>(
+        &self,
+        obj: O,
+        heads: &[ChangeHash],
+    ) -> Result<Spans<'_>, AutomergeError> {
+        let clock = self.doc.clock_at(heads);
+        self.doc.spans_for(obj.as_ref(), Some(clock))
+    }
+
+    fn get_cursor<O: AsRef<ExId>, I: Into<CursorPosition>>(
+        &self,
+        obj: O,
+        position: I,
+        at: Option<&[ChangeHash]>,
+    ) -> Result<Cursor, AutomergeError> {
+        let clock = at
+            .map(|h| self.doc.clock_at(h))
+            .unwrap_or_else(|| self.clock.clone());
+        self.doc.get_cursor_for(
+            obj.as_ref(),
+            position.into(),
+            Some(clock),
+            MoveCursor::After,
+        )
+    }
+
+    fn get_cursor_moving<O: AsRef<ExId>, I: Into<CursorPosition>>(
+        &self,
+        obj: O,
+        position: I,
+        at: Option<&[ChangeHash]>,
+        move_cursor: MoveCursor,
+    ) -> Result<Cursor, AutomergeError> {
+        let clock = at
+            .map(|h| self.doc.clock_at(h))
+            .unwrap_or_else(|| self.clock.clone());
+        self.doc
+            .get_cursor_for(obj.as_ref(), position.into(), Some(clock), move_cursor)
+    }
+
+    fn get_cursor_position<O: AsRef<ExId>>(
+        &self,
+        obj: O,
+        cursor: &Cursor,
+        at: Option<&[ChangeHash]>,
+    ) -> Result<usize, AutomergeError> {
+        let clock = at
+            .map(|h| self.doc.clock_at(h))
+            .unwrap_or_else(|| self.clock.clone());
+        self.doc
+            .get_cursor_position_for(obj.as_ref(), cursor, Some(clock))
+    }
+
+    fn hydrate<O: AsRef<ExId>>(
+        &self,
+        obj: O,
+        heads: Option<&[ChangeHash]>,
+    ) -> Result<hydrate::Value, AutomergeError> {
+        let heads_to_use = heads.unwrap_or(&self.heads);
+        ReadDoc::hydrate(self.doc, obj, Some(heads_to_use))
+    }
+
+    fn get<O: AsRef<ExId>, P: Into<Prop>>(
+        &self,
+        obj: O,
+        prop: P,
+    ) -> Result<Option<(Value<'_>, ExId)>, AutomergeError> {
+        self.doc
+            .get_for(obj.as_ref(), prop.into(), Some(self.clock.clone()))
+    }
+
+    fn get_at<O: AsRef<ExId>, P: Into<Prop>>(
+        &self,
+        obj: O,
+        prop: P,
+        heads: &[ChangeHash],
+    ) -> Result<Option<(Value<'_>, ExId)>, AutomergeError> {
+        let clock = self.doc.clock_at(heads);
+        self.doc.get_for(obj.as_ref(), prop.into(), Some(clock))
+    }
+
+    fn get_all<O: AsRef<ExId>, P: Into<Prop>>(
+        &self,
+        obj: O,
+        prop: P,
+    ) -> Result<Vec<(Value<'_>, ExId)>, AutomergeError> {
+        self.doc
+            .get_all_for(obj.as_ref(), prop.into(), Some(self.clock.clone()))
+    }
+
+    fn get_all_at<O: AsRef<ExId>, P: Into<Prop>>(
+        &self,
+        obj: O,
+        prop: P,
+        heads: &[ChangeHash],
+    ) -> Result<Vec<(Value<'_>, ExId)>, AutomergeError> {
+        let clock = self.doc.clock_at(heads);
+        self.doc.get_all_for(obj.as_ref(), prop.into(), Some(clock))
+    }
+
+    fn get_missing_deps(&self, heads: &[ChangeHash]) -> Vec<ChangeHash> {
+        self.doc.get_missing_deps(heads)
+    }
+
+    fn get_change_by_hash(&self, hash: &ChangeHash) -> Option<Change> {
+        self.doc.get_change_by_hash(hash)
+    }
+
+    fn stats(&self) -> crate::read::Stats {
+        self.doc.stats()
+    }
+
+    fn text_encoding(&self) -> TextEncoding {
+        self.doc.text_encoding()
+    }
+}

--- a/rust/automerge/tests/view_at.rs
+++ b/rust/automerge/tests/view_at.rs
@@ -1,0 +1,313 @@
+//! Tests for the `view_at` API.
+
+use automerge::{transaction::Transactable, AutoCommit, ChangeHash, ReadDoc, ROOT};
+
+#[test]
+fn test_view_at_basic() {
+    let mut doc = AutoCommit::new();
+
+    // Make first change
+    doc.put(&ROOT, "key", "value1").unwrap();
+    let heads1 = doc.get_heads();
+
+    // Make second change
+    doc.put(&ROOT, "key", "value2").unwrap();
+    let heads2 = doc.get_heads();
+
+    // View at first state
+    let view1 = doc.view_at(&heads1).unwrap();
+    let (value, _) = view1.get(&ROOT, "key").unwrap().unwrap();
+    assert_eq!(value.to_str(), Some("value1"));
+
+    // View at second state
+    let view2 = doc.view_at(&heads2).unwrap();
+    let (value, _) = view2.get(&ROOT, "key").unwrap().unwrap();
+    assert_eq!(value.to_str(), Some("value2"));
+
+    // Current state should still be value2
+    let (value, _) = doc.get(&ROOT, "key").unwrap().unwrap();
+    assert_eq!(value.to_str(), Some("value2"));
+}
+
+#[test]
+fn test_view_at_invalid_heads() {
+    let doc = AutoCommit::new();
+    let fake_hash = ChangeHash([0u8; 32]);
+
+    let result = doc.view_at(&[fake_hash]);
+    assert!(result.is_err());
+
+    let err = result.unwrap_err();
+    assert_eq!(err.missing, fake_hash);
+}
+
+#[test]
+fn test_view_at_empty_heads() {
+    let mut doc = AutoCommit::new();
+    doc.put(&ROOT, "key", "value").unwrap();
+
+    // Empty heads represents state before any changes
+    let view = doc.view_at(&[]).unwrap();
+
+    // Key should not exist in empty state
+    let result = view.get(&ROOT, "key").unwrap();
+    assert!(result.is_none());
+}
+
+#[test]
+fn test_view_at_multiple_keys() {
+    let mut doc = AutoCommit::new();
+
+    doc.put(&ROOT, "a", "1").unwrap();
+    doc.put(&ROOT, "b", "2").unwrap();
+    let heads1 = doc.get_heads();
+
+    doc.put(&ROOT, "a", "10").unwrap();
+    doc.put(&ROOT, "c", "3").unwrap();
+
+    let view = doc.view_at(&heads1).unwrap();
+
+    // Check values at heads1
+    let (val_a, _) = view.get(&ROOT, "a").unwrap().unwrap();
+    assert_eq!(val_a.to_str(), Some("1"));
+
+    let (val_b, _) = view.get(&ROOT, "b").unwrap().unwrap();
+    assert_eq!(val_b.to_str(), Some("2"));
+
+    // "c" didn't exist at heads1
+    let val_c = view.get(&ROOT, "c").unwrap();
+    assert!(val_c.is_none());
+}
+
+#[test]
+fn test_view_at_keys() {
+    let mut doc = AutoCommit::new();
+
+    doc.put(&ROOT, "a", "1").unwrap();
+    doc.put(&ROOT, "b", "2").unwrap();
+    let heads1 = doc.get_heads();
+
+    doc.put(&ROOT, "c", "3").unwrap();
+
+    let view = doc.view_at(&heads1).unwrap();
+
+    let keys: Vec<_> = view.keys(&ROOT).collect();
+    assert_eq!(keys, vec!["a", "b"]);
+}
+
+#[test]
+fn test_view_at_length() {
+    let mut doc = AutoCommit::new();
+
+    let list = doc
+        .put_object(&ROOT, "list", automerge::ObjType::List)
+        .unwrap();
+    doc.insert(&list, 0, "a").unwrap();
+    doc.insert(&list, 1, "b").unwrap();
+    let heads1 = doc.get_heads();
+
+    doc.insert(&list, 2, "c").unwrap();
+
+    let view = doc.view_at(&heads1).unwrap();
+    assert_eq!(view.length(&list), 2);
+
+    // Current length should be 3
+    assert_eq!(doc.length(&list), 3);
+}
+
+#[test]
+fn test_view_at_text() {
+    let mut doc = AutoCommit::new();
+
+    let text = doc
+        .put_object(&ROOT, "text", automerge::ObjType::Text)
+        .unwrap();
+    doc.splice_text(&text, 0, 0, "hello").unwrap();
+    let heads1 = doc.get_heads();
+
+    doc.splice_text(&text, 5, 0, " world").unwrap();
+
+    let view = doc.view_at(&heads1).unwrap();
+    assert_eq!(view.text(&text).unwrap(), "hello");
+
+    // Current text should be "hello world"
+    assert_eq!(doc.text(&text).unwrap(), "hello world");
+}
+
+#[test]
+fn test_view_at_nested_objects() {
+    let mut doc = AutoCommit::new();
+
+    let map = doc
+        .put_object(&ROOT, "map", automerge::ObjType::Map)
+        .unwrap();
+    doc.put(&map, "nested_key", "nested_value1").unwrap();
+    let heads1 = doc.get_heads();
+
+    doc.put(&map, "nested_key", "nested_value2").unwrap();
+
+    let view = doc.view_at(&heads1).unwrap();
+    let (value, _) = view.get(&map, "nested_key").unwrap().unwrap();
+    assert_eq!(value.to_str(), Some("nested_value1"));
+}
+
+#[test]
+fn test_view_of_view() {
+    let mut doc = AutoCommit::new();
+
+    doc.put(&ROOT, "key", "value1").unwrap();
+    let heads1 = doc.get_heads();
+
+    doc.put(&ROOT, "key", "value2").unwrap();
+    let heads2 = doc.get_heads();
+
+    doc.put(&ROOT, "key", "value3").unwrap();
+
+    // Create a view at heads2
+    let view2 = doc.view_at(&heads2).unwrap();
+
+    // Create a view at heads1 from the view at heads2
+    let view1 = view2.view_at(&heads1).unwrap();
+
+    let (value, _) = view1.get(&ROOT, "key").unwrap().unwrap();
+    assert_eq!(value.to_str(), Some("value1"));
+}
+
+#[test]
+fn test_view_at_with_automerge() {
+    use automerge::Automerge;
+
+    let mut doc = Automerge::new();
+    let mut tx = doc.transaction();
+    tx.put(&ROOT, "key", "value1").unwrap();
+    tx.commit();
+    let heads1 = doc.get_heads();
+
+    let mut tx = doc.transaction();
+    tx.put(&ROOT, "key", "value2").unwrap();
+    tx.commit();
+
+    let view = doc.view_at(&heads1).unwrap();
+    let (value, _) = view.get(&ROOT, "key").unwrap().unwrap();
+    assert_eq!(value.to_str(), Some("value1"));
+}
+
+#[test]
+fn test_view_at_list_range() {
+    let mut doc = AutoCommit::new();
+
+    let list = doc
+        .put_object(&ROOT, "list", automerge::ObjType::List)
+        .unwrap();
+    doc.insert(&list, 0, "a").unwrap();
+    doc.insert(&list, 1, "b").unwrap();
+    doc.insert(&list, 2, "c").unwrap();
+    let heads1 = doc.get_heads();
+
+    doc.insert(&list, 3, "d").unwrap();
+
+    let view = doc.view_at(&heads1).unwrap();
+
+    // Check the count of items in list_range
+    let count = view.list_range(&list, ..).count();
+    assert_eq!(count, 3);
+}
+
+#[test]
+fn test_view_at_map_range() {
+    let mut doc = AutoCommit::new();
+
+    doc.put(&ROOT, "a", "1").unwrap();
+    doc.put(&ROOT, "b", "2").unwrap();
+    doc.put(&ROOT, "c", "3").unwrap();
+    let heads1 = doc.get_heads();
+
+    doc.put(&ROOT, "d", "4").unwrap();
+
+    let view = doc.view_at(&heads1).unwrap();
+    let keys: Vec<_> = view.map_range(&ROOT, ..).map(|item| item.key).collect();
+    assert_eq!(keys, vec!["a", "b", "c"]);
+}
+
+#[test]
+fn test_view_at_values() {
+    let mut doc = AutoCommit::new();
+
+    doc.put(&ROOT, "a", "1").unwrap();
+    doc.put(&ROOT, "b", "2").unwrap();
+    let heads1 = doc.get_heads();
+
+    doc.put(&ROOT, "c", "3").unwrap();
+
+    let view = doc.view_at(&heads1).unwrap();
+    let values: Vec<_> = view
+        .values(&ROOT)
+        .map(|(v, _)| v.to_str().map(|s| s.to_string()))
+        .collect();
+    assert_eq!(values, vec![Some("1".to_string()), Some("2".to_string())]);
+}
+
+#[test]
+fn test_view_at_object_type() {
+    let mut doc = AutoCommit::new();
+
+    let list = doc
+        .put_object(&ROOT, "list", automerge::ObjType::List)
+        .unwrap();
+    let heads = doc.get_heads();
+
+    let view = doc.view_at(&heads).unwrap();
+    assert_eq!(view.object_type(&list).unwrap(), automerge::ObjType::List);
+}
+
+#[test]
+fn test_view_at_parents() {
+    let mut doc = AutoCommit::new();
+
+    let map = doc
+        .put_object(&ROOT, "parent", automerge::ObjType::Map)
+        .unwrap();
+    let nested = doc
+        .put_object(&map, "child", automerge::ObjType::Map)
+        .unwrap();
+    let heads = doc.get_heads();
+
+    let view = doc.view_at(&heads).unwrap();
+    let parents: Vec<_> = view.parents(&nested).unwrap().collect();
+    assert_eq!(parents.len(), 2); // child -> parent -> ROOT
+}
+
+#[test]
+fn test_view_at_get_all() {
+    let mut doc1 = AutoCommit::new();
+    doc1.set_actor(automerge::ActorId::from([1]));
+    doc1.put(&ROOT, "key", "value1").unwrap();
+
+    let mut doc2 = doc1.fork();
+    doc2.set_actor(automerge::ActorId::from([2]));
+
+    // Both make concurrent changes
+    doc1.put(&ROOT, "key", "doc1_value").unwrap();
+    doc2.put(&ROOT, "key", "doc2_value").unwrap();
+
+    doc1.merge(&mut doc2).unwrap();
+    let heads = doc1.get_heads();
+
+    // Now there are two concurrent values
+    let view = doc1.view_at(&heads).unwrap();
+    let all_values = view.get_all(&ROOT, "key").unwrap();
+    assert_eq!(all_values.len(), 2);
+}
+
+#[test]
+fn test_view_at_stats() {
+    let mut doc = AutoCommit::new();
+    doc.put(&ROOT, "key", "value").unwrap();
+    let heads = doc.get_heads();
+
+    let view = doc.view_at(&heads).unwrap();
+    let stats = view.stats();
+
+    // Stats should reflect the underlying document
+    assert!(stats.num_ops > 0);
+}


### PR DESCRIPTION
Problem: sometimes (especially in generic code) you want to work generically with `ReadDoc`, but the caller wants to be able to specify the head to view at. To achieve that at the moment you have to accept an `Option<&[ChangeHash]>` parameter and then call the appropriate `ReadDoc::*_at` method if it's `Some` or the normal method if it's `None`. This is awkward and relies on the implementor to add this logic.

Solution: add a `ReadDoc::view_at(&self, heads: Option<&[ChangeHash]>)` method that returns an implementation of `ReadDoc` that returns the values from the original `ReadDoc` but viewed at the specified heads.