### PR TITLE
Fix stale inactive patch log migration during sync

### DIFF
--- a/rust/automerge/src/autocommit.rs
+++ b/rust/automerge/src/autocommit.rs
@@ -1275,8 +1275,8 @@ impl OpRange {
 #[cfg(test)]
 mod tests {
     use crate::{
-        sync::SyncDoc, transaction::Transactable, ActorId, AutoCommit, ReadDoc, ScalarValue, Value,
-        ROOT,
+        patches::PatchLog, sync::SyncDoc, transaction::Transactable, ActorId, AutoCommit, ReadDoc,
+        ScalarValue, Value, ROOT,
     };
 
     fn is_send<S: Send>() {}
@@ -1289,10 +1289,14 @@ mod tests {
     #[test]
     fn sync_receive_with_stale_inactive_patch_log_does_not_fail() {
         let mut receiver = AutoCommit::new();
-        receiver.patch_log.actors = vec![ActorId::from(b"stale-actor" as &[u8])];
+        receiver.set_actor(ActorId::from(b"receiver" as &[u8]));
+        receiver.put(ROOT, "starter", "ready").unwrap();
+
+        let mut patch_log = PatchLog::inactive();
+        patch_log.actors = vec![ActorId::from(b"aaa-stale-actor" as &[u8])];
 
         let mut donor = AutoCommit::new();
-        donor.set_actor(ActorId::from(b"donor" as &[u8]));
+        donor.set_actor(ActorId::from(b"zzz-donor" as &[u8]));
         donor.put(ROOT, "key", "value").unwrap();
 
         let mut receiver_sync = crate::sync::State::new();
@@ -1312,7 +1316,7 @@ mod tests {
 
         receiver
             .sync()
-            .receive_sync_message(&mut receiver_sync, message)
+            .receive_sync_message_log_patches(&mut receiver_sync, message, &mut patch_log)
             .unwrap();
 
         match receiver.get(ROOT, "key").unwrap() {

--- a/rust/automerge/src/autocommit.rs
+++ b/rust/automerge/src/autocommit.rs
@@ -1274,11 +1274,52 @@ impl OpRange {
 
 #[cfg(test)]
 mod tests {
+    use crate::{
+        sync::SyncDoc, transaction::Transactable, ActorId, AutoCommit, ReadDoc, ScalarValue, Value,
+        ROOT,
+    };
 
     fn is_send<S: Send>() {}
 
     #[test]
     fn test_autocommit_is_send() {
         is_send::<super::AutoCommit>();
+    }
+
+    #[test]
+    fn sync_receive_with_stale_inactive_patch_log_does_not_fail() {
+        let mut receiver = AutoCommit::new();
+        receiver.patch_log.actors = vec![ActorId::from(b"stale-actor" as &[u8])];
+
+        let mut donor = AutoCommit::new();
+        donor.set_actor(ActorId::from(b"donor" as &[u8]));
+        donor.put(ROOT, "key", "value").unwrap();
+
+        let mut receiver_sync = crate::sync::State::new();
+        let mut donor_sync = crate::sync::State::new();
+
+        if let Some(handshake) = receiver.sync().generate_sync_message(&mut receiver_sync) {
+            donor
+                .sync()
+                .receive_sync_message(&mut donor_sync, handshake)
+                .unwrap();
+        }
+
+        let message = donor
+            .sync()
+            .generate_sync_message(&mut donor_sync)
+            .expect("donor should advertise its change");
+
+        receiver
+            .sync()
+            .receive_sync_message(&mut receiver_sync, message)
+            .unwrap();
+
+        match receiver.get(ROOT, "key").unwrap() {
+            Some((Value::Scalar(value), _)) => {
+                assert_eq!(value.as_ref(), &ScalarValue::Str("value".into()));
+            }
+            other => panic!("expected synced scalar value, got {other:?}"),
+        }
     }
 }

--- a/rust/automerge/src/op_set2/change/batch.rs
+++ b/rust/automerge/src/op_set2/change/batch.rs
@@ -801,10 +801,14 @@ impl BatchApply {
         doc.remove_unused_actors(true);
     }
 
-    pub(crate) fn apply(&mut self, doc: &mut Automerge, log: &mut PatchLog) {
+    pub(crate) fn apply(
+        &mut self,
+        doc: &mut Automerge,
+        log: &mut PatchLog,
+    ) -> Result<(), AutomergeError> {
         self.insert_new_actors(doc);
 
-        log.migrate_actors(&doc.ops().actors).unwrap();
+        log.migrate_actors(&doc.ops().actors)?;
 
         self.import_ops(doc);
 
@@ -882,6 +886,7 @@ impl BatchApply {
         self.insert_runs_of_ops(doc);
 
         debug_assert!(doc.ops.validate_op_order());
+        Ok(())
     }
 
     fn insert_runs_of_ops(&mut self, doc: &mut Automerge) {
@@ -1080,8 +1085,7 @@ impl Automerge {
             self.queue.push(c);
         }
 
-        chap.apply(self, log);
-        Ok(())
+        chap.apply(self, log)
     }
 
     fn import_ops_to(

--- a/rust/automerge/src/patches/patch_log.rs
+++ b/rust/automerge/src/patches/patch_log.rs
@@ -456,6 +456,10 @@ impl PatchLog {
     // for every objid and opid
     pub(crate) fn migrate_actors(&mut self, others: &Vec<ActorId>) -> Result<(), AutomergeError> {
         if &self.actors != others {
+            if !self.active && self.events.is_empty() && self.expose.is_empty() {
+                self.actors = others.clone();
+                return Ok(());
+            }
             if self.actors.is_empty() {
                 self.actors = others.clone();
                 return Ok(());


### PR DESCRIPTION
## Summary

- tolerate inactive, empty patch logs whose actor table is stale during sync receive
- propagate `PatchLogMismatch` from batch change application instead of panicking on `unwrap()`
- add a regression test that reproduces the stale inactive patch log sync path

## Details

During sync receive, `AutoCommit` can apply an incoming change while its internal patch log is inactive and empty. That patch log can still retain an older actor table. After the incoming change updates the document actor table, patch-log actor migration can see a mismatch.

For an inactive patch log with no events and no exposed IDs, there is nothing to migrate. Retargeting the log to the document actor table is safe and avoids a panic in the sync path. Non-empty mismatches still return `PatchLogMismatch`.

This is the upstream version of the downstream nteract/automerge patch used by nteract/desktop to stop `PatchLogMismatch` panics during runtime-state sync.

## Verification

- `cargo test --manifest-path rust/automerge/Cargo.toml sync_receive_with_stale_inactive_patch_log_does_not_fail -- --nocapture`
- `cargo fmt --all --check` from `rust/`
- `git diff --check origin/main..HEAD`
