### PR TITLE
rust: optimize generated wasm artifacts

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -75,6 +75,8 @@ jobs:
         with:
           # Optional version of wasm-bindgen to install(eg. '0.2.83', 'latest')
           version: "0.2.118"
+      - name: Install wasm-opt
+        run: sudo apt-get update && sudo apt-get install -y binaryen
       - name: Install wasm32 target
         working-directory: rust
         run: rustup target add wasm32-unknown-unknown
@@ -95,6 +97,8 @@ jobs:
         with:
           # Optional version of wasm-bindgen to install(eg. '0.2.83', 'latest')
           version: "0.2.118"
+      - name: Install wasm-opt
+        run: sudo apt-get update && sudo apt-get install -y binaryen
       - name: Install wasm32 target
         working-directory: rust
         run: rustup target add wasm32-unknown-unknown
@@ -117,6 +121,8 @@ jobs:
         with:
           # Optional version of wasm-bindgen to install(eg. '0.2.83', 'latest')
           version: "0.2.118"
+      - name: Install wasm-opt
+        run: sudo apt-get update && sudo apt-get install -y binaryen
       - name: Install wasm32 target
         working-directory: rust
         run: rustup target add wasm32-unknown-unknown

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,6 +19,8 @@ jobs:
         with:
           # Optional version of wasm-bindgen to install(eg. '0.2.83', 'latest')
           version: "0.2.118"
+      - name: Install wasm-opt
+        run: sudo apt-get update && sudo apt-get install -y binaryen
       - name: Install wasm32 target
         working-directory: rust
         run: rustup target add wasm32-unknown-unknown
@@ -49,8 +51,12 @@ jobs:
         with:
           node-version: "20.x"
           registry-url: "https://registry.npmjs.org"
-      - name: Install wasm-bindgen-cli
-        run: cargo install wasm-bindgen-cli wasm-opt
+      - uses: jetli/wasm-bindgen-action@v0.2.0
+        with:
+          # Optional version of wasm-bindgen to install(eg. '0.2.83', 'latest')
+          version: "0.2.118"
+      - name: Install wasm-opt
+        run: sudo apt-get update && sudo apt-get install -y binaryen
       - name: Install wasm32 target
         working-directory: rust
         run: rustup target add wasm32-unknown-unknown

--- a/javascript/scripts/build.mjs
+++ b/javascript/scripts/build.mjs
@@ -151,6 +151,12 @@ function buildWasm(outputDir, gitHead) {
         cwd: __dirname,
       },
     )
+    execSync(
+      `wasm-opt -Oz --converge --strip-debug --strip-dwarf --strip-producers --enable-bulk-memory --enable-nontrapping-float-to-int ${path.join(outputPath, "automerge_wasm_bg.wasm")} -o ${path.join(outputPath, "automerge_wasm_bg.wasm")}`,
+      {
+        cwd: __dirname,
+      },
+    )
 
     // Patch `automerge_wasm.js` to prevent Vite from bundling multiple `automerge_wasm_bg.wasm` files
     //

--- a/rust/automerge-wasm/opt-wasm.mjs
+++ b/rust/automerge-wasm/opt-wasm.mjs
@@ -1,0 +1,44 @@
+import { execFileSync } from "child_process"
+import fs from "fs"
+import path from "path"
+
+const target = process.env.TARGET
+const profile = process.env.PROFILE ?? "dev"
+
+if (!target) {
+  throw new Error("TARGET must be set before running opt-wasm.mjs")
+}
+
+const wasmPath = path.join(target, "automerge_wasm_bg.wasm")
+if (!fs.existsSync(wasmPath)) {
+  throw new Error(`WASM artifact not found: ${wasmPath}`)
+}
+
+try {
+  execFileSync("wasm-opt", ["--version"], { stdio: "ignore" })
+} catch (error) {
+  if (profile === "dev") {
+    console.warn("wasm-opt not found; skipping dev WASM optimization")
+    process.exit(0)
+  }
+  throw new Error("wasm-opt is required for release WASM builds")
+}
+
+execFileSync(
+  "wasm-opt",
+  [
+    "-Oz",
+    "--converge",
+    "--strip-debug",
+    "--strip-dwarf",
+    "--strip-producers",
+    "--enable-bulk-memory",
+    "--enable-nontrapping-float-to-int",
+    wasmPath,
+    "-o",
+    wasmPath,
+  ],
+  {
+    stdio: "inherit",
+  },
+)

--- a/rust/automerge-wasm/package.json
+++ b/rust/automerge-wasm/package.json
@@ -35,12 +35,12 @@
     "debug": "cross-env PROFILE=dev TARGET_DIR=debug npm run buildall",
     "dev": "cross-env PROFILE=dev TARGET_DIR=debug FEATURES='' TARGET=nodejs npm run target && node -e \"require('fs').cpSync('./nodejs/automerge_wasm.d.ts', './index.d.ts')\" && node ./fixup-node-cjs.mjs",
     "build": "cross-env PROFILE=dev TARGET_DIR=debug FEATURES='' npm run buildall",
-    "release": "cross-env PROFILE=release TARGET_DIR=release npm run buildall",
+    "release": "cross-env PROFILE=wasm-release TARGET_DIR=wasm-release npm run buildall",
     "buildall": "cross-env TARGET=nodejs npm run target && cross-env TARGET=bundler npm run target && cross-env TARGET=deno npm run target && TARGET=web npm run target && node -e \"require('fs').cpSync('./src/export-web-wasm.js', './web/index.js')\" && node -e \"require('fs').cpSync('./nodejs/automerge_wasm.d.ts', './index.d.ts')\" && node ./fixup-node-cjs.mjs",
-    "target": "rimraf ./$TARGET && npm run compile && npm run bindgen && npm run opt",
-    "compile": "cargo build --target wasm32-unknown-unknown --profile $PROFILE",
-    "bindgen": "wasm-bindgen --omit-default-module-path --weak-refs --typescript --target $TARGET --out-dir $TARGET ../target/wasm32-unknown-unknown/$TARGET_DIR/automerge_wasm.wasm",
-    "opt": "echo wasm-opt -O4 $TARGET/automerge_wasm_bg.wasm -o $TARGET/automerge_wasm_bg.wasm",
+    "target": "node ./target.mjs",
+    "compile": "node ./target.mjs compile",
+    "bindgen": "node ./target.mjs bindgen",
+    "opt": "node ./target.mjs opt",
     "test": "tsc --noEmit && mocha --loader=ts-node/esm test/**/*.mts"
   },
   "devDependencies": {

--- a/rust/automerge-wasm/target.mjs
+++ b/rust/automerge-wasm/target.mjs
@@ -1,0 +1,56 @@
+import { execFileSync } from "child_process"
+import fs from "fs"
+import path from "path"
+
+const target = process.env.TARGET
+const profile = process.env.PROFILE ?? "dev"
+const targetDir = process.env.TARGET_DIR ?? profile
+const command = process.argv[2] ?? "target"
+
+if (!target && command !== "compile") {
+  throw new Error("TARGET must be set before running target.mjs")
+}
+
+if (command === "target") {
+  fs.rmSync(target, { recursive: true, force: true })
+}
+
+if (command === "target" || command === "compile") {
+  execFileSync(
+    "cargo",
+    ["build", "--target", "wasm32-unknown-unknown", "--profile", profile],
+    {
+      stdio: "inherit",
+    },
+  )
+}
+
+if (command === "target" || command === "bindgen") {
+  execFileSync(
+    "wasm-bindgen",
+    [
+      "--omit-default-module-path",
+      "--weak-refs",
+      "--typescript",
+      "--target",
+      target,
+      "--out-dir",
+      target,
+      path.join(
+        "..",
+        "target",
+        "wasm32-unknown-unknown",
+        targetDir,
+        "automerge_wasm.wasm",
+      ),
+    ],
+    { stdio: "inherit" },
+  )
+}
+
+if (command === "target" || command === "opt") {
+  execFileSync(process.execPath, ["./opt-wasm.mjs"], {
+    env: process.env,
+    stdio: "inherit",
+  })
+}


### PR DESCRIPTION
## Summary
- Adds cross-platform Node wrappers for `automerge-wasm` compile/bindgen/opt steps.
- Runs generated `*_bg.wasm` artifacts through Binaryen `wasm-opt` during release builds.
- Installs Binaryen in CI/release jobs that produce WASM artifacts.

## Strategy
This PR makes optimization part of the packaging pipeline rather than a manual post-build step. The wrapper scripts also replace shell-specific `$TARGET`/`$PROFILE` expansion with Node environment handling, which makes the Rust WASM package build consistently on Windows and Unix.

The post-processing flags use the best raw-size path from measurement: `-Oz --converge --strip-debug --strip-dwarf --strip-producers` plus the WebAssembly feature flags needed for Rust/wasm-bindgen output.

## Tradeoffs
- Release WASM builds now require `wasm-opt`; dev builds can still skip it when unavailable.
- `-Oz` gives the best raw artifact size. In measurements, `-Os` can be slightly smaller after gzip/brotli, but produces a larger raw WASM. This PR chooses raw size as the release-artifact objective.
- Adds CI package-manager dependency on Binaryen instead of compiling `wasm-opt` from Cargo, avoiding the long local/CI build time of Binaryen from source.

## Test plan
- Measured optimized bindgen artifacts locally with Binaryen.
- Verified `wasm-opt -Oz --converge --strip-*` validates on generated artifacts.
- Ran `cargo test -p automerge-wasm` after the stable stack; it passed with 0 Rust tests.