### PR TITLE
Stop panicking on ChangeCollector MissingOps

### DIFF
--- a/rust/automerge/examples/test_missing_ops.rs
+++ b/rust/automerge/examples/test_missing_ops.rs
@@ -1,0 +1,474 @@
+// Attempt to reproduce the MissingOps panic in automerge's change collector.
+//
+// The panic occurs at collector.rs:761 when from_build_meta_inner calls
+// finish() on a VecEncoder that has gaps (None slots) in its op sequence.
+//
+// Key hypothesis: character-by-character splice_text from one actor,
+// interleaved with fork+merge from another actor, with
+// generate_sync_message calls in between, triggers the bug.
+
+use automerge::{
+    sync, sync::SyncDoc, ActorId, AutoCommit, ObjType, ReadDoc, ROOT,
+    transaction::Transactable,
+};
+
+fn main() {
+    println!("=== Test 1: Per-char splices + fork+merge + sync ===");
+    test_char_splices_with_fork_merge_sync();
+
+    println!("=== Test 2: Per-char from WASM peer + daemon fork+merge + 2-peer sync ===");
+    test_wasm_typing_with_daemon_fork_merge();
+
+    println!("=== Test 3: Interleaved per-char + fork_at(save_heads) + merge ===");
+    test_interleaved_typing_fork_at();
+
+    println!("=== Test 4: Many actors, per-char, partial sync ===");
+    test_many_actors_partial_sync();
+
+    println!("=== Test 5: Rapid fork+merge during active sync ===");
+    test_fork_merge_during_sync();
+
+    println!("=== Test 6: Per-char typing + execution outputs + sync ===");
+    test_typing_outputs_sync();
+
+    println!("=== Test 7: Character deletion interleaved with fork+merge ===");
+    test_deletion_with_fork_merge();
+
+    println!("=== Test 8: Stress: 1000 char splices + fork_at + merge + sync ===");
+    test_stress_splices_fork_sync();
+
+    println!("All tests passed without panic");
+}
+
+/// Simulate: frontend types char-by-char, daemon forks+merges for each
+/// output write, generate_sync_message after each cycle.
+fn test_char_splices_with_fork_merge_sync() {
+    let mut doc = AutoCommit::new();
+    doc.set_actor(ActorId::from(b"daemon" as &[u8]));
+
+    let text = doc.put_object(ROOT, "source", ObjType::Text).unwrap();
+    doc.commit();
+
+    let mut peer_state = sync::State::new();
+
+    // Simulate 100 cycles of: frontend types a char, daemon forks+merges
+    for i in 0..100 {
+        // Frontend char (simulated on same doc, different actor temporarily)
+        let saved_actor = doc.get_actor().clone();
+        doc.set_actor(ActorId::from(b"frontend" as &[u8]));
+        doc.splice_text(&text, i, 0, &format!("{}", (b'a' + (i % 26) as u8) as char)).unwrap();
+        doc.commit();
+        doc.set_actor(saved_actor);
+
+        // Daemon fork+merge (output write)
+        let mut fork = doc.fork();
+        fork.set_actor(ActorId::from(format!("daemon:fork-{}", i).as_bytes()));
+        fork.put(ROOT, "output_hash", format!("hash-{}", i)).unwrap();
+        fork.commit();
+        doc.merge(&mut fork).unwrap();
+
+        // Generate sync message
+        let _msg = doc.sync().generate_sync_message(&mut peer_state);
+    }
+
+    println!("  PASS");
+}
+
+/// Two separate documents syncing: WASM peer types char-by-char,
+/// daemon does fork+merge, sync after each round.
+fn test_wasm_typing_with_daemon_fork_merge() {
+    let mut daemon = AutoCommit::new();
+    daemon.set_actor(ActorId::from(b"daemon" as &[u8]));
+
+    let text = daemon.put_object(ROOT, "source", ObjType::Text).unwrap();
+    daemon.commit();
+
+    let mut wasm = AutoCommit::new();
+    wasm.set_actor(ActorId::from(b"wasm-frontend" as &[u8]));
+
+    let mut sw = sync::State::new();
+    let mut sd = sync::State::new();
+
+    // Initial sync
+    sync_docs(&mut daemon, &mut sd, &mut wasm, &mut sw);
+
+    // 200 rounds of typing + daemon fork+merge + sync
+    for i in 0..200 {
+        // WASM types one character
+        wasm.splice_text(&text, i, 0, &format!("{}", (b'a' + (i % 26) as u8) as char)).unwrap();
+        wasm.commit();
+
+        // Sync wasm -> daemon (one round)
+        sync_one(&mut wasm, &mut sw, &mut daemon, &mut sd);
+
+        // Daemon fork+merge (simulating output write or format)
+        let mut fork = daemon.fork();
+        fork.set_actor(ActorId::from(format!("daemon:op-{}", i).as_bytes()));
+        fork.put(ROOT, &format!("key_{}", i % 10), i as i64).unwrap();
+        fork.commit();
+        daemon.merge(&mut fork).unwrap();
+
+        // Sync daemon -> wasm
+        sync_one(&mut daemon, &mut sd, &mut wasm, &mut sw);
+    }
+
+    println!("  PASS");
+}
+
+/// Interleave per-char typing with fork_at(save_heads) + merge.
+/// This is the exact pattern from our file watcher.
+fn test_interleaved_typing_fork_at() {
+    let mut daemon = AutoCommit::new();
+    daemon.set_actor(ActorId::from(b"daemon" as &[u8]));
+
+    let text = daemon.put_object(ROOT, "source", ObjType::Text).unwrap();
+    daemon.splice_text(&text, 0, 0, "initial content").unwrap();
+    daemon.commit();
+
+    let save_heads = daemon.get_heads();
+
+    let mut wasm = AutoCommit::new();
+    wasm.set_actor(ActorId::from(b"wasm" as &[u8]));
+
+    let mut sw = sync::State::new();
+    let mut sd = sync::State::new();
+    sync_docs(&mut daemon, &mut sd, &mut wasm, &mut sw);
+
+    // WASM types 50 characters (each is a separate change)
+    for i in 0..50 {
+        let pos = 15 + i; // after "initial content"
+        wasm.splice_text(&text, pos, 0, &format!("{}", i % 10)).unwrap();
+        wasm.commit();
+
+        // Partial sync every 5 chars
+        if i % 5 == 0 {
+            sync_one(&mut wasm, &mut sw, &mut daemon, &mut sd);
+        }
+    }
+
+    // Full sync
+    sync_docs(&mut wasm, &mut sw, &mut daemon, &mut sd);
+
+    // Daemon does fork_at(save_heads) + merge — file watcher pattern
+    match daemon.fork_at(&save_heads) {
+        Ok(mut file_fork) => {
+            file_fork.set_actor(ActorId::from(b"filesystem" as &[u8]));
+            let len = file_fork.text(&text).unwrap().len() as isize;
+            file_fork.splice_text(&text, 0, len, "disk content replaces everything").unwrap();
+            file_fork.commit();
+            daemon.merge(&mut file_fork).unwrap();
+        }
+        Err(e) => println!("  fork_at failed: {}", e),
+    }
+
+    // Now generate sync message — crash point in production
+    let _msg = daemon.sync().generate_sync_message(&mut sd);
+
+    println!("  PASS");
+}
+
+/// Many actors: daemon, 3 WASM peers, each typing chars, all syncing
+/// through the daemon hub.
+fn test_many_actors_partial_sync() {
+    let mut daemon = AutoCommit::new();
+    daemon.set_actor(ActorId::from(b"daemon" as &[u8]));
+
+    let text = daemon.put_object(ROOT, "source", ObjType::Text).unwrap();
+    daemon.commit();
+
+    let mut peers: Vec<(AutoCommit, sync::State, sync::State)> = (0..3)
+        .map(|i| {
+            let mut p = AutoCommit::new();
+            p.set_actor(ActorId::from(format!("peer-{}", i).as_bytes()));
+            (p, sync::State::new(), sync::State::new())
+        })
+        .collect();
+
+    // Initial sync all peers
+    for (peer, sp, sd) in &mut peers {
+        sync_docs(&mut daemon, sd, peer, sp);
+    }
+
+    // 100 rounds: each peer types a char, sync to daemon, daemon syncs to others
+    for round in 0..100 {
+        let peer_idx = round % 3;
+
+        // This peer types
+        let pos = daemon.text(&text).unwrap().len();
+        let (peer, sp, sd) = &mut peers[peer_idx];
+        let ch = format!("{}", (b'A' + (round % 26) as u8) as char);
+        peer.splice_text(&text, pos, 0, &ch).unwrap();
+        peer.commit();
+
+        // Sync typing peer -> daemon
+        sync_one(peer, sp, &mut daemon, sd);
+
+        // Daemon writes kernel status
+        if round % 3 == 0 {
+            let mut fork = daemon.fork();
+            fork.set_actor(ActorId::from(b"daemon:status" as &[u8]));
+            fork.put(ROOT, "status", if round % 6 == 0 { "idle" } else { "busy" }).unwrap();
+            fork.commit();
+            daemon.merge(&mut fork).unwrap();
+        }
+
+        // Sync daemon -> other peers
+        for (j, (peer, sp, sd)) in peers.iter_mut().enumerate() {
+            if j != peer_idx {
+                sync_one(&mut daemon, sd, peer, sp);
+            }
+        }
+    }
+
+    println!("  PASS");
+}
+
+/// Rapid fork+merge operations while sync is actively exchanging messages.
+fn test_fork_merge_during_sync() {
+    let mut daemon = AutoCommit::new();
+    daemon.set_actor(ActorId::from(b"daemon" as &[u8]));
+
+    let text = daemon.put_object(ROOT, "source", ObjType::Text).unwrap();
+    daemon.splice_text(&text, 0, 0, "hello world").unwrap();
+    daemon.commit();
+
+    let mut peer = AutoCommit::new();
+    peer.set_actor(ActorId::from(b"peer" as &[u8]));
+    let mut sp = sync::State::new();
+    let mut sd = sync::State::new();
+    sync_docs(&mut daemon, &mut sd, &mut peer, &mut sp);
+
+    // 50 rounds: peer types, partial sync, daemon fork+merge, partial sync
+    for i in 0..50 {
+        // Peer types
+        let len = peer.text(&text).unwrap().len();
+        peer.splice_text(&text, len, 0, &format!("{}", i % 10)).unwrap();
+        peer.commit();
+
+        // Partial sync (just one direction)
+        if let Some(msg) = peer.sync().generate_sync_message(&mut sp) {
+            daemon.sync().receive_sync_message(&mut sd, msg).unwrap();
+        }
+
+        // Daemon fork+merge (before responding with sync)
+        let mut fork = daemon.fork();
+        fork.set_actor(ActorId::from(format!("daemon:f{}", i).as_bytes()));
+        fork.put(ROOT, "out", format!("{}", i)).unwrap();
+        fork.commit();
+        daemon.merge(&mut fork).unwrap();
+
+        // Now daemon responds
+        if let Some(msg) = daemon.sync().generate_sync_message(&mut sd) {
+            peer.sync().receive_sync_message(&mut sp, msg).unwrap();
+        }
+    }
+
+    println!("  PASS");
+}
+
+/// Simulate typing + execution outputs interleaved.
+/// Each execution: daemon forks, writes output hash, merges back.
+/// Meanwhile peer keeps typing.
+fn test_typing_outputs_sync() {
+    let mut daemon = AutoCommit::new();
+    daemon.set_actor(ActorId::from(b"daemon" as &[u8]));
+
+    let text = daemon.put_object(ROOT, "source", ObjType::Text).unwrap();
+    let outputs = daemon.put_object(ROOT, "outputs", ObjType::Map).unwrap();
+    daemon.commit();
+
+    let mut peer = AutoCommit::new();
+    peer.set_actor(ActorId::from(b"frontend" as &[u8]));
+    let mut sp = sync::State::new();
+    let mut sd = sync::State::new();
+    sync_docs(&mut daemon, &mut sd, &mut peer, &mut sp);
+
+    for i in 0..100 {
+        // Peer types 3 chars rapidly
+        for j in 0..3 {
+            let pos = peer.text(&text).unwrap().len();
+            peer.splice_text(&text, pos, 0, &format!("{}", (i * 3 + j) % 10)).unwrap();
+        }
+        peer.commit();
+
+        // Sync peer -> daemon
+        sync_one(&mut peer, &mut sp, &mut daemon, &mut sd);
+
+        // Daemon writes output (fork+merge)
+        let mut fork = daemon.fork();
+        fork.set_actor(ActorId::from(b"daemon:output" as &[u8]));
+        fork.put(&outputs, &format!("cell_{}", i % 5), format!("result_{}", i)).unwrap();
+        fork.commit();
+        daemon.merge(&mut fork).unwrap();
+
+        // Sync daemon -> peer
+        sync_one(&mut daemon, &mut sd, &mut peer, &mut sp);
+    }
+
+    // Final: get_changes from various points
+    let heads = daemon.get_heads();
+    let _changes = daemon.get_changes(&[]);
+    let _changes = daemon.get_changes(&heads);
+
+    println!("  PASS");
+}
+
+/// Character DELETION interleaved with fork+merge.
+/// Deletions create tombstones — these might cause iter_ctr_range gaps.
+fn test_deletion_with_fork_merge() {
+    let mut daemon = AutoCommit::new();
+    daemon.set_actor(ActorId::from(b"daemon" as &[u8]));
+
+    let text = daemon.put_object(ROOT, "source", ObjType::Text).unwrap();
+
+    // Type 200 characters
+    for i in 0..200 {
+        daemon.splice_text(&text, i, 0, &format!("{}", i % 10)).unwrap();
+    }
+    daemon.commit();
+
+    let mid_heads = daemon.get_heads();
+
+    let mut peer = AutoCommit::new();
+    peer.set_actor(ActorId::from(b"peer" as &[u8]));
+    let mut sp = sync::State::new();
+    let mut sd = sync::State::new();
+    sync_docs(&mut daemon, &mut sd, &mut peer, &mut sp);
+
+    // Peer deletes characters one by one (creates tombstones)
+    for i in (0..100).rev() {
+        peer.splice_text(&text, i, 1, "").unwrap();
+        peer.commit();
+
+        // Sync every 10 deletions
+        if i % 10 == 0 {
+            sync_one(&mut peer, &mut sp, &mut daemon, &mut sd);
+
+            // Daemon fork+merge during the deletion
+            let mut fork = daemon.fork();
+            fork.set_actor(ActorId::from(format!("daemon:del-{}", i).as_bytes()));
+            fork.put(ROOT, "marker", format!("del-{}", i)).unwrap();
+            fork.commit();
+            daemon.merge(&mut fork).unwrap();
+        }
+    }
+
+    // Full sync
+    sync_docs(&mut peer, &mut sp, &mut daemon, &mut sd);
+
+    // fork_at mid-point (before deletions)
+    match daemon.fork_at(&mid_heads) {
+        Ok(_) => {}
+        Err(e) => println!("  fork_at failed (expected?): {}", e),
+    }
+
+    // generate_sync_message
+    let _msg = daemon.sync().generate_sync_message(&mut sd);
+
+    println!("  PASS");
+}
+
+/// Stress test: 1000 per-char splices from peer, interleaved with
+/// fork_at(historical) + merge + sync on daemon.
+fn test_stress_splices_fork_sync() {
+    let mut daemon = AutoCommit::new();
+    daemon.set_actor(ActorId::from(b"daemon" as &[u8]));
+
+    let text = daemon.put_object(ROOT, "source", ObjType::Text).unwrap();
+    daemon.splice_text(&text, 0, 0, "# notebook cell\n").unwrap();
+    daemon.commit();
+
+    let initial_heads = daemon.get_heads();
+
+    let mut peer = AutoCommit::new();
+    peer.set_actor(ActorId::from(b"wasm" as &[u8]));
+    let mut sp = sync::State::new();
+    let mut sd = sync::State::new();
+    sync_docs(&mut daemon, &mut sd, &mut peer, &mut sp);
+
+    let mut checkpoint_heads = vec![initial_heads.clone()];
+
+    for i in 0..1000 {
+        // Peer types one character
+        let pos = peer.text(&text).unwrap().len();
+        peer.splice_text(&text, pos, 0, &format!("{}", (b'a' + (i % 26) as u8) as char)).unwrap();
+        peer.commit();
+
+        // Sync every 10 chars
+        if i % 10 == 0 {
+            sync_one(&mut peer, &mut sp, &mut daemon, &mut sd);
+
+            // Daemon fork+merge
+            let mut fork = daemon.fork();
+            fork.set_actor(ActorId::from(format!("d:f{}", i).as_bytes()));
+            fork.put(ROOT, "exec_count", (i / 10) as i64).unwrap();
+            fork.commit();
+            daemon.merge(&mut fork).unwrap();
+
+            sync_one(&mut daemon, &mut sd, &mut peer, &mut sp);
+        }
+
+        // Save checkpoint every 100 chars
+        if i % 100 == 0 && i > 0 {
+            let heads = daemon.get_heads();
+            checkpoint_heads.push(heads);
+        }
+
+        // Every 200 chars, do fork_at from an older checkpoint
+        if i % 200 == 0 && i > 0 {
+            let old_heads = &checkpoint_heads[checkpoint_heads.len() / 2];
+            match daemon.fork_at(old_heads) {
+                Ok(mut fork) => {
+                    fork.set_actor(ActorId::from(b"filesystem" as &[u8]));
+                    fork.put(ROOT, "disk_marker", format!("save-{}", i)).unwrap();
+                    fork.commit();
+                    daemon.merge(&mut fork).unwrap();
+                }
+                Err(e) => println!("  fork_at failed at i={}: {}", i, e),
+            }
+
+            // Generate sync message after fork_at+merge
+            let _msg = daemon.sync().generate_sync_message(&mut sd);
+        }
+    }
+
+    // Final sync
+    sync_docs(&mut peer, &mut sp, &mut daemon, &mut sd);
+
+    // Try get_changes from each checkpoint
+    for heads in &checkpoint_heads {
+        let _changes = daemon.get_changes(heads);
+    }
+
+    println!("  PASS");
+}
+
+fn sync_docs(
+    a: &mut AutoCommit, sa: &mut sync::State,
+    b: &mut AutoCommit, sb: &mut sync::State,
+) {
+    for _ in 0..20 {
+        let mut progressed = false;
+        if let Some(msg) = a.sync().generate_sync_message(sa) {
+            b.sync().receive_sync_message(sb, msg).unwrap();
+            progressed = true;
+        }
+        if let Some(msg) = b.sync().generate_sync_message(sb) {
+            a.sync().receive_sync_message(sa, msg).unwrap();
+            progressed = true;
+        }
+        if !progressed { break; }
+    }
+}
+
+fn sync_one(
+    from: &mut AutoCommit, sf: &mut sync::State,
+    to: &mut AutoCommit, st: &mut sync::State,
+) {
+    if let Some(msg) = from.sync().generate_sync_message(sf) {
+        to.sync().receive_sync_message(st, msg).unwrap();
+    }
+    if let Some(msg) = to.sync().generate_sync_message(st) {
+        from.sync().receive_sync_message(sf, msg).unwrap();
+    }
+}

--- a/rust/automerge/examples/test_missing_ops.rs
+++ b/rust/automerge/examples/test_missing_ops.rs
@@ -8,8 +8,7 @@
 // generate_sync_message calls in between, triggers the bug.
 
 use automerge::{
-    sync, sync::SyncDoc, ActorId, AutoCommit, ObjType, ReadDoc, ROOT,
-    transaction::Transactable,
+    sync, sync::SyncDoc, transaction::Transactable, ActorId, AutoCommit, ObjType, ReadDoc, ROOT,
 };
 
 fn main() {
@@ -56,14 +55,16 @@ fn test_char_splices_with_fork_merge_sync() {
         // Frontend char (simulated on same doc, different actor temporarily)
         let saved_actor = doc.get_actor().clone();
         doc.set_actor(ActorId::from(b"frontend" as &[u8]));
-        doc.splice_text(&text, i, 0, &format!("{}", (b'a' + (i % 26) as u8) as char)).unwrap();
+        doc.splice_text(&text, i, 0, &format!("{}", (b'a' + (i % 26) as u8) as char))
+            .unwrap();
         doc.commit();
         doc.set_actor(saved_actor);
 
         // Daemon fork+merge (output write)
         let mut fork = doc.fork();
         fork.set_actor(ActorId::from(format!("daemon:fork-{}", i).as_bytes()));
-        fork.put(ROOT, "output_hash", format!("hash-{}", i)).unwrap();
+        fork.put(ROOT, "output_hash", format!("hash-{}", i))
+            .unwrap();
         fork.commit();
         doc.merge(&mut fork).unwrap();
 
@@ -95,7 +96,8 @@ fn test_wasm_typing_with_daemon_fork_merge() {
     // 200 rounds of typing + daemon fork+merge + sync
     for i in 0..200 {
         // WASM types one character
-        wasm.splice_text(&text, i, 0, &format!("{}", (b'a' + (i % 26) as u8) as char)).unwrap();
+        wasm.splice_text(&text, i, 0, &format!("{}", (b'a' + (i % 26) as u8) as char))
+            .unwrap();
         wasm.commit();
 
         // Sync wasm -> daemon (one round)
@@ -104,7 +106,8 @@ fn test_wasm_typing_with_daemon_fork_merge() {
         // Daemon fork+merge (simulating output write or format)
         let mut fork = daemon.fork();
         fork.set_actor(ActorId::from(format!("daemon:op-{}", i).as_bytes()));
-        fork.put(ROOT, &format!("key_{}", i % 10), i as i64).unwrap();
+        fork.put(ROOT, &format!("key_{}", i % 10), i as i64)
+            .unwrap();
         fork.commit();
         daemon.merge(&mut fork).unwrap();
 
@@ -137,7 +140,8 @@ fn test_interleaved_typing_fork_at() {
     // WASM types 50 characters (each is a separate change)
     for i in 0..50 {
         let pos = 15 + i; // after "initial content"
-        wasm.splice_text(&text, pos, 0, &format!("{}", i % 10)).unwrap();
+        wasm.splice_text(&text, pos, 0, &format!("{}", i % 10))
+            .unwrap();
         wasm.commit();
 
         // Partial sync every 5 chars
@@ -154,7 +158,9 @@ fn test_interleaved_typing_fork_at() {
         Ok(mut file_fork) => {
             file_fork.set_actor(ActorId::from(b"filesystem" as &[u8]));
             let len = file_fork.text(&text).unwrap().len() as isize;
-            file_fork.splice_text(&text, 0, len, "disk content replaces everything").unwrap();
+            file_fork
+                .splice_text(&text, 0, len, "disk content replaces everything")
+                .unwrap();
             file_fork.commit();
             daemon.merge(&mut file_fork).unwrap();
         }
@@ -207,7 +213,8 @@ fn test_many_actors_partial_sync() {
         if round % 3 == 0 {
             let mut fork = daemon.fork();
             fork.set_actor(ActorId::from(b"daemon:status" as &[u8]));
-            fork.put(ROOT, "status", if round % 6 == 0 { "idle" } else { "busy" }).unwrap();
+            fork.put(ROOT, "status", if round % 6 == 0 { "idle" } else { "busy" })
+                .unwrap();
             fork.commit();
             daemon.merge(&mut fork).unwrap();
         }
@@ -242,7 +249,8 @@ fn test_fork_merge_during_sync() {
     for i in 0..50 {
         // Peer types
         let len = peer.text(&text).unwrap().len();
-        peer.splice_text(&text, len, 0, &format!("{}", i % 10)).unwrap();
+        peer.splice_text(&text, len, 0, &format!("{}", i % 10))
+            .unwrap();
         peer.commit();
 
         // Partial sync (just one direction)
@@ -287,7 +295,8 @@ fn test_typing_outputs_sync() {
         // Peer types 3 chars rapidly
         for j in 0..3 {
             let pos = peer.text(&text).unwrap().len();
-            peer.splice_text(&text, pos, 0, &format!("{}", (i * 3 + j) % 10)).unwrap();
+            peer.splice_text(&text, pos, 0, &format!("{}", (i * 3 + j) % 10))
+                .unwrap();
         }
         peer.commit();
 
@@ -297,7 +306,12 @@ fn test_typing_outputs_sync() {
         // Daemon writes output (fork+merge)
         let mut fork = daemon.fork();
         fork.set_actor(ActorId::from(b"daemon:output" as &[u8]));
-        fork.put(&outputs, &format!("cell_{}", i % 5), format!("result_{}", i)).unwrap();
+        fork.put(
+            &outputs,
+            &format!("cell_{}", i % 5),
+            format!("result_{}", i),
+        )
+        .unwrap();
         fork.commit();
         daemon.merge(&mut fork).unwrap();
 
@@ -323,7 +337,9 @@ fn test_deletion_with_fork_merge() {
 
     // Type 200 characters
     for i in 0..200 {
-        daemon.splice_text(&text, i, 0, &format!("{}", i % 10)).unwrap();
+        daemon
+            .splice_text(&text, i, 0, &format!("{}", i % 10))
+            .unwrap();
     }
     daemon.commit();
 
@@ -375,7 +391,9 @@ fn test_stress_splices_fork_sync() {
     daemon.set_actor(ActorId::from(b"daemon" as &[u8]));
 
     let text = daemon.put_object(ROOT, "source", ObjType::Text).unwrap();
-    daemon.splice_text(&text, 0, 0, "# notebook cell\n").unwrap();
+    daemon
+        .splice_text(&text, 0, 0, "# notebook cell\n")
+        .unwrap();
     daemon.commit();
 
     let initial_heads = daemon.get_heads();
@@ -391,7 +409,13 @@ fn test_stress_splices_fork_sync() {
     for i in 0..1000 {
         // Peer types one character
         let pos = peer.text(&text).unwrap().len();
-        peer.splice_text(&text, pos, 0, &format!("{}", (b'a' + (i % 26) as u8) as char)).unwrap();
+        peer.splice_text(
+            &text,
+            pos,
+            0,
+            &format!("{}", (b'a' + (i % 26) as u8) as char),
+        )
+        .unwrap();
         peer.commit();
 
         // Sync every 10 chars
@@ -420,7 +444,8 @@ fn test_stress_splices_fork_sync() {
             match daemon.fork_at(old_heads) {
                 Ok(mut fork) => {
                     fork.set_actor(ActorId::from(b"filesystem" as &[u8]));
-                    fork.put(ROOT, "disk_marker", format!("save-{}", i)).unwrap();
+                    fork.put(ROOT, "disk_marker", format!("save-{}", i))
+                        .unwrap();
                     fork.commit();
                     daemon.merge(&mut fork).unwrap();
                 }
@@ -443,10 +468,7 @@ fn test_stress_splices_fork_sync() {
     println!("  PASS");
 }
 
-fn sync_docs(
-    a: &mut AutoCommit, sa: &mut sync::State,
-    b: &mut AutoCommit, sb: &mut sync::State,
-) {
+fn sync_docs(a: &mut AutoCommit, sa: &mut sync::State, b: &mut AutoCommit, sb: &mut sync::State) {
     for _ in 0..20 {
         let mut progressed = false;
         if let Some(msg) = a.sync().generate_sync_message(sa) {
@@ -457,13 +479,17 @@ fn sync_docs(
             a.sync().receive_sync_message(sa, msg).unwrap();
             progressed = true;
         }
-        if !progressed { break; }
+        if !progressed {
+            break;
+        }
     }
 }
 
 fn sync_one(
-    from: &mut AutoCommit, sf: &mut sync::State,
-    to: &mut AutoCommit, st: &mut sync::State,
+    from: &mut AutoCommit,
+    sf: &mut sync::State,
+    to: &mut AutoCommit,
+    st: &mut sync::State,
 ) {
     if let Some(msg) = from.sync().generate_sync_message(sf) {
         to.sync().receive_sync_message(st, msg).unwrap();

--- a/rust/automerge/src/error.rs
+++ b/rust/automerge/src/error.rs
@@ -52,6 +52,8 @@ pub enum AutomergeError {
     Load(#[from] LoadError),
     #[error(transparent)]
     LoadChangeError(#[from] LoadChangeError),
+    #[error(transparent)]
+    ChangeCollector(#[from] crate::storage::load::change_collector::Error),
     #[error("increment operations must be against a counter value")]
     MissingCounter,
     #[error("hash {0} does not correspond to a change in this document")]

--- a/rust/automerge/src/op_set2/change/collector.rs
+++ b/rust/automerge/src/op_set2/change/collector.rs
@@ -648,7 +648,10 @@ impl<'a> ChangeCollector<'a> {
         have_deps: &[ChangeHash],
     ) -> Vec<Change> {
         let changes = change_graph.get_build_metadata_clock(have_deps);
+        // Note: This unwrap maintains backward compatibility for the public get_changes() API.
+        // In the future, consider propagating errors through the public API.
         Self::from_build_meta(op_set, change_graph, changes)
+            .expect("Failed to collect changes - this may indicate internal state corruption")
     }
 
     pub(crate) fn exclude_hashes_meta(
@@ -715,15 +718,15 @@ impl<'a> ChangeCollector<'a> {
         I: IntoIterator<Item = ChangeHash>,
     {
         let changes = change_graph.get_build_metadata(hashes)?;
-        Ok(Self::from_build_meta(op_set, change_graph, changes))
+        Ok(Self::from_build_meta(op_set, change_graph, changes)?)
     }
 
     fn from_build_meta(
         op_set: &'a OpSet,
         change_graph: &'a ChangeGraph,
         changes: Vec<BuildChangeMetadata<'a>>,
-    ) -> Vec<Change> {
-        let r1 = Self::from_build_meta_inner(op_set, change_graph, changes.clone());
+    ) -> Result<Vec<Change>, Error> {
+        let r1 = Self::from_build_meta_inner(op_set, change_graph, changes.clone())?;
         debug_assert_eq!(
             r1,
             crate::storage::Bundle::for_hashes(op_set, change_graph, r1.iter().map(|c| c.hash()))
@@ -731,14 +734,14 @@ impl<'a> ChangeCollector<'a> {
                 .to_changes()
                 .unwrap()
         );
-        r1
+        Ok(r1)
     }
 
     fn from_build_meta_inner(
         op_set: &'a OpSet,
         change_graph: &'a ChangeGraph,
         changes: Vec<BuildChangeMetadata<'a>>,
-    ) -> Vec<Change> {
+    ) -> Result<Vec<Change>, Error> {
         let min = changes
             .iter()
             .map(|c| c.start_op as usize)
@@ -758,7 +761,7 @@ impl<'a> ChangeCollector<'a> {
             }
         }
 
-        collector.finish(change_graph).unwrap()
+        collector.finish(change_graph)
     }
 
     pub(crate) fn process_succ(&mut self, op_id: OpId, succ_id: OpId) {

--- a/rust/automerge/src/storage/load/change_collector.rs
+++ b/rust/automerge/src/storage/load/change_collector.rs
@@ -1,5 +1,5 @@
 #[derive(Debug, thiserror::Error)]
-pub(crate) enum Error {
+pub enum Error {
     #[error("a change referenced an actor index we couldn't find")]
     MissingActor,
     #[error("changes out of order")]

--- a/rust/automerge/tests/test.rs
+++ b/rust/automerge/tests/test.rs
@@ -2597,3 +2597,47 @@ fn reproduce_clock_cache_bug() {
 
     assert!(base.get_changes(&heads).is_empty());
 }
+
+#[test]
+fn test_fork_at_merge_sync_no_panic() {
+    // Regression test for issue #1327
+    // Tests that fork_at + merge + sync operations don't panic with MissingOps error
+    let mut doc = new_doc();
+    doc.put(&ROOT, "note", "init").unwrap();
+    let h0 = doc.get_heads();
+
+    let mut branch_a = doc.fork_at(&h0).unwrap();
+    branch_a.put(&ROOT, "title", "A").unwrap();
+    doc.merge(&mut branch_a).unwrap();
+
+    doc.put(&ROOT, "a", "ok").unwrap();
+    let h1 = doc.get_heads();
+
+    // Should return an error rather than panic. The underlying MissingOps
+    // condition is not fixed here; we only require that it surfaces as an
+    // Err instead of crashing the process.
+    let _ = doc.fork_at(&h1);
+
+    // Sync operation should also not panic
+    let mut sync_state = automerge::sync::State::new();
+    let _msg = doc.sync().generate_sync_message(&mut sync_state);
+}
+
+#[test]
+fn test_fork_at_multiple_merges() {
+    // Regression test for issue #1327
+    // Tests that multiple fork_at + merge cycles work correctly
+    let mut doc = new_doc();
+    doc.put(&ROOT, "init", 1).unwrap();
+
+    for i in 0..5 {
+        let heads = doc.get_heads();
+        let mut fork = doc.fork_at(&heads).unwrap();
+        fork.put(&ROOT, format!("key_{}", i), i).unwrap();
+        doc.merge(&mut fork).unwrap();
+    }
+
+    // Should not panic during sync
+    let mut sync_state = automerge::sync::State::new();
+    let _ = doc.sync().generate_sync_message(&mut sync_state);
+}

--- a/rust/automerge/tests/test.rs
+++ b/rust/automerge/tests/test.rs
@@ -2641,3 +2641,91 @@ fn test_fork_at_multiple_merges() {
     let mut sync_state = automerge::sync::State::new();
     let _ = doc.sync().generate_sync_message(&mut sync_state);
 }
+
+#[test]
+fn test_fork_at_historical_heads_after_sync_no_panic() {
+    let mut daemon = AutoCommit::new();
+    daemon.set_actor(ActorId::from(b"daemon" as &[u8]));
+
+    let text = daemon.put_object(ROOT, "source", ObjType::Text).unwrap();
+    daemon
+        .splice_text(&text, 0, 0, "# notebook cell\n")
+        .unwrap();
+    daemon.commit();
+
+    let mut peer = AutoCommit::new();
+    peer.set_actor(ActorId::from(b"wasm" as &[u8]));
+    let mut peer_sync = automerge::sync::State::new();
+    let mut daemon_sync = automerge::sync::State::new();
+    sync_docs_until_quiet(&mut daemon, &mut daemon_sync, &mut peer, &mut peer_sync);
+
+    let mut checkpoint_heads = Vec::new();
+
+    for i in 0..=200 {
+        let pos = peer.text(&text).unwrap().len();
+        peer.splice_text(
+            &text,
+            pos,
+            0,
+            &format!("{}", (b'a' + (i % 26) as u8) as char),
+        )
+        .unwrap();
+        peer.commit();
+
+        if i % 10 == 0 {
+            sync_one_message(&mut peer, &mut peer_sync, &mut daemon, &mut daemon_sync);
+
+            let mut fork = daemon.fork();
+            fork.set_actor(ActorId::from(format!("d:f{}", i).as_bytes()));
+            fork.put(ROOT, "exec_count", (i / 10) as i64).unwrap();
+            fork.commit();
+            daemon.merge(&mut fork).unwrap();
+
+            sync_one_message(&mut daemon, &mut daemon_sync, &mut peer, &mut peer_sync);
+        }
+
+        if i == 100 {
+            checkpoint_heads.push(daemon.get_heads());
+        }
+    }
+
+    let old_heads = checkpoint_heads.pop().unwrap();
+    let fork_result = daemon.fork_at(&old_heads);
+    assert!(fork_result.is_err());
+}
+
+fn sync_docs_until_quiet(
+    left: &mut AutoCommit,
+    left_sync: &mut automerge::sync::State,
+    right: &mut AutoCommit,
+    right_sync: &mut automerge::sync::State,
+) {
+    for _ in 0..20 {
+        let mut progressed = false;
+        if let Some(msg) = left.sync().generate_sync_message(left_sync) {
+            right.sync().receive_sync_message(right_sync, msg).unwrap();
+            progressed = true;
+        }
+        if let Some(msg) = right.sync().generate_sync_message(right_sync) {
+            left.sync().receive_sync_message(left_sync, msg).unwrap();
+            progressed = true;
+        }
+        if !progressed {
+            break;
+        }
+    }
+}
+
+fn sync_one_message(
+    from: &mut AutoCommit,
+    from_sync: &mut automerge::sync::State,
+    to: &mut AutoCommit,
+    to_sync: &mut automerge::sync::State,
+) {
+    if let Some(msg) = from.sync().generate_sync_message(from_sync) {
+        to.sync().receive_sync_message(to_sync, msg).unwrap();
+    }
+    if let Some(msg) = to.sync().generate_sync_message(to_sync) {
+        from.sync().receive_sync_message(from_sync, msg).unwrap();
+    }
+}


### PR DESCRIPTION
Superseded by #1366.

This PR was the first attempt to turn the #1327 `MissingOps` panic into a propagated error. After a smaller current-main reproduction, #1366 now fixes the root cause in `fork_at` dependency traversal instead.

Keeping this open only as history for the panic-propagation approach. Unless maintainers prefer that direction, #1366 is the PR to review.

## Original approach

- Make `from_build_meta_inner()` and `from_build_meta()` return `Result`.
- Propagate collector errors through `for_hashes()`.
- Add a regression test for the `MissingOps` panic.

## Related PRs

- #1366 fixes the root cause.
- #1360 keeps other fallible collector/import paths from panicking.
- #1367 documents the actor-stream invariant that came up while debugging the nteract usage.
