### PR TITLE
Document fork actor concurrency invariant

### DIFF
--- a/rust/automerge/src/autocommit.rs
+++ b/rust/automerge/src/autocommit.rs
@@ -31,8 +31,13 @@ use crate::{LoadOptions, VerificationMode};
 /// [`Self::merge()`].
 ///
 /// If you have a document you want to split into two concurrent threads of execution you can use
-/// [`Self::fork()`]. If you want to split a document from ealier in its history you can use
-/// [`Self::fork_at()`].
+/// [`Self::fork()`]. If you want to split a document from earlier in its history you can use
+/// [`Self::fork_at()`]. Both methods give the fork a new random actor ID because an actor ID
+/// identifies a single linear sequence of changes. If the original document and a fork can both
+/// write before being merged, do not reset them to the same actor ID; the merge may fail with
+/// [`AutomergeError::DuplicateSeqNumber`]. To make historical writes against a full document while
+/// keeping one logical actor, use [`Self::isolate()`] before writing and [`Self::integrate()`] when
+/// returning to the current heads.
 ///
 /// ## Reading values
 ///
@@ -334,6 +339,12 @@ impl AutoCommit {
         patches
     }
 
+    /// Fork this document at the current heads for use by a different actor.
+    ///
+    /// The fork receives a new random actor ID. Keep that actor, or another actor that will not be
+    /// used concurrently elsewhere, if both documents may write before they are merged. Actor IDs
+    /// are linear change streams, so forcing the original and fork to share an actor ID after both
+    /// have written can make [`Self::merge()`] return [`AutomergeError::DuplicateSeqNumber`].
     pub fn fork(&mut self) -> Self {
         self.ensure_transaction_closed();
         Self {
@@ -347,6 +358,13 @@ impl AutoCommit {
         }
     }
 
+    /// Fork this document at the given heads for use by a different actor.
+    ///
+    /// The fork contains only changes reachable from `heads` and receives a new random actor ID. It
+    /// does not know about later changes in the source document, so resetting it to the source
+    /// document's actor and then writing can collide when merged into a newer source document. For
+    /// same-logical-actor historical writes on a full document, prefer [`Self::fork()`] followed by
+    /// [`Self::isolate()`] with the historical heads before writing.
     pub fn fork_at(&mut self, heads: &[ChangeHash]) -> Result<Self, AutomergeError> {
         self.ensure_transaction_closed();
         Ok(Self {
@@ -367,12 +385,22 @@ impl AutoCommit {
         &self.doc
     }
 
+    /// Set the actor ID for this document.
+    ///
+    /// Actor IDs identify linear change sequences. Do not use the same actor ID for documents that
+    /// may write concurrently and later merge, unless you are using [`Self::isolate()`] to let
+    /// Automerge choose an internal concurrent actor when needed.
     pub fn with_actor(mut self, actor: ActorId) -> Self {
         self.ensure_transaction_closed();
         self.doc.set_actor(actor);
         self
     }
 
+    /// Set the actor ID for this document.
+    ///
+    /// Actor IDs identify linear change sequences. Do not use the same actor ID for documents that
+    /// may write concurrently and later merge, unless you are using [`Self::isolate()`] to let
+    /// Automerge choose an internal concurrent actor when needed.
     pub fn set_actor(&mut self, actor: ActorId) -> &mut Self {
         self.ensure_transaction_closed();
         self.doc.set_actor(actor);
@@ -383,12 +411,22 @@ impl AutoCommit {
         self.doc.get_actor()
     }
 
+    /// View and write this document as of `heads`.
+    ///
+    /// If `heads` do not include the current actor's latest change, new changes are assigned to an
+    /// internal concurrent actor derived from the current actor. This preserves the invariant that
+    /// each actor ID has one linear change sequence while still allowing historical async work from
+    /// one logical actor.
     pub fn isolate(&mut self, heads: &[ChangeHash]) {
         self.ensure_transaction_closed();
         self.patch_to(heads);
         self.isolation = Some(heads.to_vec());
     }
 
+    /// Return an isolated document to its current heads.
+    ///
+    /// Use this after [`Self::isolate()`] when subsequent reads and writes should operate on the
+    /// document's full current state again.
     pub fn integrate(&mut self) {
         self.ensure_transaction_closed();
         self.patch_to(self.doc.get_heads().as_slice());

--- a/rust/automerge/src/automerge.rs
+++ b/rust/automerge/src/automerge.rs
@@ -181,8 +181,13 @@ impl std::default::Default for LoadOptions<'static> {
 /// [`Self::merge()`] or [`Self::merge_and_log_patches()`].
 ///
 /// If you have a document you want to split into two concurrent threads of execution you can use
-/// [`Self::fork()`]. If you want to split a document from ealier in its history you can use
-/// [`Self::fork_at()`].
+/// [`Self::fork()`]. If you want to split a document from earlier in its history you can use
+/// [`Self::fork_at()`]. Both methods give the fork a new random actor ID because an actor ID
+/// identifies a single linear sequence of changes. If the original document and a fork can both
+/// write before being merged, do not reset them to the same actor ID; the merge may fail with
+/// [`AutomergeError::DuplicateSeqNumber`]. To make historical writes against a full document while
+/// keeping one logical actor, use [`Self::transaction_at()`] or [`Self::into_transaction()`] with
+/// isolated heads so Automerge can choose an internal concurrent actor when needed.
 ///
 /// ## Reading values
 ///
@@ -282,13 +287,21 @@ impl Automerge {
         }
     }
 
-    /// Set the actor id for this document.
+    /// Set the actor ID for this document.
+    ///
+    /// Actor IDs identify linear change sequences. Do not use the same actor ID for documents that
+    /// may write concurrently and later merge, unless you are using one of the isolated-transaction
+    /// APIs to let Automerge choose an internal concurrent actor when needed.
     pub fn with_actor(mut self, actor: ActorId) -> Self {
         self.set_actor(actor);
         self
     }
 
-    /// Set the actor id for this document.
+    /// Set the actor ID for this document.
+    ///
+    /// Actor IDs identify linear change sequences. Do not use the same actor ID for documents that
+    /// may write concurrently and later merge, unless you are using one of the isolated-transaction
+    /// APIs to let Automerge choose an internal concurrent actor when needed.
     pub fn set_actor(&mut self, actor: ActorId) -> &mut Self {
         match self.ops.actors.binary_search(&actor) {
             Ok(idx) => self.actor = Actor::Cached(idx),
@@ -364,7 +377,10 @@ impl Automerge {
         Transaction::new(self, args, patch_log)
     }
 
-    /// Start a transaction isolated at a given heads
+    /// Start a transaction isolated at a given heads.
+    ///
+    /// If `heads` do not include the current actor's latest change, Automerge will use an internal
+    /// concurrent actor for new changes so the current actor's sequence remains linear.
     pub fn transaction_at(&mut self, patch_log: PatchLog, heads: &[ChangeHash]) -> Transaction<'_> {
         let args = self.transaction_args(Some(heads));
         Transaction::new(self, args, patch_log)
@@ -379,7 +395,8 @@ impl Automerge {
     /// # Arguments
     /// * `patch_log` - An optional [`PatchLog`] to log the changes in this transaction to
     /// * `heads` - An optional set of heads to isolate this transaction at, or `None` to use the
-    ///   current heads of the document
+    ///   current heads of the document. If these heads do not include the current actor's latest
+    ///   change, Automerge will use an internal concurrent actor for new changes.
     pub fn into_transaction(
         self,
         patch_log: Option<PatchLog>,
@@ -540,18 +557,25 @@ impl Automerge {
         Transaction::empty(self, args, opts)
     }
 
-    /// Fork this document at the current point for use by a different actor.
+    /// Fork this document at the current heads for use by a different actor.
     ///
-    /// This will create a new actor ID for the forked document
+    /// The fork receives a new random actor ID. Keep that actor, or another actor that will not be
+    /// used concurrently elsewhere, if both documents may write before they are merged. Actor IDs
+    /// are linear change streams, so forcing the original and fork to share an actor ID after both
+    /// have written can make [`Self::merge()`] return [`AutomergeError::DuplicateSeqNumber`].
     pub fn fork(&self) -> Self {
         let mut f = self.clone();
         f.set_actor(ActorId::random());
         f
     }
 
-    /// Fork this document at the given heads
+    /// Fork this document at the given heads for use by a different actor.
     ///
-    /// This will create a new actor ID for the forked document
+    /// The fork contains only changes reachable from `heads` and receives a new random actor ID. It
+    /// does not know about later changes in the source document, so resetting it to the source
+    /// document's actor and then writing can collide when merged into a newer source document. For
+    /// same-logical-actor historical writes on a full document, prefer [`Self::transaction_at()`]
+    /// or [`Self::into_transaction()`] with `Some(heads)`.
     pub fn fork_at(&self, heads: &[ChangeHash]) -> Result<Self, AutomergeError> {
         let mut seen = heads.iter().cloned().collect::<HashSet<_>>();
         let mut heads = heads.to_vec();

--- a/rust/automerge/tests/fork_actor_invariant.rs
+++ b/rust/automerge/tests/fork_actor_invariant.rs
@@ -1,0 +1,146 @@
+use automerge::{transaction::Transactable, ActorId, AutoCommit, AutomergeError, ObjType, ROOT};
+
+#[test]
+fn same_actor_fork_merges_if_only_the_fork_writes() {
+    let actor = ActorId::from(b"worker" as &[u8]);
+    let mut doc = AutoCommit::new().with_actor(actor.clone());
+    doc.put(ROOT, "base", 1).unwrap();
+    doc.commit();
+
+    let mut fork = doc.fork();
+    fork.set_actor(actor.clone());
+    fork.put(ROOT, "fork", 1).unwrap();
+    fork.commit();
+
+    doc.merge(&mut fork).unwrap();
+}
+
+#[test]
+fn same_actor_fork_reuses_seq_after_concurrent_writes() {
+    let actor = ActorId::from(b"worker" as &[u8]);
+    let mut doc = AutoCommit::new().with_actor(actor.clone());
+    doc.put(ROOT, "base", 1).unwrap();
+    doc.commit();
+
+    let mut fork = doc.fork();
+    fork.set_actor(actor.clone());
+
+    doc.put(ROOT, "main", 1).unwrap();
+    doc.commit();
+
+    fork.put(ROOT, "fork", 1).unwrap();
+    fork.commit();
+
+    assert!(matches!(
+        doc.merge(&mut fork),
+        Err(AutomergeError::DuplicateSeqNumber(2, duplicate_actor)) if duplicate_actor == actor
+    ));
+}
+
+#[test]
+fn two_same_actor_async_forks_collide_on_second_merge() {
+    let actor = ActorId::from(b"worker" as &[u8]);
+    let mut doc = AutoCommit::new().with_actor(actor.clone());
+    doc.put(ROOT, "base", 1).unwrap();
+    doc.commit();
+
+    let mut fork1 = doc.fork();
+    fork1.set_actor(actor.clone());
+    let mut fork2 = doc.fork();
+    fork2.set_actor(actor.clone());
+
+    fork1.put(ROOT, "fork1", 1).unwrap();
+    fork1.commit();
+    fork2.put(ROOT, "fork2", 1).unwrap();
+    fork2.commit();
+
+    doc.merge(&mut fork1).unwrap();
+    assert!(matches!(
+        doc.merge(&mut fork2),
+        Err(AutomergeError::DuplicateSeqNumber(2, duplicate_actor)) if duplicate_actor == actor
+    ));
+}
+
+#[test]
+fn isolated_historical_autocommit_writes_use_concurrent_actor() {
+    let actor = ActorId::from(b"worker" as &[u8]);
+    let mut doc = AutoCommit::new().with_actor(actor.clone());
+    let text = doc.put_object(ROOT, "text", ObjType::Text).unwrap();
+    doc.splice_text(&text, 0, 0, "abc").unwrap();
+    doc.commit();
+    let historical_heads = doc.get_heads();
+
+    doc.splice_text(&text, 3, 0, " current").unwrap();
+    doc.commit();
+
+    doc.isolate(&historical_heads);
+    doc.splice_text(&text, 3, 0, " isolated").unwrap();
+    doc.commit();
+    doc.integrate();
+
+    let actors = doc
+        .get_changes_meta(&[])
+        .into_iter()
+        .map(|change| change.actor.into_owned())
+        .collect::<std::collections::HashSet<_>>();
+
+    assert!(actors.contains(&actor));
+    assert!(actors.iter().any(|actor| {
+        actor.to_bytes().starts_with(&[0x13, 0xb2, 0x23, 0x09])
+            && actor.to_bytes().ends_with(b"worker")
+    }));
+}
+
+#[test]
+fn full_fork_plus_isolate_allows_same_logical_actor_async_merge() {
+    let actor = ActorId::from(b"worker" as &[u8]);
+    let mut doc = AutoCommit::new().with_actor(actor.clone());
+    doc.put(ROOT, "base", 1).unwrap();
+    doc.commit();
+    let historical_heads = doc.get_heads();
+
+    doc.put(ROOT, "main", 1).unwrap();
+    doc.commit();
+
+    let mut fork = doc.fork();
+    fork.set_actor(actor.clone());
+    fork.isolate(&historical_heads);
+    fork.put(ROOT, "fork", 1).unwrap();
+    fork.commit();
+
+    doc.merge(&mut fork).unwrap();
+
+    let actors = doc
+        .get_changes_meta(&[])
+        .into_iter()
+        .map(|change| change.actor.into_owned())
+        .collect::<std::collections::HashSet<_>>();
+
+    assert!(actors.contains(&actor));
+    assert!(actors.iter().any(|actor| {
+        actor.to_bytes().starts_with(&[0x13, 0xb2, 0x23, 0x09])
+            && actor.to_bytes().ends_with(b"worker")
+    }));
+}
+
+#[test]
+fn fork_at_then_same_actor_lacks_future_seq_context_and_collides() {
+    let actor = ActorId::from(b"worker" as &[u8]);
+    let mut doc = AutoCommit::new().with_actor(actor.clone());
+    doc.put(ROOT, "base", 1).unwrap();
+    doc.commit();
+    let historical_heads = doc.get_heads();
+
+    doc.put(ROOT, "main", 1).unwrap();
+    doc.commit();
+
+    let mut fork = doc.fork_at(&historical_heads).unwrap();
+    fork.set_actor(actor.clone());
+    fork.put(ROOT, "fork", 1).unwrap();
+    fork.commit();
+
+    assert!(matches!(
+        doc.merge(&mut fork),
+        Err(AutomergeError::DuplicateSeqNumber(2, duplicate_actor)) if duplicate_actor == actor
+    ));
+}


### PR DESCRIPTION
This documents an invariant that came up while debugging nteract's `fork` and `fork_at` usage: an actor ID identifies one linear stream of changes. Concurrent branches need distinct actors.

This is separate from the `MissingOps` root-cause fix in #1366. It is guidance for using the API without accidentally creating same-actor concurrent histories.

## Changes

- Document the actor-stream invariant on `fork`, `fork_at`, `set_actor`, and `with_actor`.
- Point same-logical-actor historical work at `AutoCommit::isolate()` / isolated transactions.
- Add tests for same-actor fork collisions and `fork()` plus `isolate(...)`.

## Verification

```text
cargo fmt --all -- --check
cargo test -p automerge --test fork_actor_invariant
cargo test -p automerge --doc
RUSTDOCFLAGS="-D warnings" cargo doc -p automerge --no-deps
```
