### PR TITLE
Fix stale actor indices in diff_incremental patches after fork + isolate

### DIFF
--- a/javascript/test/change_at.ts
+++ b/javascript/test/change_at.ts
@@ -71,5 +71,33 @@ describe("Automerge", () => {
       const actualHeads = new Set(Automerge.getHeads(doc1))
       assert.deepEqual(actualHeads, expectedHeads)
     })
+    // Regression test for issue #1270:
+    // clone() + changeAt() with a splice should not produce duplicate content
+    it("should not duplicate splice results with clone + changeAt", () => {
+      let doc = Automerge.change(
+        Automerge.init<{ text: string }>(),
+        doc => {
+          doc.text = ""
+        },
+      )
+      const heads = Automerge.getHeads(doc)
+      doc = Automerge.change(doc, doc =>
+        Automerge.splice(doc, ["text"], 0, 0, "def"),
+      )
+
+      const result = Automerge.changeAt(
+        Automerge.clone(doc),
+        heads,
+        doc => {
+          Automerge.splice(doc, ["text"], 0, 0, "abc")
+        },
+      )
+
+      assert.strictEqual(
+        result.newDoc.text,
+        "abcdef",
+        `Expected "abcdef" but got "${result.newDoc.text}"`,
+      )
+    })
   })
 })

--- a/rust/automerge/src/autocommit.rs
+++ b/rust/automerge/src/autocommit.rs
@@ -715,6 +715,14 @@ impl AutoCommit {
     }
 
     fn patch_to(&mut self, after: &[ChangeHash]) {
+        // Establish actor baseline in the patch log before logging events.
+        // Without this, if a new actor that sorts before existing actors is
+        // inserted later, migrate_actors() cannot properly migrate the events
+        // logged below (it early-returns when actors is empty). See issue #1270.
+        if self.patch_log.is_active() && self.patch_log.actors.is_empty() {
+            self.patch_log.actors = self.doc.ops().actors.clone();
+        }
+
         // we may be isolated so we dont use self.doc.get_heads()
         let before = self.get_heads();
         if before.as_slice() != after {

--- a/rust/automerge/tests/test.rs
+++ b/rust/automerge/tests/test.rs
@@ -1809,6 +1809,53 @@ fn can_isolate() -> Result<(), AutomergeError> {
     Ok(())
 }
 
+// Regression test for issue #1270:
+// When fork() + isolate() is used with a new actor ID that is lexicographically
+// smaller than the existing actor, the diff_incremental patches contain stale
+// actor indices, causing incorrect patches (e.g. duplicate splices).
+#[test]
+fn isolate_diff_incremental_patches_are_correct() -> Result<(), AutomergeError> {
+    let actor1 = ActorId::from(&b"2222"[..]);
+    let mut doc1 = AutoCommit::new().with_actor(actor1);
+    let txt = doc1.put_object(&ROOT, "text", ObjType::Text)?;
+    let heads = doc1.get_heads();
+    doc1.splice_text(&txt, 0, 0, "def")?;
+
+    let actor2 = ActorId::from(&b"1111"[..]);
+    let mut doc2 = doc1.fork().with_actor(actor2);
+
+    // Activate patch log — this is what the JS binding does after clone()
+    doc2.update_diff_cursor();
+
+    doc2.isolate(&heads);
+    doc2.splice_text(&txt, 0, 0, "abc")?;
+    doc2.integrate();
+
+    let patches = doc2.diff_incremental();
+
+    // Apply patches to "def" (the state at the diff cursor) — should give "abcdef"
+    let mut text = String::from("def");
+    for patch in &patches {
+        match &patch.action {
+            PatchAction::SpliceText { index, value, .. } => {
+                let s = value.make_string();
+                text.replace_range(*index..*index, &s);
+            }
+            PatchAction::DeleteSeq { index, length } => {
+                text.replace_range(*index..(*index + *length), "");
+            }
+            _ => {}
+        }
+    }
+
+    assert_eq!(
+        text, "abcdef",
+        "Applying diff_incremental patches to 'def' should give 'abcdef', got '{}'",
+        text
+    );
+    Ok(())
+}
+
 #[test]
 fn inserting_text_near_deleted_marks() {
     let mut doc = Automerge::new();


### PR DESCRIPTION
Fixes #1270. Follow-up to #1271 (closed), addressing feedback from #1272.

## Problem

When `clone()` + `changeAt()` (Rust: `fork()` + `isolate()`) is used with a new actor ID that sorts before existing actors, `diff_incremental()` produces wrong patches — e.g. `"abcdefdef"` instead of `"abcdef"`.

The document state itself is fine (`doc.text()` returns the right thing). The bug is specifically in the patches, which is what JS uses to update its object representation.

**JS reproduction** (fails on current `main`):

```js
let doc = Automerge.change(Automerge.init(), doc => { doc.text = "" });
const heads = Automerge.getHeads(doc);
doc = Automerge.change(doc, doc => Automerge.splice(doc, ["text"], 0, 0, "def"));
const result = Automerge.changeAt(Automerge.clone(doc), heads, doc => {
  Automerge.splice(doc, ["text"], 0, 0, "abc");
});
// result.newDoc.text === "abcdefdef" instead of "abcdef"
```

**Rust reproduction** (also fails on current `main`):

```rust
let actor1 = ActorId::from(&b"2222"[..]);
let mut doc1 = AutoCommit::new().with_actor(actor1);
let txt = doc1.put_object(&ROOT, "text", ObjType::Text)?;
let heads = doc1.get_heads();
doc1.splice_text(&txt, 0, 0, "def")?;

let actor2 = ActorId::from(&b"1111"[..]);
let mut doc2 = doc1.fork().with_actor(actor2);
doc2.update_diff_cursor();
doc2.isolate(&heads);
doc2.splice_text(&txt, 0, 0, "abc")?;
doc2.integrate();

let patches = doc2.diff_incremental();
// applying patches to "def" gives "abcdefdef" instead of "abcdef"
```

## Root cause

After `fork()`, the `PatchLog` has an empty `actors` list. When `patch_to()` runs (called by `isolate()`), it logs events using the current actor indices. Later, `ensure_transaction_open()` calls `migrate_actors()`, which sees `self.actors.is_empty()` and early-returns — it copies the actor list but skips migrating the events that were already logged. When the new (smaller) actor gets inserted into the actor table, it shifts existing indices, and those unmigrated events now point at the wrong objects.

## Fix

Initialize the PatchLog's actor baseline at the start of `patch_to()` before logging any events:

```rust
fn patch_to(&mut self, after: &[ChangeHash]) {
    if self.patch_log.is_active() && self.patch_log.actors.is_empty() {
        self.patch_log.actors = self.doc.ops().actors.clone();
    }
    // ...
}
```

This way `migrate_actors()` has a proper baseline to diff against and can correctly rewrite event indices when a new smaller actor appears.

This avoids the issue raised in #1271 — we don't touch the document's actor table at all, so saved documents won't contain unused actor IDs.

## Testing

- Rust regression test checking `diff_incremental()` patches — fails on `main` without the fix, passes with it
- JS regression test for `clone()` + `changeAt()` splice duplication
- Full Rust test suite passes