### PR TITLE
automerge-wasm: opt-in panic=unwind build flow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -75,9 +75,11 @@ jobs:
         with:
           # Optional version of wasm-bindgen to install(eg. '0.2.83', 'latest')
           version: "0.2.118"
-      - name: Install wasm32 target
-        working-directory: rust
-        run: rustup target add wasm32-unknown-unknown
+      - name: Install nightly + wasm32 target + rust-src
+        run: |
+          rustup toolchain install nightly --profile minimal
+          rustup component add rust-src --toolchain nightly
+          rustup target add --toolchain nightly wasm32-unknown-unknown
       - name: run tests
         run: ./scripts/ci/wasm_tests
 
@@ -95,9 +97,11 @@ jobs:
         with:
           # Optional version of wasm-bindgen to install(eg. '0.2.83', 'latest')
           version: "0.2.118"
-      - name: Install wasm32 target
-        working-directory: rust
-        run: rustup target add wasm32-unknown-unknown
+      - name: Install nightly + wasm32 target + rust-src
+        run: |
+          rustup toolchain install nightly --profile minimal
+          rustup component add rust-src --toolchain nightly
+          rustup target add --toolchain nightly wasm32-unknown-unknown
       - name: run tests
         run: ./scripts/ci/js_tests
 
@@ -117,9 +121,11 @@ jobs:
         with:
           # Optional version of wasm-bindgen to install(eg. '0.2.83', 'latest')
           version: "0.2.118"
-      - name: Install wasm32 target
-        working-directory: rust
-        run: rustup target add wasm32-unknown-unknown
+      - name: Install nightly + wasm32 target + rust-src
+        run: |
+          rustup toolchain install nightly --profile minimal
+          rustup component add rust-src --toolchain nightly
+          rustup target add --toolchain nightly wasm32-unknown-unknown
       - name: run tests
         run: ./scripts/ci/node_18_packaging_test
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -69,17 +69,21 @@ jobs:
 
   build_wasm:
     runs-on: ubuntu-latest
+    env:
+      # Pinned for reproducible wasm builds; the wasm build needs nightly for
+      # -Zbuild-std (panic=unwind). Bump deliberately when needed.
+      WASM_TOOLCHAIN: nightly-2026-04-25
     steps:
       - uses: actions/checkout@v6
       - uses: jetli/wasm-bindgen-action@v0.2.0
         with:
           # Optional version of wasm-bindgen to install(eg. '0.2.83', 'latest')
           version: "0.2.118"
-      - name: Install nightly + wasm32 target + rust-src
+      - name: Install pinned nightly + wasm32 target + rust-src
         run: |
-          rustup toolchain install nightly --profile minimal
-          rustup component add rust-src --toolchain nightly
-          rustup target add --toolchain nightly wasm32-unknown-unknown
+          rustup toolchain install "$WASM_TOOLCHAIN" --profile minimal
+          rustup component add rust-src --toolchain "$WASM_TOOLCHAIN"
+          rustup target add --toolchain "$WASM_TOOLCHAIN" wasm32-unknown-unknown
       - name: run tests
         run: ./scripts/ci/wasm_tests
 
@@ -87,6 +91,8 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - build_wasm
+    env:
+      WASM_TOOLCHAIN: nightly-2026-04-25
 
     steps:
       - uses: actions/checkout@v6
@@ -97,11 +103,11 @@ jobs:
         with:
           # Optional version of wasm-bindgen to install(eg. '0.2.83', 'latest')
           version: "0.2.118"
-      - name: Install nightly + wasm32 target + rust-src
+      - name: Install pinned nightly + wasm32 target + rust-src
         run: |
-          rustup toolchain install nightly --profile minimal
-          rustup component add rust-src --toolchain nightly
-          rustup target add --toolchain nightly wasm32-unknown-unknown
+          rustup toolchain install "$WASM_TOOLCHAIN" --profile minimal
+          rustup component add rust-src --toolchain "$WASM_TOOLCHAIN"
+          rustup target add --toolchain "$WASM_TOOLCHAIN" wasm32-unknown-unknown
       - name: run tests
         run: ./scripts/ci/js_tests
 
@@ -111,6 +117,8 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - build_wasm
+    env:
+      WASM_TOOLCHAIN: nightly-2026-04-25
 
     steps:
       - uses: actions/checkout@v6
@@ -121,11 +129,11 @@ jobs:
         with:
           # Optional version of wasm-bindgen to install(eg. '0.2.83', 'latest')
           version: "0.2.118"
-      - name: Install nightly + wasm32 target + rust-src
+      - name: Install pinned nightly + wasm32 target + rust-src
         run: |
-          rustup toolchain install nightly --profile minimal
-          rustup component add rust-src --toolchain nightly
-          rustup target add --toolchain nightly wasm32-unknown-unknown
+          rustup toolchain install "$WASM_TOOLCHAIN" --profile minimal
+          rustup component add rust-src --toolchain "$WASM_TOOLCHAIN"
+          rustup target add --toolchain "$WASM_TOOLCHAIN" wasm32-unknown-unknown
       - name: run tests
         run: ./scripts/ci/node_18_packaging_test
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,9 +19,11 @@ jobs:
         with:
           # Optional version of wasm-bindgen to install(eg. '0.2.83', 'latest')
           version: "0.2.118"
-      - name: Install wasm32 target
-        working-directory: rust
-        run: rustup target add wasm32-unknown-unknown
+      - name: Install nightly + wasm32 target + rust-src
+        run: |
+          rustup toolchain install nightly --profile minimal
+          rustup component add rust-src --toolchain nightly
+          rustup target add --toolchain nightly wasm32-unknown-unknown
       - name: npm install
         run: npm install
       - name: build js
@@ -51,9 +53,11 @@ jobs:
           registry-url: "https://registry.npmjs.org"
       - name: Install wasm-bindgen-cli
         run: cargo install wasm-bindgen-cli wasm-opt
-      - name: Install wasm32 target
-        working-directory: rust
-        run: rustup target add wasm32-unknown-unknown
+      - name: Install nightly + wasm32 target + rust-src
+        run: |
+          rustup toolchain install nightly --profile minimal
+          rustup component add rust-src --toolchain nightly
+          rustup target add --toolchain nightly wasm32-unknown-unknown
       - name: npm install
         run: npm install
       - name: build js

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,6 +6,9 @@ on:
 jobs:
   publish-js:
     runs-on: ubuntu-latest
+    env:
+      # Pinned for reproducible wasm builds; bump deliberately when needed.
+      WASM_TOOLCHAIN: nightly-2026-04-25
     defaults:
       run:
         working-directory: ./javascript
@@ -19,11 +22,11 @@ jobs:
         with:
           # Optional version of wasm-bindgen to install(eg. '0.2.83', 'latest')
           version: "0.2.118"
-      - name: Install nightly + wasm32 target + rust-src
+      - name: Install pinned nightly + wasm32 target + rust-src
         run: |
-          rustup toolchain install nightly --profile minimal
-          rustup component add rust-src --toolchain nightly
-          rustup target add --toolchain nightly wasm32-unknown-unknown
+          rustup toolchain install "$WASM_TOOLCHAIN" --profile minimal
+          rustup component add rust-src --toolchain "$WASM_TOOLCHAIN"
+          rustup target add --toolchain "$WASM_TOOLCHAIN" wasm32-unknown-unknown
       - name: npm install
         run: npm install
       - name: build js
@@ -42,6 +45,8 @@ jobs:
   publish-js-docs:
     runs-on: ubuntu-latest
     if: "!github.event.release.prerelease"
+    env:
+      WASM_TOOLCHAIN: nightly-2026-04-25
     defaults:
       run:
         working-directory: ./javascript
@@ -53,11 +58,11 @@ jobs:
           registry-url: "https://registry.npmjs.org"
       - name: Install wasm-bindgen-cli
         run: cargo install wasm-bindgen-cli wasm-opt
-      - name: Install nightly + wasm32 target + rust-src
+      - name: Install pinned nightly + wasm32 target + rust-src
         run: |
-          rustup toolchain install nightly --profile minimal
-          rustup component add rust-src --toolchain nightly
-          rustup target add --toolchain nightly wasm32-unknown-unknown
+          rustup toolchain install "$WASM_TOOLCHAIN" --profile minimal
+          rustup component add rust-src --toolchain "$WASM_TOOLCHAIN"
+          rustup target add --toolchain "$WASM_TOOLCHAIN" wasm32-unknown-unknown
       - name: npm install
         run: npm install
       - name: build js

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ You will also need to install the following with `cargo install`
 - `wasm-opt`
 - `cargo-deny`
 
-And ensure you have added the `wasm32-unknown-unknown` target for rust cross-compilation.
+And ensure you have added the `wasm32-unknown-unknown` target for rust cross-compilation. The wasm build also requires the nightly toolchain and the `rust-src` component (see the macOS instructions below for the exact commands); these are used by `automerge-wasm` and the JS package to build std with `panic=unwind` so panics surface as JS exceptions.
 
 The various subprojects (the rust code, the wrapper projects) have their own
 build instructions, but to run the tests that will be run in CI you can run

--- a/javascript/HACKING.md
+++ b/javascript/HACKING.md
@@ -26,6 +26,15 @@ npm run build
 npm test
 ```
 
+The wasm build requires the nightly Rust toolchain plus the `rust-src`
+component, since we rebuild std with the unwind panic runtime so Rust panics
+surface as JS exceptions instead of aborting the WASM module:
+
+```
+rustup toolchain install nightly
+rustup component add rust-src --toolchain nightly
+```
+
 Any time you change the rust code in `../rust/*` you'll need to re-run the
 `npm run build` command.
 

--- a/javascript/scripts/build.mjs
+++ b/javascript/scripts/build.mjs
@@ -113,12 +113,19 @@ function isStep(stepStr) {
 function buildWasm(outputDir, gitHead) {
   const automergeWasmPath = path.join(rustProjectDir, "automerge-wasm")
   console.log("building automerge-wasm")
+  // Build with the nightly toolchain + panic=unwind so panics in exported
+  // Rust functions surface as `PanicError` exceptions at the JS boundary
+  // (wasm-bindgen 0.2.118+) instead of aborting the WASM module. This requires
+  // a nightly toolchain (for -Zbuild-std) and the `rust-src` rustup component.
+  const wasmRustflags = [process.env.RUSTFLAGS, "-C panic=unwind"]
+    .filter(Boolean)
+    .join(" ")
   execSync(
-    //"cargo build --target wasm32-unknown-unknown --profile dev",
-    "cargo build --target wasm32-unknown-unknown --release",
+    "cargo +nightly build --target wasm32-unknown-unknown --release " +
+      "-Zbuild-std=std,panic_unwind",
     {
       cwd: automergeWasmPath,
-      env: { ...process.env, GIT_HEAD: gitHead },
+      env: { ...process.env, GIT_HEAD: gitHead, RUSTFLAGS: wasmRustflags },
     },
   )
 

--- a/javascript/scripts/build.mjs
+++ b/javascript/scripts/build.mjs
@@ -117,11 +117,13 @@ function buildWasm(outputDir, gitHead) {
   // Rust functions surface as `PanicError` exceptions at the JS boundary
   // (wasm-bindgen 0.2.118+) instead of aborting the WASM module. This requires
   // a nightly toolchain (for -Zbuild-std) and the `rust-src` rustup component.
+  // CI sets WASM_TOOLCHAIN to a pinned dated nightly for reproducible builds.
   const wasmRustflags = [process.env.RUSTFLAGS, "-C panic=unwind"]
     .filter(Boolean)
     .join(" ")
+  const toolchain = process.env.WASM_TOOLCHAIN ?? "nightly"
   execSync(
-    "cargo +nightly build --target wasm32-unknown-unknown --release " +
+    `cargo +${toolchain} build --target wasm32-unknown-unknown --release ` +
       "-Zbuild-std=std,panic_unwind",
     {
       cwd: automergeWasmPath,

--- a/rust/automerge-wasm/Cargo.toml
+++ b/rust/automerge-wasm/Cargo.toml
@@ -20,11 +20,10 @@ crate-type = ["cdylib", "rlib"]
 bench = false
 
 [features]
-# default = ["console_error_panic_hook", "wee_alloc"]
-default = ["console_error_panic_hook"]
+# default = ["wee_alloc"]
+default = []
 
 [dependencies]
-console_error_panic_hook = { version = "^0.1", optional = true }
 # wee_alloc = { version = "^0.4", optional = true }
 automerge = { path = "../automerge", features = ["wasm", "utf16-indexing"] }
 js-sys = "^0.3"

--- a/rust/automerge-wasm/README.md
+++ b/rust/automerge-wasm/README.md
@@ -439,16 +439,29 @@ Object Ids uniquely identify an object within a document.  They are represented 
 
 ### Appendix: Building
 
-  The following steps should allow you to build the package
+The wasm package is built with the nightly toolchain and the `panic=unwind`
+strategy so that Rust panics in exported functions are caught at the JS
+boundary by wasm-bindgen 0.2.118+ and thrown as `PanicError` exceptions
+(async exports reject the returned promise) rather than aborting the WASM
+module. This requires the nightly toolchain (for `-Zbuild-std`) and the
+`rust-src` rustup component.
 
   ```
    $ rustup target add wasm32-unknown-unknown
+   $ rustup toolchain install nightly
+   $ rustup component add rust-src --toolchain nightly
    $ cargo install wasm-bindgen-cli
    $ cargo install wasm-opt
    $ npm install
    $ npm run release
    $ npm pack
   ```
+
+Under the hood `npm run release` invokes
+`cargo +nightly build … -Zbuild-std=std,panic_unwind` with
+`RUSTFLAGS="-C panic=unwind"`. The rest of the workspace still builds with
+the pinned stable toolchain in `rust/rust-toolchain.toml`; the nightly
+toolchain is only used for this wasm build.
 
 ### Appendix: WASM and Memory Allocation
 

--- a/rust/automerge-wasm/package.json
+++ b/rust/automerge-wasm/package.json
@@ -38,7 +38,7 @@
     "release": "cross-env PROFILE=release TARGET_DIR=release npm run buildall",
     "buildall": "cross-env TARGET=nodejs npm run target && cross-env TARGET=bundler npm run target && cross-env TARGET=deno npm run target && TARGET=web npm run target && node -e \"require('fs').cpSync('./src/export-web-wasm.js', './web/index.js')\" && node -e \"require('fs').cpSync('./nodejs/automerge_wasm.d.ts', './index.d.ts')\" && node ./fixup-node-cjs.mjs",
     "target": "rimraf ./$TARGET && npm run compile && npm run bindgen && npm run opt",
-    "compile": "cargo build --target wasm32-unknown-unknown --profile $PROFILE",
+    "compile": "node ./scripts/compile.mjs",
     "bindgen": "wasm-bindgen --omit-default-module-path --weak-refs --typescript --target $TARGET --out-dir $TARGET ../target/wasm32-unknown-unknown/$TARGET_DIR/automerge_wasm.wasm",
     "opt": "echo wasm-opt -O4 $TARGET/automerge_wasm_bg.wasm -o $TARGET/automerge_wasm_bg.wasm",
     "test": "tsc --noEmit && mocha --loader=ts-node/esm test/**/*.mts"

--- a/rust/automerge-wasm/scripts/compile.mjs
+++ b/rust/automerge-wasm/scripts/compile.mjs
@@ -1,0 +1,35 @@
+// Runs `cargo build` for the wasm target with the panic=unwind strategy so
+// that Rust panics are caught at the JS boundary by wasm-bindgen and thrown as
+// `PanicError` exceptions instead of aborting the WASM module.
+//
+// This requires the nightly toolchain (for -Zbuild-std) and the rust-src
+// rustup component. The nightly toolchain is selected here via rustup's
+// "+toolchain" argument so the workspace's pinned stable toolchain (see
+// rust/rust-toolchain.toml) is left untouched for everything else.
+
+import { spawnSync } from "node:child_process"
+
+const profile = process.env.PROFILE ?? "dev"
+
+const args = [
+  "+nightly",
+  "build",
+  "--target",
+  "wasm32-unknown-unknown",
+  "--profile",
+  profile,
+  // Rebuild std with the unwind panic runtime (only available on nightly).
+  "-Zbuild-std=std,panic_unwind",
+]
+
+// Compose RUSTFLAGS, preserving any the user already set.
+const env = { ...process.env }
+const extra = "-C panic=unwind"
+env.RUSTFLAGS = env.RUSTFLAGS ? `${env.RUSTFLAGS} ${extra}` : extra
+
+const result = spawnSync("cargo", args, { stdio: "inherit", env })
+if (result.error) {
+  console.error(result.error)
+  process.exit(1)
+}
+process.exit(result.status ?? 1)

--- a/rust/automerge-wasm/scripts/compile.mjs
+++ b/rust/automerge-wasm/scripts/compile.mjs
@@ -6,13 +6,18 @@
 // rustup component. The nightly toolchain is selected here via rustup's
 // "+toolchain" argument so the workspace's pinned stable toolchain (see
 // rust/rust-toolchain.toml) is left untouched for everything else.
+//
+// CI overrides WASM_TOOLCHAIN with a pinned dated nightly (e.g.
+// `nightly-2026-04-25`) for reproducible builds. Local dev defaults to
+// `nightly`.
 
 import { spawnSync } from "node:child_process"
 
 const profile = process.env.PROFILE ?? "dev"
+const toolchain = process.env.WASM_TOOLCHAIN ?? "nightly"
 
 const args = [
-  "+nightly",
+  `+${toolchain}`,
   "build",
   "--target",
   "wasm32-unknown-unknown",

--- a/rust/automerge-wasm/src/lib.rs
+++ b/rust/automerge-wasm/src/lib.rs
@@ -1708,6 +1708,26 @@ impl Automerge {
     }
 }
 
+// Runs once at module instantiation (wasm-bindgen's `start` function). We
+// install a console-logging hook for hard aborts (instance termination) so
+// that even when wasm traps and the module is permanently torn down, the
+// failure is visible in the console rather than just surfacing as the
+// generic "Module terminated" error on every subsequent export call.
+//
+// Recoverable Rust panics still go through `console_error_panic_hook` (set
+// in `create` below) and surface as `PanicError` exceptions at the JS
+// boundary thanks to the `panic=unwind` build.
+#[wasm_bindgen(start)]
+fn on_start() {
+    fn log_abort() {
+        web_sys::console::error_1(
+            &"automerge-wasm: WASM instance aborted; subsequent calls will throw \"Module terminated\""
+                .into(),
+        );
+    }
+    let _ = wasm_bindgen::__rt::set_on_abort(log_abort);
+}
+
 // skip_typescript as the definition requires an optional argument so we define
 // the function in the typescript custom section at the top of the file
 #[wasm_bindgen(js_name = create, skip_typescript)]

--- a/rust/automerge-wasm/src/lib.rs
+++ b/rust/automerge-wasm/src/lib.rs
@@ -1714,9 +1714,10 @@ impl Automerge {
 // failure is visible in the console rather than just surfacing as the
 // generic "Module terminated" error on every subsequent export call.
 //
-// Recoverable Rust panics still go through `console_error_panic_hook` (set
-// in `create` below) and surface as `PanicError` exceptions at the JS
-// boundary thanks to the `panic=unwind` build.
+// Recoverable Rust panics surface as `PanicError` exceptions at the JS
+// boundary thanks to the `panic=unwind` build, so we don't install
+// `console_error_panic_hook`: the panic info already reaches the caller as
+// a thrown exception and there's no need to additionally log it.
 #[wasm_bindgen(start)]
 fn on_start() {
     fn log_abort() {
@@ -1732,7 +1733,6 @@ fn on_start() {
 // the function in the typescript custom section at the top of the file
 #[wasm_bindgen(js_name = create, skip_typescript)]
 pub fn init(options: JsValue) -> Result<Automerge, error::BadActorId> {
-    console_error_panic_hook::set_once();
     let actor = js_get(&options, "actor").ok().and_then(|a| a.as_string());
     Automerge::new(actor)
 }


### PR DESCRIPTION
This builds the wasm artifact shipped to JS consumers with the nightly toolchain and `panic=unwind`, and registers a console-logging handler for hard wasm aborts. Together this means panics in exported Rust functions surface as `PanicError` exceptions at the JS boundary (async exports reject the returned promise) instead of silently aborting the WASM module, and the rarer case of a real wasm trap leaves a diagnostic in the console.

Both wasm-producing build paths switch to nightly:

* `rust/automerge-wasm/scripts/compile.mjs` (used by `npm run build`/`release` in the wasm package) now invokes `cargo +nightly build --target wasm32-unknown-unknown -Zbuild-std=std,panic_unwind` with `RUSTFLAGS="-C panic=unwind"` composed onto any user-provided `RUSTFLAGS`.
* `javascript/scripts/build.mjs` (used by the top-level `@automerge/automerge` package build) uses the same nightly + `-Zbuild-std` invocation.

The workspace pins stable in `rust/rust-toolchain.toml`; the nightly toolchain is selected per-invocation via rustup's `+nightly` argument so nothing else in the workspace is affected.

A `#[wasm_bindgen(start)]` function in `rust/automerge-wasm/src/lib.rs` registers an abort handler via `wasm_bindgen::__rt::set_on_abort`. When a wasm trap (memory OOB, OOM, double panic, etc.) sets `__instance_terminated`, the handler logs a `console.error` line so the abort is visible rather than only showing up as the generic "Module terminated" error on later calls.

```rust
#[wasm_bindgen(start)]
fn on_start() {
    fn log_abort() {
        web_sys::console::error_1(&"automerge-wasm: WASM instance aborted; …".into());
    }
    let _ = wasm_bindgen::__rt::set_on_abort(log_abort);
}
```

CI (`build_wasm`, `js_tests`, `node_18_packaging_test`) and the release workflow now install nightly + `rust-src` + the wasm32 target on the nightly toolchain. README and HACKING docs updated accordingly.

### Testing

* `npm run build && npm test` in `rust/automerge-wasm` — 155 passing
* `node scripts/build.mjs && npm test` in `javascript` — 312 passing