### PR TITLE
Propagate errors from change building, unbundle, and import_obj

### DIFF
--- a/rust/automerge/src/automerge.rs
+++ b/rust/automerge/src/automerge.rs
@@ -1145,7 +1145,10 @@ impl Automerge {
             let counter = s[0..n]
                 .parse()
                 .map_err(|_| AutomergeError::InvalidObjIdFormat(s.to_owned()))?;
-            let actor = ActorId::from(hex::decode(&s[(n + 1)..]).unwrap());
+            let actor = ActorId::from(
+                hex::decode(&s[(n + 1)..])
+                    .map_err(|_| AutomergeError::InvalidObjIdFormat(s.to_owned()))?,
+            );
             let actor = self
                 .ops
                 .lookup_actor(&actor)

--- a/rust/automerge/src/op_set2/change/collector.rs
+++ b/rust/automerge/src/op_set2/change/collector.rs
@@ -208,12 +208,11 @@ impl<'a> OpEncoderStrategy<'a> {
 
         leb128::write::unsigned(&mut data, change.deps.len() as u64).unwrap();
 
-        // FIXME missing value here is changes out of order error
         let deps: Vec<_> = change
             .deps
             .iter()
-            .map(|i| graph.get_hash(*i as usize).unwrap())
-            .collect();
+            .map(|i| graph.get_hash(*i as usize).ok_or(Error::ChangesOutOfOrder))
+            .collect::<Result<_, _>>()?;
 
         for hash in &deps {
             data.write_all(hash.as_bytes()).unwrap();
@@ -870,8 +869,7 @@ impl<'a> ChangeCollector<'a> {
 
             let all_deps = BundleDeps::new(num_changes, &changes, deps);
             let change = self.builders[change.builder]
-                .finish(&change, &all_deps, &mut self.mapper)
-                .unwrap();
+                .finish(&change, &all_deps, &mut self.mapper)?;
 
             changes.push(Change::from(change));
         }

--- a/rust/automerge/src/op_set2/change/collector.rs
+++ b/rust/automerge/src/op_set2/change/collector.rs
@@ -868,8 +868,8 @@ impl<'a> ChangeCollector<'a> {
             }
 
             let all_deps = BundleDeps::new(num_changes, &changes, deps);
-            let change = self.builders[change.builder]
-                .finish(&change, &all_deps, &mut self.mapper)?;
+            let change =
+                self.builders[change.builder].finish(&change, &all_deps, &mut self.mapper)?;
 
             changes.push(Change::from(change));
         }
@@ -963,6 +963,67 @@ pub(crate) struct ChangeCols {
     pub(crate) actor: ActorId,
     pub(crate) other_actors: Vec<ActorId>,
     pub(crate) data: Vec<u8>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn change_with_missing_dep() -> BuildChangeMetadata<'static> {
+        BuildChangeMetadata {
+            actor: 0,
+            seq: 1,
+            max_op: 0,
+            timestamp: 0,
+            message: None,
+            deps: vec![1],
+            extra: Cow::Borrowed(&[]),
+            start_op: 1,
+            builder: 0,
+        }
+    }
+
+    fn change_with_missing_ops() -> BuildChangeMetadata<'static> {
+        BuildChangeMetadata {
+            actor: 0,
+            seq: 1,
+            max_op: 1,
+            timestamp: 0,
+            message: None,
+            deps: Vec::new(),
+            extra: Cow::Borrowed(&[]),
+            start_op: 1,
+            builder: 0,
+        }
+    }
+
+    #[test]
+    fn finish_returns_error_for_missing_dep_index() {
+        let actors = vec![ActorId::from(&[1][..])];
+        let collector = ChangeCollector::from_change_meta(vec![change_with_missing_dep()], &actors);
+        let graph = ChangeGraph::new(actors.len());
+        let err = collector.finish(&graph).unwrap_err();
+
+        assert!(matches!(err, Error::ChangesOutOfOrder));
+    }
+
+    #[test]
+    fn unbundle_returns_error_for_missing_dep_index() {
+        let actors = vec![ActorId::from(&[1][..])];
+        let collector = ChangeCollector::from_change_meta(vec![change_with_missing_dep()], &actors);
+        let err = collector.unbundle(&actors, &[]).unwrap_err();
+
+        assert!(matches!(err, Error::ChangesOutOfOrder));
+    }
+
+    #[test]
+    fn unbundle_returns_error_for_missing_ops() {
+        let actors = vec![ActorId::from(&[1][..])];
+        let collector = ChangeCollector::from_change_meta(vec![change_with_missing_ops()], &actors);
+        let err = collector.unbundle(&actors, &[]).unwrap_err();
+
+        assert!(matches!(err, Error::MissingOps));
+    }
 }
 
 #[cfg(all(feature = "wasm", target_family = "wasm"))]

--- a/rust/automerge/tests/test.rs
+++ b/rust/automerge/tests/test.rs
@@ -2597,3 +2597,15 @@ fn reproduce_clock_cache_bug() {
 
     assert!(base.get_changes(&heads).is_empty());
 }
+
+#[test]
+fn import_obj_with_bad_hex_returns_err_not_panic() {
+    // Regression: import_obj() called hex::decode().unwrap() on the actor
+    // suffix, so any non-hex string after `@` crashed the process.
+    let doc = new_doc();
+    let err = doc.import_obj("1@notvalidhex").unwrap_err();
+    assert!(matches!(
+        err,
+        automerge::AutomergeError::InvalidObjIdFormat(_)
+    ));
+}

--- a/rust/automerge/tests/test.rs
+++ b/rust/automerge/tests/test.rs
@@ -2608,4 +2608,10 @@ fn import_obj_with_bad_hex_returns_err_not_panic() {
         err,
         automerge::AutomergeError::InvalidObjIdFormat(_)
     ));
+
+    let err = doc.import_obj("1@a").unwrap_err();
+    assert!(matches!(
+        err,
+        automerge::AutomergeError::InvalidObjIdFormat(_)
+    ));
 }


### PR DESCRIPTION
This is defensive cleanup for fallible paths that already return `Result`. It is not the root-cause fix for #1327. I ended up handling that in #1366.

## Changes

- `OpEncoderStrategy::finish`: a missing dependency index now returns `Error::ChangesOutOfOrder` instead of panicking.
- `ChangeCollector::unbundle`: `builders[i].finish()` already returns `Result`, so the error is propagated with `?`.
- `Automerge::import_obj`: malformed actor hex now returns `AutomergeError::InvalidObjIdFormat`, matching the counter parse path.

## Tests

- Bad actor hex in `import_obj` returns an error.
- Missing dependency indexes in the collector return `ChangesOutOfOrder`.
- Missing ops in `unbundle` return `MissingOps`.

## Verification

```text
cargo fmt
cargo test -p automerge --manifest-path rust/Cargo.toml
```
