### PR TITLE
Prototype compact wasm hydration tape

### DIFF
--- a/javascript/src/implementation.ts
+++ b/javascript/src/implementation.ts
@@ -131,7 +131,7 @@ function materializeFromCompactTape<T>(
         objects[ops[offset + 1]],
         ops[offset + 2],
         ops[offset + 3],
-        values[ops[offset + 5]],
+        reifyCompactScalar(ops[offset + 4], values[ops[offset + 5]]),
         strings,
       )
     } else if (op === 3) {
@@ -151,6 +151,19 @@ function materializeFromCompactTape<T>(
   }
 
   return objects[0] as T
+}
+
+function reifyCompactScalar(datatype: number, value: unknown): unknown {
+  if (datatype === 6) {
+    return new ImmutableString(value as string)
+  }
+  if (datatype === 8) {
+    return new Counter(value as number)
+  }
+  if (datatype === 9 && !(value instanceof Date)) {
+    return new Date(value as number)
+  }
+  return value
 }
 
 function makeCompactMaterializedObject(type: number): unknown {

--- a/javascript/src/implementation.ts
+++ b/javascript/src/implementation.ts
@@ -123,7 +123,7 @@ function materializeFromCompactTape<T>(
       objects[index] = makeCompactMaterializedObject(type)
       objectMeta[index] = { type, parent, propKind, prop }
       setAutomergeMetadata(objects[index], strings[ops[offset + 6]], meta)
-      if (type !== 2) {
+      if (type !== 4) {
         setCompactMaterializedValue(objects[parent], propKind, prop, objects[index], strings)
       }
     } else if (op === 2) {
@@ -141,7 +141,7 @@ function materializeFromCompactTape<T>(
 
   for (let index = 0; index < objects.length; index++) {
     const meta = objectMeta[index]
-    if (meta?.type === 2) {
+    if (meta?.type === 4) {
       const value = (objects[index] as string[]).join("")
       objects[index] = value
       if (meta.parent != null && meta.propKind != null && meta.prop != null) {
@@ -154,7 +154,7 @@ function materializeFromCompactTape<T>(
 }
 
 function makeCompactMaterializedObject(type: number): unknown {
-  if (type === 1 || type === 2) {
+  if (type === 2 || type === 4) {
     return []
   }
   return {}

--- a/javascript/src/implementation.ts
+++ b/javascript/src/implementation.ts
@@ -89,13 +89,29 @@ type SyncState = JsSyncState & {
   _opaque: typeof _SyncStateSymbol
 }
 
-function materializeFromCompactTape<T>(
+const TAPE_ROOT_OBJECT = 0
+const TAPE_CHILD_OBJECT = 1
+const TAPE_SCALAR_VALUE = 2
+const TAPE_TEXT_CHUNK = 3
+
+const TAPE_MAP_PROP = 0
+
+// These match Rust storage Action codes for object creation.
+const TAPE_LIST_OBJECT = 2
+const TAPE_TEXT_OBJECT = 4
+
+// These match Rust ValueMeta low-nibble scalar codes.
+const TAPE_STRING_VALUE = 6
+const TAPE_COUNTER_VALUE = 8
+const TAPE_TIMESTAMP_VALUE = 9
+
+function materializeFromTape<T>(
   handle: Automerge,
   obj: ObjID = "/",
   heads?: Heads,
   meta?: unknown,
 ): T {
-  const tape = handle.materializeCompactTape(obj, heads) as {
+  const tape = handle.materializeTape(obj, heads) as {
     ops: Uint32Array
     strings: string[]
     values: unknown[]
@@ -108,44 +124,44 @@ function materializeFromCompactTape<T>(
 
   for (let offset = 0; offset < ops.length; offset += 8) {
     const op = ops[offset]
-    if (op === 0) {
+    if (op === TAPE_ROOT_OBJECT) {
       const index = ops[offset + 1]
       const type = ops[offset + 2]
-      objects[index] = makeCompactMaterializedObject(type)
+      objects[index] = makeTapeMaterializedObject(type)
       objectMeta[index] = { type }
       setAutomergeMetadata(objects[index], strings[ops[offset + 3]], meta)
-    } else if (op === 1) {
+    } else if (op === TAPE_CHILD_OBJECT) {
       const parent = ops[offset + 1]
       const propKind = ops[offset + 2]
       const prop = ops[offset + 3]
       const type = ops[offset + 4]
       const index = ops[offset + 5]
-      objects[index] = makeCompactMaterializedObject(type)
+      objects[index] = makeTapeMaterializedObject(type)
       objectMeta[index] = { type, parent, propKind, prop }
       setAutomergeMetadata(objects[index], strings[ops[offset + 6]], meta)
-      if (type !== 4) {
-        setCompactMaterializedValue(objects[parent], propKind, prop, objects[index], strings)
+      if (type !== TAPE_TEXT_OBJECT) {
+        setTapeMaterializedValue(objects[parent], propKind, prop, objects[index], strings)
       }
-    } else if (op === 2) {
-      setCompactMaterializedValue(
+    } else if (op === TAPE_SCALAR_VALUE) {
+      setTapeMaterializedValue(
         objects[ops[offset + 1]],
         ops[offset + 2],
         ops[offset + 3],
-        reifyCompactScalar(ops[offset + 4], values[ops[offset + 5]]),
+        reifyTapeScalar(ops[offset + 4], values[ops[offset + 5]]),
         strings,
       )
-    } else if (op === 3) {
+    } else if (op === TAPE_TEXT_CHUNK) {
       ;(objects[ops[offset + 1]] as string[]).push(strings[ops[offset + 2]])
     }
   }
 
   for (let index = 0; index < objects.length; index++) {
     const meta = objectMeta[index]
-    if (meta?.type === 4) {
+    if (meta?.type === TAPE_TEXT_OBJECT) {
       const value = (objects[index] as string[]).join("")
       objects[index] = value
       if (meta.parent != null && meta.propKind != null && meta.prop != null) {
-        setCompactMaterializedValue(objects[meta.parent], meta.propKind, meta.prop, value, strings)
+        setTapeMaterializedValue(objects[meta.parent], meta.propKind, meta.prop, value, strings)
       }
     }
   }
@@ -153,34 +169,36 @@ function materializeFromCompactTape<T>(
   return objects[0] as T
 }
 
-function reifyCompactScalar(datatype: number, value: unknown): unknown {
-  if (datatype === 6) {
+function reifyTapeScalar(datatype: number, value: unknown): unknown {
+  if (datatype === TAPE_STRING_VALUE) {
     return new ImmutableString(value as string)
   }
-  if (datatype === 8) {
+  if (datatype === TAPE_COUNTER_VALUE) {
     return new Counter(value as number)
   }
-  if (datatype === 9 && !(value instanceof Date)) {
+  if (datatype === TAPE_TIMESTAMP_VALUE && !(value instanceof Date)) {
     return new Date(value as number)
   }
   return value
 }
 
-function makeCompactMaterializedObject(type: number): unknown {
-  if (type === 2 || type === 4) {
+function makeTapeMaterializedObject(type: number): unknown {
+  if (type === TAPE_LIST_OBJECT || type === TAPE_TEXT_OBJECT) {
     return []
   }
   return {}
 }
 
-function setCompactMaterializedValue(
+function setTapeMaterializedValue(
   target: unknown,
   propKind: number,
   prop: number,
   value: unknown,
   strings: string[],
 ) {
-  ;(target as Record<string | number, unknown>)[propKind === 0 ? strings[prop] : prop] = value
+  ;(target as Record<string | number, unknown>)[
+    propKind === TAPE_MAP_PROP ? strings[prop] : prop
+  ] = value
 }
 
 function setAutomergeMetadata(target: unknown, objectId: ObjID, meta: unknown) {
@@ -370,7 +388,7 @@ export function init<T>(_opts?: ActorId | InitOptions<T>): Doc<T> {
   const handle = ApiHandler.create({ actor })
   handle.enableFreeze(!!opts.freeze)
   registerDatatypes(handle)
-  const doc = materializeFromCompactTape<T>(handle, "/", undefined, {
+  const doc = materializeFromTape<T>(handle, "/", undefined, {
     handle,
     heads: undefined,
     freeze,
@@ -397,7 +415,7 @@ export function init<T>(_opts?: ActorId | InitOptions<T>): Doc<T> {
 export function view<T>(doc: Doc<T>, heads: Heads): Doc<T> {
   const state = _state(doc)
   const handle = state.handle
-  return materializeFromCompactTape<T>(state.handle, "/", heads, {
+  return materializeFromTape<T>(state.handle, "/", heads, {
     ...state,
     handle,
     heads,
@@ -433,7 +451,7 @@ export function clone<T>(
   // set it to undefined to indicate that this is a full fat document
   const { heads: _oldHeads, ...stateSansHeads } = state
   stateSansHeads.patchCallback = opts.patchCallback
-  return materializeFromCompactTape<T>(handle, "/", undefined, {
+  return materializeFromTape<T>(handle, "/", undefined, {
     ...stateSansHeads,
     handle,
   }) as Doc<T>
@@ -652,7 +670,7 @@ function progressDocument<T>(
   const state = _state(doc)
   const nextState = { ...state, heads: undefined }
 
-  const nextDoc = materializeFromCompactTape<T>(
+  const nextDoc = materializeFromTape<T>(
     state.handle,
     "/",
     undefined,
@@ -824,7 +842,7 @@ export function load<T>(
   })
   handle.enableFreeze(!!opts.freeze)
   registerDatatypes(handle)
-  const doc = materializeFromCompactTape<T>(handle, "/", undefined, {
+  const doc = materializeFromTape<T>(handle, "/", undefined, {
     handle,
     heads: undefined,
     patchCallback,
@@ -1392,7 +1410,7 @@ export function dump<T>(doc: Doc<T>) {
 export function toJS<T>(doc: Doc<T>): T {
   const state = _state(doc)
   const enabled = state.handle.enableFreeze(false)
-  const result = materializeFromCompactTape<T>(
+  const result = materializeFromTape<T>(
     state.handle,
     "/",
     state.heads,

--- a/javascript/src/implementation.ts
+++ b/javascript/src/implementation.ts
@@ -5,7 +5,7 @@ import {
   validateForBatchInsert,
 } from "./proxies.js"
 export { isImmutableString, isCounter } from "./proxies.js"
-import { STATE } from "./constants.js"
+import { OBJECT_ID, STATE } from "./constants.js"
 
 import {
   type AutomergeValue,
@@ -87,6 +87,96 @@ const _SyncStateSymbol = Symbol("_syncstate")
 type SyncState = JsSyncState & {
   /** @hidden */
   _opaque: typeof _SyncStateSymbol
+}
+
+function materializeFromCompactTape<T>(
+  handle: Automerge,
+  obj: ObjID = "/",
+  heads?: Heads,
+  meta?: unknown,
+): T {
+  const tape = handle.materializeCompactTape(obj, heads) as {
+    ops: Uint32Array
+    strings: string[]
+    values: unknown[]
+  }
+  const objects: unknown[] = []
+  const objectMeta: Array<{ type: number; parent?: number; propKind?: number; prop?: number }> = []
+  const ops = tape.ops
+  const strings = tape.strings
+  const values = tape.values
+
+  for (let offset = 0; offset < ops.length; offset += 8) {
+    const op = ops[offset]
+    if (op === 0) {
+      const index = ops[offset + 1]
+      const type = ops[offset + 2]
+      objects[index] = makeCompactMaterializedObject(type)
+      objectMeta[index] = { type }
+      setAutomergeMetadata(objects[index], strings[ops[offset + 3]], meta)
+    } else if (op === 1) {
+      const parent = ops[offset + 1]
+      const propKind = ops[offset + 2]
+      const prop = ops[offset + 3]
+      const type = ops[offset + 4]
+      const index = ops[offset + 5]
+      objects[index] = makeCompactMaterializedObject(type)
+      objectMeta[index] = { type, parent, propKind, prop }
+      setAutomergeMetadata(objects[index], strings[ops[offset + 6]], meta)
+      if (type !== 2) {
+        setCompactMaterializedValue(objects[parent], propKind, prop, objects[index], strings)
+      }
+    } else if (op === 2) {
+      setCompactMaterializedValue(
+        objects[ops[offset + 1]],
+        ops[offset + 2],
+        ops[offset + 3],
+        values[ops[offset + 5]],
+        strings,
+      )
+    } else if (op === 3) {
+      ;(objects[ops[offset + 1]] as string[]).push(strings[ops[offset + 2]])
+    }
+  }
+
+  for (let index = 0; index < objects.length; index++) {
+    const meta = objectMeta[index]
+    if (meta?.type === 2) {
+      const value = (objects[index] as string[]).join("")
+      objects[index] = value
+      if (meta.parent != null && meta.propKind != null && meta.prop != null) {
+        setCompactMaterializedValue(objects[meta.parent], meta.propKind, meta.prop, value, strings)
+      }
+    }
+  }
+
+  return objects[0] as T
+}
+
+function makeCompactMaterializedObject(type: number): unknown {
+  if (type === 1 || type === 2) {
+    return []
+  }
+  return {}
+}
+
+function setCompactMaterializedValue(
+  target: unknown,
+  propKind: number,
+  prop: number,
+  value: unknown,
+  strings: string[],
+) {
+  ;(target as Record<string | number, unknown>)[propKind === 0 ? strings[prop] : prop] = value
+}
+
+function setAutomergeMetadata(target: unknown, objectId: ObjID, meta: unknown) {
+  if (target && typeof target === "object") {
+    Object.defineProperties(target, {
+      [OBJECT_ID]: { value: objectId },
+      [STATE]: { value: meta },
+    })
+  }
 }
 
 import { ApiHandler, type ChangeToEncode, UseApi } from "./low_level.js"
@@ -267,7 +357,7 @@ export function init<T>(_opts?: ActorId | InitOptions<T>): Doc<T> {
   const handle = ApiHandler.create({ actor })
   handle.enableFreeze(!!opts.freeze)
   registerDatatypes(handle)
-  const doc = handle.materialize("/", undefined, {
+  const doc = materializeFromCompactTape<T>(handle, "/", undefined, {
     handle,
     heads: undefined,
     freeze,
@@ -294,7 +384,7 @@ export function init<T>(_opts?: ActorId | InitOptions<T>): Doc<T> {
 export function view<T>(doc: Doc<T>, heads: Heads): Doc<T> {
   const state = _state(doc)
   const handle = state.handle
-  return state.handle.materialize("/", heads, {
+  return materializeFromCompactTape<T>(state.handle, "/", heads, {
     ...state,
     handle,
     heads,
@@ -330,7 +420,10 @@ export function clone<T>(
   // set it to undefined to indicate that this is a full fat document
   const { heads: _oldHeads, ...stateSansHeads } = state
   stateSansHeads.patchCallback = opts.patchCallback
-  return handle.applyPatches(doc, { ...stateSansHeads, handle })
+  return materializeFromCompactTape<T>(handle, "/", undefined, {
+    ...stateSansHeads,
+    handle,
+  }) as Doc<T>
 }
 
 /** Explicity free the memory backing a document. Note that this is note
@@ -546,10 +639,13 @@ function progressDocument<T>(
   const state = _state(doc)
   const nextState = { ...state, heads: undefined }
 
-  const { value: nextDoc, patches } = state.handle.applyAndReturnPatches(
-    doc,
+  const nextDoc = materializeFromCompactTape<T>(
+    state.handle,
+    "/",
+    undefined,
     nextState,
-  )
+  ) as Doc<T>
+  const patches: Patch[] = []
 
   if (patches.length > 0) {
     if (callback != null) {
@@ -715,7 +811,7 @@ export function load<T>(
   })
   handle.enableFreeze(!!opts.freeze)
   registerDatatypes(handle)
-  const doc = handle.materialize("/", undefined, {
+  const doc = materializeFromCompactTape<T>(handle, "/", undefined, {
     handle,
     heads: undefined,
     patchCallback,
@@ -1283,7 +1379,12 @@ export function dump<T>(doc: Doc<T>) {
 export function toJS<T>(doc: Doc<T>): T {
   const state = _state(doc)
   const enabled = state.handle.enableFreeze(false)
-  const result = state.handle.materialize("/", state.heads)
+  const result = materializeFromCompactTape<T>(
+    state.handle,
+    "/",
+    state.heads,
+    undefined,
+  )
   state.handle.enableFreeze(enabled)
   return result as T
 }

--- a/rust/automerge-wasm/Cargo.toml
+++ b/rust/automerge-wasm/Cargo.toml
@@ -22,6 +22,8 @@ bench = false
 [features]
 # default = ["console_error_panic_hook", "wee_alloc"]
 default = []
+rust-materialize = []
+old-js-export = []
 
 [dependencies]
 console_error_panic_hook = { version = "^0.1", optional = true }

--- a/rust/automerge-wasm/bench-materialize-tape.cjs
+++ b/rust/automerge-wasm/bench-materialize-tape.cjs
@@ -56,48 +56,6 @@ function materializeValueFromReads(handle, obj, prop, heads, meta) {
   return raw
 }
 
-function materializeFromTape(handle, obj = "/", heads, meta) {
-  const tape = handle.materializeTape(obj, heads)
-  const values = []
-  const objectMeta = []
-  for (const entry of tape) {
-    const op = entry[0]
-    if (op === 0) {
-      const index = entry[1]
-      const type = entry[2]
-      values[index] = makeMaterializedObject(type)
-      objectMeta[index] = { type }
-      setMeta(values[index], entry[3], meta)
-    } else if (op === 1) {
-      const parent = entry[1]
-      const prop = entry[2]
-      const type = entry[3]
-      const index = entry[4]
-      values[index] = makeMaterializedObject(type)
-      objectMeta[index] = { type, parent, prop }
-      setMeta(values[index], entry[5], meta)
-      if (type !== "text") {
-        values[parent][prop] = values[index]
-      }
-    } else if (op === 2) {
-      values[entry[1]][entry[2]] = entry[4]
-    } else if (op === 3) {
-      values[entry[1]].push(entry[2])
-    }
-  }
-  for (let index = 0; index < values.length; index++) {
-    const meta = objectMeta[index]
-    if (meta?.type === "text") {
-      const value = values[index].join("")
-      values[index] = value
-      if (meta.parent != null && meta.prop != null) {
-        values[meta.parent][meta.prop] = value
-      }
-    }
-  }
-  return values[0]
-}
-
 function materializeFromCompactTape(handle, obj = "/", heads, meta) {
   const tape = handle.materializeCompactTape(obj, heads)
   const objects = []
@@ -159,11 +117,6 @@ function setCompactMaterializedValue(target, propKind, prop, value, strings) {
   target[propKind === 0 ? strings[prop] : prop] = value
 }
 
-function makeMaterializedObject(type) {
-  if (type === "list" || type === "text") return []
-  return {}
-}
-
 function setMeta(target, objectId, meta) {
   if (target && typeof target === "object") {
     Object.defineProperties(target, {
@@ -197,14 +150,10 @@ const doc = makeDoc()
 const meta = { handle: doc, heads: undefined }
 const rust = doc.materialize("/", undefined, meta)
 const reads = materializeFromWasmReads(doc, "/", undefined, meta)
-const tape = materializeFromTape(doc, "/", undefined, meta)
 const compactTape = materializeFromCompactTape(doc, "/", undefined, meta)
 
 if (JSON.stringify(canonical(rust)) !== JSON.stringify(canonical(reads))) {
   throw new Error("per-read materialization did not match Rust materialization")
-}
-if (JSON.stringify(canonical(rust)) !== JSON.stringify(canonical(tape))) {
-  throw new Error("tape materialization did not match Rust materialization")
 }
 if (JSON.stringify(canonical(rust)) !== JSON.stringify(canonical(compactTape))) {
   throw new Error("compact tape materialization did not match Rust materialization")
@@ -212,5 +161,4 @@ if (JSON.stringify(canonical(rust)) !== JSON.stringify(canonical(compactTape))) 
 
 bench("rust_materialize", () => doc.materialize("/", undefined, meta), 100)
 bench("js_per_read_materialize", () => materializeFromWasmReads(doc, "/", undefined, meta), 100)
-bench("tape_materialize", () => materializeFromTape(doc, "/", undefined, meta), 100)
 bench("compact_tape_materialize", () => materializeFromCompactTape(doc, "/", undefined, meta), 100)

--- a/rust/automerge-wasm/bench-materialize-tape.cjs
+++ b/rust/automerge-wasm/bench-materialize-tape.cjs
@@ -1,0 +1,216 @@
+const am = require("./bench-node/automerge_wasm.js")
+
+const STATE = Symbol.for("_am_meta")
+const OBJECT_ID = Symbol.for("_am_objectId")
+
+function makeDoc() {
+  const doc = am.create({})
+  for (let i = 0; i < 400; i++) {
+    doc.put("/", `k${i}`, i)
+  }
+  const items = doc.putObject("/", "items", [])
+  for (let i = 0; i < 250; i++) {
+    const item = doc.insertObject(items, i, {})
+    doc.put(item, "id", i)
+    doc.put(item, "name", `item-${i}`)
+    doc.put(item, "active", i % 2 === 0)
+    const scores = doc.putObject(item, "scores", [])
+    for (let j = 0; j < 8; j++) {
+      doc.insert(scores, j, i * 10 + j)
+    }
+  }
+  const text = doc.putObject("/", "body", "")
+  doc.splice(text, 0, 0, "hello ".repeat(2000))
+  doc.commit(null, null)
+  return doc
+}
+
+function materializeFromWasmReads(handle, obj = "/", heads, meta) {
+  const info = handle.objInfo(obj, heads)
+  let result
+  if (info.type === "text") {
+    result = handle.text(info.id, heads)
+  } else if (info.type === "list") {
+    result = []
+    const length = handle.length(info.id, heads)
+    for (let index = 0; index < length; index++) {
+      result.push(materializeValueFromReads(handle, info.id, index, heads, meta))
+    }
+  } else {
+    result = {}
+    for (const key of handle.keys(info.id, heads)) {
+      result[key] = materializeValueFromReads(handle, info.id, key, heads, meta)
+    }
+  }
+  setMeta(result, info.id, meta)
+  return result
+}
+
+function materializeValueFromReads(handle, obj, prop, heads, meta) {
+  const value = handle.getWithType(obj, prop, heads)
+  if (value == null) return undefined
+  const [datatype, raw] = value
+  if (datatype === "map" || datatype === "table" || datatype === "list" || datatype === "text") {
+    return materializeFromWasmReads(handle, raw, heads, meta)
+  }
+  return raw
+}
+
+function materializeFromTape(handle, obj = "/", heads, meta) {
+  const tape = handle.materializeTape(obj, heads)
+  const values = []
+  const objectMeta = []
+  for (const entry of tape) {
+    const op = entry[0]
+    if (op === 0) {
+      const index = entry[1]
+      const type = entry[2]
+      values[index] = makeMaterializedObject(type)
+      objectMeta[index] = { type }
+      setMeta(values[index], entry[3], meta)
+    } else if (op === 1) {
+      const parent = entry[1]
+      const prop = entry[2]
+      const type = entry[3]
+      const index = entry[4]
+      values[index] = makeMaterializedObject(type)
+      objectMeta[index] = { type, parent, prop }
+      setMeta(values[index], entry[5], meta)
+      if (type !== "text") {
+        values[parent][prop] = values[index]
+      }
+    } else if (op === 2) {
+      values[entry[1]][entry[2]] = entry[4]
+    } else if (op === 3) {
+      values[entry[1]].push(entry[2])
+    }
+  }
+  for (let index = 0; index < values.length; index++) {
+    const meta = objectMeta[index]
+    if (meta?.type === "text") {
+      const value = values[index].join("")
+      values[index] = value
+      if (meta.parent != null && meta.prop != null) {
+        values[meta.parent][meta.prop] = value
+      }
+    }
+  }
+  return values[0]
+}
+
+function materializeFromCompactTape(handle, obj = "/", heads, meta) {
+  const tape = handle.materializeCompactTape(obj, heads)
+  const objects = []
+  const objectMeta = []
+  const ops = tape.ops
+  const strings = tape.strings
+  const values = tape.values
+  for (let offset = 0; offset < ops.length; offset += 8) {
+    const op = ops[offset]
+    if (op === 0) {
+      const index = ops[offset + 1]
+      const type = ops[offset + 2]
+      objects[index] = makeCompactMaterializedObject(type)
+      objectMeta[index] = { type }
+      setMeta(objects[index], strings[ops[offset + 3]], meta)
+    } else if (op === 1) {
+      const parent = ops[offset + 1]
+      const propKind = ops[offset + 2]
+      const prop = ops[offset + 3]
+      const type = ops[offset + 4]
+      const index = ops[offset + 5]
+      objects[index] = makeCompactMaterializedObject(type)
+      objectMeta[index] = { type, parent, propKind, prop }
+      setMeta(objects[index], strings[ops[offset + 6]], meta)
+      if (type !== 2) {
+        setCompactMaterializedValue(objects[parent], propKind, prop, objects[index], strings)
+      }
+    } else if (op === 2) {
+      setCompactMaterializedValue(
+        objects[ops[offset + 1]],
+        ops[offset + 2],
+        ops[offset + 3],
+        values[ops[offset + 5]],
+        strings,
+      )
+    } else if (op === 3) {
+      objects[ops[offset + 1]].push(strings[ops[offset + 2]])
+    }
+  }
+  for (let index = 0; index < objects.length; index++) {
+    const meta = objectMeta[index]
+    if (meta?.type === 2) {
+      const value = objects[index].join("")
+      objects[index] = value
+      if (meta.parent != null && meta.propKind != null && meta.prop != null) {
+        setCompactMaterializedValue(objects[meta.parent], meta.propKind, meta.prop, value, strings)
+      }
+    }
+  }
+  return objects[0]
+}
+
+function makeCompactMaterializedObject(type) {
+  if (type === 1 || type === 2) return []
+  return {}
+}
+
+function setCompactMaterializedValue(target, propKind, prop, value, strings) {
+  target[propKind === 0 ? strings[prop] : prop] = value
+}
+
+function makeMaterializedObject(type) {
+  if (type === "list" || type === "text") return []
+  return {}
+}
+
+function setMeta(target, objectId, meta) {
+  if (target && typeof target === "object") {
+    Object.defineProperties(target, {
+      [OBJECT_ID]: { value: objectId },
+      [STATE]: { value: meta },
+    })
+  }
+}
+
+function bench(name, fn, iterations) {
+  for (let i = 0; i < 5; i++) fn()
+  const start = process.hrtime.bigint()
+  for (let i = 0; i < iterations; i++) fn()
+  const elapsed = Number(process.hrtime.bigint() - start) / 1e6
+  console.log(JSON.stringify({ name, iterations, total_ms: elapsed, per_iter_ms: elapsed / iterations }))
+}
+
+function canonical(value) {
+  if (Array.isArray(value)) return value.map(canonical)
+  if (value && typeof value === "object") {
+    return Object.fromEntries(
+      Object.keys(value)
+        .sort()
+        .map(key => [key, canonical(value[key])]),
+    )
+  }
+  return value
+}
+
+const doc = makeDoc()
+const meta = { handle: doc, heads: undefined }
+const rust = doc.materialize("/", undefined, meta)
+const reads = materializeFromWasmReads(doc, "/", undefined, meta)
+const tape = materializeFromTape(doc, "/", undefined, meta)
+const compactTape = materializeFromCompactTape(doc, "/", undefined, meta)
+
+if (JSON.stringify(canonical(rust)) !== JSON.stringify(canonical(reads))) {
+  throw new Error("per-read materialization did not match Rust materialization")
+}
+if (JSON.stringify(canonical(rust)) !== JSON.stringify(canonical(tape))) {
+  throw new Error("tape materialization did not match Rust materialization")
+}
+if (JSON.stringify(canonical(rust)) !== JSON.stringify(canonical(compactTape))) {
+  throw new Error("compact tape materialization did not match Rust materialization")
+}
+
+bench("rust_materialize", () => doc.materialize("/", undefined, meta), 100)
+bench("js_per_read_materialize", () => materializeFromWasmReads(doc, "/", undefined, meta), 100)
+bench("tape_materialize", () => materializeFromTape(doc, "/", undefined, meta), 100)
+bench("compact_tape_materialize", () => materializeFromCompactTape(doc, "/", undefined, meta), 100)

--- a/rust/automerge-wasm/bench-materialize-tape.cjs
+++ b/rust/automerge-wasm/bench-materialize-tape.cjs
@@ -80,7 +80,7 @@ function materializeFromCompactTape(handle, obj = "/", heads, meta) {
       objects[index] = makeCompactMaterializedObject(type)
       objectMeta[index] = { type, parent, propKind, prop }
       setMeta(objects[index], strings[ops[offset + 6]], meta)
-      if (type !== 2) {
+      if (type !== 4) {
         setCompactMaterializedValue(objects[parent], propKind, prop, objects[index], strings)
       }
     } else if (op === 2) {
@@ -97,7 +97,7 @@ function materializeFromCompactTape(handle, obj = "/", heads, meta) {
   }
   for (let index = 0; index < objects.length; index++) {
     const meta = objectMeta[index]
-    if (meta?.type === 2) {
+    if (meta?.type === 4) {
       const value = objects[index].join("")
       objects[index] = value
       if (meta.parent != null && meta.propKind != null && meta.prop != null) {
@@ -109,7 +109,7 @@ function materializeFromCompactTape(handle, obj = "/", heads, meta) {
 }
 
 function makeCompactMaterializedObject(type) {
-  if (type === 1 || type === 2) return []
+  if (type === 2 || type === 4) return []
   return {}
 }
 

--- a/rust/automerge-wasm/bench-materialize-tape.cjs
+++ b/rust/automerge-wasm/bench-materialize-tape.cjs
@@ -56,8 +56,8 @@ function materializeValueFromReads(handle, obj, prop, heads, meta) {
   return raw
 }
 
-function materializeFromCompactTape(handle, obj = "/", heads, meta) {
-  const tape = handle.materializeCompactTape(obj, heads)
+function materializeFromTape(handle, obj = "/", heads, meta) {
+  const tape = handle.materializeTape(obj, heads)
   const objects = []
   const objectMeta = []
   const ops = tape.ops
@@ -68,7 +68,7 @@ function materializeFromCompactTape(handle, obj = "/", heads, meta) {
     if (op === 0) {
       const index = ops[offset + 1]
       const type = ops[offset + 2]
-      objects[index] = makeCompactMaterializedObject(type)
+      objects[index] = makeTapeMaterializedObject(type)
       objectMeta[index] = { type }
       setMeta(objects[index], strings[ops[offset + 3]], meta)
     } else if (op === 1) {
@@ -77,14 +77,14 @@ function materializeFromCompactTape(handle, obj = "/", heads, meta) {
       const prop = ops[offset + 3]
       const type = ops[offset + 4]
       const index = ops[offset + 5]
-      objects[index] = makeCompactMaterializedObject(type)
+      objects[index] = makeTapeMaterializedObject(type)
       objectMeta[index] = { type, parent, propKind, prop }
       setMeta(objects[index], strings[ops[offset + 6]], meta)
       if (type !== 4) {
-        setCompactMaterializedValue(objects[parent], propKind, prop, objects[index], strings)
+        setTapeMaterializedValue(objects[parent], propKind, prop, objects[index], strings)
       }
     } else if (op === 2) {
-      setCompactMaterializedValue(
+      setTapeMaterializedValue(
         objects[ops[offset + 1]],
         ops[offset + 2],
         ops[offset + 3],
@@ -101,19 +101,19 @@ function materializeFromCompactTape(handle, obj = "/", heads, meta) {
       const value = objects[index].join("")
       objects[index] = value
       if (meta.parent != null && meta.propKind != null && meta.prop != null) {
-        setCompactMaterializedValue(objects[meta.parent], meta.propKind, meta.prop, value, strings)
+        setTapeMaterializedValue(objects[meta.parent], meta.propKind, meta.prop, value, strings)
       }
     }
   }
   return objects[0]
 }
 
-function makeCompactMaterializedObject(type) {
+function makeTapeMaterializedObject(type) {
   if (type === 2 || type === 4) return []
   return {}
 }
 
-function setCompactMaterializedValue(target, propKind, prop, value, strings) {
+function setTapeMaterializedValue(target, propKind, prop, value, strings) {
   target[propKind === 0 ? strings[prop] : prop] = value
 }
 
@@ -150,15 +150,15 @@ const doc = makeDoc()
 const meta = { handle: doc, heads: undefined }
 const rust = doc.materialize("/", undefined, meta)
 const reads = materializeFromWasmReads(doc, "/", undefined, meta)
-const compactTape = materializeFromCompactTape(doc, "/", undefined, meta)
+const tape = materializeFromTape(doc, "/", undefined, meta)
 
 if (JSON.stringify(canonical(rust)) !== JSON.stringify(canonical(reads))) {
   throw new Error("per-read materialization did not match Rust materialization")
 }
-if (JSON.stringify(canonical(rust)) !== JSON.stringify(canonical(compactTape))) {
-  throw new Error("compact tape materialization did not match Rust materialization")
+if (JSON.stringify(canonical(rust)) !== JSON.stringify(canonical(tape))) {
+  throw new Error("tape materialization did not match Rust materialization")
 }
 
 bench("rust_materialize", () => doc.materialize("/", undefined, meta), 100)
 bench("js_per_read_materialize", () => materializeFromWasmReads(doc, "/", undefined, meta), 100)
-bench("compact_tape_materialize", () => materializeFromCompactTape(doc, "/", undefined, meta), 100)
+bench("tape_materialize", () => materializeFromTape(doc, "/", undefined, meta), 100)

--- a/rust/automerge-wasm/src/lib.rs
+++ b/rust/automerge-wasm/src/lib.rs
@@ -292,7 +292,6 @@ interface Automerge {
     objInfo(obj: ObjID, heads?: Heads): ObjInfo;
 
     materialize(obj?: ObjID, heads?: Heads, metadata?: unknown): MaterializeValue;
-    materializeTape(obj?: ObjID, heads?: Heads): unknown[];
     materializeCompactTape(obj?: ObjID, heads?: Heads): { ops: Uint32Array; strings: string[]; values: unknown[] };
 
     push(obj: ObjID, value: Value, datatype?: Datatype): void;
@@ -1494,123 +1493,6 @@ impl Automerge {
         self.doc.update_diff_cursor();
         let mut cache = interop::ExportCache::new(self)?;
         Ok(cache.materialize(obj, obj_type.into(), heads.as_deref(), &meta)?)
-    }
-
-    #[wasm_bindgen(js_name = materializeTape, skip_typescript)]
-    #[cfg(feature = "old-js-export")]
-    pub fn materialize_tape(
-        &mut self,
-        obj: JsValue,
-        heads: JsValue,
-    ) -> Result<Array, error::Materialize> {
-        let (root, root_type) = self.import(obj).unwrap_or((ROOT, am::ObjType::Map));
-        let heads = get_heads(heads)?;
-        self.doc.update_diff_cursor();
-
-        let tape = Array::new();
-        let mut obj_indexes = HashMap::<am::ObjId, f64>::default();
-        let mut list_indexes = HashMap::<am::ObjId, usize>::default();
-        let mut next_obj_index = 0_f64;
-
-        obj_indexes.insert(root.clone(), next_obj_index);
-        let root_entry = Array::new();
-        root_entry.push(&0.into());
-        root_entry.push(&next_obj_index.into());
-        root_entry.push(&root_type.to_string().into());
-        root_entry.push(&root.to_string().into());
-        tape.push(&root_entry);
-        next_obj_index += 1.0;
-
-        let iter = self.doc.iter_at(root, heads.as_deref());
-        for DocObjItem { obj, item } in iter {
-            let Some(parent_index) = obj_indexes.get(obj.as_ref()).copied() else {
-                continue;
-            };
-
-            match item {
-                DocItem::Text(span) => {
-                    let entry = Array::new();
-                    entry.push(&3.into());
-                    entry.push(&parent_index.into());
-                    entry.push(&span.as_str().into());
-                    tape.push(&entry);
-                }
-                DocItem::Map(map) => {
-                    let prop = JsValue::from_str(map.key.as_ref());
-                    match map.value {
-                        ValueRef::Object(obj_type) => {
-                            let child_id = map.id();
-                            let child_index = if let Some(index) = obj_indexes.get(&child_id) {
-                                *index
-                            } else {
-                                let index = next_obj_index;
-                                obj_indexes.insert(child_id.clone(), index);
-                                next_obj_index += 1.0;
-                                index
-                            };
-                            let entry = Array::new();
-                            entry.push(&1.into());
-                            entry.push(&parent_index.into());
-                            entry.push(&prop);
-                            entry.push(&obj_type.to_string().into());
-                            entry.push(&child_index.into());
-                            entry.push(&child_id.to_string().into());
-                            tape.push(&entry);
-                        }
-                        ValueRef::Scalar(value) => {
-                            let value = ValueRef::Scalar(value).into_value();
-                            let (datatype, value) = alloc(&value);
-                            let entry = Array::new();
-                            entry.push(&2.into());
-                            entry.push(&parent_index.into());
-                            entry.push(&prop);
-                            entry.push(&datatype.into());
-                            entry.push(&value);
-                            tape.push(&entry);
-                        }
-                    }
-                }
-                DocItem::List(list) => {
-                    let index = list_indexes.entry((*obj).clone()).or_default();
-                    let prop = JsValue::from_f64(*index as f64);
-                    *index += 1;
-                    match list.value {
-                        ValueRef::Object(obj_type) => {
-                            let child_id = list.id();
-                            let child_index = if let Some(index) = obj_indexes.get(&child_id) {
-                                *index
-                            } else {
-                                let index = next_obj_index;
-                                obj_indexes.insert(child_id.clone(), index);
-                                next_obj_index += 1.0;
-                                index
-                            };
-                            let entry = Array::new();
-                            entry.push(&1.into());
-                            entry.push(&parent_index.into());
-                            entry.push(&prop);
-                            entry.push(&obj_type.to_string().into());
-                            entry.push(&child_index.into());
-                            entry.push(&child_id.to_string().into());
-                            tape.push(&entry);
-                        }
-                        ValueRef::Scalar(value) => {
-                            let value = ValueRef::Scalar(value).into_value();
-                            let (datatype, value) = alloc(&value);
-                            let entry = Array::new();
-                            entry.push(&2.into());
-                            entry.push(&parent_index.into());
-                            entry.push(&prop);
-                            entry.push(&datatype.into());
-                            entry.push(&value);
-                            tape.push(&entry);
-                        }
-                    }
-                }
-            }
-        }
-
-        Ok(tape)
     }
 
     #[wasm_bindgen(js_name = materializeCompactTape, skip_typescript)]

--- a/rust/automerge-wasm/src/lib.rs
+++ b/rust/automerge-wasm/src/lib.rs
@@ -292,7 +292,7 @@ interface Automerge {
     objInfo(obj: ObjID, heads?: Heads): ObjInfo;
 
     materialize(obj?: ObjID, heads?: Heads, metadata?: unknown): MaterializeValue;
-    materializeCompactTape(obj?: ObjID, heads?: Heads): { ops: Uint32Array; strings: string[]; values: unknown[] };
+    materializeTape(obj?: ObjID, heads?: Heads): { ops: Uint32Array; strings: string[]; values: unknown[] };
 
     push(obj: ObjID, value: Value, datatype?: Datatype): void;
 
@@ -1495,8 +1495,8 @@ impl Automerge {
         Ok(cache.materialize(obj, obj_type.into(), heads.as_deref(), &meta)?)
     }
 
-    #[wasm_bindgen(js_name = materializeCompactTape, skip_typescript)]
-    pub fn materialize_compact_tape(
+    #[wasm_bindgen(js_name = materializeTape, skip_typescript)]
+    pub fn materialize_tape(
         &mut self,
         obj: JsValue,
         heads: JsValue,

--- a/rust/automerge-wasm/src/lib.rs
+++ b/rust/automerge-wasm/src/lib.rs
@@ -31,12 +31,14 @@ use am::OnPartialLoad;
 use am::ScalarValue;
 use am::StringMigration;
 use am::VerificationMode;
+use am::ValueRef;
 use automerge as am;
+use automerge::iter::{DocItem, DocObjItem};
 use automerge::TextEncoding;
 use automerge::{sync::SyncDoc, AutoCommit, Change, Prop, ReadDoc, Value, ROOT};
 use interop::import_scalar;
 use js_sys::Reflect;
-use js_sys::{Array, Function, Object, Uint8Array};
+use js_sys::{Array, Function, Object, Uint32Array, Uint8Array};
 use serde::ser::Serialize;
 use std::borrow::Cow;
 use std::collections::HashMap;
@@ -290,6 +292,8 @@ interface Automerge {
     objInfo(obj: ObjID, heads?: Heads): ObjInfo;
 
     materialize(obj?: ObjID, heads?: Heads, metadata?: unknown): MaterializeValue;
+    materializeTape(obj?: ObjID, heads?: Heads): unknown[];
+    materializeCompactTape(obj?: ObjID, heads?: Heads): { ops: Uint32Array; strings: string[]; values: unknown[] };
 
     push(obj: ObjID, value: Value, datatype?: Datatype): void;
 
@@ -556,6 +560,7 @@ impl Automerge {
 
     // skip_typescript as the optional heads parameter can't be typed
     #[wasm_bindgen(skip_typescript)]
+    #[cfg(feature = "old-js-export")]
     pub fn spans(&self, obj: JsValue, heads: JsValue) -> Result<Array, error::GetSpans> {
         let (obj, _) = self.import(obj)?;
         let spans = if let Some(heads) = get_heads(heads)? {
@@ -755,6 +760,7 @@ impl Automerge {
 
     // skip_typescript as the optional heads parameter can't be typed here
     #[wasm_bindgen(js_name = getBlock, skip_typescript)]
+    #[cfg(feature = "old-js-export")]
     pub fn get_block(
         &mut self,
         text: JsValue,
@@ -1103,6 +1109,7 @@ impl Automerge {
 
     // skip_typescript as the function can only by typed in the custom section
     #[wasm_bindgen(js_name = applyPatches, skip_typescript)]
+    #[cfg(feature = "old-js-export")]
     pub fn apply_patches(&mut self, object: JsValue, meta: JsValue) -> Result<JsValue, JsValue> {
         let (value, _patches) = self.apply_patches_impl(object, meta)?;
         Ok(value)
@@ -1110,6 +1117,7 @@ impl Automerge {
 
     // skip_typescript as the function can only by typed in the custom section
     #[wasm_bindgen(js_name = applyAndReturnPatches, skip_typescript)]
+    #[cfg(feature = "old-js-export")]
     pub fn apply_and_return_patches(
         &mut self,
         object: JsValue,
@@ -1125,6 +1133,7 @@ impl Automerge {
         Ok(result.into())
     }
 
+    #[cfg(feature = "old-js-export")]
     fn apply_patches_impl(
         &mut self,
         object: JsValue,
@@ -1139,6 +1148,7 @@ impl Automerge {
 
         let mut cache = interop::ExportCache::new(self)?;
 
+        #[cfg(feature = "rust-materialize")]
         if shortcut {
             let value = cache.materialize(ROOT, Datatype::Map, None, &meta)?;
             return Ok((value, patches));
@@ -1163,6 +1173,7 @@ impl Automerge {
     }
 
     #[wasm_bindgen(js_name = diffIncremental, unchecked_return_type="Patch[]")]
+    #[cfg(feature = "old-js-export")]
     pub fn diff_incremental(&mut self) -> Result<Array, error::PopPatches> {
         // transactions send out observer updates as they occur, not waiting for them to be
         // committed.
@@ -1184,6 +1195,7 @@ impl Automerge {
     }
 
     #[wasm_bindgen(unchecked_return_type = "Patch[]")]
+    #[cfg(feature = "old-js-export")]
     pub fn diff(
         &mut self,
         #[wasm_bindgen(unchecked_param_type = "Heads")] before: JsValue,
@@ -1202,6 +1214,7 @@ impl Automerge {
     }
 
     #[wasm_bindgen(js_name = diffPath, skip_typescript)]
+    #[cfg(feature = "old-js-export")]
     pub fn diff_path(
         &mut self,
         #[wasm_bindgen(unchecked_param_type = "Prop[] | string")] path: JsValue,
@@ -1460,6 +1473,7 @@ impl Automerge {
     }
 
     #[wasm_bindgen(js_name = toJS, unchecked_return_type="MaterializeValue")]
+    #[cfg(feature = "rust-materialize")]
     pub fn to_js(&mut self, meta: JsValue) -> Result<JsValue, interop::error::Export> {
         let mut cache = interop::ExportCache::new(self)?;
         cache.materialize(ROOT, Datatype::Map, None, &meta)
@@ -1468,6 +1482,7 @@ impl Automerge {
     // Skip typescript as the arguments are all optional which can only be typed
     // in the typescript custom section
     #[wasm_bindgen(skip_typescript)]
+    #[cfg(feature = "rust-materialize")]
     pub fn materialize(
         &mut self,
         obj: JsValue,
@@ -1479,6 +1494,264 @@ impl Automerge {
         self.doc.update_diff_cursor();
         let mut cache = interop::ExportCache::new(self)?;
         Ok(cache.materialize(obj, obj_type.into(), heads.as_deref(), &meta)?)
+    }
+
+    #[wasm_bindgen(js_name = materializeTape, skip_typescript)]
+    #[cfg(feature = "old-js-export")]
+    pub fn materialize_tape(
+        &mut self,
+        obj: JsValue,
+        heads: JsValue,
+    ) -> Result<Array, error::Materialize> {
+        let (root, root_type) = self.import(obj).unwrap_or((ROOT, am::ObjType::Map));
+        let heads = get_heads(heads)?;
+        self.doc.update_diff_cursor();
+
+        let tape = Array::new();
+        let mut obj_indexes = HashMap::<am::ObjId, f64>::default();
+        let mut list_indexes = HashMap::<am::ObjId, usize>::default();
+        let mut next_obj_index = 0_f64;
+
+        obj_indexes.insert(root.clone(), next_obj_index);
+        let root_entry = Array::new();
+        root_entry.push(&0.into());
+        root_entry.push(&next_obj_index.into());
+        root_entry.push(&root_type.to_string().into());
+        root_entry.push(&root.to_string().into());
+        tape.push(&root_entry);
+        next_obj_index += 1.0;
+
+        let iter = self.doc.iter_at(root, heads.as_deref());
+        for DocObjItem { obj, item } in iter {
+            let Some(parent_index) = obj_indexes.get(obj.as_ref()).copied() else {
+                continue;
+            };
+
+            match item {
+                DocItem::Text(span) => {
+                    let entry = Array::new();
+                    entry.push(&3.into());
+                    entry.push(&parent_index.into());
+                    entry.push(&span.as_str().into());
+                    tape.push(&entry);
+                }
+                DocItem::Map(map) => {
+                    let prop = JsValue::from_str(map.key.as_ref());
+                    match map.value {
+                        ValueRef::Object(obj_type) => {
+                            let child_id = map.id();
+                            let child_index = if let Some(index) = obj_indexes.get(&child_id) {
+                                *index
+                            } else {
+                                let index = next_obj_index;
+                                obj_indexes.insert(child_id.clone(), index);
+                                next_obj_index += 1.0;
+                                index
+                            };
+                            let entry = Array::new();
+                            entry.push(&1.into());
+                            entry.push(&parent_index.into());
+                            entry.push(&prop);
+                            entry.push(&obj_type.to_string().into());
+                            entry.push(&child_index.into());
+                            entry.push(&child_id.to_string().into());
+                            tape.push(&entry);
+                        }
+                        ValueRef::Scalar(value) => {
+                            let value = ValueRef::Scalar(value).into_value();
+                            let (datatype, value) = alloc(&value);
+                            let entry = Array::new();
+                            entry.push(&2.into());
+                            entry.push(&parent_index.into());
+                            entry.push(&prop);
+                            entry.push(&datatype.into());
+                            entry.push(&value);
+                            tape.push(&entry);
+                        }
+                    }
+                }
+                DocItem::List(list) => {
+                    let index = list_indexes.entry((*obj).clone()).or_default();
+                    let prop = JsValue::from_f64(*index as f64);
+                    *index += 1;
+                    match list.value {
+                        ValueRef::Object(obj_type) => {
+                            let child_id = list.id();
+                            let child_index = if let Some(index) = obj_indexes.get(&child_id) {
+                                *index
+                            } else {
+                                let index = next_obj_index;
+                                obj_indexes.insert(child_id.clone(), index);
+                                next_obj_index += 1.0;
+                                index
+                            };
+                            let entry = Array::new();
+                            entry.push(&1.into());
+                            entry.push(&parent_index.into());
+                            entry.push(&prop);
+                            entry.push(&obj_type.to_string().into());
+                            entry.push(&child_index.into());
+                            entry.push(&child_id.to_string().into());
+                            tape.push(&entry);
+                        }
+                        ValueRef::Scalar(value) => {
+                            let value = ValueRef::Scalar(value).into_value();
+                            let (datatype, value) = alloc(&value);
+                            let entry = Array::new();
+                            entry.push(&2.into());
+                            entry.push(&parent_index.into());
+                            entry.push(&prop);
+                            entry.push(&datatype.into());
+                            entry.push(&value);
+                            tape.push(&entry);
+                        }
+                    }
+                }
+            }
+        }
+
+        Ok(tape)
+    }
+
+    #[wasm_bindgen(js_name = materializeCompactTape, skip_typescript)]
+    pub fn materialize_compact_tape(
+        &mut self,
+        obj: JsValue,
+        heads: JsValue,
+    ) -> Result<Object, error::Materialize> {
+        let (root, root_type) = self.import(obj).unwrap_or((ROOT, am::ObjType::Map));
+        let heads = get_heads(heads)?;
+        self.doc.update_diff_cursor();
+
+        let mut obj_indexes = HashMap::<am::ObjId, u32>::default();
+        let mut string_indexes = HashMap::<String, u32>::default();
+        let mut list_indexes = HashMap::<am::ObjId, usize>::default();
+        let mut ops = Vec::<u32>::new();
+        let strings = Array::new();
+        let values = Array::new();
+        let mut next_obj_index = 0_u32;
+
+        obj_indexes.insert(root.clone(), next_obj_index);
+        let root_id = intern_string(&strings, &mut string_indexes, root.to_string());
+        push_op(
+            &mut ops,
+            0,
+            next_obj_index,
+            obj_type_code(root_type),
+            root_id,
+            0,
+            0,
+            0,
+            0,
+        );
+        next_obj_index += 1;
+
+        let iter = self.doc.iter_at(root, heads.as_deref());
+        for DocObjItem { obj, item } in iter {
+            let Some(parent_index) = obj_indexes.get(obj.as_ref()).copied() else {
+                continue;
+            };
+
+            match item {
+                DocItem::Text(span) => {
+                    let text = intern_string(&strings, &mut string_indexes, span.as_str().to_owned());
+                    push_op(&mut ops, 3, parent_index, text, 0, 0, 0, 0, 0);
+                }
+                DocItem::Map(map) => {
+                    let prop = intern_string(&strings, &mut string_indexes, map.key.to_string());
+                    match map.value {
+                        ValueRef::Object(obj_type) => {
+                            let child_id = map.id();
+                            let child_index =
+                                ensure_obj_index(&mut obj_indexes, &mut next_obj_index, &child_id);
+                            let child_id =
+                                intern_string(&strings, &mut string_indexes, child_id.to_string());
+                            push_op(
+                                &mut ops,
+                                1,
+                                parent_index,
+                                0,
+                                prop,
+                                obj_type_code(obj_type),
+                                child_index,
+                                child_id,
+                                0,
+                            );
+                        }
+                        ValueRef::Scalar(value) => {
+                            let value = ValueRef::Scalar(value).into_value();
+                            let (datatype, value) = alloc(&value);
+                            let value_index = values.length();
+                            values.push(&value);
+                            push_op(
+                                &mut ops,
+                                2,
+                                parent_index,
+                                0,
+                                prop,
+                                datatype_code(datatype),
+                                value_index,
+                                0,
+                                0,
+                            );
+                        }
+                    }
+                }
+                DocItem::List(list) => {
+                    let index = list_indexes.entry((*obj).clone()).or_default();
+                    let prop = *index as u32;
+                    *index += 1;
+                    match list.value {
+                        ValueRef::Object(obj_type) => {
+                            let child_id = list.id();
+                            let child_index =
+                                ensure_obj_index(&mut obj_indexes, &mut next_obj_index, &child_id);
+                            let child_id =
+                                intern_string(&strings, &mut string_indexes, child_id.to_string());
+                            push_op(
+                                &mut ops,
+                                1,
+                                parent_index,
+                                1,
+                                prop,
+                                obj_type_code(obj_type),
+                                child_index,
+                                child_id,
+                                0,
+                            );
+                        }
+                        ValueRef::Scalar(value) => {
+                            let value = ValueRef::Scalar(value).into_value();
+                            let (datatype, value) = alloc(&value);
+                            let value_index = values.length();
+                            values.push(&value);
+                            push_op(
+                                &mut ops,
+                                2,
+                                parent_index,
+                                1,
+                                prop,
+                                datatype_code(datatype),
+                                value_index,
+                                0,
+                                0,
+                            );
+                        }
+                    }
+                }
+            }
+        }
+
+        let result = Object::new();
+        Reflect::set(
+            &result,
+            &"ops".into(),
+            &Uint32Array::from(ops.as_slice()).into(),
+        )
+        .unwrap();
+        Reflect::set(&result, &"strings".into(), &strings).unwrap();
+        Reflect::set(&result, &"values".into(), &values).unwrap();
+        Ok(result)
     }
 
     // skip_typescript as the heads and move_cursor arguments are optional which
@@ -1718,6 +1991,74 @@ pub fn init(options: JsValue) -> Result<Automerge, error::BadActorId> {
     console_error_panic_hook::set_once();
     let actor = js_get(&options, "actor").ok().and_then(|a| a.as_string());
     Automerge::new(actor)
+}
+
+fn push_op(
+    ops: &mut Vec<u32>,
+    a: u32,
+    b: u32,
+    c: u32,
+    d: u32,
+    e: u32,
+    f: u32,
+    g: u32,
+    h: u32,
+) {
+    ops.extend_from_slice(&[a, b, c, d, e, f, g, h]);
+}
+
+fn ensure_obj_index(
+    indexes: &mut HashMap<am::ObjId, u32>,
+    next_index: &mut u32,
+    obj: &am::ObjId,
+) -> u32 {
+    if let Some(index) = indexes.get(obj) {
+        *index
+    } else {
+        let index = *next_index;
+        indexes.insert(obj.clone(), index);
+        *next_index += 1;
+        index
+    }
+}
+
+fn intern_string(strings: &Array, indexes: &mut HashMap<String, u32>, value: String) -> u32 {
+    if let Some(index) = indexes.get(&value) {
+        *index
+    } else {
+        let index = strings.length();
+        strings.push(&value.clone().into());
+        indexes.insert(value, index);
+        index
+    }
+}
+
+fn obj_type_code(obj_type: am::ObjType) -> u32 {
+    match obj_type {
+        am::ObjType::Map => 0,
+        am::ObjType::List => 1,
+        am::ObjType::Text => 2,
+        am::ObjType::Table => 3,
+    }
+}
+
+fn datatype_code(datatype: Datatype) -> u32 {
+    match datatype {
+        Datatype::Map => 0,
+        Datatype::List => 1,
+        Datatype::Text => 2,
+        Datatype::Table => 3,
+        Datatype::Str => 4,
+        Datatype::Int => 5,
+        Datatype::Uint => 6,
+        Datatype::F64 => 7,
+        Datatype::Boolean => 8,
+        Datatype::Timestamp => 9,
+        Datatype::Counter => 10,
+        Datatype::Bytes => 11,
+        Datatype::Null => 12,
+        Datatype::Unknown(_) => 13,
+    }
 }
 
 // skip_typescript as the options argument is optional which can only be typed

--- a/rust/automerge-wasm/src/lib.rs
+++ b/rust/automerge-wasm/src/lib.rs
@@ -1561,8 +1561,9 @@ impl Automerge {
                             );
                         }
                         ValueRef::Scalar(value) => {
+                            let datatype = scalar_value_ref_code(&value);
                             let value = ValueRef::Scalar(value).into_value();
-                            let (datatype, value) = alloc(&value);
+                            let (_, value) = alloc(&value);
                             let value_index = values.length();
                             values.push(&value);
                             push_op(
@@ -1571,7 +1572,7 @@ impl Automerge {
                                 parent_index,
                                 0,
                                 prop,
-                                datatype_code(datatype),
+                                datatype,
                                 value_index,
                                 0,
                                 0,
@@ -1603,8 +1604,9 @@ impl Automerge {
                             );
                         }
                         ValueRef::Scalar(value) => {
+                            let datatype = scalar_value_ref_code(&value);
                             let value = ValueRef::Scalar(value).into_value();
-                            let (datatype, value) = alloc(&value);
+                            let (_, value) = alloc(&value);
                             let value_index = values.length();
                             values.push(&value);
                             push_op(
@@ -1613,7 +1615,7 @@ impl Automerge {
                                 parent_index,
                                 1,
                                 prop,
-                                datatype_code(datatype),
+                                datatype,
                                 value_index,
                                 0,
                                 0,
@@ -1917,29 +1919,28 @@ fn intern_string(strings: &Array, indexes: &mut HashMap<String, u32>, value: Str
 
 fn obj_type_code(obj_type: am::ObjType) -> u32 {
     match obj_type {
+        // Match the storage action codes for object creation.
         am::ObjType::Map => 0,
-        am::ObjType::List => 1,
-        am::ObjType::Text => 2,
-        am::ObjType::Table => 3,
+        am::ObjType::List => 2,
+        am::ObjType::Text => 4,
+        am::ObjType::Table => 6,
     }
 }
 
-fn datatype_code(datatype: Datatype) -> u32 {
-    match datatype {
-        Datatype::Map => 0,
-        Datatype::List => 1,
-        Datatype::Text => 2,
-        Datatype::Table => 3,
-        Datatype::Str => 4,
-        Datatype::Int => 5,
-        Datatype::Uint => 6,
-        Datatype::F64 => 7,
-        Datatype::Boolean => 8,
-        Datatype::Timestamp => 9,
-        Datatype::Counter => 10,
-        Datatype::Bytes => 11,
-        Datatype::Null => 12,
-        Datatype::Unknown(_) => 13,
+fn scalar_value_ref_code(value: &am::ScalarValueRef<'_>) -> u32 {
+    match value {
+        // Match the low-nibble ValueMeta codes used by storage.
+        am::ScalarValueRef::Null => 0,
+        am::ScalarValueRef::Boolean(false) => 1,
+        am::ScalarValueRef::Boolean(true) => 2,
+        am::ScalarValueRef::Uint(_) => 3,
+        am::ScalarValueRef::Int(_) => 4,
+        am::ScalarValueRef::F64(_) => 5,
+        am::ScalarValueRef::Str(_) => 6,
+        am::ScalarValueRef::Bytes(_) => 7,
+        am::ScalarValueRef::Counter(_) => 8,
+        am::ScalarValueRef::Timestamp(_) => 9,
+        am::ScalarValueRef::Unknown { type_code, .. } => (*type_code).into(),
     }
 }
 


### PR DESCRIPTION
## Summary
- Prototypes compact JS hydration by having wasm emit a single typed-array materialization tape and applying it in JavaScript.
- Gates the old Rust-side JS object export/materialize path behind prototype features so the size impact can be measured directly.
- Aligns tape type tags with existing Automerge numeric tags: object creation uses storage action codes and scalar values use `ValueMeta` low-nibble codes.

## Strategy and tradeoffs
The goal is to test whether hydration can move out of wasm without paying a large performance tax. The compact tape keeps document traversal in Rust but moves JS object construction to JavaScript, which lets the old Rust JS-object construction/export machinery fall out of the wasm binary.

This is intentionally experimental. It breaks API completeness in this branch: patch export/application paths, spans/block hydration, and Rust `materialize`/`toJS` are gated out, and `progressDocument` rematerializes without preserving patch callback fidelity. The point of the PR is to make the size/performance tradeoff reviewable, not to land as-is.

Final nightly-smallest size for this PR:
- Optimized wasm: `1,168,578 B` raw / `475,305 B` gzip

Measured impact from removing the old Rust JS-object export path in the compact tape prototype was roughly `-79 KB` raw / `-28 KB` gzip versus keeping both paths alive. The production JS delta is about `+101` net lines in `javascript/src/implementation.ts`; the benchmark script is not shipped runtime JS.

## Test plan
- `cargo build -p automerge-wasm --target wasm32-unknown-unknown --profile wasm-release`
- Nightly-smallest compile via `WASM_SMALLEST=1 PROFILE=wasm-release TARGET_DIR=wasm-release node ./target.mjs compile`
- `wasm-bindgen ... --target bundler --weak-refs`
- `wasm-opt -Oz --converge --strip-debug --strip-dwarf --strip-producers --enable-bulk-memory --enable-nontrapping-float-to-int`
- Local benchmark script: `rust/automerge-wasm/bench-materialize-tape.cjs`