### PR TITLE
'`doc.fragments()`' experimental - rust only

### DIFF
--- a/javascript/src/implementation.ts
+++ b/javascript/src/implementation.ts
@@ -53,6 +53,10 @@ import type {
   ObjID,
   Change,
   ChangeMetadata,
+  FragmentMeta,
+  Commit,
+  Fragment,
+  FragmentLevelRange,
   DecodedChange,
   DiffOptions,
   Heads,
@@ -65,6 +69,10 @@ import type {
 } from "./wasm_types.js"
 export type {
   ChangeMetadata,
+  FragmentMeta,
+  Commit,
+  Fragment,
+  FragmentLevelRange,
   PutPatch,
   DelPatch,
   DiffOptions,
@@ -1832,6 +1840,150 @@ export const RawString = ImmutableString
 export function saveBundle(doc: Doc<unknown>, hashes: string[]): Uint8Array {
   const state = _state(doc, false)
   return state.handle.saveBundle(hashes)
+}
+
+/**
+ * Return the Automerge fragments currently covering the document history.
+ *
+ * Fragments are ordered oldest-to-newest. Passing a number returns only that
+ * fragment level. Passing `{ start, end }` returns levels in the half-open range
+ * `[start, end)`. Omitting `levels` returns all levels, including loose commits
+ * at level 0.
+ */
+export function getFragmentMetadata(
+  doc: Doc<unknown>,
+  levels?: FragmentLevelRange,
+): FragmentMeta[] {
+  const state = _state(doc, false)
+  return state.handle.getFragmentMetadata(levels)
+}
+
+/**
+ * Return a fragment by its head hash, or `null` if the hash is unknown or does
+ * not identify an available fragment.
+ */
+export function getFragmentMeta(
+  doc: Doc<unknown>,
+  head: string,
+): FragmentMeta | null {
+  const state = _state(doc, false)
+  return state.handle.getFragmentMeta(head)
+}
+
+/**
+ * Encode fragments as the blob bytes expected by Subduction's `addFragments`
+ * path. Level-0 fragments are encoded as individual Automerge changes; higher
+ * level fragments are encoded as Automerge bundles.
+ */
+export function bundleFragmentMetadata(
+  doc: Doc<unknown>,
+  fragments: FragmentMeta[],
+): Uint8Array[] {
+  const state = _state(doc, false)
+  return state.handle.bundleFragmentMetadata(fragments)
+}
+
+/**
+ * Return level-0 fragments in the object shape expected by Subduction's
+ * `addCommits` path.
+ */
+export function getCommits(doc: Doc<unknown>): Commit[] {
+  const state = _state(doc, false)
+  const commits = state.handle.getFragmentMetadata(0)
+  const bytes = state.handle.bundleFragmentMetadata(commits)
+  return commits.map((fragment, index) => ({
+    head: fragment.head,
+    parents: fragment.boundary,
+    bytes: bytes[index],
+  }))
+}
+
+/**
+ * Return bundled Automerge fragments in the object shape expected by
+ * Subduction's `addFragments` path. By default this excludes level-0 loose
+ * commits; use {@link getCommits} for those.
+ */
+export function getFragments(
+  doc: Doc<unknown>,
+  levels?: FragmentLevelRange,
+): Fragment[] {
+  const state = _state(doc, false)
+  const fragmentMetadata = state.handle.getFragmentMetadata(levels ?? { start: 1 })
+  const bytes = state.handle.bundleFragmentMetadata(fragmentMetadata)
+  return fragmentMetadata.map((fragment, index) => ({
+    ...fragment,
+    bytes: bytes[index],
+  }))
+}
+
+/**
+ * Add commit-shaped Automerge changes to a document.
+ *
+ * This mirrors Subduction's `addCommits` shape: each input carries the commit
+ * head, its parents, and the encoded change bytes. The encoded bytes are
+ * authoritative and are checked against the supplied metadata.
+ */
+export function addCommits<T>(
+  doc: Doc<T>,
+  commits: Commit[],
+  opts?: ApplyOptions<T>,
+): Doc<T> {
+  const state = _state(doc)
+  if (!opts) {
+    opts = {}
+  }
+  if (state.heads) {
+    throw new RangeError(
+      "Attempting to change an outdated document.  Use Automerge.clone() if you wish to make a writable copy.",
+    )
+  }
+  if (_is_proxy(doc)) {
+    throw new RangeError("Calls to Automerge.change cannot be nested")
+  }
+  const heads = state.handle.getHeads()
+  state.handle.addCommits(commits)
+  state.heads = heads
+  return progressDocument(
+    doc,
+    "addCommits",
+    heads,
+    opts.patchCallback || state.patchCallback,
+  )
+}
+
+/**
+ * Add fragment-shaped Automerge bundles to a document.
+ *
+ * This mirrors Subduction's `addFragments` shape: each input contains fragment
+ * metadata plus encoded bytes from {@link bundleFragmentMetadata}. Fragment bytes are
+ * loaded incrementally, so this can ingest bundles and loose level-0 changes.
+ */
+export function addFragments<T>(
+  doc: Doc<T>,
+  fragments: Fragment[],
+  opts?: ApplyOptions<T>,
+): Doc<T> {
+  const state = _state(doc)
+  if (!opts) {
+    opts = {}
+  }
+  if (state.heads) {
+    throw new RangeError(
+      "Attempting to change an outdated document.  Use Automerge.clone() if you wish to make a writable copy.",
+    )
+  }
+  if (_is_proxy(doc)) {
+    throw new RangeError("Calls to Automerge.change cannot be nested")
+  }
+  const heads = state.handle.getHeads()
+  state.handle.addFragments(fragments)
+  state.heads = heads
+  return progressDocument(
+    doc,
+    "addFragments",
+    heads,
+    opts.patchCallback || state.patchCallback,
+  )
 }
 
 /**

--- a/javascript/src/low_level.ts
+++ b/javascript/src/low_level.ts
@@ -12,8 +12,18 @@ import type {
   InitOptions,
   DecodedBundle,
   WasmReleaseInfo,
+  FragmentMeta,
+  Commit,
+  Fragment,
+  FragmentLevelRange,
 } from "./wasm_types.js"
-export type { ChangeToEncode } from "./wasm_types.js"
+export type {
+  ChangeToEncode,
+  FragmentMeta,
+  Commit,
+  Fragment,
+  FragmentLevelRange,
+} from "./wasm_types.js"
 import { default as initWasm } from "./wasm_bindgen_output/web/automerge_wasm.js"
 import * as WasmApi from "./wasm_bindgen_output/web/automerge_wasm.js"
 

--- a/javascript/src/types.ts
+++ b/javascript/src/types.ts
@@ -36,6 +36,8 @@ export type PatchSource =
   | "merge"
   | "loadIncremental"
   | "applyChanges"
+  | "addCommits"
+  | "addFragments"
   | "receiveSyncMessage"
 export type PatchInfo<T> = {
   before: Doc<T>

--- a/javascript/test/fragments_test.ts
+++ b/javascript/test/fragments_test.ts
@@ -1,0 +1,108 @@
+import { default as assert } from "assert"
+import * as Automerge from "../src/entrypoints/fullfat_node.js"
+
+type CounterDoc = { counter: number }
+
+function makeDoc(numChanges = 1500): Automerge.Doc<CounterDoc> {
+  let doc = Automerge.from<CounterDoc>({ counter: 0 })
+  for (let i = 1; i <= numChanges; i++) {
+    doc = Automerge.change(doc, d => {
+      d.counter = i
+    })
+  }
+  return doc
+}
+
+describe("the fragments API", () => {
+  it("returns fragment metadata with level filtering and lookup", () => {
+    const doc = makeDoc()
+
+    const allFragments = Automerge.getFragmentMetadata(doc)
+    const commits = Automerge.getFragmentMetadata(doc, 0)
+    const bundledFragments = Automerge.getFragmentMetadata(doc, { start: 1 })
+
+    assert.ok(allFragments.length > 0)
+    assert.ok(commits.length > 0)
+    assert.ok(bundledFragments.length > 0)
+    assert.equal(allFragments.length, commits.length + bundledFragments.length)
+    assert.ok(commits.every(fragment => fragment.level === 0))
+    assert.ok(bundledFragments.every(fragment => fragment.level > 0))
+
+    for (const fragment of allFragments) {
+      assert.equal(fragment.head.length, 64)
+      assert.equal(fragment.level, leadingZeroBytes(fragment.head))
+      assert.ok(fragment.members.includes(fragment.head))
+      assert.deepEqual(Automerge.getFragmentMeta(doc, fragment.head), fragment)
+    }
+
+    assert.equal(Automerge.getFragmentMeta(doc, "ff".repeat(32)), null)
+  })
+
+  it("exports commit and fragment inputs with matching bytes", () => {
+    const doc = makeDoc()
+
+    const commitFragments = Automerge.getFragmentMetadata(doc, 0)
+    const commits = Automerge.getCommits(doc)
+    const fragmentMetadata = Automerge.getFragmentMetadata(doc, { start: 1 })
+    const fragments = Automerge.getFragments(doc)
+
+    assert.equal(commits.length, commitFragments.length)
+    assert.equal(fragments.length, fragmentMetadata.length)
+    assert.ok(fragments.length > 0)
+
+    for (let i = 0; i < commits.length; i++) {
+      assert.equal(commits[i].head, commitFragments[i].head)
+      assert.deepEqual(commits[i].parents, commitFragments[i].boundary)
+      assert.deepEqual(commits[i].bytes, Automerge.getBackend(doc).bundleFragmentMetadata([commitFragments[i]])[0])
+    }
+
+    for (let i = 0; i < fragments.length; i++) {
+      const { bytes, ...metadata } = fragments[i]
+      assert.deepEqual(metadata, fragmentMetadata[i])
+      assert.deepEqual(bytes, Automerge.getBackend(doc).bundleFragmentMetadata([fragmentMetadata[i]])[0])
+    }
+  })
+
+  it("can reconstruct a document from fragments and commits", () => {
+    const doc = makeDoc()
+    const commits = Automerge.getCommits(doc)
+    const fragments = Automerge.getFragments(doc)
+
+    let loaded = Automerge.init<CounterDoc>()
+    loaded = Automerge.addFragments(loaded, fragments)
+    loaded = Automerge.addCommits(loaded, commits)
+
+    assert.deepEqual(Automerge.getHeads(loaded).sort(), Automerge.getHeads(doc).sort())
+    assert.equal(loaded.counter, 1500)
+  })
+
+  it("reports addCommits and addFragments patch sources", () => {
+    const doc = makeDoc()
+    const commits = Automerge.getCommits(doc)
+    const fragments = Automerge.getFragments(doc)
+    const sources: Automerge.PatchSource[] = []
+
+    let loaded = Automerge.init<CounterDoc>()
+    loaded = Automerge.addFragments(loaded, fragments, {
+      patchCallback: (_patches, info) => sources.push(info.source),
+    })
+    loaded = Automerge.addCommits(loaded, commits, {
+      patchCallback: (_patches, info) => sources.push(info.source),
+    })
+
+    assert.ok(sources.includes("addFragments"))
+    assert.ok(sources.includes("addCommits"))
+    assert.equal(loaded.counter, 1500)
+  })
+})
+
+function leadingZeroBytes(hash: string): number {
+  let level = 0
+  for (let i = 0; i < hash.length; i += 2) {
+    if (hash.slice(i, i + 2) !== "00") {
+      break
+    }
+    level++
+  }
+  return level
+}

--- a/rust/automerge-wasm/src/lib.rs
+++ b/rust/automerge-wasm/src/lib.rs
@@ -41,6 +41,7 @@ use serde::ser::Serialize;
 use std::borrow::Cow;
 use std::collections::HashMap;
 use std::convert::TryInto;
+use std::ops::{Bound, RangeBounds};
 use wasm_bindgen::prelude::*;
 use wasm_bindgen::JsCast;
 
@@ -61,6 +62,7 @@ export type Actor = string;
 export type ObjID = string;
 export type Change = Uint8Array;
 export type SyncMessage = Uint8Array;
+export type FragmentLevelRange = number | { start?: number; end?: number } | null | undefined;
 export type Prop = string | number;
 export type Hash = string;
 export type Heads = Hash[];
@@ -164,6 +166,24 @@ export type ChangeMetadata = {
   message: string | null;
   deps: Heads;
   hash: Hash;
+};
+
+export type FragmentMeta = {
+  head: Hash;
+  level: number;
+  boundary: Heads;
+  checkpoints: Heads;
+  members: Heads;
+};
+
+export type Commit = {
+  head: Hash;
+  parents: Heads;
+  bytes: Uint8Array;
+};
+
+export type Fragment = FragmentMeta & {
+  bytes: Uint8Array;
 };
 
 type PartialBy<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, K>>;
@@ -323,6 +343,12 @@ interface Automerge {
       obj: Doc,
       meta?: unknown,
     ): { value: Doc; patches: Patch[] };
+
+    getFragmentMetadata(levels?: FragmentLevelRange): FragmentMeta[];
+    getFragmentMeta(head: Hash): FragmentMeta | null;
+    bundleFragmentMetadata(fragments: FragmentMeta[]): Uint8Array[];
+    addCommits(commits: Commit[]): void;
+    addFragments(fragments: Fragment[]): void;
 
     getBlock(obj: ObjID, index: number, heads?: Heads): { [key: string]: MaterializeValue } | null;
 
@@ -1395,6 +1421,78 @@ impl Automerge {
         changes
     }
 
+    #[wasm_bindgen(js_name = getFragmentMetadata, unchecked_return_type = "FragmentMeta[]")]
+    pub fn get_fragment_metadata(
+        &mut self,
+        #[wasm_bindgen(unchecked_param_type = "FragmentLevelRange")] levels: JsValue,
+    ) -> Result<Array, error::Fragments> {
+        let levels = JsFragmentLevelRange::try_from(levels)?;
+        Ok(self
+            .doc
+            .fragments(levels)
+            .iter()
+            .map(fragment_to_js)
+            .collect())
+    }
+
+    #[wasm_bindgen(js_name = getFragmentMeta, unchecked_return_type = "FragmentMeta | null")]
+    pub fn get_fragment_meta(
+        &mut self,
+        #[wasm_bindgen(unchecked_param_type = "Hash")] head: JsValue,
+    ) -> Result<JsValue, interop::error::BadChangeHash> {
+        let head = JS(head).try_into()?;
+        Ok(self
+            .doc
+            .get_fragment(head)
+            .map(|f| fragment_to_js(&f))
+            .unwrap_or(JsValue::null()))
+    }
+
+    #[wasm_bindgen(js_name = bundleFragmentMetadata, unchecked_return_type = "Uint8Array[]")]
+    pub fn bundle_fragment_metadata(
+        &mut self,
+        #[wasm_bindgen(unchecked_param_type = "FragmentMeta[]")] fragments: JsValue,
+    ) -> Result<Array, error::BadJSFragments> {
+        let fragments = Vec::<am::Fragment>::try_from(JS(fragments))?;
+        Ok(self
+            .doc
+            .bundle_fragments(fragments)
+            .iter()
+            .map(|bytes| Uint8Array::from(bytes.as_slice()))
+            .collect())
+    }
+
+    #[wasm_bindgen(js_name = addCommits)]
+    pub fn add_commits(
+        &mut self,
+        #[wasm_bindgen(unchecked_param_type = "Commit[]")] commits: JsValue,
+    ) -> Result<(), error::AddCommits> {
+        let commits = Vec::<Commit>::try_from(JS(commits))?;
+        let changes = commits
+            .into_iter()
+            .map(|commit| commit.into_change())
+            .collect::<Result<Vec<_>, _>>()?;
+        self.doc.apply_changes(changes)?;
+        Ok(())
+    }
+
+    #[wasm_bindgen(js_name = addFragments)]
+    pub fn add_fragments(
+        &mut self,
+        #[wasm_bindgen(unchecked_param_type = "Fragment[]")] fragments: JsValue,
+    ) -> Result<(), error::AddFragments> {
+        let fragments = Vec::<FragmentInput>::try_from(JS(fragments))?;
+        let mut bytes = Vec::new();
+        for fragment in fragments {
+            // Touch the metadata so parsing validates the whole input shape even
+            // though the bundle bytes remain the authoritative representation.
+            let _metadata = fragment.fragment;
+            bytes.extend(fragment.bytes);
+        }
+        self.doc.load_incremental(&bytes)?;
+        Ok(())
+    }
+
     #[wasm_bindgen(js_name = getHeads, unchecked_return_type="Heads")]
     pub fn get_heads(&mut self) -> Array {
         let heads = self.doc.get_heads();
@@ -1886,6 +1984,223 @@ pub fn decode_sync_state(data: Uint8Array) -> Result<SyncState, sync::DecodeSync
 
 struct UpdateSpansArgs(Vec<am::iter::Span>);
 
+struct JsFragmentLevelRange {
+    start: usize,
+    end: Option<usize>,
+}
+
+impl RangeBounds<usize> for JsFragmentLevelRange {
+    fn start_bound(&self) -> Bound<&usize> {
+        Bound::Included(&self.start)
+    }
+
+    fn end_bound(&self) -> Bound<&usize> {
+        match &self.end {
+            Some(end) => Bound::Excluded(end),
+            None => Bound::Unbounded,
+        }
+    }
+}
+
+impl TryFrom<JsValue> for JsFragmentLevelRange {
+    type Error = error::BadFragmentLevelRange;
+
+    fn try_from(value: JsValue) -> Result<Self, Self::Error> {
+        if value.is_undefined() || value.is_null() {
+            return Ok(Self {
+                start: 0,
+                end: None,
+            });
+        }
+        if let Some(level) = value.as_f64() {
+            let level = js_usize(level).ok_or(error::BadFragmentLevelRange::InvalidNumber)?;
+            return Ok(Self {
+                start: level,
+                end: Some(level + 1),
+            });
+        }
+
+        let start = match js_get(&value, "start")?.0.as_f64() {
+            Some(start) => js_usize(start).ok_or(error::BadFragmentLevelRange::InvalidStart)?,
+            None => 0,
+        };
+        let end = match js_get(&value, "end")?.0.as_f64() {
+            Some(end) => Some(js_usize(end).ok_or(error::BadFragmentLevelRange::InvalidEnd)?),
+            None => None,
+        };
+        Ok(Self { start, end })
+    }
+}
+
+fn js_usize(n: f64) -> Option<usize> {
+    if n.is_finite() && n >= 0.0 && n.fract() == 0.0 {
+        Some(n as usize)
+    } else {
+        None
+    }
+}
+
+fn fragment_to_js(fragment: &am::Fragment) -> JsValue {
+    let obj: JsValue = Object::new().into();
+    js_set(&obj, "head", fragment.head.to_string()).unwrap();
+    js_set(&obj, "level", fragment.level as f64).unwrap();
+    js_set(&obj, "boundary", AR::from(fragment.boundary.as_slice())).unwrap();
+    js_set(
+        &obj,
+        "checkpoints",
+        AR::from(fragment.checkpoints.as_slice()),
+    )
+    .unwrap();
+    js_set(&obj, "members", AR::from(fragment.members.as_slice())).unwrap();
+    obj
+}
+
+struct Commit {
+    head: am::ChangeHash,
+    parents: Vec<am::ChangeHash>,
+    bytes: Vec<u8>,
+}
+
+impl Commit {
+    fn into_change(self) -> Result<Change, error::BadCommitBytes> {
+        let change = Change::try_from(self.bytes.as_slice())?;
+        // Validate that JS metadata lines up with the supplied bytes. This keeps
+        // Automerge's API shaped like Subduction's addCommits input while still
+        // treating the encoded change as authoritative.
+        if change.hash() != self.head {
+            return Err(error::BadCommitBytes::HeadMismatch {
+                expected: self.head.to_string(),
+                actual: change.hash().to_string(),
+            });
+        }
+        if change.deps() != self.parents.as_slice() {
+            return Err(error::BadCommitBytes::ParentsMismatch);
+        }
+        Ok(change)
+    }
+}
+
+impl TryFrom<JS> for Commit {
+    type Error = error::BadJSCommit;
+
+    fn try_from(value: JS) -> Result<Self, Self::Error> {
+        let head = js_get(&value.0, "head")?
+            .try_into()
+            .map_err(error::BadJSCommit::BadHead)?;
+        let parents = js_get(&value.0, "parents")?
+            .try_into()
+            .map_err(error::BadJSCommit::BadParents)?;
+        let bytes = js_get(&value.0, "bytes")?
+            .try_into()
+            .map_err(error::BadJSCommit::BadBytes)?;
+        Ok(Self {
+            head,
+            parents,
+            bytes,
+        })
+    }
+}
+
+impl TryFrom<JS> for Vec<Commit> {
+    type Error = error::BadJSCommits;
+
+    fn try_from(value: JS) -> Result<Self, Self::Error> {
+        let value = value
+            .0
+            .dyn_into::<Array>()
+            .map_err(|_| error::BadJSCommits::NotArray)?;
+        value
+            .iter()
+            .enumerate()
+            .map(|(i, v)| Commit::try_from(JS(v)).map_err(|e| error::BadJSCommits::BadElem(i, e)))
+            .collect()
+    }
+}
+
+struct FragmentInput {
+    fragment: am::Fragment,
+    bytes: Vec<u8>,
+}
+
+impl TryFrom<JS> for FragmentInput {
+    type Error = error::BadJSFragmentInput;
+
+    fn try_from(value: JS) -> Result<Self, Self::Error> {
+        let fragment = am::Fragment::try_from(JS(value.0.clone()))?;
+        let bytes = js_get(&value.0, "bytes")?
+            .try_into()
+            .map_err(error::BadJSFragmentInput::BadBytes)?;
+        Ok(Self { fragment, bytes })
+    }
+}
+
+impl TryFrom<JS> for Vec<FragmentInput> {
+    type Error = error::BadJSFragmentInputs;
+
+    fn try_from(value: JS) -> Result<Self, Self::Error> {
+        let value = value
+            .0
+            .dyn_into::<Array>()
+            .map_err(|_| error::BadJSFragmentInputs::NotArray)?;
+        value
+            .iter()
+            .enumerate()
+            .map(|(i, v)| {
+                FragmentInput::try_from(JS(v))
+                    .map_err(|e| error::BadJSFragmentInputs::BadElem(i, e))
+            })
+            .collect()
+    }
+}
+
+impl TryFrom<JS> for am::Fragment {
+    type Error = error::BadJSFragmentInput;
+
+    fn try_from(value: JS) -> Result<Self, Self::Error> {
+        let head: am::ChangeHash = js_get(&value.0, "head")?
+            .try_into()
+            .map_err(error::BadJSFragmentInput::BadHead)?;
+        let level = match js_get(&value.0, "level")?.0.as_f64() {
+            Some(level) => js_usize(level).ok_or(error::BadJSFragmentInput::BadLevel)?,
+            None => return Err(error::BadJSFragmentInput::BadLevel),
+        };
+        let boundary = js_get(&value.0, "boundary")?
+            .try_into()
+            .map_err(error::BadJSFragmentInput::BadBoundary)?;
+        let checkpoints = js_get(&value.0, "checkpoints")?
+            .try_into()
+            .map_err(error::BadJSFragmentInput::BadCheckpoints)?;
+        let members = js_get(&value.0, "members")?
+            .try_into()
+            .map_err(error::BadJSFragmentInput::BadMembers)?;
+        Ok(Self {
+            head,
+            level,
+            boundary,
+            checkpoints,
+            members,
+        })
+    }
+}
+
+impl TryFrom<JS> for Vec<am::Fragment> {
+    type Error = error::BadJSFragments;
+
+    fn try_from(value: JS) -> Result<Self, Self::Error> {
+        let value = value
+            .0
+            .dyn_into::<Array>()
+            .map_err(|_| error::BadJSFragments::NotArray)?;
+        value
+            .iter()
+            .enumerate()
+            .map(|(i, v)| {
+                am::Fragment::try_from(JS(v)).map_err(|e| error::BadJSFragments::BadElem(i, e))
+            })
+            .collect()
+    }
+}
+
 #[wasm_bindgen(js_name = "readBundle")]
 pub fn read_bundle(bundle: Uint8Array) -> Result<JsValue, error::ReadBundle> {
     let bundle_bytes = bundle.to_vec();
@@ -1924,7 +2239,7 @@ pub mod error {
 
     use crate::interop::{
         self,
-        error::{BadChangeHashes, BadJSChanges},
+        error::{BadChangeHash, BadChangeHashes, BadJSChanges, BadUint8Array, GetProp},
     };
 
     #[derive(Debug, thiserror::Error)]
@@ -1947,6 +2262,136 @@ pub mod error {
 
     impl From<ApplyChangesError> for JsValue {
         fn from(e: ApplyChangesError) -> Self {
+            RangeError::new(&e.to_string()).into()
+        }
+    }
+
+    #[derive(Debug, thiserror::Error)]
+    pub enum BadFragmentLevelRange {
+        #[error("bad fragment level range property: {0}")]
+        Prop(#[from] GetProp),
+        #[error("fragment level must be a non-negative integer")]
+        InvalidNumber,
+        #[error("fragment level range start must be a non-negative integer")]
+        InvalidStart,
+        #[error("fragment level range end must be a non-negative integer")]
+        InvalidEnd,
+    }
+
+    impl From<BadFragmentLevelRange> for JsValue {
+        fn from(e: BadFragmentLevelRange) -> Self {
+            RangeError::new(&e.to_string()).into()
+        }
+    }
+
+    #[derive(Debug, thiserror::Error)]
+    pub enum Fragments {
+        #[error(transparent)]
+        BadLevelRange(#[from] BadFragmentLevelRange),
+    }
+
+    impl From<Fragments> for JsValue {
+        fn from(e: Fragments) -> Self {
+            RangeError::new(&e.to_string()).into()
+        }
+    }
+
+    #[derive(Debug, thiserror::Error)]
+    pub enum BadJSCommit {
+        #[error("bad commit input property: {0}")]
+        Prop(#[from] GetProp),
+        #[error("bad commit head: {0}")]
+        BadHead(BadChangeHash),
+        #[error("bad commit parents: {0}")]
+        BadParents(BadChangeHashes),
+        #[error("bad commit bytes: {0}")]
+        BadBytes(BadUint8Array),
+    }
+
+    #[derive(Debug, thiserror::Error)]
+    pub enum BadJSCommits {
+        #[error("commit inputs must be an array")]
+        NotArray,
+        #[error("bad commit input at index {0}: {1}")]
+        BadElem(usize, BadJSCommit),
+    }
+
+    #[derive(Debug, thiserror::Error)]
+    pub enum BadCommitBytes {
+        #[error("bad commit bytes: {0}")]
+        Load(#[from] automerge::LoadChangeError),
+        #[error("commit input head mismatch: expected {expected}, actual {actual}")]
+        HeadMismatch { expected: String, actual: String },
+        #[error("commit input parents do not match encoded change dependencies")]
+        ParentsMismatch,
+    }
+
+    #[derive(Debug, thiserror::Error)]
+    pub enum AddCommits {
+        #[error(transparent)]
+        BadInputs(#[from] BadJSCommits),
+        #[error(transparent)]
+        BadBytes(#[from] BadCommitBytes),
+        #[error("error applying commits: {0}")]
+        Apply(#[from] AutomergeError),
+    }
+
+    impl From<AddCommits> for JsValue {
+        fn from(e: AddCommits) -> Self {
+            RangeError::new(&e.to_string()).into()
+        }
+    }
+
+    #[derive(Debug, thiserror::Error)]
+    pub enum BadJSFragmentInput {
+        #[error("bad fragment input property: {0}")]
+        Prop(#[from] GetProp),
+        #[error("bad fragment head: {0}")]
+        BadHead(BadChangeHash),
+        #[error("bad fragment level")]
+        BadLevel,
+        #[error("bad fragment boundary: {0}")]
+        BadBoundary(BadChangeHashes),
+        #[error("bad fragment checkpoints: {0}")]
+        BadCheckpoints(BadChangeHashes),
+        #[error("bad fragment members: {0}")]
+        BadMembers(BadChangeHashes),
+        #[error("bad fragment bytes: {0}")]
+        BadBytes(BadUint8Array),
+    }
+
+    #[derive(Debug, thiserror::Error)]
+    pub enum BadJSFragmentInputs {
+        #[error("fragment inputs must be an array")]
+        NotArray,
+        #[error("bad fragment input at index {0}: {1}")]
+        BadElem(usize, BadJSFragmentInput),
+    }
+
+    #[derive(Debug, thiserror::Error)]
+    pub enum BadJSFragments {
+        #[error("fragments must be an array")]
+        NotArray,
+        #[error("bad fragment at index {0}: {1}")]
+        BadElem(usize, BadJSFragmentInput),
+    }
+
+    impl From<BadJSFragments> for JsValue {
+        fn from(e: BadJSFragments) -> Self {
+            RangeError::new(&e.to_string()).into()
+        }
+    }
+
+    #[derive(Debug, thiserror::Error)]
+    pub enum AddFragments {
+        #[error(transparent)]
+        BadInputs(#[from] BadJSFragmentInputs),
+        #[error("error loading fragment bundles: {0}")]
+        Load(#[from] AutomergeError),
+    }
+
+    impl From<AddFragments> for JsValue {
+        fn from(e: AddFragments) -> Self {
             RangeError::new(&e.to_string()).into()
         }
     }

--- a/rust/automerge/Cargo.toml
+++ b/rust/automerge/Cargo.toml
@@ -21,7 +21,7 @@ slow_path_assertions = ["hexane/slow_path_assertions"]
 hexane = { version = "0.2.1", path = "../hexane" }
 hex = "^0.4.3"
 leb128 = "^0.2.5"
-sha2 = "0.11.0"
+sha2 = "^0.11.0-rc.5"
 thiserror = "^2.0.12"
 itertools = "0.14.0"
 flate2 = "^1.0.22"

--- a/rust/automerge/src/autocommit.rs
+++ b/rust/automerge/src/autocommit.rs
@@ -1,7 +1,6 @@
 use std::ops::RangeBounds;
 
 use crate::automerge::SaveOptions;
-use crate::change_graph::Fragment;
 use crate::clock::Clock;
 use crate::cursor::{CursorPosition, MoveCursor};
 use crate::exid::ExId;
@@ -13,6 +12,7 @@ use crate::patches::PatchLog;
 use crate::sync::SyncDoc;
 use crate::transaction::{CommitOptions, Transactable};
 use crate::types::{ObjId, ObjMeta};
+use crate::Fragment;
 use crate::{hydrate, Bundle, OnPartialLoad, TextEncoding};
 use crate::{sync, ObjType, Patch, ReadDoc, ScalarValue, ROOT};
 use crate::{

--- a/rust/automerge/src/autocommit.rs
+++ b/rust/automerge/src/autocommit.rs
@@ -614,8 +614,16 @@ impl AutoCommit {
         self.doc.dump()
     }
 
-    pub fn fragments(&self) -> Vec<Fragment> {
-        self.doc.fragments()
+    pub fn fragments<R: RangeBounds<usize>>(&self, levels: R) -> Vec<Fragment> {
+        self.doc.fragments(levels)
+    }
+
+    pub fn get_fragment(&self, head: ChangeHash) -> Option<Fragment> {
+        self.doc.get_fragment(head)
+    }
+
+    pub fn bundle_fragments<I: IntoIterator<Item = Fragment>>(&self, fragments: I) -> Vec<Vec<u8>> {
+        self.doc.bundle_fragments(fragments)
     }
 
     /// Get the current heads of the document.

--- a/rust/automerge/src/autocommit.rs
+++ b/rust/automerge/src/autocommit.rs
@@ -1,6 +1,7 @@
 use std::ops::RangeBounds;
 
 use crate::automerge::SaveOptions;
+use crate::change_graph::Fragment;
 use crate::clock::Clock;
 use crate::cursor::{CursorPosition, MoveCursor};
 use crate::exid::ExId;
@@ -611,6 +612,10 @@ impl AutoCommit {
     pub fn dump(&mut self) {
         self.ensure_transaction_closed();
         self.doc.dump()
+    }
+
+    pub fn fragments(&self) -> Vec<Fragment> {
+        self.doc.fragments()
     }
 
     /// Get the current heads of the document.

--- a/rust/automerge/src/automerge.rs
+++ b/rust/automerge/src/automerge.rs
@@ -1277,8 +1277,33 @@ impl Automerge {
         Ok(patch_log.make_patches(self))
     }
 
-    pub fn fragments(&self) -> Vec<Fragment> {
-        self.change_graph.fragments(&self.get_heads()).collect()
+    pub fn fragments<R: RangeBounds<usize>>(&self, levels: R) -> Vec<Fragment> {
+        // these produce fragments newest to oldest
+        let mut fragments: Vec<_> = self
+            .change_graph
+            .fragments(&self.get_heads(), levels)
+            .collect();
+        // but we want to return them oldest to newest
+        fragments.reverse();
+        fragments
+    }
+
+    pub fn get_fragment(&self, head: ChangeHash) -> Option<Fragment> {
+        self.change_graph.get_fragment(head)
+    }
+
+    pub fn bundle_fragments<I: IntoIterator<Item = Fragment>>(&self, fragments: I) -> Vec<Vec<u8>> {
+        fragments
+            .into_iter()
+            .filter_map(|f| {
+                if f.head.fragment_level() == 0 && f.members.len() == 1 {
+                    // there should be a unwrap().into_owned()/to_vec() to avoid a memory copy
+                    Some(self.get_change_by_hash(&f.head)?.bytes().to_vec())
+                } else {
+                    Some(self.bundle(f.members).ok()?.bytes().to_vec())
+                }
+            })
+            .collect()
     }
 
     /// Get the heads of this document.

--- a/rust/automerge/src/automerge.rs
+++ b/rust/automerge/src/automerge.rs
@@ -7,6 +7,7 @@ use std::ops::RangeBounds;
 
 use itertools::Itertools;
 
+pub(crate) use crate::change_graph::Fragment;
 pub(crate) use crate::op_set2::change::ChangeCollector;
 pub(crate) use crate::op_set2::types::ScalarValue;
 pub(crate) use crate::op_set2::{
@@ -1274,6 +1275,10 @@ impl Automerge {
         DiffIter::log(self, obj, clock, &mut patch_log, recursive);
         patch_log.heads = Some(after_heads.to_vec());
         Ok(patch_log.make_patches(self))
+    }
+
+    pub fn fragments(&self) -> Vec<Fragment> {
+        self.change_graph.fragments(&self.get_heads()).collect()
     }
 
     /// Get the heads of this document.

--- a/rust/automerge/src/automerge.rs
+++ b/rust/automerge/src/automerge.rs
@@ -7,7 +7,6 @@ use std::ops::RangeBounds;
 
 use itertools::Itertools;
 
-pub(crate) use crate::change_graph::Fragment;
 pub(crate) use crate::op_set2::change::ChangeCollector;
 pub(crate) use crate::op_set2::types::ScalarValue;
 pub(crate) use crate::op_set2::{
@@ -31,7 +30,7 @@ use crate::transaction::{
 use crate::clock::{Clock, ClockRange};
 use crate::hydrate;
 use crate::types::{ActorId, ChangeHash, ObjId, ObjMeta, OpId, SequenceType, TextEncoding, Value};
-use crate::{AutomergeError, Change, Cursor, ObjType, Prop};
+use crate::{AutomergeError, Change, Cursor, Fragment, ObjType, Prop};
 
 pub(crate) mod current_state;
 

--- a/rust/automerge/src/change_graph.rs
+++ b/rust/automerge/src/change_graph.rs
@@ -1,6 +1,6 @@
 use std::borrow::Cow;
 use std::cmp::Ordering;
-use std::collections::{BTreeSet, HashMap};
+use std::collections::{BTreeSet, HashMap, HashSet, VecDeque};
 use std::num::NonZeroU32;
 use std::ops::Add;
 
@@ -46,6 +46,8 @@ pub(crate) struct ChangeGraph {
     nodes_by_hash: HashMap<ChangeHash, NodeIdx>,
     clock_cache: HashMap<NodeIdx, SeqClock>,
     seq_index: Vec<Vec<NodeIdx>>,
+    fragment_top: SeqClock,
+    fragments: Vec<FragmentNode>,
 }
 
 pub(crate) struct ChangeGraphCols(ChangeGraph);
@@ -102,6 +104,8 @@ impl ChangeGraph {
             heads: BTreeSet::new(),
             clock_cache: HashMap::new(),
             seq_index: vec![vec![]; num_actors],
+            fragments: vec![],
+            fragment_top: SeqClock::new(num_actors),
         }
     }
 
@@ -148,6 +152,10 @@ impl ChangeGraph {
         for clock in self.clock_cache.values_mut() {
             clock.rewrite_with_new_actor(idx)
         }
+        for f in &mut self.fragments {
+            f.clock.rewrite_with_new_actor(idx)
+        }
+        self.fragment_top.rewrite_with_new_actor(idx);
         self.seq_index.insert(idx, vec![]);
     }
 
@@ -558,8 +566,109 @@ impl ChangeGraph {
             if (node_idx + 1).0 % CACHE_STEP == 0 {
                 self.cache_clock(node_idx);
             }
+
+            self.cache_fragment(node_idx);
         }
         Ok(())
+    }
+
+    pub(crate) fn fragments<'a>(
+        &'a self,
+        heads: &'a [ChangeHash],
+    ) -> impl Iterator<Item = Fragment> + 'a {
+        self.loose_fragments(heads)
+            .chain(self.fragments.iter().rev().map(|f| f.export(self)))
+    }
+
+    fn loose_fragments<'a>(
+        &'a self,
+        heads: &'a [ChangeHash],
+    ) -> impl Iterator<Item = Fragment> + 'a {
+        let nodes = heads
+            .iter()
+            .filter(|h| h.fragment_level() == 0)
+            .filter_map(|h| self.nodes_by_hash.get(h).copied());
+        self.bfs_until_clock(nodes, &self.fragment_top)
+            .map(move |n| {
+                let id = self.hashes[n.0 as usize];
+                assert_eq!(id.fragment_level(), 0);
+                let deps = self.parents(n).map(|p| self.hashes[p.0 as usize]).collect();
+                let content = vec![id];
+                let level = id.fragment_level();
+                Fragment {
+                    id,
+                    level,
+                    deps,
+                    content,
+                }
+            })
+    }
+
+    fn fragment_content<'a>(
+        &'a self,
+        node: NodeIdx,
+        clock: &'a SeqClock,
+    ) -> impl Iterator<Item = ChangeHash> + 'a {
+        self.bfs_until_clock([node], clock)
+            .map(|n| self.hashes[n.0 as usize])
+    }
+
+    fn bfs_until_clock<'a, I>(
+        &'a self,
+        seed: I,
+        clock: &'a SeqClock,
+    ) -> impl Iterator<Item = NodeIdx> + 'a
+    where
+        I: IntoIterator<Item = NodeIdx>,
+    {
+        let mut to_visit: VecDeque<_> = seed.into_iter().collect();
+        let mut seen: HashSet<_> = to_visit.iter().copied().collect();
+
+        std::iter::from_fn(move || {
+            let idx = to_visit.pop_front()?;
+            for p in self.parents(idx) {
+                if !seen.contains(&p) {
+                    let actor = self.actors[p.0 as usize].into();
+                    let seq = self.seq[p.0 as usize];
+                    if clock.get_for_actor(&actor) < NonZeroU32::new(seq) {
+                        seen.insert(p);
+                        to_visit.push_back(p);
+                    }
+                }
+            }
+            Some(idx)
+        })
+    }
+
+    fn cache_fragments(&mut self) {
+        for n in 0..self.hashes.len() {
+            self.cache_fragment(NodeIdx(n as u32))
+        }
+    }
+
+    fn cache_fragment(&mut self, id: NodeIdx) {
+        let hash = &self.hashes[id.0 as usize];
+        let level = hash.fragment_level();
+        if level == 0 {
+            return;
+        }
+        let mut deps = vec![];
+        let mut supercede = vec![];
+        let clock = self.calculate_clock(vec![id]);
+        for (i, f) in self.fragments.iter().enumerate().rev() {
+            if clock.covers(&f.clock) {
+                if self.hashes[f.id.0 as usize].fragment_level() >= level {
+                    deps.push(f.id);
+                } else {
+                    supercede.push(i);
+                }
+            }
+        }
+        for i in supercede {
+            self.fragments.remove(i);
+        }
+        SeqClock::merge(&mut self.fragment_top, &clock);
+        self.fragments.push(FragmentNode { id, deps, clock });
     }
 
     pub(crate) fn add_change(&mut self, change: &Change, actor: usize) -> Result<(), MissingDep> {
@@ -759,6 +868,8 @@ impl ChangeGraphCols {
             }
         }
 
+        graph.cache_fragments();
+
         graph
     }
 
@@ -859,6 +970,8 @@ impl ChangeGraphCols {
         let clock_cache = HashMap::default();
         let hashes = vec![];
         let nodes_by_hash = HashMap::new();
+        let fragments = vec![];
+        let fragment_top = SeqClock::new(num_actors);
 
         Ok(ChangeGraphCols(ChangeGraph {
             edges,
@@ -877,6 +990,8 @@ impl ChangeGraphCols {
             nodes_by_hash,
             clock_cache,
             seq_index,
+            fragments,
+            fragment_top,
         }))
     }
 }
@@ -1067,6 +1182,183 @@ mod tests {
             }
             graph
         }
+
+        fn all_hashes(&self) -> Vec<ChangeHash> {
+            self.changes.iter().map(|c| c.hash()).collect()
+        }
+    }
+
+    #[test]
+    fn fragments_cover_all_changes() {
+        // Create a long linear chain — with ~1000 changes, we expect several
+        // with fragment_level >= 1 (roughly 1 in 256).
+        let mut builder = TestGraphBuilder::new();
+        let actor = builder.actor();
+        let mut prev = vec![];
+        for _ in 0..1000 {
+            let h = builder.change(&actor, 1, &prev);
+            prev = vec![h];
+        }
+        let graph = builder.build();
+        let all_hashes: BTreeSet<_> = builder.all_hashes().into_iter().collect();
+        let heads: Vec<_> = graph.heads().collect();
+
+        let fragments: Vec<_> = graph.fragments(&heads).collect();
+
+        // Collect all content hashes across all fragments
+        // (hashes may appear in multiple fragments — this is expected)
+        let mut covered: BTreeSet<ChangeHash> = BTreeSet::new();
+        for f in &fragments {
+            for h in &f.content {
+                covered.insert(*h);
+            }
+        }
+
+        // Every change must appear in at least one fragment
+        let missing: Vec<_> = all_hashes.difference(&covered).collect();
+        assert!(
+            missing.is_empty(),
+            "changes not covered by any fragment: {:?}",
+            missing,
+        );
+    }
+
+    fn assert_fragment_invariants(fragments: &[Fragment]) {
+        for f in fragments {
+            // level must match the fragment_level of the id hash
+            assert_eq!(
+                f.level,
+                f.id.fragment_level(),
+                "fragment level mismatch for {:?}",
+                f.id
+            );
+
+            // id must be in content
+            assert!(
+                f.content.contains(&f.id),
+                "fragment id {:?} not found in its own content",
+                f.id
+            );
+
+            // deps must be equal or higher level than the fragment
+            for dep in &f.deps {
+                assert!(
+                    dep.fragment_level() >= f.level,
+                    "fragment {:?} (level {}) has dep {:?} with lower level {}",
+                    f.id,
+                    f.level,
+                    dep,
+                    dep.fragment_level(),
+                );
+            }
+
+            // content must not contain a hash with a higher level than the id
+            for h in &f.content {
+                assert!(
+                    h.fragment_level() <= f.level,
+                    "fragment {:?} (level {}) contains {:?} with higher level {}",
+                    f.id,
+                    f.level,
+                    h,
+                    h.fragment_level(),
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn fragment_id_and_level_consistent() {
+        let mut builder = TestGraphBuilder::new();
+        let actor = builder.actor();
+        let mut prev = vec![];
+        for _ in 0..1000 {
+            let h = builder.change(&actor, 1, &prev);
+            prev = vec![h];
+        }
+        let graph = builder.build();
+        let heads: Vec<_> = graph.heads().collect();
+        let fragments: Vec<_> = graph.fragments(&heads).collect();
+
+        assert_fragment_invariants(&fragments);
+    }
+
+    #[test]
+    fn fragments_work_with_concurrent_actors() {
+        let mut builder = TestGraphBuilder::new();
+        let actor1 = builder.actor();
+        let actor2 = builder.actor();
+
+        // Build two concurrent chains that merge periodically
+        let root = builder.change(&actor1, 1, &[]);
+        let mut tip1 = root;
+        let mut tip2 = root;
+        for i in 0..500 {
+            tip1 = builder.change(&actor1, 1, &[tip1]);
+            tip2 = builder.change(&actor2, 1, &[tip2]);
+            if i % 50 == 49 {
+                // merge
+                let merge = builder.change(&actor1, 1, &[tip1, tip2]);
+                tip1 = merge;
+                tip2 = merge;
+            }
+        }
+        let graph = builder.build();
+        let all_hashes: BTreeSet<_> = builder.all_hashes().into_iter().collect();
+        let heads: Vec<_> = graph.heads().collect();
+        let fragments: Vec<_> = graph.fragments(&heads).collect();
+
+        let mut covered: BTreeSet<ChangeHash> = BTreeSet::new();
+        for f in &fragments {
+            for h in &f.content {
+                covered.insert(*h);
+            }
+        }
+
+        let missing: Vec<_> = all_hashes.difference(&covered).collect();
+        assert!(
+            missing.is_empty(),
+            "changes not covered by any fragment: {:?}",
+            missing,
+        );
+
+        assert_fragment_invariants(&fragments);
+    }
+
+    #[test]
+    fn fragment_deps_reference_known_hashes() {
+        let mut builder = TestGraphBuilder::new();
+        let actor = builder.actor();
+        let mut prev = vec![];
+        for _ in 0..1000 {
+            let h = builder.change(&actor, 1, &prev);
+            prev = vec![h];
+        }
+        let graph = builder.build();
+        let all_hashes: BTreeSet<_> = builder.all_hashes().into_iter().collect();
+        let heads: Vec<_> = graph.heads().collect();
+        let fragments: Vec<_> = graph.fragments(&heads).collect();
+        let fragment_ids: BTreeSet<_> = fragments.iter().map(|f| f.id).collect();
+
+        for f in &fragments {
+            for dep in &f.deps {
+                assert!(
+                    all_hashes.contains(dep),
+                    "fragment {:?} has dep {:?} not in change graph",
+                    f.id,
+                    dep
+                );
+                // Deps of cached fragments (level > 0) should point to other fragment ids
+                // Deps of loose fragments (level == 0) point to change-level parents
+                if f.level > 0 {
+                    assert!(
+                        fragment_ids.contains(dep) || dep.fragment_level() == 0,
+                        "cached fragment {:?} has dep {:?} that is not a fragment id",
+                        f.id,
+                        dep
+                    );
+                }
+            }
+        }
     }
 }
 
@@ -1189,6 +1481,41 @@ impl<'a> Iterator for ChangeIter<'a> {
             builder: 0,
         })
     }
+}
+
+#[derive(Debug, PartialEq, Clone)]
+struct FragmentNode {
+    id: NodeIdx,
+    deps: Vec<NodeIdx>,
+    clock: SeqClock,
+}
+
+impl FragmentNode {
+    fn export(&self, graph: &ChangeGraph) -> Fragment {
+        let id = graph.hashes[self.id.0 as usize];
+        let level = id.fragment_level();
+        let deps = self
+            .deps
+            .iter()
+            .map(|d| graph.hashes[d.0 as usize])
+            .collect();
+        let clock = graph.calculate_clock(self.deps.clone());
+        let content = graph.fragment_content(self.id, &clock).collect();
+        Fragment {
+            id,
+            level,
+            deps,
+            content,
+        }
+    }
+}
+
+#[derive(Debug, PartialEq, Clone)]
+pub struct Fragment {
+    pub id: ChangeHash,
+    pub level: usize,
+    pub deps: Vec<ChangeHash>,
+    pub content: Vec<ChangeHash>,
 }
 
 #[rustfmt::skip]

--- a/rust/automerge/src/change_graph.rs
+++ b/rust/automerge/src/change_graph.rs
@@ -1485,6 +1485,60 @@ mod tests {
         let b = loaded.save();
         assert_eq!(a, b);
     }
+
+    /// Regression test: `bundle()` must be insensitive to the order in which
+    /// callers provide change hashes. The change-metadata columns inside a
+    /// bundle are RLE/delta encoded, so if `from_meta` didn't sort its input
+    /// the column data would thrash and the bundle would inflate 10–20× on
+    /// common workloads (this is what `bundle_fragments` was hitting because
+    /// `Fragment::members` is in topological iteration order, not start_op
+    /// order).
+    #[test]
+    fn bundle_size_is_independent_of_input_hash_order() {
+        use crate::transaction::Transactable;
+        use crate::ROOT;
+
+        let mut doc = Automerge::new();
+        doc.set_actor(crate::ActorId::from(b"alice" as &[u8]));
+        let mut tx = doc.transaction();
+        tx.put(ROOT, "counter", 0i64).unwrap();
+        tx.commit();
+        for i in 1..=1_000_i64 {
+            let mut tx = doc.transaction();
+            tx.put(ROOT, "counter", i).unwrap();
+            tx.commit();
+        }
+
+        let hashes: Vec<_> = doc.get_changes(&[]).iter().map(|c| c.hash()).collect();
+
+        let sorted_bytes = doc.bundle(hashes.iter().copied()).unwrap().bytes().len();
+
+        let mut reversed = hashes.clone();
+        reversed.reverse();
+        let reversed_bytes = doc.bundle(reversed).unwrap().bytes().len();
+
+        // Implementation must internally sort; the two bundles' sizes should
+        // be identical (or at worst within a handful of bytes from differing
+        // varint widths). They must NOT differ by an order of magnitude.
+        assert_eq!(
+            sorted_bytes, reversed_bytes,
+            "bundle size depends on input hash order (sorted={}, reversed={}). \
+             from_meta must sort by start_op before encoding columns.",
+            sorted_bytes, reversed_bytes
+        );
+
+        // Sanity: the bundle should be within a small constant factor of the
+        // doc's save_nocompress() size — the underlying columnar encoding is
+        // the same, just without DEFLATE.
+        let snc = doc.save_nocompress().len();
+        assert!(
+            sorted_bytes < snc * 2,
+            "bundle of all changes ({} B) is suspiciously larger than \
+             save_nocompress() ({} B); columns may not be packing.",
+            sorted_bytes,
+            snc
+        );
+    }
 }
 
 fn to_vec<'a, I, T>(iter: I) -> Result<Vec<T>, PackError>

--- a/rust/automerge/src/change_graph.rs
+++ b/rust/automerge/src/change_graph.rs
@@ -3,6 +3,7 @@ use std::cmp::Ordering;
 use std::collections::{BTreeSet, HashMap, HashSet, VecDeque};
 use std::num::NonZeroU32;
 use std::ops::Add;
+use std::ops::RangeBounds;
 
 use hexane::{
     ColGroupIter, ColumnCursor, ColumnData, ColumnDataIter, DeltaCursor, PackError, StrCursor,
@@ -572,12 +573,48 @@ impl ChangeGraph {
         Ok(())
     }
 
-    pub(crate) fn fragments<'a>(
+    pub(crate) fn get_fragment(&self, head: ChangeHash) -> Option<Fragment> {
+        let n = self.nodes_by_hash.get(&head).copied()?;
+        if head.fragment_level() == 0 {
+            self.loose_commit(n)
+        } else {
+            assert!(self.fragments.is_sorted_by(|a, b| a.head.0 < b.head.0));
+            self.fragments
+                .binary_search_by_key(&n.0, |f| f.head.0)
+                .ok()
+                .map(|i| self.fragments[i].export(self))
+        }
+    }
+
+    fn loose_commit(&self, n: NodeIdx) -> Option<Fragment> {
+        let head = self.hashes.get(n.0 as usize).copied()?;
+        assert_eq!(head.fragment_level(), 0);
+        let boundary = self.parents(n).map(|p| self.hashes[p.0 as usize]).collect();
+        let members = vec![head];
+        let checkpoints = vec![];
+        let level = head.fragment_level();
+        Some(Fragment {
+            head,
+            level,
+            boundary,
+            checkpoints,
+            members,
+        })
+    }
+
+    pub(crate) fn fragments<'a, R: RangeBounds<usize> + 'a>(
         &'a self,
         heads: &'a [ChangeHash],
+        levels: R,
     ) -> impl Iterator<Item = Fragment> + 'a {
-        self.loose_fragments(heads)
-            .chain(self.fragments.iter().rev().map(|f| f.export(self)))
+        let heads = if levels.contains(&0) { heads } else { &[] };
+        self.loose_fragments(heads).chain(
+            self.fragments
+                .iter()
+                .rev()
+                .filter(move |f| levels.contains(&self.hashes[f.head.0 as usize].fragment_level()))
+                .map(|f| f.export(self)),
+        )
     }
 
     fn loose_fragments<'a>(
@@ -589,19 +626,7 @@ impl ChangeGraph {
             .filter(|h| h.fragment_level() == 0)
             .filter_map(|h| self.nodes_by_hash.get(h).copied());
         self.bfs_until_clock(nodes, &self.fragment_top)
-            .map(move |n| {
-                let id = self.hashes[n.0 as usize];
-                assert_eq!(id.fragment_level(), 0);
-                let deps = self.parents(n).map(|p| self.hashes[p.0 as usize]).collect();
-                let content = vec![id];
-                let level = id.fragment_level();
-                Fragment {
-                    id,
-                    level,
-                    deps,
-                    content,
-                }
-            })
+            .filter_map(|n| self.loose_commit(n))
     }
 
     fn fragment_content<'a>(
@@ -646,19 +671,19 @@ impl ChangeGraph {
         }
     }
 
-    fn cache_fragment(&mut self, id: NodeIdx) {
-        let hash = &self.hashes[id.0 as usize];
+    fn cache_fragment(&mut self, head: NodeIdx) {
+        let hash = &self.hashes[head.0 as usize];
         let level = hash.fragment_level();
         if level == 0 {
             return;
         }
         let mut deps = vec![];
         let mut supercede = vec![];
-        let clock = self.calculate_clock(vec![id]);
+        let clock = self.calculate_clock(vec![head]);
         for (i, f) in self.fragments.iter().enumerate().rev() {
             if clock.covers(&f.clock) {
-                if self.hashes[f.id.0 as usize].fragment_level() >= level {
-                    deps.push(f.id);
+                if self.hashes[f.head.0 as usize].fragment_level() >= level {
+                    deps.push(f.head);
                 } else {
                     supercede.push(i);
                 }
@@ -668,7 +693,7 @@ impl ChangeGraph {
             self.fragments.remove(i);
         }
         SeqClock::merge(&mut self.fragment_top, &clock);
-        self.fragments.push(FragmentNode { id, deps, clock });
+        self.fragments.push(FragmentNode { head, deps, clock });
     }
 
     pub(crate) fn add_change(&mut self, change: &Change, actor: usize) -> Result<(), MissingDep> {
@@ -1028,10 +1053,13 @@ mod tests {
     };
 
     use crate::{
+        make_rng,
         op_set2::{change::build_change, op_set::ResolvedAction, OpSet, TxOp},
+        transaction::Transactable,
         types::{ObjMeta, OpId, OpType},
-        ActorId, TextEncoding,
+        ActorId, Automerge, AutoCommit, TextEncoding, ROOT,
     };
+    use rand::RngExt;
 
     use super::*;
 
@@ -1203,13 +1231,13 @@ mod tests {
         let all_hashes: BTreeSet<_> = builder.all_hashes().into_iter().collect();
         let heads: Vec<_> = graph.heads().collect();
 
-        let fragments: Vec<_> = graph.fragments(&heads).collect();
+        let fragments: Vec<_> = graph.fragments(&heads, ..).collect();
 
-        // Collect all content hashes across all fragments
+        // Collect all members hashes across all fragments
         // (hashes may appear in multiple fragments — this is expected)
         let mut covered: BTreeSet<ChangeHash> = BTreeSet::new();
         for f in &fragments {
-            for h in &f.content {
+            for h in &f.members {
                 covered.insert(*h);
             }
         }
@@ -1228,36 +1256,36 @@ mod tests {
             // level must match the fragment_level of the id hash
             assert_eq!(
                 f.level,
-                f.id.fragment_level(),
+                f.head.fragment_level(),
                 "fragment level mismatch for {:?}",
-                f.id
+                f.head
             );
 
-            // id must be in content
+            // id must be in members
             assert!(
-                f.content.contains(&f.id),
-                "fragment id {:?} not found in its own content",
-                f.id
+                f.members.contains(&f.head),
+                "fragment id {:?} not found in its own members",
+                f.head
             );
 
             // deps must be equal or higher level than the fragment
-            for dep in &f.deps {
+            for dep in &f.boundary {
                 assert!(
                     dep.fragment_level() >= f.level,
                     "fragment {:?} (level {}) has dep {:?} with lower level {}",
-                    f.id,
+                    f.head,
                     f.level,
                     dep,
                     dep.fragment_level(),
                 );
             }
 
-            // content must not contain a hash with a higher level than the id
-            for h in &f.content {
+            // members must not contain a hash with a higher level than the id
+            for h in &f.members {
                 assert!(
                     h.fragment_level() <= f.level,
                     "fragment {:?} (level {}) contains {:?} with higher level {}",
-                    f.id,
+                    f.head,
                     f.level,
                     h,
                     h.fragment_level(),
@@ -1277,7 +1305,7 @@ mod tests {
         }
         let graph = builder.build();
         let heads: Vec<_> = graph.heads().collect();
-        let fragments: Vec<_> = graph.fragments(&heads).collect();
+        let fragments: Vec<_> = graph.fragments(&heads, ..).collect();
 
         assert_fragment_invariants(&fragments);
     }
@@ -1305,11 +1333,11 @@ mod tests {
         let graph = builder.build();
         let all_hashes: BTreeSet<_> = builder.all_hashes().into_iter().collect();
         let heads: Vec<_> = graph.heads().collect();
-        let fragments: Vec<_> = graph.fragments(&heads).collect();
+        let fragments: Vec<_> = graph.fragments(&heads, ..).collect();
 
         let mut covered: BTreeSet<ChangeHash> = BTreeSet::new();
         for f in &fragments {
-            for h in &f.content {
+            for h in &f.members {
                 covered.insert(*h);
             }
         }
@@ -1336,15 +1364,15 @@ mod tests {
         let graph = builder.build();
         let all_hashes: BTreeSet<_> = builder.all_hashes().into_iter().collect();
         let heads: Vec<_> = graph.heads().collect();
-        let fragments: Vec<_> = graph.fragments(&heads).collect();
-        let fragment_ids: BTreeSet<_> = fragments.iter().map(|f| f.id).collect();
+        let fragments: Vec<_> = graph.fragments(&heads, ..).collect();
+        let fragment_ids: BTreeSet<_> = fragments.iter().map(|f| f.head).collect();
 
         for f in &fragments {
-            for dep in &f.deps {
+            for dep in &f.boundary {
                 assert!(
                     all_hashes.contains(dep),
                     "fragment {:?} has dep {:?} not in change graph",
-                    f.id,
+                    f.head,
                     dep
                 );
                 // Deps of cached fragments (level > 0) should point to other fragment ids
@@ -1353,12 +1381,109 @@ mod tests {
                     assert!(
                         fragment_ids.contains(dep) || dep.fragment_level() == 0,
                         "cached fragment {:?} has dep {:?} that is not a fragment id",
-                        f.id,
+                        f.head,
                         dep
                     );
                 }
             }
         }
+    }
+
+    #[test]
+    fn fragments_filtered_by_levels() {
+        // 5000 changes gives ~20 expected level-1 fragments (1 hash in 256)
+        // so seeing zero cached fragments would be extraordinarily unlikely.
+        let mut builder = TestGraphBuilder::new();
+        let actor = builder.actor();
+        let mut prev = vec![];
+        for _ in 0..5000 {
+            let h = builder.change(&actor, 1, &prev);
+            prev = vec![h];
+        }
+        let graph = builder.build();
+        let heads: Vec<_> = graph.heads().collect();
+
+        let all: Vec<_> = graph.fragments(&heads, ..).collect();
+        let loose: Vec<_> = graph.fragments(&heads, 0..=0).collect();
+        let cached: Vec<_> = graph.fragments(&heads, 1..).collect();
+
+        // loose + cached partition the full range
+        assert_eq!(loose.len() + cached.len(), all.len());
+        assert!(!loose.is_empty());
+        assert!(
+            !cached.is_empty(),
+            "expected at least one cached fragment from 5000 changes",
+        );
+
+        for f in &loose {
+            assert_eq!(f.level, 0, "0..=0 returned a non-zero level fragment");
+        }
+        for f in &cached {
+            assert!(f.level >= 1, "1.. returned a level-0 fragment");
+        }
+
+        // empty range yields nothing
+        assert_eq!(graph.fragments(&heads, 0..0).count(), 0);
+    }
+
+    #[test]
+    fn get_fragment_returns_loose_and_cached() {
+        let mut builder = TestGraphBuilder::new();
+        let actor = builder.actor();
+        let mut prev = vec![];
+        for _ in 0..5000 {
+            let h = builder.change(&actor, 1, &prev);
+            prev = vec![h];
+        }
+        let graph = builder.build();
+        let heads: Vec<_> = graph.heads().collect();
+
+        let loose: Vec<_> = graph.fragments(&heads, 0..=0).collect();
+        let cached: Vec<_> = graph.fragments(&heads, 1..).collect();
+        assert!(!loose.is_empty());
+        assert!(!cached.is_empty(), "expected at least one cached fragment");
+
+        // get_fragment on a loose (level 0) commit hash returns an equivalent Fragment
+        let l = &loose[0];
+        let got = graph.get_fragment(l.head).expect("loose fragment exists");
+        assert_eq!(got, *l);
+
+        // get_fragment on a cached (level >= 1) fragment id returns an equivalent Fragment
+        let c = &cached[0];
+        let got = graph.get_fragment(c.head).expect("cached fragment exists");
+        assert_eq!(got, *c);
+
+        // unknown hash returns None
+        assert!(graph.get_fragment(ChangeHash([0xff; 32])).is_none());
+    }
+
+    #[test]
+    fn bundle_fragments_roundtrips_through_load_incremental() {
+        let mut rng = make_rng();
+        let mut doc = Automerge::new();
+
+        for _ in 0..1_000 {
+            let key = format!("k{}", rng.random::<u32>() % 32);
+            let value = (rng.random::<u32>() % 1000) as i64;
+            let mut tx = doc.transaction();
+            tx.put(ROOT, key, value).unwrap();
+            tx.commit();
+        }
+
+        let fragments = doc.fragments(..);
+
+        let bundles = doc.bundle_fragments(fragments);
+
+        let joined: Vec<u8> = bundles.into_iter().flatten().collect();
+
+        let mut loaded = AutoCommit::new();
+        loaded.load_incremental(&joined).unwrap();
+
+        assert_eq!(doc.get_heads(), loaded.get_heads());
+
+        let a = doc.save();
+        let b = loaded.save();
+        assert_eq!(a, b);
     }
 }
 
@@ -1485,37 +1610,44 @@ impl<'a> Iterator for ChangeIter<'a> {
 
 #[derive(Debug, PartialEq, Clone)]
 struct FragmentNode {
-    id: NodeIdx,
+    head: NodeIdx,
     deps: Vec<NodeIdx>,
     clock: SeqClock,
 }
 
 impl FragmentNode {
     fn export(&self, graph: &ChangeGraph) -> Fragment {
-        let id = graph.hashes[self.id.0 as usize];
-        let level = id.fragment_level();
-        let deps = self
+        let head = graph.hashes[self.head.0 as usize];
+        let level = head.fragment_level();
+        let boundary = self
             .deps
             .iter()
             .map(|d| graph.hashes[d.0 as usize])
             .collect();
         let clock = graph.calculate_clock(self.deps.clone());
-        let content = graph.fragment_content(self.id, &clock).collect();
+        let members: Vec<_> = graph.fragment_content(self.head, &clock).collect();
+        let checkpoints = members
+            .iter()
+            .copied()
+            .filter(|h| h.fragment_level() > 0)
+            .collect();
         Fragment {
-            id,
+            head,
             level,
-            deps,
-            content,
+            boundary,
+            checkpoints,
+            members,
         }
     }
 }
 
 #[derive(Debug, PartialEq, Clone)]
 pub struct Fragment {
-    pub id: ChangeHash,
+    pub head: ChangeHash,
     pub level: usize,
-    pub deps: Vec<ChangeHash>,
-    pub content: Vec<ChangeHash>,
+    pub boundary: Vec<ChangeHash>,
+    pub checkpoints: Vec<ChangeHash>,
+    pub members: Vec<ChangeHash>,
 }
 
 #[rustfmt::skip]

--- a/rust/automerge/src/change_graph.rs
+++ b/rust/automerge/src/change_graph.rs
@@ -1057,7 +1057,7 @@ mod tests {
         op_set2::{change::build_change, op_set::ResolvedAction, OpSet, TxOp},
         transaction::Transactable,
         types::{ObjMeta, OpId, OpType},
-        ActorId, Automerge, AutoCommit, TextEncoding, ROOT,
+        ActorId, AutoCommit, Automerge, TextEncoding, ROOT,
     };
     use rand::RngExt;
 

--- a/rust/automerge/src/clock.rs
+++ b/rust/automerge/src/clock.rs
@@ -54,6 +54,15 @@ impl SeqClock {
             }
         }
     }
+
+    pub(crate) fn covers(&self, other: &SeqClock) -> bool {
+        assert_eq!(self.0.len(), other.0.len());
+        std::iter::zip(self.0.iter(), other.0.iter()).all(|(a, b)| match (a, b) {
+            (_, None) => true,
+            (Some(s1), Some(s2)) => s1 >= s2,
+            _ => false,
+        })
+    }
 }
 
 #[derive(Debug, Clone, PartialEq)]

--- a/rust/automerge/src/lib.rs
+++ b/rust/automerge/src/lib.rs
@@ -295,6 +295,7 @@ pub use crate::automerge::{Automerge, LoadOptions, OnPartialLoad, SaveOptions, S
 pub use autocommit::AutoCommit;
 pub use autoserde::AutoSerde;
 pub use change::{Change, LoadError as LoadChangeError};
+pub use change_graph::Fragment;
 pub use cursor::{Cursor, CursorPosition, MoveCursor, OpCursor};
 pub use error::InvalidActorId;
 pub use error::InvalidChangeHashSlice;

--- a/rust/automerge/src/lib.rs
+++ b/rust/automerge/src/lib.rs
@@ -313,3 +313,16 @@ pub use value::{ScalarValue, Value};
 
 /// The object ID for the root map of a document
 pub const ROOT: ObjId = ObjId::Root;
+
+#[cfg(test)]
+fn make_rng() -> rand::rngs::SmallRng {
+    // use rand::RngExt;
+    use rand::SeedableRng;
+
+    let seed = std::env::var("AUTOMERGE_TEST_SEED")
+        .ok()
+        .and_then(|s| s.parse::<u64>().ok())
+        .unwrap_or_else(rand::random::<u64>);
+    log!("SEED: {}", seed);
+    rand::rngs::SmallRng::seed_from_u64(seed)
+}

--- a/rust/automerge/src/op_set2/change/batch.rs
+++ b/rust/automerge/src/op_set2/change/batch.rs
@@ -1147,7 +1147,7 @@ mod tests {
     use crate::read::ReadDoc;
     use crate::transaction::Transactable;
     use crate::types;
-    use crate::{ActorId, AutoCommit, ROOT};
+    use crate::{make_rng, ActorId, AutoCommit, ROOT};
     use rand::prelude::*;
 
     impl AutoCommit {
@@ -1360,15 +1360,6 @@ mod tests {
         doc1.apply_changes_batch(changes).unwrap();
         doc1.validate_top_index();
         assert_eq!(doc1.save(), doc2.save());
-    }
-
-    fn make_rng() -> SmallRng {
-        let seed = std::env::var("AUTOMERGE_TEST_SEED")
-            .ok()
-            .and_then(|s| s.parse::<u64>().ok())
-            .unwrap_or_else(rand::random::<u64>);
-        log!("SEED: {}", seed);
-        SmallRng::seed_from_u64(seed)
     }
 
     #[test]

--- a/rust/automerge/src/op_set2/change/collector.rs
+++ b/rust/automerge/src/op_set2/change/collector.rs
@@ -724,13 +724,25 @@ impl<'a> ChangeCollector<'a> {
         changes: Vec<BuildChangeMetadata<'a>>,
     ) -> Vec<Change> {
         let r1 = Self::from_build_meta_inner(op_set, change_graph, changes.clone());
-        debug_assert_eq!(
-            r1,
-            crate::storage::Bundle::for_hashes(op_set, change_graph, r1.iter().map(|c| c.hash()))
-                .unwrap()
-                .to_changes()
-                .unwrap()
-        );
+        #[cfg(debug_assertions)]
+        {
+            // Bundle::from_meta sorts changes by (start_op, actor) before
+            // encoding columns, so the two paths produce the same set of
+            // changes but not necessarily in the same order. Compare as sets
+            // keyed by hash.
+            let bundle_changes = crate::storage::Bundle::for_hashes(
+                op_set,
+                change_graph,
+                r1.iter().map(|c| c.hash()),
+            )
+            .unwrap()
+            .to_changes()
+            .unwrap();
+            let r1_hashes: std::collections::HashSet<_> = r1.iter().map(|c| c.hash()).collect();
+            let bundle_hashes: std::collections::HashSet<_> =
+                bundle_changes.iter().map(|c| c.hash()).collect();
+            debug_assert_eq!(r1_hashes, bundle_hashes);
+        }
         r1
     }
 

--- a/rust/automerge/src/storage/bundle.rs
+++ b/rust/automerge/src/storage/bundle.rs
@@ -51,7 +51,7 @@ impl Bundle {
         Ok(Self::from_meta(op_set, changes))
     }
 
-    fn from_meta(op_set: &OpSet, mut changes: Vec<BundleMetadata<'_>>) -> Bundle {
+    fn from_meta(op_set: &OpSet, changes: Vec<BundleMetadata<'_>>) -> Bundle {
         let min = changes
             .iter()
             .map(|c| c.start_op as usize)

--- a/rust/automerge/src/storage/bundle.rs
+++ b/rust/automerge/src/storage/bundle.rs
@@ -51,7 +51,21 @@ impl Bundle {
         Ok(Self::from_meta(op_set, changes))
     }
 
-    fn from_meta(op_set: &OpSet, changes: Vec<BundleMetadata<'_>>) -> Bundle {
+    fn from_meta(op_set: &OpSet, mut changes: Vec<BundleMetadata<'_>>) -> Bundle {
+        // Sort changes by start_op before encoding the change columns.
+        // This is a valid topological sort (a change's start_op is strictly
+        // greater than the max_op of any of its deps, which is in turn ≥ those
+        // deps' start_ops) so the bundle's "internal deps come first" invariant
+        // is preserved. Without this, change columns are encoded in whatever
+        // order callers happened to provide hashes — which for fragment
+        // bundling (topological/iteration order) thrashes the delta-encoded
+        // start_op / max_op / seq / timestamp columns and inflates output by
+        // 10–20× on common workloads.
+        changes.sort_by(|a, b| {
+            a.start_op
+                .cmp(&b.start_op)
+                .then_with(|| a.actor.cmp(&b.actor))
+        });
         let min = changes
             .iter()
             .map(|c| c.start_op as usize)

--- a/rust/automerge/src/storage/bundle.rs
+++ b/rust/automerge/src/storage/bundle.rs
@@ -52,20 +52,6 @@ impl Bundle {
     }
 
     fn from_meta(op_set: &OpSet, mut changes: Vec<BundleMetadata<'_>>) -> Bundle {
-        // Sort changes by start_op before encoding the change columns.
-        // This is a valid topological sort (a change's start_op is strictly
-        // greater than the max_op of any of its deps, which is in turn ≥ those
-        // deps' start_ops) so the bundle's "internal deps come first" invariant
-        // is preserved. Without this, change columns are encoded in whatever
-        // order callers happened to provide hashes — which for fragment
-        // bundling (topological/iteration order) thrashes the delta-encoded
-        // start_op / max_op / seq / timestamp columns and inflates output by
-        // 10–20× on common workloads.
-        changes.sort_by(|a, b| {
-            a.start_op
-                .cmp(&b.start_op)
-                .then_with(|| a.actor.cmp(&b.actor))
-        });
         let min = changes
             .iter()
             .map(|c| c.start_op as usize)
@@ -116,8 +102,16 @@ impl Bundle {
             .map_err(|e| AutomergeError::Unbundle(Box::new(e)))
     }
 
+    /// On-disk form of the bundle, with per-column DEFLATE applied where
+    /// each column is large enough to benefit. Falls back to the
+    /// uncompressed buffer for bundles whose construction predates the
+    /// per-column compression pass (or that were parsed from input with no
+    /// compressed columns).
     pub fn bytes(&self) -> &[u8] {
-        &self.storage.bytes
+        match &self.storage.compressed_bytes {
+            Some(c) => c,
+            None => &self.storage.bytes,
+        }
     }
 
     pub fn deps(&self) -> &[ChangeHash] {

--- a/rust/automerge/src/storage/bundle/builder.rs
+++ b/rust/automerge/src/storage/bundle/builder.rs
@@ -8,6 +8,7 @@ use crate::op_set2::change::{length_prefixed_bytes, shift_range, ActorMapper};
 use crate::op_set2::op::{Op, OpBuilder};
 use crate::op_set2::types::{ActionCursor, ActorCursor, ActorIdx, KeyRef, MetaCursor};
 use crate::op_set2::{ReadOpError, ScalarValue};
+use crate::storage::change::DEFLATE_MIN_SIZE;
 use crate::storage::columns::{compression, ColumnType};
 use crate::storage::{ChunkType, Header, RawColumn, RawColumns};
 use crate::types::{ChangeHash, ObjId, OpId};
@@ -33,6 +34,18 @@ impl<'a> BundleBuilder<'a> {
         mut changes: Vec<BundleMetadata<'a>>,
         mut mapper: ActorMapper<'a>,
     ) -> BundleBuilder<'a> {
+        // At entry, `changes[i].builder` is the change graph NodeIdx (set by
+        // `ChangeGraph::get_bundle_metadata`). NodeIdx is assigned in load
+        // order, which is topological — every change is loaded after its
+        // deps. Capture this topological ordering before the actor+seq sort
+        // overwrites `builder` with a column index, so we can iterate
+        // changes in dep-before-dependent order when populating the bundle
+        // (this keeps the `external` deps list small: only deps that point
+        // outside the bundle's member set become external, instead of every
+        // not-yet-added member dep).
+        let mut topo_order: Vec<usize> = (0..changes.len()).collect();
+        topo_order.sort_by_key(|&i| changes[i].builder);
+
         let mut builders: Vec<_> = changes
             .iter()
             .enumerate()
@@ -53,8 +66,8 @@ impl<'a> BundleBuilder<'a> {
             .for_each(|(index, b)| changes[b.change].builder = index);
 
         let mut change_writer = BundleChangeWriter::new(changes.len());
-        for c in &changes {
-            change_writer.add(c, &mut mapper);
+        for &i in &topo_order {
+            change_writer.add(&changes[i], &mut mapper);
         }
 
         let op_writer = BundleOpWriter::default();
@@ -122,49 +135,79 @@ impl<'a> BundleBuilder<'a> {
 
         mapper.build_mapping(None);
 
-        let mut data = vec![];
-
         let deps = self.change_writer.external.clone();
         let actors = mapper.iter().collect::<Vec<_>>();
 
-        leb128::write::unsigned(&mut data, deps.len() as u64).unwrap();
+        // Prefix: deps + actors. Identical in both the uncompressed and
+        // compressed representations.
+        let mut prefix = Vec::new();
+        leb128::write::unsigned(&mut prefix, deps.len() as u64).unwrap();
         for hash in &deps {
-            data.extend(hash.as_bytes());
+            prefix.extend(hash.as_bytes());
         }
-
-        leb128::write::unsigned(&mut data, actors.len() as u64).unwrap();
+        leb128::write::unsigned(&mut prefix, actors.len() as u64).unwrap();
         for actor in &actors {
-            length_prefixed_bytes(actor, &mut data);
+            length_prefixed_bytes(actor, &mut prefix);
         }
 
-        let mut change_bytes = vec![];
-        let change_cols = self.change_writer.finish(&mapper, &mut change_bytes);
-        let (changes_data, changes_meta) = change_cols.write(&mut data, change_bytes);
+        // Column data (uncompressed) and per-column metadata.
+        let mut change_data_buf = Vec::new();
+        let change_cols = self.change_writer.finish(&mapper, &mut change_data_buf);
+        let changes_meta = change_cols.raw_columns();
+        let mut ops_data_buf = Vec::new();
+        let (ops_cols, id_ctr_values) = self.op_writer.finish(&mapper, &mut ops_data_buf);
+        let ops_meta = ops_cols.raw_columns();
 
-        let mut ops_bytes = vec![];
-        let ops_cols = self.op_writer.finish(&mapper, &mut ops_bytes);
-        let (ops_data, ops_meta) = ops_cols.write(&mut data, ops_bytes);
+        // ---- Uncompressed assembly (used in-memory for iteration) ----
+        let mut data_u = prefix.clone();
+        changes_meta.write(&mut data_u);
+        let changes_data_start_u = data_u.len();
+        data_u.extend_from_slice(&change_data_buf);
+        let changes_data_end_u = data_u.len();
+        ops_meta.write(&mut data_u);
+        let ops_data_start_u = data_u.len();
+        data_u.extend_from_slice(&ops_data_buf);
+        let ops_data_end_u = data_u.len();
 
-        let header = Header::new(ChunkType::Bundle, &data);
+        let header_u = Header::new(ChunkType::Bundle, &data_u);
+        let mut bytes_u = Vec::with_capacity(header_u.len() + data_u.len());
+        header_u.write(&mut bytes_u);
+        bytes_u.extend(data_u);
 
-        let mut bytes = Vec::with_capacity(header.len() + data.len());
-        header.write(&mut bytes);
-        bytes.extend(data);
+        let changes_data_u_range =
+            shift_range(changes_data_start_u..changes_data_end_u, header_u.len());
+        let ops_data_u_range = shift_range(ops_data_start_u..ops_data_end_u, header_u.len());
 
-        let bytes = Cow::Owned(bytes);
+        // ---- Compressed assembly (used as the on-disk/wire form) ----
+        // Per-column DEFLATE above DEFLATE_MIN_SIZE, mirroring Document.
+        let mut data_c = prefix;
+        let mut compressed_change_data = Vec::new();
+        let changes_meta_c =
+            changes_meta.compress(&change_data_buf, &mut compressed_change_data, DEFLATE_MIN_SIZE);
+        changes_meta_c.write(&mut data_c);
+        data_c.extend_from_slice(&compressed_change_data);
+        let mut compressed_ops_data = Vec::new();
+        let ops_meta_c =
+            ops_meta.compress(&ops_data_buf, &mut compressed_ops_data, DEFLATE_MIN_SIZE);
+        ops_meta_c.write(&mut data_c);
+        data_c.extend_from_slice(&compressed_ops_data);
 
-        let ops_data = shift_range(ops_data, header.len());
-        let changes_data = shift_range(changes_data, header.len());
+        let header_c = Header::new(ChunkType::Bundle, &data_c);
+        let mut bytes_c = Vec::with_capacity(header_c.len() + data_c.len());
+        header_c.write(&mut bytes_c);
+        bytes_c.extend(data_c);
 
         let storage = BundleStorage {
-            bytes,
-            header,
+            bytes: Cow::Owned(bytes_u),
+            compressed_bytes: Some(Cow::Owned(bytes_c)),
+            header: header_u,
             ops_meta,
-            ops_data,
+            ops_data: ops_data_u_range,
             deps,
             actors,
             changes_meta,
-            changes_data,
+            changes_data: changes_data_u_range,
+            id_ctr_values,
             _phantom: PhantomData,
         };
 
@@ -276,7 +319,6 @@ pub(crate) struct BundleOpWriter<'a> {
     key_ctr: Encoder<'a, DeltaCursor>,
     key_str: Encoder<'a, StrCursor>,
     id_actor: Encoder<'a, ActorCursor>,
-    id_ctr: Encoder<'a, DeltaCursor>,
     insert: Encoder<'a, BooleanCursor>,
     action: Encoder<'a, ActionCursor>,
     value_meta: Encoder<'a, MetaCursor>,
@@ -286,13 +328,19 @@ pub(crate) struct BundleOpWriter<'a> {
     pred_ctr: Encoder<'a, DeltaCursor>,
     expand: Encoder<'a, BooleanCursor>,
     mark_name: Encoder<'a, StrCursor>,
+    /// `(actor, counter, doc_pos)` for each op as we process it. At
+    /// `finish` time these are sorted by `(actor, counter)` and the
+    /// `doc_pos` values are emitted as a delta-int column. Readers
+    /// reconstruct each op's counter from this column plus the change
+    /// metadata, so we don't need an explicit `id_ctr` column on the wire.
+    inverse_positions: Vec<(usize, u64, u32)>,
 }
 
 impl<'a> BundleOpWriter<'a> {
     fn add(&mut self, op: OpBuilder<'a>, _index: usize, mapper: &mut ActorMapper<'a>) {
         mapper.process_op(&op);
+        let doc_pos = self.id_actor.len as u32;
         self.id_actor.append(op.id.actoridx());
-        self.id_ctr.append(op.id.icounter());
         self.obj_actor.append(op.obj.actor());
         self.obj_ctr.append(op.obj.icounter());
         self.key_actor.append(op.key.actor());
@@ -309,9 +357,15 @@ impl<'a> BundleOpWriter<'a> {
         }
         self.expand.append(op.expand);
         self.mark_name.append(op.mark_name);
+        self.inverse_positions
+            .push((op.id.actor(), op.id.counter(), doc_pos));
     }
 
-    fn finish(self, mapper: &ActorMapper<'a>, data: &mut Vec<u8>) -> BundleOpsColumns {
+    fn finish(
+        mut self,
+        mapper: &ActorMapper<'a>,
+        data: &mut Vec<u8>,
+    ) -> (BundleOpsColumns, Vec<i64>) {
         let remap = move |a: &ActorIdx| mapper.mapping[usize::from(*a)].as_ref();
         let obj_actor = self.obj_actor.save_to_and_remap_unless_empty(data, remap);
         let obj_ctr = self.obj_ctr.save_to_unless_empty(data);
@@ -319,7 +373,6 @@ impl<'a> BundleOpWriter<'a> {
         let key_ctr = self.key_ctr.save_to_unless_empty(data);
         let key_str = self.key_str.save_to_unless_empty(data);
         let id_actor = self.id_actor.save_to_and_remap(data, remap);
-        let id_ctr = self.id_ctr.save_to(data);
         let insert = self.insert.save_to(data);
         let action = self.action.save_to_unless_empty(data);
         let value_meta = self.value_meta.save_to_unless_empty(data);
@@ -330,31 +383,59 @@ impl<'a> BundleOpWriter<'a> {
         let expand = self.expand.save_to_unless_empty(data);
         let mark_name = self.mark_name.save_to_unless_empty(data);
 
-        BundleOpsColumns {
-            id_actor,
-            id_ctr,
-            obj_actor,
-            obj_ctr,
-            key_actor,
-            key_ctr,
-            key_str,
-            insert,
-            action,
-            value_meta,
-            value,
-            pred_count,
-            pred_actor,
-            pred_ctr,
-            expand,
-            mark_name,
+        // Capture doc-order counters before sorting `inverse_positions`.
+        // `add()` populates this Vec in doc order, so element k is the
+        // counter of the op at doc position k.
+        let id_ctr_values: Vec<i64> = self
+            .inverse_positions
+            .iter()
+            .map(|(_, counter, _)| *counter as i64)
+            .collect();
+
+        // Sort by canonical (actor, counter) order and emit each op's
+        // doc_pos as a delta-int — the inverse permutation. Readers walk
+        // the change metadata in (actor, seq) order to materialise the
+        // canonical (actor, counter) for each `k`, then look up
+        // `doc_pos = inverse[k]` to place that op's id in the doc-order
+        // column. For editing-style workloads where each new op lands
+        // close to its predecessor, the deltas are almost all `+1`s —
+        // far more compressible than the doc-order counter sequence.
+        self.inverse_positions
+            .sort_unstable_by_key(|(a, c, _)| (*a, *c));
+        let mut id_ctr_inverse_enc: Encoder<'_, DeltaCursor> = Encoder::default();
+        for (_, _, doc_pos) in &self.inverse_positions {
+            id_ctr_inverse_enc.append(*doc_pos as i64);
         }
+        let id_ctr_inverse = id_ctr_inverse_enc.save_to_unless_empty(data);
+
+        (
+            BundleOpsColumns {
+                id_actor,
+                id_ctr_inverse,
+                obj_actor,
+                obj_ctr,
+                key_actor,
+                key_ctr,
+                key_str,
+                insert,
+                action,
+                value_meta,
+                value,
+                pred_count,
+                pred_actor,
+                pred_ctr,
+                expand,
+                mark_name,
+            },
+            id_ctr_values,
+        )
     }
 }
 
 #[derive(Default)]
 pub(crate) struct BundleOpsColumns {
     pub(crate) id_actor: Range<usize>,
-    pub(crate) id_ctr: Range<usize>,
+    pub(crate) id_ctr_inverse: Range<usize>,
     pub(crate) obj_actor: Range<usize>,
     pub(crate) obj_ctr: Range<usize>,
     pub(crate) key_actor: Range<usize>,
@@ -386,19 +467,6 @@ pub(crate) struct BundleChangeColumns {
 }
 
 impl BundleChangeColumns {
-    fn write(
-        &self,
-        data: &mut Vec<u8>,
-        col_data: Vec<u8>,
-    ) -> (Range<usize>, RawColumns<compression::Uncompressed>) {
-        let cols = self.raw_columns();
-        cols.write(data);
-        let start = data.len();
-        data.extend(col_data);
-        let end = data.len();
-        (start..end, cols)
-    }
-
     fn raw_columns(&self) -> RawColumns<compression::Uncompressed> {
         [
             (change::ACTOR, &self.actor),
@@ -420,18 +488,6 @@ impl BundleChangeColumns {
 }
 
 impl BundleOpsColumns {
-    fn write(
-        &self,
-        data: &mut Vec<u8>,
-        col_data: Vec<u8>,
-    ) -> (Range<usize>, RawColumns<compression::Uncompressed>) {
-        let cols = self.raw_columns();
-        cols.write(data);
-        let start = data.len();
-        data.extend(col_data);
-        let end = data.len();
-        (start..end, cols)
-    }
     fn raw_columns(&self) -> RawColumns<compression::Uncompressed> {
         [
             (ops::OBJ_ACTOR, &self.obj_actor),
@@ -440,7 +496,6 @@ impl BundleOpsColumns {
             (ops::KEY_CTR, &self.key_ctr),
             (ops::KEY_STR, &self.key_str),
             (ops::ID_ACTOR, &self.id_actor),
-            (ops::ID_CTR, &self.id_ctr),
             (ops::INSERT, &self.insert),
             (ops::ACTION, &self.action),
             (ops::VALUE_META, &self.value_meta),
@@ -450,6 +505,7 @@ impl BundleOpsColumns {
             (ops::PRED_CTR, &self.pred_ctr),
             (ops::MARK_NAME, &self.mark_name),
             (ops::EXPAND, &self.expand),
+            (ops::ID_CTR_INVERSE, &self.id_ctr_inverse),
         ]
         .into_iter()
         .filter(|(_, range)| !range.is_empty())
@@ -672,18 +728,23 @@ pub(crate) struct OpIterUnverified<'a> {
 }
 
 impl<'a> OpIterUnverified<'a> {
-    pub(crate) fn new(columns: &RawColumns<compression::Uncompressed>, data: &'a [u8]) -> Self {
+    pub(crate) fn new(
+        columns: &RawColumns<compression::Uncompressed>,
+        data: &'a [u8],
+        id_ctr_values: &'a [i64],
+    ) -> Self {
         Self {
-            inner: OpIterInner::try_new(columns, data).ok(),
+            inner: OpIterInner::try_new(columns, data, id_ctr_values).ok(),
         }
     }
 
     pub(crate) fn try_new(
         columns: &RawColumns<compression::Uncompressed>,
         data: &'a [u8],
+        id_ctr_values: &'a [i64],
     ) -> Result<Self, ParseError> {
         Ok(Self {
-            inner: Some(OpIterInner::try_new(columns, data)?),
+            inner: Some(OpIterInner::try_new(columns, data, id_ctr_values)?),
         })
     }
 }
@@ -695,7 +756,10 @@ struct OpIterInner<'a> {
     key_ctr: CursorIter<'a, DeltaCursor>,
     key_str: CursorIter<'a, StrCursor>,
     id_actor: CursorIter<'a, ActorCursor>,
-    id_ctr: CursorIter<'a, DeltaCursor>,
+    /// Doc-order counter values, reconstructed at parse time from the
+    /// wire's `ID_CTR_INVERSE` column. Read directly as `i64`s instead
+    /// of going through a re-encoded columnar form.
+    id_ctr: std::slice::Iter<'a, i64>,
     insert: CursorIter<'a, BooleanCursor>,
     action: CursorIter<'a, ActionCursor>,
     meta: CursorIter<'a, MetaCursor>,
@@ -712,9 +776,13 @@ pub(crate) struct OpIter<'a> {
 }
 
 impl<'a> OpIter<'a> {
-    pub(crate) fn new(columns: &RawColumns<compression::Uncompressed>, data: &'a [u8]) -> Self {
+    pub(crate) fn new(
+        columns: &RawColumns<compression::Uncompressed>,
+        data: &'a [u8],
+        id_ctr_values: &'a [i64],
+    ) -> Self {
         Self {
-            iter: OpIterUnverified::new(columns, data),
+            iter: OpIterUnverified::new(columns, data, id_ctr_values),
         }
     }
 }
@@ -742,7 +810,7 @@ impl<'a> Iterator for OpIterUnverified<'a> {
 impl<'a> OpIterInner<'a> {
     fn try_next(&mut self) -> Result<Option<OpBuilder<'a>>, ParseError> {
         let id_actor = self.id_actor.next().transpose()?.flatten();
-        let id_ctr = self.id_ctr.next().transpose()?.flatten();
+        let id_ctr = self.id_ctr.next().map(std::borrow::Cow::Borrowed);
         let id = match OpId::try_load(id_actor, id_ctr) {
             Ok(id) => id,
             Err(_) => return Ok(None),
@@ -822,6 +890,7 @@ impl<'a> OpIterInner<'a> {
     fn try_new(
         columns: &RawColumns<compression::Uncompressed>,
         data: &'a [u8],
+        id_ctr_values: &'a [i64],
     ) -> Result<Self, ParseError> {
         let mut obj_actor = ActorCursor::iter(&[]);
         let mut obj_ctr = DeltaCursor::iter(&[]);
@@ -829,7 +898,11 @@ impl<'a> OpIterInner<'a> {
         let mut key_ctr = DeltaCursor::iter(&[]);
         let mut key_str = StrCursor::iter(&[]);
         let mut id_actor = ActorCursor::iter(&[]);
-        let mut id_ctr = DeltaCursor::iter(&[]);
+        // id_ctr is not stored on the wire — it's reconstructed in
+        // `BundleStorage::parse_following_header` from `ID_CTR_INVERSE`
+        // plus the change metadata. We iterate over the reconstructed
+        // values directly as a slice, no columnar round-trip needed.
+        let id_ctr = id_ctr_values.iter();
         let mut insert = BooleanCursor::iter(&[]);
         let mut action = ActionCursor::iter(&[]);
         let mut meta = MetaCursor::iter(&[]);
@@ -850,7 +923,6 @@ impl<'a> OpIterInner<'a> {
                 (ops::KEY_COL_ID, C::DeltaInteger) => key_ctr = DeltaCursor::iter(d),
                 (ops::KEY_COL_ID, C::String) => key_str = StrCursor::iter(d),
                 (ops::ID_COL_ID, C::Actor) => id_actor = ActorCursor::iter(d),
-                (ops::ID_COL_ID, C::DeltaInteger) => id_ctr = DeltaCursor::iter(d),
                 (ops::INSERT_COL_ID, C::Boolean) => insert = BooleanCursor::iter(d),
                 (ops::ACTION_COL_ID, C::Integer) => action = ActionCursor::iter(d),
                 (ops::VAL_COL_ID, C::ValueMetadata) => meta = MetaCursor::iter(d),
@@ -860,6 +932,12 @@ impl<'a> OpIterInner<'a> {
                 (ops::PRED_COL_ID, C::DeltaInteger) => pred_ctr = DeltaCursor::iter(d),
                 (ops::EXPAND_COL_ID, C::Boolean) => expand = BooleanCursor::iter(d),
                 (ops::MARK_NAME_COL_ID, C::String) => mark_name = StrCursor::iter(d),
+                // `ID_CTR_INVERSE` and the legacy `ID_CTR` are both
+                // handled at the storage layer: it picks whichever is
+                // present and feeds the resulting doc-order counters in
+                // via `id_ctr_values`.
+                (ops::ID_CTR_INVERSE_COL_ID, C::DeltaInteger) => {}
+                (ops::ID_COL_ID, C::DeltaInteger) => {}
                 _ => return Err(ParseError::InvalidOpColumn(u32::from(col.spec()))),
             }
         }
@@ -897,9 +975,15 @@ pub(crate) mod ops {
     pub(super) const PRED_COL_ID:           ColumnId = ColumnId::new(7);
     pub(super) const EXPAND_COL_ID:         ColumnId = ColumnId::new(9);
     pub(super) const MARK_NAME_COL_ID:      ColumnId = ColumnId::new(10);
+    /// Inverse permutation of doc positions. For each op in canonical
+    /// `(actor, counter)` order, stores its doc-order index as a
+    /// delta-int. Readers reconstruct each op's `counter` from this
+    /// column plus the change metadata — no separate `ID_CTR` column on
+    /// the wire.
+    pub(super) const ID_CTR_INVERSE_COL_ID: ColumnId = ColumnId::new(11);
 
     pub(super) const ID_ACTOR:   ColumnSpec = ColumnSpec::new_actor(ID_COL_ID);
-    pub(super) const ID_CTR:     ColumnSpec = ColumnSpec::new_delta(ID_COL_ID);
+    pub(super) const ID_CTR_INVERSE: ColumnSpec = ColumnSpec::new_delta(ID_CTR_INVERSE_COL_ID);
     pub(super) const OBJ_ACTOR:  ColumnSpec = ColumnSpec::new_actor(OBJ_COL_ID);
     pub(super) const OBJ_CTR:    ColumnSpec = ColumnSpec::new_delta(OBJ_COL_ID);
     pub(super) const KEY_ACTOR:  ColumnSpec = ColumnSpec::new_actor(KEY_COL_ID);

--- a/rust/automerge/src/storage/bundle/builder.rs
+++ b/rust/automerge/src/storage/bundle/builder.rs
@@ -34,17 +34,9 @@ impl<'a> BundleBuilder<'a> {
         mut changes: Vec<BundleMetadata<'a>>,
         mut mapper: ActorMapper<'a>,
     ) -> BundleBuilder<'a> {
-        // At entry, `changes[i].builder` is the change graph NodeIdx (set by
-        // `ChangeGraph::get_bundle_metadata`). NodeIdx is assigned in load
-        // order, which is topological — every change is loaded after its
-        // deps. Capture this topological ordering before the actor+seq sort
-        // overwrites `builder` with a column index, so we can iterate
-        // changes in dep-before-dependent order when populating the bundle
-        // (this keeps the `external` deps list small: only deps that point
-        // outside the bundle's member set become external, instead of every
-        // not-yet-added member dep).
-        let mut topo_order: Vec<usize> = (0..changes.len()).collect();
-        topo_order.sort_by_key(|&i| changes[i].builder);
+        // change[n].builder starts off as NodeIdx which is topo order
+        // writing the changes in topo order prevents un-needed hashes in the external buffer
+        changes.sort_by(|a, b| a.builder.cmp(&b.builder));
 
         let mut builders: Vec<_> = changes
             .iter()
@@ -66,8 +58,8 @@ impl<'a> BundleBuilder<'a> {
             .for_each(|(index, b)| changes[b.change].builder = index);
 
         let mut change_writer = BundleChangeWriter::new(changes.len());
-        for &i in &topo_order {
-            change_writer.add(&changes[i], &mut mapper);
+        for c in &changes {
+            change_writer.add(c, &mut mapper);
         }
 
         let op_writer = BundleOpWriter::default();
@@ -155,7 +147,7 @@ impl<'a> BundleBuilder<'a> {
         let change_cols = self.change_writer.finish(&mapper, &mut change_data_buf);
         let changes_meta = change_cols.raw_columns();
         let mut ops_data_buf = Vec::new();
-        let (ops_cols, id_ctr_values) = self.op_writer.finish(&mapper, &mut ops_data_buf);
+        let (ops_cols, id_ctr) = self.op_writer.finish(&mapper, &mut ops_data_buf);
         let ops_meta = ops_cols.raw_columns();
 
         // ---- Uncompressed assembly (used in-memory for iteration) ----
@@ -182,8 +174,11 @@ impl<'a> BundleBuilder<'a> {
         // Per-column DEFLATE above DEFLATE_MIN_SIZE, mirroring Document.
         let mut data_c = prefix;
         let mut compressed_change_data = Vec::new();
-        let changes_meta_c =
-            changes_meta.compress(&change_data_buf, &mut compressed_change_data, DEFLATE_MIN_SIZE);
+        let changes_meta_c = changes_meta.compress(
+            &change_data_buf,
+            &mut compressed_change_data,
+            DEFLATE_MIN_SIZE,
+        );
         changes_meta_c.write(&mut data_c);
         data_c.extend_from_slice(&compressed_change_data);
         let mut compressed_ops_data = Vec::new();
@@ -207,7 +202,7 @@ impl<'a> BundleBuilder<'a> {
             actors,
             changes_meta,
             changes_data: changes_data_u_range,
-            id_ctr_values,
+            id_ctr,
             _phantom: PhantomData,
         };
 

--- a/rust/automerge/src/storage/bundle/error.rs
+++ b/rust/automerge/src/storage/bundle/error.rs
@@ -30,6 +30,10 @@ pub(crate) enum ParseError {
     Deflate(#[from] std::io::Error),
     #[error("failed to unbundle: {0}")]
     Unbundle(Box<dyn std::error::Error + Send + Sync + 'static>),
+    #[error("failed to decode ID_CTR_INVERSE column")]
+    InverseDecode,
+    #[error("ID_CTR_INVERSE length does not match op count")]
+    InverseLengthMismatch,
 }
 
 impl<E: Into<ParseError>> From<parse::ParseError<E>> for ParseError {

--- a/rust/automerge/src/storage/bundle/storage.rs
+++ b/rust/automerge/src/storage/bundle/storage.rs
@@ -42,7 +42,7 @@ pub(crate) struct BundleStorage<'a, OpReadState> {
     /// wire's `ID_CTR_INVERSE` column plus the change metadata, then
     /// handed to `OpIter` as a plain slice — no columnar encoding round
     /// trip.
-    pub(crate) id_ctr_values: Vec<i64>,
+    pub(crate) id_ctr: Vec<i64>,
     pub(crate) _phantom: PhantomData<OpReadState>,
 }
 
@@ -58,7 +58,7 @@ impl<O: OpReadState> BundleStorage<'_, O> {
             ops_data: self.ops_data,
             changes_meta: self.changes_meta,
             changes_data: self.changes_data,
-            id_ctr_values: self.id_ctr_values,
+            id_ctr: self.id_ctr,
             _phantom: self._phantom,
         }
     }
@@ -188,20 +188,14 @@ impl<'a> BundleStorage<'a, Unverified> {
         let ops_data_range = ops.range.clone();
 
         // Fast path: nothing is compressed — keep input bytes as-is.
-        if let (Some(changes_meta), Some(ops_meta)) = (
-            changes_meta_raw.uncompressed(),
-            ops_meta_raw.uncompressed(),
-        ) {
+        if let (Some(changes_meta), Some(ops_meta)) =
+            (changes_meta_raw.uncompressed(), ops_meta_raw.uncompressed())
+        {
             BundleChangeIterUnverified::try_new(&changes_meta, changes.value)
                 .map_err(|e| parse::ParseError::Error(ParseError::InvalidColumns(Box::new(e))))?;
-            let id_ctr_values = extract_id_ctr_values(
-                &changes_meta,
-                changes.value,
-                &ops_meta,
-                ops.value,
-            )
-            .map_err(parse::ParseError::Error)?;
-            OpIterUnverified::try_new(&ops_meta, ops.value, &id_ctr_values)
+            let id_ctr = extract_id_ctr_values(&changes_meta, changes.value, &ops_meta, ops.value)
+                .map_err(parse::ParseError::Error)?;
+            OpIterUnverified::try_new(&ops_meta, ops.value, &id_ctr)
                 .map_err(|e| parse::ParseError::Error(ParseError::InvalidColumns(Box::new(e))))?;
             return Ok((
                 parse::Input::empty(),
@@ -215,7 +209,7 @@ impl<'a> BundleStorage<'a, Unverified> {
                     ops_data: ops_data_range,
                     changes_meta,
                     changes_data: changes_data_range,
-                    id_ctr_values,
+                    id_ctr,
                     _phantom: PhantomData,
                 },
             ));
@@ -233,7 +227,10 @@ impl<'a> BundleStorage<'a, Unverified> {
 
         let mut changes_data_buf = Vec::new();
         let changes_meta = changes_meta_raw
-            .uncompress(&full_bytes[changes_data_range.clone()], &mut changes_data_buf)
+            .uncompress(
+                &full_bytes[changes_data_range.clone()],
+                &mut changes_data_buf,
+            )
             .map_err(|_| parse::ParseError::Error(ParseError::CompressedChangeCols))?;
         changes_meta.write(&mut out);
         let new_changes_start = out.len();
@@ -254,14 +251,14 @@ impl<'a> BundleStorage<'a, Unverified> {
             &out[new_changes_start..new_changes_end],
         )
         .map_err(|e| parse::ParseError::Error(ParseError::InvalidColumns(Box::new(e))))?;
-        let id_ctr_values = extract_id_ctr_values(
+        let id_ctr = extract_id_ctr_values(
             &changes_meta,
             &out[new_changes_start..new_changes_end],
             &ops_meta,
             &out[new_ops_start..new_ops_end],
         )
         .map_err(parse::ParseError::Error)?;
-        OpIterUnverified::try_new(&ops_meta, &out[new_ops_start..new_ops_end], &id_ctr_values)
+        OpIterUnverified::try_new(&ops_meta, &out[new_ops_start..new_ops_end], &id_ctr)
             .map_err(|e| parse::ParseError::Error(ParseError::InvalidColumns(Box::new(e))))?;
 
         Ok((
@@ -276,7 +273,7 @@ impl<'a> BundleStorage<'a, Unverified> {
                 ops_data: new_ops_start..new_ops_end,
                 changes_meta,
                 changes_data: new_changes_start..new_changes_end,
-                id_ctr_values,
+                id_ctr,
                 _phantom: PhantomData,
             },
         ))
@@ -299,14 +296,14 @@ impl<'a> BundleStorage<'a, Unverified> {
             ops_data: self.ops_data,
             changes_meta: self.changes_meta,
             changes_data: self.changes_data,
-            id_ctr_values: self.id_ctr_values,
+            id_ctr: self.id_ctr,
             _phantom: PhantomData,
         })
     }
 
     pub(crate) fn iter_ops(&self) -> OpIterUnverified<'_> {
         let bytes = &self.bytes[self.ops_data.clone()];
-        OpIterUnverified::new(&self.ops_meta, bytes, &self.id_ctr_values)
+        OpIterUnverified::new(&self.ops_meta, bytes, &self.id_ctr)
     }
 
     fn iter_change_meta(&self) -> BundleChangeIterUnverified<'_> {
@@ -330,7 +327,7 @@ impl BundleStorage<'_, Verified> {
 
     pub(crate) fn iter_ops(&self) -> OpIter<'_> {
         let bytes = &self.bytes[self.ops_data.clone()];
-        OpIter::new(&self.ops_meta, bytes, &self.id_ctr_values)
+        OpIter::new(&self.ops_meta, bytes, &self.id_ctr)
     }
 
     pub(crate) fn iter_change_meta(&self) -> BundleChangeIter<'_> {

--- a/rust/automerge/src/storage/bundle/storage.rs
+++ b/rust/automerge/src/storage/bundle/storage.rs
@@ -2,18 +2,35 @@ use std::borrow::Cow;
 use std::marker::PhantomData;
 use std::ops::Range;
 
+use hexane::{ColumnCursor, DeltaCursor};
+
 use crate::op_set2::change::ChangeCollector;
 use crate::storage::change::{OpReadState, Unverified, Verified};
 use crate::storage::columns::compression;
+use crate::storage::columns::{ColumnId, ColumnType};
 use crate::storage::{parse, Header, RawColumns};
 use crate::types::{ActorId, ChangeHash};
 use crate::Change;
 
 use super::{BundleChangeIter, BundleChangeIterUnverified, OpIter, OpIterUnverified, ParseError};
 
+/// `(actor, counter)` order index of the `ID_CTR_INVERSE` column. Must
+/// match the `ID_CTR_INVERSE_COL_ID` constant in `builder.rs`.
+const ID_CTR_INVERSE_COL_ID: ColumnId = ColumnId::new(11);
+
+/// Column id of the legacy doc-order `ID_CTR` column. Bundles produced
+/// before the inverse-encoding switch carry this directly; new bundles
+/// reconstruct it from `ID_CTR_INVERSE`.
+const ID_COL_ID: ColumnId = ColumnId::new(2);
+
 #[derive(Clone, Debug)]
 pub(crate) struct BundleStorage<'a, OpReadState> {
+    /// Uncompressed in-memory form. Iterators index into this.
     pub(crate) bytes: Cow<'a, [u8]>,
+    /// On-disk form, if columns were DEFLATE-compressed. `None` for
+    /// bundles that were written or received in fully-uncompressed form
+    /// (in which case `bytes` is also the on-disk form).
+    pub(crate) compressed_bytes: Option<Cow<'a, [u8]>>,
     pub(crate) header: Header,
     pub(crate) deps: Vec<ChangeHash>,
     pub(crate) actors: Vec<ActorId>,
@@ -21,6 +38,11 @@ pub(crate) struct BundleStorage<'a, OpReadState> {
     pub(crate) ops_data: Range<usize>,
     pub(crate) changes_meta: RawColumns<compression::Uncompressed>,
     pub(crate) changes_data: Range<usize>,
+    /// Op counters in doc order. Materialised at parse time from the
+    /// wire's `ID_CTR_INVERSE` column plus the change metadata, then
+    /// handed to `OpIter` as a plain slice — no columnar encoding round
+    /// trip.
+    pub(crate) id_ctr_values: Vec<i64>,
     pub(crate) _phantom: PhantomData<OpReadState>,
 }
 
@@ -28,6 +50,7 @@ impl<O: OpReadState> BundleStorage<'_, O> {
     pub(crate) fn into_owned(self) -> BundleStorage<'static, O> {
         BundleStorage {
             bytes: Cow::Owned(self.bytes.into_owned()),
+            compressed_bytes: self.compressed_bytes.map(|c| Cow::Owned(c.into_owned())),
             header: self.header,
             deps: self.deps,
             actors: self.actors,
@@ -35,6 +58,7 @@ impl<O: OpReadState> BundleStorage<'_, O> {
             ops_data: self.ops_data,
             changes_meta: self.changes_meta,
             changes_data: self.changes_data,
+            id_ctr_values: self.id_ctr_values,
             _phantom: self._phantom,
         }
     }
@@ -44,43 +68,215 @@ impl<O: OpReadState> BundleStorage<'_, O> {
     }
 }
 
+/// Materialise the doc-order id_ctr values. Accepts bundles in either
+/// the current format (only `ID_CTR_INVERSE` on the wire — reconstructed
+/// here by walking change metadata in canonical `(actor, seq)` order and
+/// applying `inverse[k] = doc_pos`) or the legacy format (an explicit
+/// doc-order `ID_CTR` column — decoded directly). New format takes
+/// precedence if both are somehow present. Returns the counters as a
+/// plain `Vec<i64>` for `OpIter` to read directly — no columnar round
+/// trip.
+fn extract_id_ctr_values(
+    changes_meta: &RawColumns<compression::Uncompressed>,
+    changes_data: &[u8],
+    ops_meta: &RawColumns<compression::Uncompressed>,
+    ops_data: &[u8],
+) -> Result<Vec<i64>, ParseError> {
+    let mut inverse_bytes: Option<&[u8]> = None;
+    let mut id_ctr_bytes: Option<&[u8]> = None;
+    for col in ops_meta.0.iter() {
+        let spec = col.spec();
+        if spec.col_type() != ColumnType::DeltaInteger {
+            continue;
+        }
+        match spec.id() {
+            id if id == ID_CTR_INVERSE_COL_ID => {
+                let d = col.data();
+                inverse_bytes = Some(&ops_data[d.start..d.end]);
+            }
+            id if id == ID_COL_ID => {
+                let d = col.data();
+                id_ctr_bytes = Some(&ops_data[d.start..d.end]);
+            }
+            _ => {}
+        }
+    }
+
+    // New format: reconstruct doc-order counters from the inverse
+    // permutation column.
+    if let Some(inverse_bytes) = inverse_bytes {
+        let inverse: Vec<i64> = decode_delta_int(inverse_bytes)?;
+
+        let mut change_meta: Vec<(usize, u64, u64, u64)> =
+            BundleChangeIterUnverified::try_new(changes_meta, changes_data)?
+                .map(|c| c.map(|c| (c.actor, c.seq, c.start_op, c.max_op)))
+                .collect::<Result<_, _>>()?;
+        change_meta.sort_unstable_by_key(|(actor, seq, _, _)| (*actor, *seq));
+
+        let mut counters = vec![0i64; inverse.len()];
+        let mut k = 0usize;
+        for (_actor, _seq, start_op, max_op) in &change_meta {
+            for ctr in *start_op..=*max_op {
+                if k >= inverse.len() {
+                    return Err(ParseError::InverseLengthMismatch);
+                }
+                let doc_pos = inverse[k] as usize;
+                if doc_pos >= counters.len() {
+                    return Err(ParseError::InverseDecode);
+                }
+                counters[doc_pos] = ctr as i64;
+                k += 1;
+            }
+        }
+        if k != inverse.len() {
+            return Err(ParseError::InverseLengthMismatch);
+        }
+        return Ok(counters);
+    }
+
+    // Legacy format: decode the explicit doc-order id_ctr column.
+    if let Some(id_ctr_bytes) = id_ctr_bytes {
+        return decode_delta_int(id_ctr_bytes);
+    }
+
+    // Empty bundle (no ops) — both columns absent.
+    Ok(Vec::new())
+}
+
+fn decode_delta_int(bytes: &[u8]) -> Result<Vec<i64>, ParseError> {
+    DeltaCursor::iter(bytes)
+        .map(|item| {
+            let cow = item
+                .map_err(|_| ParseError::InverseDecode)?
+                .ok_or(ParseError::InverseDecode)?;
+            Ok::<i64, ParseError>(*cow)
+        })
+        .collect()
+}
+
 impl<'a> BundleStorage<'a, Unverified> {
     pub(crate) fn parse_following_header(
         input: parse::Input<'a>,
         header: Header,
     ) -> parse::ParseResult<'a, BundleStorage<'a, Unverified>, ParseError> {
-        let (i, deps) = parse::length_prefixed(parse::change_hash)(input)?;
-        let (i, actors) = parse::length_prefixed(parse::actor_id)(i)?;
+        // `input.bytes()` returns the full chunk (header + body); positions
+        // tracked by the parser are absolute offsets within that buffer.
+        let full_bytes = input.bytes();
 
-        let (i, changes_meta) = RawColumns::parse(i)?;
+        // Parse the prefix (deps + actors), capturing its byte range so we
+        // know where the change-column metadata begins.
+        let (i, prefix_r) = parse::range_of(
+            |i| -> parse::ParseResult<'_, _, ParseError> {
+                let (i, deps) = parse::length_prefixed(parse::change_hash)(i)?;
+                let (i, actors) = parse::length_prefixed(parse::actor_id)(i)?;
+                Ok((i, (deps, actors)))
+            },
+            input,
+        )?;
+        let (deps, actors) = prefix_r.value;
+        let prefix_end = prefix_r.range.end;
+
+        // Change column metadata + data.
+        let (i, changes_meta_raw) = RawColumns::parse(i)?;
         let (i, changes) =
-            parse::range_of(|i| parse::take_n(changes_meta.total_column_len(), i), i)?;
-        let changes_meta = changes_meta
-            .uncompressed()
-            .ok_or(parse::ParseError::Error(ParseError::CompressedChangeCols))?;
-        // this validates that the iterator can be created
-        BundleChangeIterUnverified::try_new(&changes_meta, changes.value)
-            .map_err(|e| parse::ParseError::Error(ParseError::InvalidColumns(Box::new(e))))?;
+            parse::range_of(|i| parse::take_n(changes_meta_raw.total_column_len(), i), i)?;
+        let changes_data_range = changes.range.clone();
 
-        let (i, ops_meta) = RawColumns::parse(i)?;
-        let ops_meta = ops_meta
-            .uncompressed()
-            .ok_or(parse::ParseError::Error(ParseError::CompressedOpCols))?;
-        let (_, ops) = parse::range_of(|i| parse::take_n(ops_meta.total_column_len(), i), i)?;
-        OpIterUnverified::try_new(&ops_meta, ops.value)
+        // Op column metadata + data.
+        let (i, ops_meta_raw) = RawColumns::parse(i)?;
+        let (_, ops) = parse::range_of(|i| parse::take_n(ops_meta_raw.total_column_len(), i), i)?;
+        let ops_data_range = ops.range.clone();
+
+        // Fast path: nothing is compressed — keep input bytes as-is.
+        if let (Some(changes_meta), Some(ops_meta)) = (
+            changes_meta_raw.uncompressed(),
+            ops_meta_raw.uncompressed(),
+        ) {
+            BundleChangeIterUnverified::try_new(&changes_meta, changes.value)
+                .map_err(|e| parse::ParseError::Error(ParseError::InvalidColumns(Box::new(e))))?;
+            let id_ctr_values = extract_id_ctr_values(
+                &changes_meta,
+                changes.value,
+                &ops_meta,
+                ops.value,
+            )
+            .map_err(parse::ParseError::Error)?;
+            OpIterUnverified::try_new(&ops_meta, ops.value, &id_ctr_values)
+                .map_err(|e| parse::ParseError::Error(ParseError::InvalidColumns(Box::new(e))))?;
+            return Ok((
+                parse::Input::empty(),
+                BundleStorage {
+                    bytes: full_bytes.into(),
+                    compressed_bytes: None,
+                    header,
+                    deps,
+                    actors,
+                    ops_meta,
+                    ops_data: ops_data_range,
+                    changes_meta,
+                    changes_data: changes_data_range,
+                    id_ctr_values,
+                    _phantom: PhantomData,
+                },
+            ));
+        }
+
+        // Slow path: at least one column is DEFLATE-encoded. Reconstruct a
+        // fully-uncompressed buffer with the same section layout:
+        //   header | deps | actors | change_meta' | change_data' | ops_meta' | ops_data'
+        // where the primed sections use uncompressed column specs and
+        // inflated data. The header bytes inside `out` are preserved
+        // verbatim — they only matter for re-emission, and we keep the
+        // compressed input around for that.
+        let mut out = Vec::with_capacity(full_bytes.len());
+        out.extend_from_slice(&full_bytes[..prefix_end]);
+
+        let mut changes_data_buf = Vec::new();
+        let changes_meta = changes_meta_raw
+            .uncompress(&full_bytes[changes_data_range.clone()], &mut changes_data_buf)
+            .map_err(|_| parse::ParseError::Error(ParseError::CompressedChangeCols))?;
+        changes_meta.write(&mut out);
+        let new_changes_start = out.len();
+        out.extend_from_slice(&changes_data_buf);
+        let new_changes_end = out.len();
+
+        let mut ops_data_buf = Vec::new();
+        let ops_meta = ops_meta_raw
+            .uncompress(&full_bytes[ops_data_range.clone()], &mut ops_data_buf)
+            .map_err(|_| parse::ParseError::Error(ParseError::CompressedOpCols))?;
+        ops_meta.write(&mut out);
+        let new_ops_start = out.len();
+        out.extend_from_slice(&ops_data_buf);
+        let new_ops_end = out.len();
+
+        BundleChangeIterUnverified::try_new(
+            &changes_meta,
+            &out[new_changes_start..new_changes_end],
+        )
+        .map_err(|e| parse::ParseError::Error(ParseError::InvalidColumns(Box::new(e))))?;
+        let id_ctr_values = extract_id_ctr_values(
+            &changes_meta,
+            &out[new_changes_start..new_changes_end],
+            &ops_meta,
+            &out[new_ops_start..new_ops_end],
+        )
+        .map_err(parse::ParseError::Error)?;
+        OpIterUnverified::try_new(&ops_meta, &out[new_ops_start..new_ops_end], &id_ctr_values)
             .map_err(|e| parse::ParseError::Error(ParseError::InvalidColumns(Box::new(e))))?;
 
         Ok((
             parse::Input::empty(),
             BundleStorage {
-                bytes: input.bytes().into(),
+                bytes: Cow::Owned(out),
+                compressed_bytes: Some(full_bytes.into()),
                 header,
                 deps,
                 actors,
                 ops_meta,
-                ops_data: ops.range,
+                ops_data: new_ops_start..new_ops_end,
                 changes_meta,
-                changes_data: changes.range,
+                changes_data: new_changes_start..new_changes_end,
+                id_ctr_values,
                 _phantom: PhantomData,
             },
         ))
@@ -95,6 +291,7 @@ impl<'a> BundleStorage<'a, Unverified> {
         }
         Ok(BundleStorage {
             bytes: self.bytes,
+            compressed_bytes: self.compressed_bytes,
             header: self.header,
             deps: self.deps,
             actors: self.actors,
@@ -102,13 +299,14 @@ impl<'a> BundleStorage<'a, Unverified> {
             ops_data: self.ops_data,
             changes_meta: self.changes_meta,
             changes_data: self.changes_data,
+            id_ctr_values: self.id_ctr_values,
             _phantom: PhantomData,
         })
     }
 
     pub(crate) fn iter_ops(&self) -> OpIterUnverified<'_> {
         let bytes = &self.bytes[self.ops_data.clone()];
-        OpIterUnverified::new(&self.ops_meta, bytes)
+        OpIterUnverified::new(&self.ops_meta, bytes, &self.id_ctr_values)
     }
 
     fn iter_change_meta(&self) -> BundleChangeIterUnverified<'_> {
@@ -132,7 +330,7 @@ impl BundleStorage<'_, Verified> {
 
     pub(crate) fn iter_ops(&self) -> OpIter<'_> {
         let bytes = &self.bytes[self.ops_data.clone()];
-        OpIter::new(&self.ops_meta, bytes)
+        OpIter::new(&self.ops_meta, bytes, &self.id_ctr_values)
     }
 
     pub(crate) fn iter_change_meta(&self) -> BundleChangeIter<'_> {

--- a/rust/automerge/src/types.rs
+++ b/rust/automerge/src/types.rs
@@ -676,6 +676,10 @@ impl ChangeHash {
     pub(crate) fn checksum(&self) -> [u8; 4] {
         [self.0[0], self.0[1], self.0[2], self.0[3]]
     }
+
+    pub(crate) fn fragment_level(&self) -> usize {
+        self.0.iter().rev().take_while(|&&b| b == 0).count()
+    }
 }
 
 impl AsRef<[u8]> for ChangeHash {

--- a/rust/automerge/src/types.rs
+++ b/rust/automerge/src/types.rs
@@ -678,7 +678,7 @@ impl ChangeHash {
     }
 
     pub(crate) fn fragment_level(&self) -> usize {
-        self.0.iter().rev().take_while(|&&b| b == 0).count()
+        self.0.iter().take_while(|&&b| b == 0).count()
     }
 }
 


### PR DESCRIPTION
experimental fragments function where automerge tracks fragments incrementally as the document is loaded and manipulated.

Using SeqClock's internally to quickly calculate set membership for fragments.  Not 100% sure if this is to spec but its a frist pass.  Performance cost to load was less than 1% of load time. 

thanks to Cladue for the tests.
