### PR TITLE
rust: add wasm release size profile

### DIFF
--- a/javascript/scripts/build.mjs
+++ b/javascript/scripts/build.mjs
@@ -112,10 +112,11 @@ function isStep(stepStr) {
  */
 function buildWasm(outputDir, gitHead) {
   const automergeWasmPath = path.join(rustProjectDir, "automerge-wasm")
+  const wasmProfile = process.env.WASM_PROFILE ?? "wasm-release"
   console.log("building automerge-wasm")
   execSync(
     //"cargo build --target wasm32-unknown-unknown --profile dev",
-    "cargo build --target wasm32-unknown-unknown --release",
+    `cargo build --target wasm32-unknown-unknown --profile ${wasmProfile}`,
     {
       cwd: automergeWasmPath,
       env: { ...process.env, GIT_HEAD: gitHead },
@@ -126,7 +127,7 @@ function buildWasm(outputDir, gitHead) {
     rustProjectDir,
     "target",
     "wasm32-unknown-unknown",
-    "release",
+    wasmProfile,
     //"debug",
     "automerge_wasm.wasm",
   )

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -14,5 +14,12 @@ resolver = "2"
 lto = true
 codegen-units = 1
 
+[profile.wasm-release]
+inherits = "release"
+opt-level = "z"
+panic = "abort"
+strip = true
+debug = 0
+
 [profile.bench]
 debug = true


### PR DESCRIPTION
## Summary
- Adds a dedicated `wasm-release` Cargo profile for size-oriented WASM builds.
- Wires the JavaScript package build to use that profile by default while preserving `WASM_PROFILE` as an override.

## Strategy
This is the foundation of the stack. The normal Rust `release` profile is a broad default; the generated npm artifacts care more about transfer size than native throughput. A separate profile lets WASM builds use `opt-level = z`, `panic = abort`, stripping, and no debug info without changing native release behavior.

## Tradeoffs
- Optimizes for binary size, not peak runtime speed.
- Keeps the decision scoped to WASM packaging rather than changing the workspace release profile for every Rust consumer.
- Downstream PRs build on this profile for consistent measurement and CI behavior.

## Test plan
- Built `automerge-wasm` with `cargo build -p automerge-wasm --target wasm32-unknown-unknown --profile wasm-release` during local measurement.
- Ran `cargo test -p automerge-wasm` after the stable stack; it passed with 0 Rust tests.