### PR TITLE
Fix fork_at dependency traversal duplication

### DIFF
--- a/rust/automerge/src/automerge.rs
+++ b/rust/automerge/src/automerge.rs
@@ -575,20 +575,24 @@ impl Automerge {
     ///
     /// This will create a new actor ID for the forked document
     pub fn fork_at(&self, heads: &[ChangeHash]) -> Result<Self, AutomergeError> {
-        let mut seen = heads.iter().cloned().collect::<HashSet<_>>();
-        let mut heads = heads.to_vec();
+        let mut seen = HashSet::new();
+        let mut stack = Vec::new();
+        for head in heads {
+            if seen.insert(*head) {
+                stack.push(*head);
+            }
+        }
         let mut hashes = vec![];
-        while let Some(hash) = heads.pop() {
+        while let Some(hash) = stack.pop() {
             if !self.change_graph.has_change(&hash) {
                 return Err(AutomergeError::InvalidHash(hash));
             }
             for dep in self.change_graph.deps_for_hash(&hash) {
-                if !seen.contains(&dep) {
-                    heads.push(dep);
+                if seen.insert(dep) {
+                    stack.push(dep);
                 }
             }
             hashes.push(hash);
-            seen.insert(hash);
         }
         let mut f = Self::new();
         f.set_actor(ActorId::random());

--- a/rust/automerge/tests/test.rs
+++ b/rust/automerge/tests/test.rs
@@ -2666,3 +2666,95 @@ fn reproduce_clock_cache_bug() {
 
     assert!(base.get_changes(&heads).is_empty());
 }
+
+#[test]
+fn test_fork_at_historical_heads_after_sync() {
+    let mut daemon = AutoCommit::new();
+    daemon.set_actor(ActorId::from(b"daemon" as &[u8]));
+
+    let text = daemon.put_object(ROOT, "source", ObjType::Text).unwrap();
+    daemon
+        .splice_text(&text, 0, 0, "# notebook cell\n")
+        .unwrap();
+    daemon.commit();
+
+    let mut peer = AutoCommit::new();
+    peer.set_actor(ActorId::from(b"wasm" as &[u8]));
+    let mut peer_sync = automerge::sync::State::new();
+    let mut daemon_sync = automerge::sync::State::new();
+    sync_docs_until_quiet(&mut daemon, &mut daemon_sync, &mut peer, &mut peer_sync);
+
+    let mut checkpoint_heads = Vec::new();
+
+    for i in 0..=200 {
+        let pos = peer.text(&text).unwrap().len();
+        peer.splice_text(
+            &text,
+            pos,
+            0,
+            &format!("{}", (b'a' + (i % 26) as u8) as char),
+        )
+        .unwrap();
+        peer.commit();
+
+        if i % 10 == 0 {
+            sync_one_message(&mut peer, &mut peer_sync, &mut daemon, &mut daemon_sync);
+
+            let mut fork = daemon.fork();
+            fork.set_actor(ActorId::from(format!("d:f{}", i).as_bytes()));
+            fork.put(ROOT, "exec_count", (i / 10) as i64).unwrap();
+            fork.commit();
+            daemon.merge(&mut fork).unwrap();
+
+            sync_one_message(&mut daemon, &mut daemon_sync, &mut peer, &mut peer_sync);
+        }
+
+        if i == 100 {
+            checkpoint_heads.push(daemon.get_heads());
+        }
+    }
+
+    let old_heads = checkpoint_heads.pop().unwrap();
+    let mut fork = daemon.fork_at(&old_heads).unwrap();
+
+    fork.set_actor(ActorId::from(b"filesystem" as &[u8]));
+    fork.put(ROOT, "disk_marker", "save-200").unwrap();
+    fork.commit();
+    daemon.merge(&mut fork).unwrap();
+}
+
+fn sync_docs_until_quiet(
+    left: &mut AutoCommit,
+    left_sync: &mut automerge::sync::State,
+    right: &mut AutoCommit,
+    right_sync: &mut automerge::sync::State,
+) {
+    for _ in 0..20 {
+        let mut progressed = false;
+        if let Some(msg) = left.sync().generate_sync_message(left_sync) {
+            right.sync().receive_sync_message(right_sync, msg).unwrap();
+            progressed = true;
+        }
+        if let Some(msg) = right.sync().generate_sync_message(right_sync) {
+            left.sync().receive_sync_message(left_sync, msg).unwrap();
+            progressed = true;
+        }
+        if !progressed {
+            break;
+        }
+    }
+}
+
+fn sync_one_message(
+    from: &mut AutoCommit,
+    from_sync: &mut automerge::sync::State,
+    to: &mut AutoCommit,
+    to_sync: &mut automerge::sync::State,
+) {
+    if let Some(msg) = from.sync().generate_sync_message(from_sync) {
+        to.sync().receive_sync_message(to_sync, msg).unwrap();
+    }
+    if let Some(msg) = to.sync().generate_sync_message(to_sync) {
+        from.sync().receive_sync_message(from_sync, msg).unwrap();
+    }
+}


### PR DESCRIPTION
Fixes #1327.

`Automerge::fork_at` walks backwards from the requested heads and builds the set of changes to replay. The old traversal marked a hash as seen only after it was popped from the stack. In some DAG shapes the same dependency could be scheduled twice before either copy was processed.

That duplicate hash produced duplicate `BuildChangeMetadata` entries for the same `(actor, seq, op range)`. The collector would fill one builder and then try to finish the duplicate, surfacing as `MissingOps`.

## Changes

- Mark dependency hashes as seen when they are scheduled.
- Add a regression test for historical `fork_at` after sync/merge activity.

## Fails on main

With only the new test applied to `origin/main`:

```text
cargo test -p automerge test_fork_at_historical_heads_after_sync --test test
called `Result::unwrap()` on an `Err` value: MissingOps
```

## Related PRs

- #1360 is separate hardening for fallible paths that already return `Result`.
- #1367 documents the actor-stream invariant that came up while debugging nteract's fork usage.
- #1359 was the earlier panic-propagation approach and is now superseded by this root-cause fix.

## Verification

```text
cargo fmt --all
cargo test -p automerge test_fork_at_historical_heads_after_sync --test test
cargo test -p automerge --test test
```
