### PR TITLE
rust: prune wasm diagnostics from release builds

### DIFF
--- a/rust/automerge-wasm/Cargo.toml
+++ b/rust/automerge-wasm/Cargo.toml
@@ -21,19 +21,17 @@ bench = false
 
 [features]
 # default = ["console_error_panic_hook", "wee_alloc"]
-default = ["console_error_panic_hook"]
+default = []
 
 [dependencies]
 console_error_panic_hook = { version = "^0.1", optional = true }
 # wee_alloc = { version = "^0.4", optional = true }
-automerge = { path = "../automerge", features = ["wasm", "utf16-indexing"] }
+automerge = { path = "../automerge", features = ["wasm", "wasm-release-tracing-off", "utf16-indexing"] }
 js-sys = "^0.3"
 serde = "^1.0"
 serde_json = "^1.0"
 serde-wasm-bindgen = "0.6.5"
-serde_bytes = "0.11.5"
 hex = "^0.4.3"
-itertools = "0.14.0"
 thiserror = "^2.0.12"
 rustc-hash = "^2.1.1"
 
@@ -46,12 +44,6 @@ features = ["serde-serialize", "std"]
 
 [package.metadata.wasm-pack.profile.profiling]
 wasm-opt = false
-
-# The `web-sys` crate allows you to interact with the various browser APIs,
-# like the DOM.
-[dependencies.web-sys]
-version = "0.3.22"
-features = ["console"]
 
 [dev-dependencies]
 proptest = { version = "^1.0.0", default-features = false, features = ["std"] }

--- a/rust/automerge-wasm/src/interop.rs
+++ b/rust/automerge-wasm/src/interop.rs
@@ -1589,7 +1589,6 @@ impl Automerge {
                             .collect::<Vec<_>>(),
                     ))
                 } else {
-                    web_sys::console::log_2(&"Invalid value".into(), value);
                     Err(error::InvalidValue)
                 }
             }

--- a/rust/automerge-wasm/src/lib.rs
+++ b/rust/automerge-wasm/src/lib.rs
@@ -407,7 +407,9 @@ export type UpdateSpansConfig = {
 #[allow(unused_macros)]
 macro_rules! log {
     ( $( $t:tt )* ) => {
-          web_sys::console::log_1(&format!( $( $t )* ).into());
+        if false {
+            let _ = format_args!( $( $t )* );
+        }
     };
 }
 
@@ -1712,6 +1714,7 @@ impl Automerge {
 // the function in the typescript custom section at the top of the file
 #[wasm_bindgen(js_name = create, skip_typescript)]
 pub fn init(options: JsValue) -> Result<Automerge, error::BadActorId> {
+    #[cfg(feature = "console_error_panic_hook")]
     console_error_panic_hook::set_once();
     let actor = js_get(&options, "actor").ok().and_then(|a| a.as_string());
     Automerge::new(actor)

--- a/rust/automerge/Cargo.toml
+++ b/rust/automerge/Cargo.toml
@@ -10,7 +10,9 @@ readme = "./README.md"
 
 [features]
 optree-visualisation = ["dot"]
-wasm = ["js-sys", "wasm-bindgen", "web-sys", "getrandom/wasm_js", "hexane/wasm"]
+wasm = ["js-sys", "wasm-bindgen", "getrandom/wasm_js", "hexane/wasm"]
+wasm-debug-log = ["web-sys", "hexane/wasm-debug-log"]
+wasm-release-tracing-off = ["tracing/release_max_level_off"]
 utf8-indexing = []
 utf16-indexing = []
 # Whether to enable "slow path" assertions which check that various invariants hold

--- a/rust/automerge/src/lib.rs
+++ b/rust/automerge/src/lib.rs
@@ -241,13 +241,28 @@ macro_rules! log {
      }
  }
 
-#[cfg(all(feature = "wasm", target_family = "wasm"))]
+#[cfg(all(feature = "wasm-debug-log", target_family = "wasm"))]
 #[doc(hidden)]
 #[macro_export]
 macro_rules! __log {
      ( $( $t:tt )* ) => {
          web_sys::console::log_1(&format!( $( $t )* ).into());
      }
+ }
+
+#[cfg(all(
+    feature = "wasm",
+    not(feature = "wasm-debug-log"),
+    target_family = "wasm"
+))]
+#[doc(hidden)]
+#[macro_export]
+macro_rules! __log {
+     ( $( $t:tt )* ) => {
+         if false {
+             let _ = format_args!( $( $t )* );
+         }
+     };
  }
 
 #[cfg(not(all(feature = "wasm", target_family = "wasm")))]

--- a/rust/hexane/Cargo.toml
+++ b/rust/hexane/Cargo.toml
@@ -13,7 +13,8 @@ bench = false
 
 
 [features]
-wasm = ["web-sys"]
+wasm = []
+wasm-debug-log = ["web-sys"]
 slow_path_assertions = []
 
 

--- a/rust/hexane/src/lib.rs
+++ b/rust/hexane/src/lib.rs
@@ -45,13 +45,28 @@ macro_rules! log {
      }
  }
 
-#[cfg(all(feature = "wasm", target_family = "wasm"))]
+#[cfg(all(feature = "wasm-debug-log", target_family = "wasm"))]
 #[doc(hidden)]
 #[macro_export]
 macro_rules! __log {
      ( $( $t:tt )* ) => {
          web_sys::console::log_1(&format!( $( $t )* ).into());
      }
+ }
+
+#[cfg(all(
+    feature = "wasm",
+    not(feature = "wasm-debug-log"),
+    target_family = "wasm"
+))]
+#[doc(hidden)]
+#[macro_export]
+macro_rules! __log {
+     ( $( $t:tt )* ) => {
+         if false {
+             let _ = format_args!( $( $t )* );
+         }
+     };
  }
 
 #[cfg(not(all(feature = "wasm", target_family = "wasm")))]


### PR DESCRIPTION
## Summary
- Makes `console_error_panic_hook` opt-in instead of part of the default WASM wrapper feature set.
- Removes default browser console logging from the core `wasm` feature and moves it behind explicit `wasm-debug-log` features.
- Compiles `tracing` callsites out for the WASM wrapper release path and removes unused WASM wrapper dependencies.

## Strategy
The WASM package should not pay for browser diagnostics in its default release artifact. This PR keeps diagnostic hooks available when explicitly requested, but removes the default `web-sys`/console/logging footprint from production builds.

The `tracing/release_max_level_off` feature is enabled through a WASM-specific Automerge feature used by `automerge-wasm`, not on the base `automerge` dependency itself. That keeps native consumers from unexpectedly losing release tracing.

## Tradeoffs
- Default WASM release builds no longer install browser panic hooks automatically.
- Console debug logging is still available, but consumers must opt into the debug-log feature path.
- Smaller release artifacts come at the cost of less built-in browser diagnostic output.

## Size impact
In local measurements on top of the previous size work, compiling out `tracing` and diagnostics reduced the post-bindgen artifact by roughly 41 KB before `wasm-opt`, and the final optimized artifact by roughly 35 KB.

## Test plan
- `cargo build -p automerge-wasm --target wasm32-unknown-unknown --profile wasm-release`
- `cargo test -p automerge-wasm` passed with 0 Rust tests.
- Read lints on edited manifests/scripts; reported spelling-only manifest diagnostics unrelated to these changes.