### PR TITLE
Wasm panic unwind

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -75,9 +75,11 @@ jobs:
         with:
           # Optional version of wasm-bindgen to install(eg. '0.2.83', 'latest')
           version: "0.2.121"
-      - name: Install wasm32 target
-        working-directory: rust
-        run: rustup target add wasm32-unknown-unknown
+      - name: Install nightly + wasm32 target + rust-src
+        run: |
+          rustup toolchain install nightly --profile minimal
+          rustup component add rust-src --toolchain nightly
+          rustup target add --toolchain nightly wasm32-unknown-unknown
       - name: run tests
         run: ./scripts/ci/wasm_tests
 
@@ -95,9 +97,11 @@ jobs:
         with:
           # Optional version of wasm-bindgen to install(eg. '0.2.83', 'latest')
           version: "0.2.121"
-      - name: Install wasm32 target
-        working-directory: rust
-        run: rustup target add wasm32-unknown-unknown
+      - name: Install nightly + wasm32 target + rust-src
+        run: |
+          rustup toolchain install nightly --profile minimal
+          rustup component add rust-src --toolchain nightly
+          rustup target add --toolchain nightly wasm32-unknown-unknown
       - name: run tests
         run: ./scripts/ci/js_tests
 
@@ -117,9 +121,11 @@ jobs:
         with:
           # Optional version of wasm-bindgen to install(eg. '0.2.83', 'latest')
           version: "0.2.121"
-      - name: Install wasm32 target
-        working-directory: rust
-        run: rustup target add wasm32-unknown-unknown
+      - name: Install nightly + wasm32 target + rust-src
+        run: |
+          rustup toolchain install nightly --profile minimal
+          rustup component add rust-src --toolchain nightly
+          rustup target add --toolchain nightly wasm32-unknown-unknown
       - name: run tests
         run: ./scripts/ci/node_18_packaging_test
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -69,17 +69,21 @@ jobs:
 
   build_wasm:
     runs-on: ubuntu-latest
+    env:
+      # Pinned for reproducible wasm builds; the wasm build needs nightly for
+      # -Zbuild-std (panic=unwind). Bump deliberately when needed.
+      WASM_TOOLCHAIN: nightly-2026-04-25
     steps:
       - uses: actions/checkout@v6
       - uses: jetli/wasm-bindgen-action@v0.2.0
         with:
           # Optional version of wasm-bindgen to install(eg. '0.2.83', 'latest')
           version: "0.2.121"
-      - name: Install nightly + wasm32 target + rust-src
+      - name: Install pinned nightly + wasm32 target + rust-src
         run: |
-          rustup toolchain install nightly --profile minimal
-          rustup component add rust-src --toolchain nightly
-          rustup target add --toolchain nightly wasm32-unknown-unknown
+          rustup toolchain install "$WASM_TOOLCHAIN" --profile minimal
+          rustup component add rust-src --toolchain "$WASM_TOOLCHAIN"
+          rustup target add --toolchain "$WASM_TOOLCHAIN" wasm32-unknown-unknown
       - name: run tests
         run: ./scripts/ci/wasm_tests
 
@@ -87,6 +91,8 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - build_wasm
+    env:
+      WASM_TOOLCHAIN: nightly-2026-04-25
 
     steps:
       - uses: actions/checkout@v6
@@ -97,11 +103,11 @@ jobs:
         with:
           # Optional version of wasm-bindgen to install(eg. '0.2.83', 'latest')
           version: "0.2.121"
-      - name: Install nightly + wasm32 target + rust-src
+      - name: Install pinned nightly + wasm32 target + rust-src
         run: |
-          rustup toolchain install nightly --profile minimal
-          rustup component add rust-src --toolchain nightly
-          rustup target add --toolchain nightly wasm32-unknown-unknown
+          rustup toolchain install "$WASM_TOOLCHAIN" --profile minimal
+          rustup component add rust-src --toolchain "$WASM_TOOLCHAIN"
+          rustup target add --toolchain "$WASM_TOOLCHAIN" wasm32-unknown-unknown
       - name: run tests
         run: ./scripts/ci/js_tests
 
@@ -111,6 +117,8 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - build_wasm
+    env:
+      WASM_TOOLCHAIN: nightly-2026-04-25
 
     steps:
       - uses: actions/checkout@v6
@@ -121,11 +129,11 @@ jobs:
         with:
           # Optional version of wasm-bindgen to install(eg. '0.2.83', 'latest')
           version: "0.2.121"
-      - name: Install nightly + wasm32 target + rust-src
+      - name: Install pinned nightly + wasm32 target + rust-src
         run: |
-          rustup toolchain install nightly --profile minimal
-          rustup component add rust-src --toolchain nightly
-          rustup target add --toolchain nightly wasm32-unknown-unknown
+          rustup toolchain install "$WASM_TOOLCHAIN" --profile minimal
+          rustup component add rust-src --toolchain "$WASM_TOOLCHAIN"
+          rustup target add --toolchain "$WASM_TOOLCHAIN" wasm32-unknown-unknown
       - name: run tests
         run: ./scripts/ci/node_18_packaging_test
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,9 +19,11 @@ jobs:
         with:
           # Optional version of wasm-bindgen to install(eg. '0.2.83', 'latest')
           version: "0.2.121"
-      - name: Install wasm32 target
-        working-directory: rust
-        run: rustup target add wasm32-unknown-unknown
+      - name: Install nightly + wasm32 target + rust-src
+        run: |
+          rustup toolchain install nightly --profile minimal
+          rustup component add rust-src --toolchain nightly
+          rustup target add --toolchain nightly wasm32-unknown-unknown
       - name: npm install
         run: npm install
       - name: build js
@@ -51,9 +53,11 @@ jobs:
           registry-url: "https://registry.npmjs.org"
       - name: Install wasm-bindgen-cli
         run: cargo install wasm-bindgen-cli wasm-opt
-      - name: Install wasm32 target
-        working-directory: rust
-        run: rustup target add wasm32-unknown-unknown
+      - name: Install nightly + wasm32 target + rust-src
+        run: |
+          rustup toolchain install nightly --profile minimal
+          rustup component add rust-src --toolchain nightly
+          rustup target add --toolchain nightly wasm32-unknown-unknown
       - name: npm install
         run: npm install
       - name: build js

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,6 +6,9 @@ on:
 jobs:
   publish-js:
     runs-on: ubuntu-latest
+    env:
+      # Pinned for reproducible wasm builds; bump deliberately when needed.
+      WASM_TOOLCHAIN: nightly-2026-04-25
     defaults:
       run:
         working-directory: ./javascript
@@ -19,11 +22,11 @@ jobs:
         with:
           # Optional version of wasm-bindgen to install(eg. '0.2.83', 'latest')
           version: "0.2.121"
-      - name: Install nightly + wasm32 target + rust-src
+      - name: Install pinned nightly + wasm32 target + rust-src
         run: |
-          rustup toolchain install nightly --profile minimal
-          rustup component add rust-src --toolchain nightly
-          rustup target add --toolchain nightly wasm32-unknown-unknown
+          rustup toolchain install "$WASM_TOOLCHAIN" --profile minimal
+          rustup component add rust-src --toolchain "$WASM_TOOLCHAIN"
+          rustup target add --toolchain "$WASM_TOOLCHAIN" wasm32-unknown-unknown
       - name: npm install
         run: npm install
       - name: build js
@@ -42,6 +45,8 @@ jobs:
   publish-js-docs:
     runs-on: ubuntu-latest
     if: "!github.event.release.prerelease"
+    env:
+      WASM_TOOLCHAIN: nightly-2026-04-25
     defaults:
       run:
         working-directory: ./javascript
@@ -53,11 +58,11 @@ jobs:
           registry-url: "https://registry.npmjs.org"
       - name: Install wasm-bindgen-cli
         run: cargo install wasm-bindgen-cli wasm-opt
-      - name: Install nightly + wasm32 target + rust-src
+      - name: Install pinned nightly + wasm32 target + rust-src
         run: |
-          rustup toolchain install nightly --profile minimal
-          rustup component add rust-src --toolchain nightly
-          rustup target add --toolchain nightly wasm32-unknown-unknown
+          rustup toolchain install "$WASM_TOOLCHAIN" --profile minimal
+          rustup component add rust-src --toolchain "$WASM_TOOLCHAIN"
+          rustup target add --toolchain "$WASM_TOOLCHAIN" wasm32-unknown-unknown
       - name: npm install
         run: npm install
       - name: build js

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ You will also need to install the following with `cargo install`
 - `wasm-opt`
 - `cargo-deny`
 
-And ensure you have added the `wasm32-unknown-unknown` target for rust cross-compilation.
+And ensure you have added the `wasm32-unknown-unknown` target for rust cross-compilation. The wasm build also requires the nightly toolchain and the `rust-src` component (see the macOS instructions below for the exact commands); these are used by `automerge-wasm` and the JS package to build std with `panic=unwind` so panics surface as JS exceptions.
 
 The various subprojects (the rust code, the wrapper projects) have their own
 build instructions, but to run the tests that will be run in CI you can run

--- a/javascript/HACKING.md
+++ b/javascript/HACKING.md
@@ -26,6 +26,15 @@ npm run build
 npm test
 ```
 
+The wasm build requires the nightly Rust toolchain plus the `rust-src`
+component, since we rebuild std with the unwind panic runtime so Rust panics
+surface as JS exceptions instead of aborting the WASM module:
+
+```
+rustup toolchain install nightly
+rustup component add rust-src --toolchain nightly
+```
+
 Any time you change the rust code in `../rust/*` you'll need to re-run the
 `npm run build` command.
 

--- a/javascript/package.json
+++ b/javascript/package.json
@@ -38,6 +38,10 @@
         "import": "./dist/mjs/entrypoints/fullfat_node.js",
         "require": "./dist/cjs/fullfat_node.cjs"
       },
+      "webpack": {
+        "import": "./dist/mjs/entrypoints/fullfat_base64.js",
+        "require": "./dist/cjs/fullfat_base64.cjs"
+      },
       "browser": {
         "import": "./dist/mjs/entrypoints/fullfat_bundler.js",
         "require": "./dist/cjs/fullfat_base64.cjs"

--- a/javascript/scripts/build.mjs
+++ b/javascript/scripts/build.mjs
@@ -113,12 +113,19 @@ function isStep(stepStr) {
 function buildWasm(outputDir, gitHead) {
   const automergeWasmPath = path.join(rustProjectDir, "automerge-wasm")
   console.log("building automerge-wasm")
+  // Build with the nightly toolchain + panic=unwind so panics in exported
+  // Rust functions surface as `PanicError` exceptions at the JS boundary
+  // (wasm-bindgen 0.2.118+) instead of aborting the WASM module. This requires
+  // a nightly toolchain (for -Zbuild-std) and the `rust-src` rustup component.
+  const wasmRustflags = [process.env.RUSTFLAGS, "-C panic=unwind"]
+    .filter(Boolean)
+    .join(" ")
   execSync(
-    //"cargo build --target wasm32-unknown-unknown --profile dev",
-    "cargo build --target wasm32-unknown-unknown --release",
+    "cargo +nightly build --target wasm32-unknown-unknown --release " +
+      "-Zbuild-std=std,panic_unwind",
     {
       cwd: automergeWasmPath,
-      env: { ...process.env, GIT_HEAD: gitHead },
+      env: { ...process.env, GIT_HEAD: gitHead, RUSTFLAGS: wasmRustflags },
     },
   )
 

--- a/javascript/scripts/build.mjs
+++ b/javascript/scripts/build.mjs
@@ -117,11 +117,13 @@ function buildWasm(outputDir, gitHead) {
   // Rust functions surface as `PanicError` exceptions at the JS boundary
   // (wasm-bindgen 0.2.118+) instead of aborting the WASM module. This requires
   // a nightly toolchain (for -Zbuild-std) and the `rust-src` rustup component.
+  // CI sets WASM_TOOLCHAIN to a pinned dated nightly for reproducible builds.
   const wasmRustflags = [process.env.RUSTFLAGS, "-C panic=unwind"]
     .filter(Boolean)
     .join(" ")
+  const toolchain = process.env.WASM_TOOLCHAIN ?? "nightly"
   execSync(
-    "cargo +nightly build --target wasm32-unknown-unknown --release " +
+    `cargo +${toolchain} build --target wasm32-unknown-unknown --release ` +
       "-Zbuild-std=std,panic_unwind",
     {
       cwd: automergeWasmPath,

--- a/rust/automerge-wasm/Cargo.toml
+++ b/rust/automerge-wasm/Cargo.toml
@@ -20,11 +20,10 @@ crate-type = ["cdylib", "rlib"]
 bench = false
 
 [features]
-# default = ["console_error_panic_hook", "wee_alloc"]
-default = ["console_error_panic_hook"]
+# default = ["wee_alloc"]
+default = []
 
 [dependencies]
-console_error_panic_hook = { version = "^0.1", optional = true }
 # wee_alloc = { version = "^0.4", optional = true }
 automerge = { path = "../automerge", features = ["wasm", "utf16-indexing"] }
 js-sys = "^0.3"

--- a/rust/automerge-wasm/README.md
+++ b/rust/automerge-wasm/README.md
@@ -439,16 +439,29 @@ Object Ids uniquely identify an object within a document.  They are represented 
 
 ### Appendix: Building
 
-  The following steps should allow you to build the package
+The wasm package is built with the nightly toolchain and the `panic=unwind`
+strategy so that Rust panics in exported functions are caught at the JS
+boundary by wasm-bindgen 0.2.118+ and thrown as `PanicError` exceptions
+(async exports reject the returned promise) rather than aborting the WASM
+module. This requires the nightly toolchain (for `-Zbuild-std`) and the
+`rust-src` rustup component.
 
   ```
    $ rustup target add wasm32-unknown-unknown
+   $ rustup toolchain install nightly
+   $ rustup component add rust-src --toolchain nightly
    $ cargo install wasm-bindgen-cli
    $ cargo install wasm-opt
    $ npm install
    $ npm run release
    $ npm pack
   ```
+
+Under the hood `npm run release` invokes
+`cargo +nightly build … -Zbuild-std=std,panic_unwind` with
+`RUSTFLAGS="-C panic=unwind"`. The rest of the workspace still builds with
+the pinned stable toolchain in `rust/rust-toolchain.toml`; the nightly
+toolchain is only used for this wasm build.
 
 ### Appendix: WASM and Memory Allocation
 

--- a/rust/automerge-wasm/package.json
+++ b/rust/automerge-wasm/package.json
@@ -38,7 +38,7 @@
     "release": "cross-env PROFILE=release TARGET_DIR=release npm run buildall",
     "buildall": "cross-env TARGET=nodejs npm run target && cross-env TARGET=bundler npm run target && cross-env TARGET=deno npm run target && TARGET=web npm run target && node -e \"require('fs').cpSync('./src/export-web-wasm.js', './web/index.js')\" && node -e \"require('fs').cpSync('./nodejs/automerge_wasm.d.ts', './index.d.ts')\" && node ./fixup-node-cjs.mjs",
     "target": "rimraf ./$TARGET && npm run compile && npm run bindgen && npm run opt",
-    "compile": "cargo build --target wasm32-unknown-unknown --profile $PROFILE",
+    "compile": "node ./scripts/compile.mjs",
     "bindgen": "wasm-bindgen --omit-default-module-path --weak-refs --typescript --target $TARGET --out-dir $TARGET ../target/wasm32-unknown-unknown/$TARGET_DIR/automerge_wasm.wasm",
     "opt": "echo wasm-opt -O4 $TARGET/automerge_wasm_bg.wasm -o $TARGET/automerge_wasm_bg.wasm",
     "test": "tsc --noEmit && mocha --loader=ts-node/esm test/**/*.mts"

--- a/rust/automerge-wasm/scripts/compile.mjs
+++ b/rust/automerge-wasm/scripts/compile.mjs
@@ -1,0 +1,35 @@
+// Runs `cargo build` for the wasm target with the panic=unwind strategy so
+// that Rust panics are caught at the JS boundary by wasm-bindgen and thrown as
+// `PanicError` exceptions instead of aborting the WASM module.
+//
+// This requires the nightly toolchain (for -Zbuild-std) and the rust-src
+// rustup component. The nightly toolchain is selected here via rustup's
+// "+toolchain" argument so the workspace's pinned stable toolchain (see
+// rust/rust-toolchain.toml) is left untouched for everything else.
+
+import { spawnSync } from "node:child_process"
+
+const profile = process.env.PROFILE ?? "dev"
+
+const args = [
+  "+nightly",
+  "build",
+  "--target",
+  "wasm32-unknown-unknown",
+  "--profile",
+  profile,
+  // Rebuild std with the unwind panic runtime (only available on nightly).
+  "-Zbuild-std=std,panic_unwind",
+]
+
+// Compose RUSTFLAGS, preserving any the user already set.
+const env = { ...process.env }
+const extra = "-C panic=unwind"
+env.RUSTFLAGS = env.RUSTFLAGS ? `${env.RUSTFLAGS} ${extra}` : extra
+
+const result = spawnSync("cargo", args, { stdio: "inherit", env })
+if (result.error) {
+  console.error(result.error)
+  process.exit(1)
+}
+process.exit(result.status ?? 1)

--- a/rust/automerge-wasm/scripts/compile.mjs
+++ b/rust/automerge-wasm/scripts/compile.mjs
@@ -6,13 +6,18 @@
 // rustup component. The nightly toolchain is selected here via rustup's
 // "+toolchain" argument so the workspace's pinned stable toolchain (see
 // rust/rust-toolchain.toml) is left untouched for everything else.
+//
+// CI overrides WASM_TOOLCHAIN with a pinned dated nightly (e.g.
+// `nightly-2026-04-25`) for reproducible builds. Local dev defaults to
+// `nightly`.
 
 import { spawnSync } from "node:child_process"
 
 const profile = process.env.PROFILE ?? "dev"
+const toolchain = process.env.WASM_TOOLCHAIN ?? "nightly"
 
 const args = [
-  "+nightly",
+  `+${toolchain}`,
   "build",
   "--target",
   "wasm32-unknown-unknown",

--- a/rust/automerge-wasm/src/lib.rs
+++ b/rust/automerge-wasm/src/lib.rs
@@ -1708,6 +1708,26 @@ impl Automerge {
     }
 }
 
+// Runs once at module instantiation (wasm-bindgen's `start` function). We
+// install a console-logging hook for hard aborts (instance termination) so
+// that even when wasm traps and the module is permanently torn down, the
+// failure is visible in the console rather than just surfacing as the
+// generic "Module terminated" error on every subsequent export call.
+//
+// Recoverable Rust panics still go through `console_error_panic_hook` (set
+// in `create` below) and surface as `PanicError` exceptions at the JS
+// boundary thanks to the `panic=unwind` build.
+#[wasm_bindgen(start)]
+fn on_start() {
+    fn log_abort() {
+        web_sys::console::error_1(
+            &"automerge-wasm: WASM instance aborted; subsequent calls will throw \"Module terminated\""
+                .into(),
+        );
+    }
+    let _ = wasm_bindgen::__rt::set_on_abort(log_abort);
+}
+
 // skip_typescript as the definition requires an optional argument so we define
 // the function in the typescript custom section at the top of the file
 #[wasm_bindgen(js_name = create, skip_typescript)]

--- a/rust/automerge-wasm/src/lib.rs
+++ b/rust/automerge-wasm/src/lib.rs
@@ -1714,9 +1714,10 @@ impl Automerge {
 // failure is visible in the console rather than just surfacing as the
 // generic "Module terminated" error on every subsequent export call.
 //
-// Recoverable Rust panics still go through `console_error_panic_hook` (set
-// in `create` below) and surface as `PanicError` exceptions at the JS
-// boundary thanks to the `panic=unwind` build.
+// Recoverable Rust panics surface as `PanicError` exceptions at the JS
+// boundary thanks to the `panic=unwind` build, so we don't install
+// `console_error_panic_hook`: the panic info already reaches the caller as
+// a thrown exception and there's no need to additionally log it.
 #[wasm_bindgen(start)]
 fn on_start() {
     fn log_abort() {
@@ -1732,7 +1733,6 @@ fn on_start() {
 // the function in the typescript custom section at the top of the file
 #[wasm_bindgen(js_name = create, skip_typescript)]
 pub fn init(options: JsValue) -> Result<Automerge, error::BadActorId> {
-    console_error_panic_hook::set_once();
     let actor = js_get(&options, "actor").ok().and_then(|a| a.as_string());
     Automerge::new(actor)
 }


### PR DESCRIPTION
Rebasing #1363 on `main` to pick up the latest wasm-bindgen and switching to loading the webassembly as base64 in webpack. 

The latter point there might be a little surprising. The problem is that the panic unwinding stuff introduces a new import definition of type `0x4` in the webassembly for the exception types used by the webassembly exception handling spec. Unfortunately WebPacks wasm parser (@webassembly/wasm-parser) has not been updated for two years and chokes on this type, which means that webpack can't handle the bundler output. I've opted here to switch to bundling the base64 for webpack (and only for webpack, other bundlers are unaffected). We've already had this problem once before (https://github.com/automerge/automerge/pull/1025). I've [filed an issue](https://github.com/xtuc/webassemblyjs/issues/1210), if that gets fixed then we can revert to using the wasm directly. I think the advantages of panic handling outweight the disadvantage of a 30% file size increase for webpack users.