### PR TITLE
rust: add experimental smallest wasm build

### DIFF
--- a/javascript/scripts/build.mjs
+++ b/javascript/scripts/build.mjs
@@ -113,13 +113,36 @@ function isStep(stepStr) {
 function buildWasm(outputDir, gitHead) {
   const automergeWasmPath = path.join(rustProjectDir, "automerge-wasm")
   const wasmProfile = process.env.WASM_PROFILE ?? "wasm-release"
+  const smallestWasm = process.env.WASM_SMALLEST === "1"
+  const cargoArgs = [
+    "build",
+    "--target",
+    "wasm32-unknown-unknown",
+    "--profile",
+    wasmProfile,
+  ]
+  const cargoEnv = { ...process.env, GIT_HEAD: gitHead }
+
+  if (smallestWasm) {
+    cargoArgs.unshift("+nightly")
+    cargoArgs.splice(2, 0, "-Z", "build-std=std,panic_abort")
+    cargoEnv.RUSTFLAGS = [
+      cargoEnv.RUSTFLAGS,
+      "-Zunstable-options",
+      "-Cpanic=immediate-abort",
+      "-Zlocation-detail=none",
+    ]
+      .filter(Boolean)
+      .join(" ")
+  }
+
   console.log("building automerge-wasm")
   execSync(
     //"cargo build --target wasm32-unknown-unknown --profile dev",
-    `cargo build --target wasm32-unknown-unknown --profile ${wasmProfile}`,
+    `cargo ${cargoArgs.join(" ")}`,
     {
       cwd: automergeWasmPath,
-      env: { ...process.env, GIT_HEAD: gitHead },
+      env: cargoEnv,
     },
   )
 

--- a/rust/automerge-wasm/package.json
+++ b/rust/automerge-wasm/package.json
@@ -36,6 +36,7 @@
     "dev": "cross-env PROFILE=dev TARGET_DIR=debug FEATURES='' TARGET=nodejs npm run target && node -e \"require('fs').cpSync('./nodejs/automerge_wasm.d.ts', './index.d.ts')\" && node ./fixup-node-cjs.mjs",
     "build": "cross-env PROFILE=dev TARGET_DIR=debug FEATURES='' npm run buildall",
     "release": "cross-env PROFILE=wasm-release TARGET_DIR=wasm-release npm run buildall",
+    "release:smallest": "cross-env PROFILE=wasm-release TARGET_DIR=wasm-release WASM_SMALLEST=1 npm run buildall",
     "buildall": "cross-env TARGET=nodejs npm run target && cross-env TARGET=bundler npm run target && cross-env TARGET=deno npm run target && TARGET=web npm run target && node -e \"require('fs').cpSync('./src/export-web-wasm.js', './web/index.js')\" && node -e \"require('fs').cpSync('./nodejs/automerge_wasm.d.ts', './index.d.ts')\" && node ./fixup-node-cjs.mjs",
     "target": "node ./target.mjs",
     "compile": "node ./target.mjs compile",

--- a/rust/automerge-wasm/target.mjs
+++ b/rust/automerge-wasm/target.mjs
@@ -6,6 +6,7 @@ const target = process.env.TARGET
 const profile = process.env.PROFILE ?? "dev"
 const targetDir = process.env.TARGET_DIR ?? profile
 const command = process.argv[2] ?? "target"
+const smallest = process.env.WASM_SMALLEST === "1"
 
 if (!target && command !== "compile") {
   throw new Error("TARGET must be set before running target.mjs")
@@ -16,10 +17,27 @@ if (command === "target") {
 }
 
 if (command === "target" || command === "compile") {
+  const cargoArgs = ["build", "--target", "wasm32-unknown-unknown", "--profile", profile]
+  const env = { ...process.env }
+
+  if (smallest) {
+    cargoArgs.unshift("+nightly")
+    cargoArgs.splice(2, 0, "-Z", "build-std=std,panic_abort")
+    env.RUSTFLAGS = [
+      env.RUSTFLAGS,
+      "-Zunstable-options",
+      "-Cpanic=immediate-abort",
+      "-Zlocation-detail=none",
+    ]
+      .filter(Boolean)
+      .join(" ")
+  }
+
   execFileSync(
     "cargo",
-    ["build", "--target", "wasm32-unknown-unknown", "--profile", profile],
+    cargoArgs,
     {
+      env,
       stdio: "inherit",
     },
   )


### PR DESCRIPTION
## Summary
- Adds an opt-in `WASM_SMALLEST=1` path for `automerge-wasm` package builds.
- Provides `npm run release:smallest` as an explicit nightly/unstable build mode.
- Uses nightly `build-std`, immediate-abort panics, and no panic location details to minimize the generated WASM artifact.

## Strategy
The stable stack keeps the default release path conservative and mergeable. This PR captures the largest build-only size win we found as an explicit experimental mode instead of replacing the normal release build.

When `WASM_SMALLEST=1` is set, the build uses `cargo +nightly -Z build-std=std,panic_abort` with `RUSTFLAGS='-Zunstable-options -Cpanic=immediate-abort -Zlocation-detail=none'`. That rebuilds the standard library for a smaller panic/runtime footprint.

## Tradeoffs
- Requires nightly Rust and unstable Cargo/rustc flags.
- Produces warnings from existing no-op logging macro imports under nightly; the build still succeeds.
- Panic behavior is more abrupt and carries less diagnostic location information.
- This should be treated as an optional artifact mode until the team decides whether unstable build plumbing belongs in release automation.

## Size impact
Local measurement found this path reduced the optimized raw WASM artifact from roughly 1.46 MB on the stable stack to roughly 1.25 MB with nightly immediate-abort/location stripping.

## Test plan
- Verified `WASM_SMALLEST=1 PROFILE=wasm-release TARGET_DIR=wasm-release node ./target.mjs compile` succeeds locally.
- Earlier measured bindgen and `wasm-opt` outputs with the same nightly flags.