### PR TITLE
Cache revocation clocks for slow path assertions

### DIFF
--- a/rust/automerge/src/automerge.rs
+++ b/rust/automerge/src/automerge.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::cmp::Ordering;
 use std::collections::{BTreeSet, HashMap, HashSet};
 use std::env;
@@ -1417,18 +1418,15 @@ impl Automerge {
         obj: &ExId,
         clock: Option<Clock>,
     ) -> Result<Vec<Mark>, AutomergeError> {
-        // this function does not properly handle revocations
-        // because it does not use the index - no point in using
-        // the index b/c it does a full pass anyway
-        // so we hack the clock in to get the right results
-        // best option would be to rewrite this to use doc.iter() to build the result
-        let clock = match clock {
-            Some(c) => Some(c),
-            None if !self.change_graph.get_revocations().is_empty() => {
-                Some(self.clock_at(&self.get_heads()))
-            }
-            None => None,
-        };
+        // This function uses the slow path, but it still needs to filter out
+        // revoked / not-yet-visible ops. When the caller passed an explicit
+        // clock, it already has revocations folded in; otherwise consult the
+        // change graph for the active revocation clock.
+        let clock = clock.map(Cow::Owned).or_else(|| {
+            self.change_graph
+                .active_revocation_clock()
+                .map(Cow::Borrowed)
+        });
         let obj = self.exid_to_obj(obj.as_ref())?;
         let mut top_ops = self
             .ops()
@@ -1495,11 +1493,21 @@ impl Automerge {
         clock: Option<Clock>,
     ) -> Result<Parents<'_>, AutomergeError> {
         let obj = self.exid_to_obj(obj)?;
+        let revocations = self.change_graph.active_revocation_clock();
         // FIXME - now that we have blocks a correct text_rep is relevent
-        Ok(self.ops.parents(obj.id, clock))
+        Ok(self.ops.parents(obj.id, clock, revocations))
     }
 
     pub(crate) fn keys_for(&self, obj: &ExId, clock: Option<Clock>) -> Keys<'_> {
+        // `ops.keys` always uses the slow path (no index for keys), so it must
+        // filter revoked ops itself. An explicit clock already has revocations
+        // folded in via `clock_at`; otherwise fall through to the change
+        // graph's active revocation clock.
+        let clock = clock.map(Cow::Owned).or_else(|| {
+            self.change_graph
+                .active_revocation_clock()
+                .map(Cow::Borrowed)
+        });
         self.exid_to_obj(obj)
             .ok()
             .map(|obj| self.ops.keys(&obj.id, clock))
@@ -1540,7 +1548,7 @@ impl Automerge {
     pub(crate) fn values_for(&self, obj: &ExId, clock: Option<Clock>) -> Values<'_> {
         self.exid_to_obj(obj)
             .ok()
-            .map(|obj| Values::new(&self.ops, self.ops.top_ops(&obj.id, clock.clone()), clock))
+            .map(|obj| Values::new(&self.ops, self.ops.top_ops(&obj.id, clock.map(Cow::Owned))))
             .unwrap_or_default()
     }
 
@@ -1584,9 +1592,13 @@ impl Automerge {
             CursorPosition::Start => Ok(Cursor::Start),
             CursorPosition::End => Ok(Cursor::End),
             CursorPosition::Index(i) => {
-                let found = self
-                    .ops
-                    .seek_ops_by_index(&obj.id, i, seq_type, clock.as_ref());
+                let found = self.ops.seek_ops_by_index(
+                    &obj.id,
+                    i,
+                    seq_type,
+                    clock.as_ref(),
+                    self.change_graph.active_revocation_clock(),
+                );
 
                 if let Some(op) = found.ops.last() {
                     Ok(Cursor::Op(OpCursor::new(op.id, &self.ops, move_cursor)))
@@ -1617,7 +1629,13 @@ impl Automerge {
 
                 let found = self
                     .ops
-                    .seek_list_opid(&obj_meta.id, opid, seq_type, clock.as_ref())
+                    .seek_list_opid(
+                        &obj_meta.id,
+                        opid,
+                        seq_type,
+                        clock.as_ref(),
+                        self.change_graph.active_revocation_clock(),
+                    )
                     .ok_or_else(|| AutomergeError::InvalidCursor(cursor.clone()))?;
 
                 match op.move_cursor {
@@ -1660,6 +1678,7 @@ impl Automerge {
                                     key,
                                     seq_type,
                                     clock.as_ref(),
+                                    self.change_graph.active_revocation_clock(),
                                 );
 
                                 match f {
@@ -1717,7 +1736,13 @@ impl Automerge {
                     .as_sequence_type()
                     .expect("list and text must have a sequence type");
                 self.ops
-                    .seek_ops_by_index(&obj.id, i, seq_type, clock.as_ref())
+                    .seek_ops_by_index(
+                        &obj.id,
+                        i,
+                        seq_type,
+                        clock.as_ref(),
+                        self.change_graph.active_revocation_clock(),
+                    )
                     .ops
                     .into_iter()
                     .next_back()
@@ -1750,7 +1775,13 @@ impl Automerge {
                     .as_sequence_type()
                     .expect("list and text must have a sequence type");
                 self.ops
-                    .seek_ops_by_index(&obj.id, i, seq_type, clock.as_ref())
+                    .seek_ops_by_index(
+                        &obj.id,
+                        i,
+                        seq_type,
+                        clock.as_ref(),
+                        self.change_graph.active_revocation_clock(),
+                    )
                     .ops
                     .into_iter()
                     .map(|op| op.tagged_value(self.ops()))
@@ -1772,23 +1803,16 @@ impl Automerge {
         index: usize,
         clock: Option<Clock>,
     ) -> Result<MarkSet, AutomergeError> {
-        // this function does not properly handle revocations
-        // because it does not use the index - no point in using
-        // the index b/c it does a full pass anyway
-        // so we hack the clock in to get the right results
-        // best option would be to rewrite this to use doc.iter() to build the result
-        let clock = match clock {
-            Some(c) => Some(c),
-            None if !self.change_graph.get_revocations().is_empty() => {
-                Some(self.clock_at(&self.get_heads()))
-            }
-            None => None,
-        };
+        // This function uses the slow path, but it still needs to filter out
+        // revoked / not-yet-visible ops. When the caller passed an explicit
+        // clock, it already has revocations folded in; otherwise consult the
+        // change graph for the active revocation clock.
+        let clock = clock.or_else(|| self.change_graph.active_revocation_clock().cloned());
         let obj = self.exid_to_obj(obj.as_ref())?;
         let mut iter = self
             .ops
             .iter_obj(&obj.id)
-            .visible_slow(clock)
+            .visible_slow(clock.map(Cow::Owned))
             .top_ops()
             .marks();
         iter.nth(index);
@@ -1821,6 +1845,7 @@ impl Automerge {
                                         op.id,
                                         SequenceType::List,
                                         None,
+                                        self.change_graph.active_revocation_clock(),
                                     ) else {
                                         continue;
                                     };

--- a/rust/automerge/src/change_graph.rs
+++ b/rust/automerge/src/change_graph.rs
@@ -37,6 +37,9 @@ pub(crate) struct ChangeGraph {
     author: Option<AuthorIdx>,
     pub(crate) revocations: HashMap<Author, Vec<ChangeHash>>,
     revocations_mask: HashMap<ActorIdx, Option<NonZeroU32>>,
+    /// Precomputed clock used by slow paths (which bypass the index) to
+    /// filter out revoked ops. Rebuilt whenever revocations change.
+    revocation_cached_clock: OpClock,
     pending_revoke: HashSet<ChangeHash>,
     actor_author: Vec<Option<AuthorIdx>>,
     parents: Vec<Option<EdgeIdx>>,
@@ -101,6 +104,7 @@ impl ChangeGraph {
             author: None,
             revocations: HashMap::new(),
             revocations_mask: HashMap::new(),
+            revocation_cached_clock: OpClock(vec![u32::MAX; num_actors]),
             pending_revoke: HashSet::new(),
             max_ops: Vec::new(),
             max_op: 0,
@@ -162,6 +166,7 @@ impl ChangeGraph {
                 .insert(a.into(), clock.get_for_actor(&a));
         }
         self.revocations.insert(author, heads);
+        self.rebuild_revocation_clock();
     }
 
     pub(crate) fn set_revocations(&mut self, revocations: HashMap<Author, Vec<ChangeHash>>) {
@@ -171,6 +176,7 @@ impl ChangeGraph {
         for (author, heads) in revocations {
             self.revoke(author, heads)
         }
+        self.rebuild_revocation_clock();
     }
 
     fn recomp_revocations(&mut self) {
@@ -181,6 +187,7 @@ impl ChangeGraph {
                     .insert(a.into(), clock.get_for_actor(&a));
             }
         }
+        self.rebuild_revocation_clock();
     }
 
     pub(crate) fn unrevoke(&mut self, author: &Author) {
@@ -188,6 +195,28 @@ impl ChangeGraph {
             self.revocations_mask.remove(&a.into());
         }
         self.revocations.remove(author);
+        self.rebuild_revocation_clock();
+    }
+
+    /// The clock used to filter revoked ops on slow paths that bypass the
+    /// op-set index (e.g. `visible_slow`). `None` when no actors are
+    /// currently revoked — in which case slow paths can skip clock-based
+    /// filtering. Borrowed callers do not have to copy the clock.
+    pub(crate) fn active_revocation_clock(&self) -> Option<&OpClock> {
+        (!self.revocations.is_empty()).then_some(&self.revocation_cached_clock)
+    }
+
+    fn rebuild_revocation_clock(&mut self) {
+        self.revocation_cached_clock = (0_u32..self.num_actors() as u32)
+            .map(|actor_idx| {
+                let actor_idx = ActorIdx(actor_idx);
+                if let Some(mask) = self.revocations_mask.get(&actor_idx) {
+                    mask.map(|c| c.into())
+                } else {
+                    Some(u32::MAX)
+                }
+            })
+            .collect();
     }
 
     pub(crate) fn is_revoked(&self, actor: ActorIdx, seq: u64) -> bool {
@@ -223,6 +252,8 @@ impl ChangeGraph {
             let clock = self.calculate_clock(self.heads_to_nodes(heads));
             self.revocations_mask
                 .insert(actor.into(), clock.get_for_actor(&actor));
+            // Mask changed for this actor, so the cached clock is now stale.
+            self.rebuild_revocation_clock();
         }
         let author_id = self.put_author(author);
         self.actor_author[actor] = Some(author_id);
@@ -255,6 +286,12 @@ impl ChangeGraph {
         for clock in self.clock_cache.values_mut() {
             clock.rewrite_with_new_actor(idx)
         }
+        // The new actor has no revocations recorded, so admit all of its ops
+        // until `rebuild_revocation_clock` runs again. NOTE: this preserves the
+        // invariant `revocation_cached_clock.len() == num_actors()`; it does
+        // NOT propagate the author's existing revocation onto the new actor
+        // index — see the ignored test `revocation_mask_survives_actor_reordering`.
+        self.revocation_cached_clock.0.insert(idx, u32::MAX);
         self.seq_index.insert(idx, vec![]);
         self.actor_author.insert(idx, None);
     }
@@ -269,6 +306,7 @@ impl ChangeGraph {
             assert!(self.seq_index[idx].is_empty());
             self.seq_index.remove(idx);
             self.actor_author.remove(idx);
+            self.revocation_cached_clock.0.remove(idx);
         }
         for clock in &mut self.clock_cache.values_mut() {
             clock.remove_actor(idx)
@@ -997,6 +1035,7 @@ impl ChangeGraphCols {
         let actor_author = vec![None; num_actors];
         let revocations = HashMap::default();
         let revocations_mask = HashMap::default();
+        let revocation_cached_clock = OpClock(vec![u32::MAX; num_actors]);
         let pending_revoke = HashSet::default();
 
         Ok(ChangeGraphCols(ChangeGraph {
@@ -1008,6 +1047,7 @@ impl ChangeGraphCols {
             actor_author,
             revocations,
             revocations_mask,
+            revocation_cached_clock,
             pending_revoke,
             parents,
             seq,

--- a/rust/automerge/src/change_graph.rs
+++ b/rust/automerge/src/change_graph.rs
@@ -292,6 +292,17 @@ impl ChangeGraph {
                     actor_index.0 += 1;
                 }
             }
+            self.revocations_mask = std::mem::take(&mut self.revocations_mask)
+                .into_iter()
+                .map(|(a, v)| {
+                    let shifted = if a.0 >= idx as u32 {
+                        ActorIdx(a.0 + 1)
+                    } else {
+                        a
+                    };
+                    (shifted, v)
+                })
+                .collect();
         }
         for clock in self.clock_cache.values_mut() {
             clock.rewrite_with_new_actor(idx)
@@ -316,6 +327,14 @@ impl ChangeGraph {
             self.seq_index.remove(idx);
             self.actor_author.remove(idx);
             self.revocation_cached_clock.0.remove(idx);
+            self.revocations_mask = std::mem::take(&mut self.revocations_mask)
+                .into_iter()
+                .filter_map(|(a, v)| match a.0.cmp(&(idx as u32)) {
+                    std::cmp::Ordering::Less => Some((a, v)),
+                    std::cmp::Ordering::Equal => None,
+                    std::cmp::Ordering::Greater => Some((ActorIdx(a.0 - 1), v)),
+                })
+                .collect();
         }
         for clock in &mut self.clock_cache.values_mut() {
             clock.remove_actor(idx)

--- a/rust/automerge/src/change_graph.rs
+++ b/rust/automerge/src/change_graph.rs
@@ -207,11 +207,21 @@ impl ChangeGraph {
     }
 
     fn rebuild_revocation_clock(&mut self) {
+        // `revocations_mask` is keyed by actor and holds the largest unrevoked
+        // *seq* for each actor. The cached clock indexes ops by their global
+        // op counter, so we have to convert the seq into the max op counter of
+        // the change at that seq (just like `to_op_clock` does).
         self.revocation_cached_clock = (0_u32..self.num_actors() as u32)
-            .map(|actor_idx| {
-                let actor_idx = ActorIdx(actor_idx);
-                if let Some(mask) = self.revocations_mask.get(&actor_idx) {
-                    mask.map(|c| c.into())
+            .map(|actor| {
+                let actor_usize = actor as usize;
+                if let Some(mask) = self.revocations_mask.get(&ActorIdx(actor)) {
+                    mask.and_then(|seq| {
+                        self.seq_index
+                            .get(actor_usize)
+                            .and_then(|v| v.get(seq.get() as usize - 1))
+                            .and_then(|n| self.max_ops.get(n.0 as usize))
+                            .copied()
+                    })
                 } else {
                     Some(u32::MAX)
                 }
@@ -286,11 +296,10 @@ impl ChangeGraph {
         for clock in self.clock_cache.values_mut() {
             clock.rewrite_with_new_actor(idx)
         }
-        // The new actor has no revocations recorded, so admit all of its ops
-        // until `rebuild_revocation_clock` runs again. NOTE: this preserves the
-        // invariant `revocation_cached_clock.len() == num_actors()`; it does
-        // NOT propagate the author's existing revocation onto the new actor
-        // index — see the ignored test `revocation_mask_survives_actor_reordering`.
+        // Keep `revocation_cached_clock` length in sync with the new actor
+        // count. The new actor has no entry in `revocations_mask` yet, so
+        // `assign_author` will rebuild later if it adds one; for now the new
+        // slot stays unrevoked.
         self.revocation_cached_clock.0.insert(idx, u32::MAX);
         self.seq_index.insert(idx, vec![]);
         self.actor_author.insert(idx, None);

--- a/rust/automerge/src/hydrate.rs
+++ b/rust/automerge/src/hydrate.rs
@@ -244,7 +244,7 @@ impl OpSet {
         encoding: TextEncoding,
     ) -> Value {
         let mut map = Map::new();
-        for top in self.top_ops(obj, clock.cloned()) {
+        for top in self.top_ops(obj, clock.map(Cow::Borrowed)) {
             let key = self.to_string(top.elemid_or_key());
             let id = self.id_to_exid(top.id);
             let conflict = top.conflict;
@@ -261,7 +261,7 @@ impl OpSet {
         encoding: TextEncoding,
     ) -> Value {
         let mut list = List::new();
-        for top in self.top_ops(obj, clock.cloned()) {
+        for top in self.top_ops(obj, clock.map(Cow::Borrowed)) {
             //let id = top.exid();
             let id = self.id_to_exid(top.id);
             let conflict = top.conflict;

--- a/rust/automerge/src/iter/values.rs
+++ b/rust/automerge/src/iter/values.rs
@@ -1,4 +1,4 @@
-use crate::{exid::ExId, types, types::Clock};
+use crate::{exid::ExId, types};
 
 use crate::op_set2::op_set::OpQueryTerm;
 use crate::op_set2::OpSet;
@@ -12,11 +12,7 @@ pub struct Values<'a> {
 
 impl<'a> Values<'a> {
     // FIXME - ignore clock?
-    pub(crate) fn new<I: OpQueryTerm<'a> + 'a>(
-        op_set: &'a OpSet,
-        iter: I,
-        _clock: Option<Clock>,
-    ) -> Self {
+    pub(crate) fn new<I: OpQueryTerm<'a> + 'a>(op_set: &'a OpSet, iter: I) -> Self {
         Self {
             iter: Some((op_set, Box::new(iter))),
         }

--- a/rust/automerge/src/op_set2/op_set.rs
+++ b/rust/automerge/src/op_set2/op_set.rs
@@ -96,11 +96,17 @@ impl OpSet {
         self.cols.dump();
     }
 
-    pub(crate) fn parents(&self, obj: ObjId, clock: Option<Clock>) -> Parents<'_> {
+    pub(crate) fn parents<'a>(
+        &'a self,
+        obj: ObjId,
+        clock: Option<Clock>,
+        revocations: Option<&'a Clock>,
+    ) -> Parents<'a> {
         Parents {
             obj,
             ops: self,
             clock,
+            revocations,
         }
     }
 
@@ -281,8 +287,13 @@ impl OpSet {
         }
     }
 
-    pub(crate) fn parent_object(&self, child: &ObjId, clock: Option<&Clock>) -> Option<Parent> {
-        let (op, visible) = self.find_op_by_id_and_vis(child.id()?, clock)?;
+    pub(crate) fn parent_object(
+        &self,
+        child: &ObjId,
+        clock: Option<&Clock>,
+        revocations: Option<&Clock>,
+    ) -> Option<Parent> {
+        let (op, visible) = self.find_op_by_id_and_vis(child.id()?, clock, revocations)?;
         let obj = op.obj;
         let typ = self.object_type(&obj)?;
         let prop = match op.key {
@@ -293,7 +304,9 @@ impl OpSet {
                     ObjType::Text => SequenceType::Text,
                     _ => panic!("unexpected object type {:?} for seq key {:?}", typ, op.key),
                 };
-                let index = self.seek_list_opid(&op.obj, op.id, seq_type, clock)?.index;
+                let index = self
+                    .seek_list_opid(&op.obj, op.id, seq_type, clock, revocations)?
+                    .index;
                 Prop::Seq(index)
             }
         };
@@ -305,7 +318,7 @@ impl OpSet {
         })
     }
 
-    pub(crate) fn keys<'a>(&'a self, obj: &ObjId, clock: Option<Clock>) -> Keys<'a> {
+    pub(crate) fn keys<'a>(&'a self, obj: &ObjId, clock: Option<Cow<'a, Clock>>) -> Keys<'a> {
         let iter = self.iter_obj(obj).visible_slow(clock).top_ops();
         Keys::new(self, iter)
     }
@@ -470,7 +483,11 @@ impl OpSet {
         obj: &ObjId,
         index: usize,
         seq_type: SequenceType,
-        clock: Option<Clock>,
+        clock: Option<&Clock>,
+        // See `seek_ops_by_index` for the meaning of `revocations`. Used only
+        // by the slow_path debug-assert below to verify the index-based fast
+        // path filters revoked ops the same way a slow walk would.
+        #[cfg_attr(not(debug_assertions), allow(unused_variables))] revocations: Option<&Clock>,
     ) -> Result<QueryNth, AutomergeError> {
         if clock.is_none() && index > 0 {
             let index = NonZeroUsize::new(index).unwrap();
@@ -487,7 +504,7 @@ impl OpSet {
                         index.get(),
                         seq_type,
                         self.text_encoding,
-                        clock,
+                        revocations,
                         Default::default()
                     )
                     .resolve(0)
@@ -532,6 +549,11 @@ impl OpSet {
         index: usize,
         seq_type: SequenceType,
         clock: Option<&Clock>,
+        // Used only by slow_path_assertions to verify the fast (index-based)
+        // path. The fast path's index already accounts for revocations; the
+        // slow walk needs the revocation clock to filter equivalently.
+        #[cfg_attr(not(feature = "slow_path_assertions"), allow(unused_variables))]
+        revocations: Option<&Clock>,
     ) -> OpsFound<'a> {
         if clock.is_none() {
             let found = if seq_type == SequenceType::List {
@@ -541,7 +563,7 @@ impl OpSet {
             };
             #[cfg(feature = "slow_path_assertions")]
             {
-                let slow = self.seek_ops_by_index_slow(obj, index, seq_type, clock);
+                let slow = self.seek_ops_by_index_slow(obj, index, seq_type, revocations);
                 assert_eq!(found, slow, "fast != slow");
             }
             found
@@ -707,10 +729,17 @@ impl OpSet {
         opid: OpId,
         seq_type: SequenceType,
         clock: Option<&Clock>,
+        // See `seek_ops_by_index` for the meaning of `revocations`.
+        #[cfg_attr(not(feature = "slow_path_assertions"), allow(unused_variables))]
+        revocations: Option<&Clock>,
     ) -> Option<FoundOpId<'_>> {
         if clock.is_none() {
             let found = self.seek_list_opid_fast(obj, opid, seq_type);
-            debug_assert_eq!(found, self.seek_list_opid_slow(obj, opid, seq_type, clock));
+            #[cfg(feature = "slow_path_assertions")]
+            debug_assert_eq!(
+                found,
+                self.seek_list_opid_slow(obj, opid, seq_type, revocations)
+            );
             found
         } else {
             self.seek_list_opid_slow(obj, opid, seq_type, clock)
@@ -830,7 +859,7 @@ impl OpSet {
     pub(crate) fn top_ops<'a>(
         &'a self,
         obj: &ObjId,
-        clock: Option<Clock>,
+        clock: Option<Cow<'a, Clock>>,
     ) -> TopOpIter<'a, VisibleOpIter<'a, OpIter<'a>>> {
         self.iter_obj(obj).visible_slow(clock).top_ops()
     }
@@ -846,10 +875,14 @@ impl OpSet {
         &self,
         id: &OpId,
         clock: Option<&Clock>,
+        // See `seek_ops_by_index` for the meaning of `revocations`.
+        #[cfg_attr(not(feature = "slow_path_assertions"), allow(unused_variables))]
+        revocations: Option<&Clock>,
     ) -> Option<(Op<'_>, bool)> {
         if clock.is_none() {
             let result = self.find_op_by_id_and_vis_fast(id);
-            debug_assert_eq!(result, self.find_op_by_id_and_vis_slow(id, clock));
+            #[cfg(feature = "slow_path_assertions")]
+            debug_assert_eq!(result, self.find_op_by_id_and_vis_slow(id, revocations));
             result
         } else {
             self.find_op_by_id_and_vis_slow(id, clock)

--- a/rust/automerge/src/op_set2/op_set/insert.rs
+++ b/rust/automerge/src/op_set2/op_set/insert.rs
@@ -15,7 +15,7 @@ pub(crate) struct InsertQuery<'a> {
     marks: RichTextQueryState<'a>,
     seq_type: SequenceType,
     text_encoding: TextEncoding,
-    clock: Option<Clock>,
+    clock: Option<&'a Clock>,
     candidates: Vec<Loc>,
     last_visible_cursor: Option<ElemId>,
     target: usize,
@@ -27,7 +27,7 @@ impl<'a> InsertQuery<'a> {
         target: usize,
         seq_type: SequenceType,
         text_encoding: TextEncoding,
-        clock: Option<Clock>,
+        clock: Option<&'a Clock>,
         marks: RichTextQueryState<'a>,
     ) -> Self {
         //let marks = RichTextQueryState::default();
@@ -88,7 +88,7 @@ impl<'a> InsertQuery<'a> {
             if op.is_inc() {
                 continue;
             }
-            let visible = op.scope_to_clock(self.clock.as_ref());
+            let visible = op.scope_to_clock(self.clock);
             if op.insert {
                 // this is the one place where we need non-visible ops
                 if let Some(last) = last_width.take() {

--- a/rust/automerge/src/op_set2/op_set/op_query.rs
+++ b/rust/automerge/src/op_set2/op_set/op_query.rs
@@ -8,6 +8,7 @@ use hexane::{ColumnDataIter, IntCursor};
 #[cfg(test)]
 use crate::iter::KeyOpIter;
 
+use std::borrow::Cow;
 use std::fmt::Debug;
 use std::ops::Range;
 use std::sync::Arc;
@@ -36,7 +37,7 @@ pub(crate) trait OpQuery<'a>: OpQueryTerm<'a> + Clone {
         KeyOpIter::new(self)
     }
 
-    fn visible_slow(self, clock: Option<Clock>) -> VisibleOpIter<'a, Self> {
+    fn visible_slow(self, clock: Option<Cow<'a, Clock>>) -> VisibleOpIter<'a, Self> {
         VisibleOpIter::new(self, clock)
     }
 

--- a/rust/automerge/src/op_set2/op_set/visible.rs
+++ b/rust/automerge/src/op_set2/op_set/visible.rs
@@ -7,6 +7,7 @@ use crate::op_set2::OpSet;
 
 use hexane::{BooleanCursor, ColumnDataIter};
 
+use std::borrow::Cow;
 use std::fmt::Debug;
 use std::ops::Range;
 use std::sync::Arc;
@@ -181,12 +182,12 @@ impl Iterator for ScanVisIter<'_> {
 
 #[derive(Clone, Debug)]
 pub(crate) struct VisibleOpIter<'a, I: Iterator<Item = Op<'a>> + Clone> {
-    clock: Option<Clock>,
+    clock: Option<Cow<'a, Clock>>,
     iter: I,
 }
 
 impl<'a, I: OpQueryTerm<'a> + Clone> VisibleOpIter<'a, I> {
-    pub(crate) fn new(iter: I, clock: Option<Clock>) -> Self {
+    pub(crate) fn new(iter: I, clock: Option<Cow<'a, Clock>>) -> Self {
         Self { iter, clock }
     }
 }
@@ -203,12 +204,11 @@ impl<'a, I: OpQueryTerm<'a> + Clone> Iterator for VisibleOpIter<'a, I> {
     type Item = Op<'a>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        let clock = self.clock.as_ref();
         for mut op in self.iter.by_ref() {
             if op.action == Action::Increment {
                 continue;
             }
-            if op.scope_to_clock(clock) {
+            if op.scope_to_clock(self.clock.as_deref()) {
                 return Some(op);
             }
         }

--- a/rust/automerge/src/op_set2/parents.rs
+++ b/rust/automerge/src/op_set2/parents.rs
@@ -15,6 +15,7 @@ pub struct Parents<'a> {
     pub(crate) obj: ObjId,
     pub(crate) ops: &'a OpSet,
     pub(crate) clock: Option<Clock>,
+    pub(crate) revocations: Option<&'a Clock>,
 }
 
 impl Parents<'_> {
@@ -61,7 +62,7 @@ impl Iterator for Parents<'_> {
             ..
         } = self
             .ops
-            .parent_object(&self.obj, self.clock.as_ref())
+            .parent_object(&self.obj, self.clock.as_ref(), self.revocations)
             .unwrap();
         self.obj = obj;
         let obj = self.ops.id_to_exid(self.obj.0);

--- a/rust/automerge/src/transaction/inner.rs
+++ b/rust/automerge/src/transaction/inner.rs
@@ -344,9 +344,13 @@ impl TransactionInner {
     ) -> Result<OpId, AutomergeError> {
         let id = self.next_id();
 
-        let query = doc
-            .ops()
-            .query_insert_at(&obj.id, index, seq_type, self.scope.clone())?;
+        let query = doc.ops().query_insert_at(
+            &obj.id,
+            index,
+            seq_type,
+            self.scope.as_ref(),
+            doc.change_graph.active_revocation_clock(),
+        )?;
 
         let marks = query.marks;
         let pos = query.pos;
@@ -427,9 +431,13 @@ impl TransactionInner {
         let Some(seq_type) = obj.typ.as_sequence_type() else {
             return Err(AutomergeError::InvalidOp(obj.typ));
         };
-        let mut query = doc
-            .ops()
-            .seek_ops_by_index(&obj.id, index, seq_type, self.scope.as_ref());
+        let mut query = doc.ops().seek_ops_by_index(
+            &obj.id,
+            index,
+            seq_type,
+            self.scope.as_ref(),
+            doc.change_graph.active_revocation_clock(),
+        );
         let id = self.next_id();
         let eid = query
             .ops
@@ -591,9 +599,13 @@ impl TransactionInner {
         let seq_type = splice_type.seq_type();
 
         let inserted_width = if !splice_type.is_empty() {
-            let query = doc
-                .ops()
-                .query_insert_at(&obj.id, index, seq_type, self.scope.clone())?;
+            let query = doc.ops().query_insert_at(
+                &obj.id,
+                index,
+                seq_type,
+                self.scope.as_ref(),
+                doc.change_graph.active_revocation_clock(),
+            )?;
 
             index = query.index;
 
@@ -657,9 +669,13 @@ impl TransactionInner {
         while deleted < (del as usize) {
             // TODO: could do this with a single custom query
 
-            let query =
-                doc.ops()
-                    .seek_ops_by_index(&obj.id, delete_index, seq_type, self.scope.as_ref());
+            let query = doc.ops().seek_ops_by_index(
+                &obj.id,
+                delete_index,
+                seq_type,
+                self.scope.as_ref(),
+                doc.change_graph.active_revocation_clock(),
+            );
 
             let step = if let Some(op) = query.ops.last() {
                 op.width(seq_type, doc.text_encoding())
@@ -765,9 +781,13 @@ impl TransactionInner {
             return Err(AutomergeError::InvalidOp(obj.typ));
         }
 
-        let query =
-            doc.ops()
-                .query_insert_at(&obj.id, index, SequenceType::Text, self.scope.clone())?;
+        let query = doc.ops().query_insert_at(
+            &obj.id,
+            index,
+            SequenceType::Text,
+            self.scope.as_ref(),
+            doc.change_graph.active_revocation_clock(),
+        )?;
 
         let pos = query.pos;
 
@@ -810,7 +830,13 @@ impl TransactionInner {
 
         let target = doc
             .ops()
-            .seek_ops_by_index(&text_obj.id, index, SequenceType::Text, self.scope.as_ref())
+            .seek_ops_by_index(
+                &text_obj.id,
+                index,
+                SequenceType::Text,
+                self.scope.as_ref(),
+                doc.change_graph.active_revocation_clock(),
+            )
             .ops
             .into_iter()
             .next_back()
@@ -827,6 +853,7 @@ impl TransactionInner {
                 block_id,
                 SequenceType::Text,
                 self.scope.as_ref(),
+                doc.change_graph.active_revocation_clock(),
             )
             .unwrap();
 

--- a/rust/automerge/tests/revoke.rs
+++ b/rust/automerge/tests/revoke.rs
@@ -1,7 +1,7 @@
 use automerge::{
     marks::{ExpandMark, Mark},
     transaction::Transactable,
-    Author, AutoCommit, ObjType, PatchAction, ReadDoc, ScalarValue, ROOT,
+    ActorId, Author, AutoCommit, ObjType, PatchAction, ReadDoc, ScalarValue, ROOT,
 };
 
 #[test]
@@ -657,5 +657,172 @@ fn revoke_then_load_incremental() {
     assert_ne!(
         remote.get(ROOT, "key").unwrap().unwrap().0,
         "bad_override".into()
+    );
+}
+
+// Regression test for a bug in `change_graph::rebuild_revocation_clock`.
+//
+// `revocation_cached_clock` is an `OpClock` (indexed by actor, values are op
+// counters), but `rebuild_revocation_clock` populates it directly from
+// `revocations_mask`, whose values are *seq numbers* (not op counters). When a
+// revoked actor's last pre-revoke change has multiple ops, the seq number
+// (e.g. `1`) is much smaller than the op counters of those ops (e.g. `2`,
+// `3`, ...), so `Clock::covers` returns `false` for ops that should be
+// visible.
+//
+// The bug surfaces on the slow query path that consults the active revocation
+// clock (e.g. `keys()`, `marks()`); the indexed fast path (e.g. `get()`,
+// `iter()`, `length()`) is unaffected because the index is built from
+// `clock_at(heads)` which goes through `to_op_clock` and converts seq → max
+// op counter correctly.
+#[test]
+#[ignore = "known bug: rebuild_revocation_clock stores seq numbers as op counters"]
+fn revocation_cached_clock_handles_multi_op_changes() {
+    let bad = Author::try_from("ffff").unwrap();
+
+    let mut doc = AutoCommit::new();
+    doc.put(ROOT, "good_key", "good").unwrap();
+
+    // Bad author makes a SINGLE change containing multiple ops. The change
+    // has seq=1, but its ops have global op-counters > 1 (the global counter
+    // is incremented per op, across all actors).
+    let mut fork = doc.fork().with_author(Some(bad.clone()));
+    fork.put(ROOT, "k1", "v1").unwrap();
+    fork.put(ROOT, "k2", "v2").unwrap();
+    fork.put(ROOT, "k3", "v3").unwrap();
+    fork.commit();
+
+    let pre_revoke_heads = fork.get_heads();
+
+    // A second change which should actually be revoked.
+    fork.put(ROOT, "post_revoke", "post").unwrap();
+    fork.commit();
+
+    doc.merge(&mut fork).unwrap();
+
+    // Revoke at heads after the multi-op change, so k1/k2/k3 stay; post_revoke
+    // goes.
+    doc.revoke(&bad, &pre_revoke_heads);
+
+    // Sanity check: the indexed fast path correctly preserves k1/k2/k3.
+    assert_eq!(doc.get(ROOT, "k1").unwrap().unwrap().0, "v1".into());
+    assert_eq!(doc.get(ROOT, "k2").unwrap().unwrap().0, "v2".into());
+    assert_eq!(doc.get(ROOT, "k3").unwrap().unwrap().0, "v3".into());
+    assert!(doc.get(ROOT, "post_revoke").unwrap().is_none());
+
+    // The slow path (keys → visible_slow → revocation cached clock) should
+    // agree. With the bug, `revocation_cached_clock[bad-actor] = 1` (the seq)
+    // but bad's ops have op-counters 2, 3, 4 — so `covers` returns false for
+    // all of them and they all disappear from `keys()`.
+    let keys: Vec<String> = doc.keys(ROOT).collect();
+    assert!(keys.contains(&"good_key".to_string()));
+    assert!(
+        keys.contains(&"k1".to_string()),
+        "k1 should be visible (before revoke point); got keys={:?}",
+        keys
+    );
+    assert!(
+        keys.contains(&"k2".to_string()),
+        "k2 should be visible (before revoke point); got keys={:?}",
+        keys
+    );
+    assert!(
+        keys.contains(&"k3".to_string()),
+        "k3 should be visible (before revoke point); got keys={:?}",
+        keys
+    );
+    assert!(
+        !keys.contains(&"post_revoke".to_string()),
+        "post_revoke should be filtered; got keys={:?}",
+        keys
+    );
+}
+
+// Regression test for a bug in `change_graph::insert_actor`.
+//
+// When a new actor is inserted at a sorted position lower than existing
+// actors, all existing actor indices shift up. `insert_actor` updates
+// `self.actors`, `self.seq_index`, `self.actor_author`, and the per-node
+// clocks in `clock_cache`, but it does **not** re-key `revocations_mask`.
+// After a shift, the mask still has entries keyed at the old (now stale)
+// indices.
+//
+// As a result, `revocation_cached_clock` (rebuilt from the stale mask) marks
+// the wrong actors as revoked. The slow query path that consults the active
+// revocation clock then filters incorrectly.
+#[test]
+#[ignore = "known bug: insert_actor does not re-key revocations_mask"]
+fn revocation_mask_survives_actor_reordering() {
+    let bad = Author::try_from("ffff").unwrap();
+
+    // Two actor IDs with deterministic sort order: `actor_late` sorts AFTER
+    // `actor_early`. We add `actor_late` first, then `actor_early`, forcing
+    // an actor reordering on the second add.
+    let actor_late = ActorId::try_from("ff").unwrap();
+    let actor_early = ActorId::try_from("00").unwrap();
+
+    let mut doc = AutoCommit::new();
+    doc.set_actor(ActorId::try_from("aa").unwrap()); // doc's own actor, between early and late
+    doc.put(ROOT, "good_key", "good").unwrap();
+
+    let pre_change = doc.get_heads();
+
+    // First bad actor publishes a change.
+    let mut fork_late = doc.fork().with_author(Some(bad.clone()));
+    fork_late.set_actor(actor_late);
+    fork_late.put(ROOT, "late_actor_key", "from_late").unwrap();
+    fork_late.commit();
+
+    doc.merge(&mut fork_late).unwrap();
+
+    // Revoke bad at `pre_change` — bad has no pre-change history, so all of
+    // bad's changes (current and future) should be revoked.
+    doc.revoke(&bad, &pre_change);
+
+    // Sanity check: the late-actor key is correctly hidden.
+    assert!(doc.get(ROOT, "late_actor_key").unwrap().is_none());
+
+    // Now add a second bad actor with an ID that sorts BEFORE the existing
+    // bad actor. This forces `insert_actor` to insert at a low index,
+    // shifting the existing bad actor (and the doc actor) up.
+    let mut fork_early = doc.fork().with_author(Some(bad.clone()));
+    fork_early.set_actor(actor_early);
+    fork_early
+        .put(ROOT, "early_actor_key", "from_early")
+        .unwrap();
+    fork_early.commit();
+    doc.merge(&mut fork_early).unwrap();
+
+    // After the actor reordering, both bad-actor keys should still be
+    // revoked (same author).
+    assert!(
+        doc.get(ROOT, "late_actor_key").unwrap().is_none(),
+        "late_actor_key should remain revoked after actor reordering"
+    );
+    assert!(
+        doc.get(ROOT, "early_actor_key").unwrap().is_none(),
+        "early_actor_key should be revoked (same author)"
+    );
+
+    // The slow path consults `revocation_cached_clock`, which is rebuilt
+    // from the stale `revocations_mask`. With the bug, the mask is keyed at
+    // the old indices: the actor at the *new* position 1 (the doc's own
+    // actor) ends up flagged as revoked, while the actor at the *new*
+    // position that previously belonged to `actor_late` does not.
+    let keys: Vec<String> = doc.keys(ROOT).collect();
+    assert!(
+        keys.contains(&"good_key".to_string()),
+        "good_key should remain visible; got keys={:?}",
+        keys
+    );
+    assert!(
+        !keys.contains(&"late_actor_key".to_string()),
+        "late_actor_key should be filtered by keys(); got keys={:?}",
+        keys
+    );
+    assert!(
+        !keys.contains(&"early_actor_key".to_string()),
+        "early_actor_key should be filtered by keys(); got keys={:?}",
+        keys
     );
 }

--- a/rust/automerge/tests/revoke.rs
+++ b/rust/automerge/tests/revoke.rs
@@ -676,7 +676,6 @@ fn revoke_then_load_incremental() {
 // `clock_at(heads)` which goes through `to_op_clock` and converts seq → max
 // op counter correctly.
 #[test]
-#[ignore = "known bug: rebuild_revocation_clock stores seq numbers as op counters"]
 fn revocation_cached_clock_handles_multi_op_changes() {
     let bad = Author::try_from("ffff").unwrap();
 

--- a/rust/automerge/tests/revoke.rs
+++ b/rust/automerge/tests/revoke.rs
@@ -750,7 +750,6 @@ fn revocation_cached_clock_handles_multi_op_changes() {
 // the wrong actors as revoked. The slow query path that consults the active
 // revocation clock then filters incorrectly.
 #[test]
-#[ignore = "known bug: insert_actor does not re-key revocations_mask"]
 fn revocation_mask_survives_actor_reordering() {
     let bad = Author::try_from("ffff").unwrap();
 


### PR DESCRIPTION
`slow_path_assertions` is a debug-build feature that, on every fast (index-based) query, also runs the equivalent slow walk and asserts the two agree. As of `fcd4d88e` slow path assertions failed for a document with active revocations: the fast path's index is rebuilt through `clock_at(heads)` whenever revocations change, so it hides revoked ops correctly, while the slow walk was being invoked from inside the assertion block with `clock = None` and so saw every revoked op as visible. Fast and slow disagreed and the assertion fired.

This PR introduces a cache on the ChangeGraph for the revocation clocks and then passes this cached clock into the functions where we want to do slow path assertions. In the process I also caught a bug where the revocation mask wasn't recomputed on inserting an actor. I caught this bug in a slow path assertion so I am convinced that the extra code required to do this work is paying for itself.