### PR TITLE
Hash DFS Sedimentree fragmentizer

### DIFF
--- a/rust/automerge/Cargo.toml
+++ b/rust/automerge/Cargo.toml
@@ -76,3 +76,7 @@ harness = false
 [[bench]]
 name = "load_save"
 harness = false
+
+[[bench]]
+name = "fragments"
+harness = false

--- a/rust/automerge/benches/fragments.rs
+++ b/rust/automerge/benches/fragments.rs
@@ -1,0 +1,188 @@
+//! Benchmarks for the change-graph fragmenter.
+//!
+//! Two implementations live side by side on this branch:
+//!
+//! - `Automerge::fragments()` — the existing eager, clock-based prototype.
+//!   Runs `cache_fragment` per change inside `add_change`, so the work is
+//!   amortised across `apply_changes` / commit; query is cheap.
+//! - `Automerge::depth_fragments()` — spec-correct, depth-stratified BFS.
+//!   Lazy: no eager work; full BFS on every query.
+//!
+//! Three bench groups:
+//!
+//! - `fragments/build` — total cost of building a doc, one tx per change.
+//!   Measures the clock-based eager pipeline (depth has no eager cost).
+//!   Reference only.
+//! - `fragments/apply` — `apply_changes` of a pre-extracted Vec.
+//!   Same caveat: the clock-based eager path is always on when calling
+//!   `add_change`, so this also measures clock-based overhead.
+//! - `fragments/query` — head-to-head: time `fragments()` (clock-based)
+//!   vs `depth_fragments()` (spec) on the same prebuilt doc. This is the
+//!   apples-to-apples comparison of pure query cost.
+//!
+//! Topologies:
+//!
+//! - `linear` — one actor, one transaction per commit.
+//! - `concurrent2` — two actors making half the commits each on forks,
+//!   then merging at the end.
+//! - `wide8` — eight actors making concurrent commits on independent
+//!   forks, then merging.
+
+use automerge::{transaction::Transactable, Automerge, ChangeHash, ROOT};
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use std::hint::black_box;
+
+/// Build function for a parameterised topology.
+type TopologyBuilder = fn(u64) -> Automerge;
+
+/// Named topology used by the parameterised bench groups.
+type Topology = (&'static str, TopologyBuilder);
+
+// ─── doc builders ──────────────────────────────────────────────────────────
+
+fn build_linear(n: u64) -> Automerge {
+    let mut doc = Automerge::new();
+    for i in 0..n {
+        let mut tx = doc.transaction();
+        tx.put(ROOT, i.to_string(), i as i64).unwrap();
+        tx.commit();
+    }
+    doc
+}
+
+fn build_concurrent2(n: u64) -> Automerge {
+    let half = n / 2;
+
+    let mut a = Automerge::new();
+    let mut b = a.fork();
+
+    for i in 0..half {
+        let mut tx = a.transaction();
+        tx.put(ROOT, format!("a{i}"), i as i64).unwrap();
+        tx.commit();
+    }
+    for i in 0..half {
+        let mut tx = b.transaction();
+        tx.put(ROOT, format!("b{i}"), i as i64).unwrap();
+        tx.commit();
+    }
+
+    a.merge(&mut b).unwrap();
+    a
+}
+
+fn build_wide8(n: u64) -> Automerge {
+    build_wide(n, 8)
+}
+
+fn build_wide(n: u64, actors: u64) -> Automerge {
+    let per = n / actors;
+
+    let base = Automerge::new();
+    let mut forks: Vec<Automerge> = (0..actors).map(|_| base.fork()).collect();
+
+    for (idx, fork) in forks.iter_mut().enumerate() {
+        for i in 0..per {
+            let mut tx = fork.transaction();
+            tx.put(ROOT, format!("a{idx}_{i}"), i as i64).unwrap();
+            tx.commit();
+        }
+    }
+
+    let mut acc = forks.remove(0);
+    for mut other in forks {
+        acc.merge(&mut other).unwrap();
+    }
+    acc
+}
+
+fn changes_topo(doc: &Automerge) -> Vec<automerge::Change> {
+    doc.get_changes(&[] as &[ChangeHash])
+}
+
+const TOPOLOGIES: &[Topology] = &[
+    ("linear", build_linear),
+    ("concurrent2", build_concurrent2),
+    ("wide8", build_wide8),
+];
+
+// ─── bench groups ──────────────────────────────────────────────────────────
+
+fn bench_build(c: &mut Criterion) {
+    let mut group = c.benchmark_group("fragments/build");
+    for &n in &[1_000u64, 10_000] {
+        group.throughput(Throughput::Elements(n));
+        for &(topo, builder) in TOPOLOGIES {
+            group.bench_with_input(BenchmarkId::new(topo, n), &n, |b, &n| {
+                b.iter(|| black_box(builder(n)))
+            });
+        }
+    }
+    group.finish();
+}
+
+/// Head-to-head: clock-based `fragments()` vs depth-stratified
+/// `depth_fragments()`, on the same prebuilt doc. This is the only bench
+/// group where the two strategies are doing work along the comparable
+/// critical path.
+fn bench_query(c: &mut Criterion) {
+    let mut group = c.benchmark_group("fragments/query");
+    for &n in &[1_000u64, 10_000] {
+        group.throughput(Throughput::Elements(n));
+        for &(topo, builder) in TOPOLOGIES {
+            let doc = builder(n);
+
+            // Sanity: print fragment counts so a glance at bench output
+            // confirms both strategies actually produced fragments and shows
+            // their semantic divergence (clock-based emits one Fragment per
+            // depth-0 commit above `fragment_top` plus one per cached
+            // FragmentNode; depth emits one per commit with `level >= 1`).
+            let frags_clock = doc.fragments();
+            let frags_depth = doc.depth_fragments();
+            eprintln!(
+                "  [{topo}/{n}] clock={} depth={} (heads={})",
+                frags_clock.len(),
+                frags_depth.len(),
+                doc.get_heads().len()
+            );
+
+            group.bench_with_input(
+                BenchmarkId::new(format!("clock/{topo}"), n),
+                &doc,
+                |b, doc| b.iter(|| black_box(doc.fragments().len())),
+            );
+            group.bench_with_input(
+                BenchmarkId::new(format!("depth/{topo}"), n),
+                &doc,
+                |b, doc| b.iter(|| black_box(doc.depth_fragments().len())),
+            );
+        }
+    }
+    group.finish();
+}
+
+fn bench_apply(c: &mut Criterion) {
+    let mut group = c.benchmark_group("fragments/apply");
+    for &n in &[1_000u64, 10_000] {
+        group.throughput(Throughput::Elements(n));
+        for &(topo, builder) in TOPOLOGIES {
+            let src = builder(n);
+            let changes = changes_topo(&src);
+            group.bench_with_input(BenchmarkId::new(topo, n), &changes, |b, changes| {
+                b.iter_batched(
+                    || changes.clone(),
+                    |changes| {
+                        let mut dst = Automerge::new();
+                        dst.apply_changes(changes).unwrap();
+                        black_box(dst.fragments().len())
+                    },
+                    criterion::BatchSize::LargeInput,
+                )
+            });
+        }
+    }
+    group.finish();
+}
+
+criterion_group!(benches, bench_build, bench_query, bench_apply);
+criterion_main!(benches);

--- a/rust/automerge/src/autocommit.rs
+++ b/rust/automerge/src/autocommit.rs
@@ -1,6 +1,7 @@
 use std::ops::RangeBounds;
 
 use crate::automerge::SaveOptions;
+use crate::change_graph::Fragment;
 use crate::clock::Clock;
 use crate::cursor::{CursorPosition, MoveCursor};
 use crate::exid::ExId;
@@ -608,6 +609,10 @@ impl AutoCommit {
     pub fn dump(&mut self) {
         self.ensure_transaction_closed();
         self.doc.dump()
+    }
+
+    pub fn fragments(&self) -> Vec<Fragment> {
+        self.doc.fragments()
     }
 
     /// Get the current heads of the document.

--- a/rust/automerge/src/autocommit.rs
+++ b/rust/automerge/src/autocommit.rs
@@ -1,7 +1,7 @@
 use std::ops::RangeBounds;
 
 use crate::automerge::SaveOptions;
-use crate::change_graph::Fragment;
+use crate::change_graph::{DepthFragment, Fragment};
 use crate::clock::Clock;
 use crate::cursor::{CursorPosition, MoveCursor};
 use crate::exid::ExId;
@@ -613,6 +613,12 @@ impl AutoCommit {
 
     pub fn fragments(&self) -> Vec<Fragment> {
         self.doc.fragments()
+    }
+
+    /// Spec-correct, depth-stratified fragments. See
+    /// [`Automerge::depth_fragments`] for the algorithm.
+    pub fn depth_fragments(&self) -> Vec<DepthFragment> {
+        self.doc.depth_fragments()
     }
 
     /// Get the current heads of the document.

--- a/rust/automerge/src/automerge.rs
+++ b/rust/automerge/src/automerge.rs
@@ -7,6 +7,7 @@ use std::ops::RangeBounds;
 
 use itertools::Itertools;
 
+pub(crate) use crate::change_graph::Fragment;
 pub(crate) use crate::op_set2::change::ChangeCollector;
 pub(crate) use crate::op_set2::types::ScalarValue;
 pub(crate) use crate::op_set2::{
@@ -1248,6 +1249,10 @@ impl Automerge {
         DiffIter::log(self, obj, clock, &mut patch_log, recursive);
         patch_log.heads = Some(after_heads.to_vec());
         Ok(patch_log.make_patches(self))
+    }
+
+    pub fn fragments(&self) -> Vec<Fragment> {
+        self.change_graph.fragments(&self.get_heads()).collect()
     }
 
     /// Get the heads of this document.

--- a/rust/automerge/src/automerge.rs
+++ b/rust/automerge/src/automerge.rs
@@ -7,7 +7,7 @@ use std::ops::RangeBounds;
 
 use itertools::Itertools;
 
-pub(crate) use crate::change_graph::Fragment;
+pub(crate) use crate::change_graph::{DepthFragment, Fragment};
 pub(crate) use crate::op_set2::change::ChangeCollector;
 pub(crate) use crate::op_set2::types::ScalarValue;
 pub(crate) use crate::op_set2::{
@@ -1253,6 +1253,20 @@ impl Automerge {
 
     pub fn fragments(&self) -> Vec<Fragment> {
         self.change_graph.fragments(&self.get_heads()).collect()
+    }
+
+    /// Spec-correct, depth-stratified fragments.
+    ///
+    /// Recomputes on demand by walking the change graph from the document's
+    /// heads. Each fragment is built by a depth-stratified BFS that stops at
+    /// ancestors whose `ChangeHash::fragment_level()` is `>=` the head's
+    /// level, classifying every other ancestor as either a member or a
+    /// checkpoint. See [`DepthFragment`] for the result shape.
+    ///
+    /// Coexists with [`Automerge::fragments`] (the clock-based prototype) so
+    /// the two strategies can be benchmarked head-to-head.
+    pub fn depth_fragments(&self) -> Vec<DepthFragment> {
+        self.change_graph.depth_fragments(&self.get_heads())
     }
 
     /// Get the heads of this document.

--- a/rust/automerge/src/change_graph.rs
+++ b/rust/automerge/src/change_graph.rs
@@ -1,6 +1,6 @@
 use std::borrow::Cow;
 use std::cmp::Ordering;
-use std::collections::{BTreeSet, HashMap};
+use std::collections::{BTreeSet, HashMap, HashSet, VecDeque};
 use std::num::NonZeroU32;
 use std::ops::Add;
 
@@ -46,6 +46,8 @@ pub(crate) struct ChangeGraph {
     nodes_by_hash: HashMap<ChangeHash, NodeIdx>,
     clock_cache: HashMap<NodeIdx, SeqClock>,
     seq_index: Vec<Vec<NodeIdx>>,
+    fragment_top: SeqClock,
+    fragments: Vec<FragmentNode>,
 }
 
 pub(crate) struct ChangeGraphCols(ChangeGraph);
@@ -102,6 +104,8 @@ impl ChangeGraph {
             heads: BTreeSet::new(),
             clock_cache: HashMap::new(),
             seq_index: vec![vec![]; num_actors],
+            fragments: vec![],
+            fragment_top: SeqClock::new(num_actors),
         }
     }
 
@@ -148,6 +152,10 @@ impl ChangeGraph {
         for clock in self.clock_cache.values_mut() {
             clock.rewrite_with_new_actor(idx)
         }
+        for f in &mut self.fragments {
+            f.clock.rewrite_with_new_actor(idx)
+        }
+        self.fragment_top.rewrite_with_new_actor(idx);
         self.seq_index.insert(idx, vec![]);
     }
 
@@ -558,8 +566,109 @@ impl ChangeGraph {
             if (node_idx + 1).0 % CACHE_STEP == 0 {
                 self.cache_clock(node_idx);
             }
+
+            self.cache_fragment(node_idx);
         }
         Ok(())
+    }
+
+    pub(crate) fn fragments<'a>(
+        &'a self,
+        heads: &'a [ChangeHash],
+    ) -> impl Iterator<Item = Fragment> + 'a {
+        self.loose_fragments(heads)
+            .chain(self.fragments.iter().rev().map(|f| f.export(self)))
+    }
+
+    fn loose_fragments<'a>(
+        &'a self,
+        heads: &'a [ChangeHash],
+    ) -> impl Iterator<Item = Fragment> + 'a {
+        let nodes = heads
+            .iter()
+            .filter(|h| h.fragment_level() == 0)
+            .filter_map(|h| self.nodes_by_hash.get(h).copied());
+        self.bfs_until_clock(nodes, &self.fragment_top)
+            .map(move |n| {
+                let id = self.hashes[n.0 as usize];
+                assert_eq!(id.fragment_level(), 0);
+                let deps = self.parents(n).map(|p| self.hashes[p.0 as usize]).collect();
+                let content = vec![id];
+                let level = id.fragment_level();
+                Fragment {
+                    id,
+                    level,
+                    deps,
+                    content,
+                }
+            })
+    }
+
+    fn fragment_content<'a>(
+        &'a self,
+        node: NodeIdx,
+        clock: &'a SeqClock,
+    ) -> impl Iterator<Item = ChangeHash> + 'a {
+        self.bfs_until_clock([node], clock)
+            .map(|n| self.hashes[n.0 as usize])
+    }
+
+    fn bfs_until_clock<'a, I>(
+        &'a self,
+        seed: I,
+        clock: &'a SeqClock,
+    ) -> impl Iterator<Item = NodeIdx> + 'a
+    where
+        I: IntoIterator<Item = NodeIdx>,
+    {
+        let mut to_visit: VecDeque<_> = seed.into_iter().collect();
+        let mut seen: HashSet<_> = to_visit.iter().copied().collect();
+
+        std::iter::from_fn(move || {
+            let idx = to_visit.pop_front()?;
+            for p in self.parents(idx) {
+                if !seen.contains(&p) {
+                    let actor = self.actors[p.0 as usize].into();
+                    let seq = self.seq[p.0 as usize];
+                    if clock.get_for_actor(&actor) < NonZeroU32::new(seq) {
+                        seen.insert(p);
+                        to_visit.push_back(p);
+                    }
+                }
+            }
+            Some(idx)
+        })
+    }
+
+    fn cache_fragments(&mut self) {
+        for n in 0..self.hashes.len() {
+            self.cache_fragment(NodeIdx(n as u32))
+        }
+    }
+
+    fn cache_fragment(&mut self, id: NodeIdx) {
+        let hash = &self.hashes[id.0 as usize];
+        let level = hash.fragment_level();
+        if level == 0 {
+            return;
+        }
+        let mut deps = vec![];
+        let mut supercede = vec![];
+        let clock = self.calculate_clock(vec![id]);
+        for (i, f) in self.fragments.iter().enumerate().rev() {
+            if clock.covers(&f.clock) {
+                if self.hashes[f.id.0 as usize].fragment_level() >= level {
+                    deps.push(f.id);
+                } else {
+                    supercede.push(i);
+                }
+            }
+        }
+        for i in supercede {
+            self.fragments.remove(i);
+        }
+        SeqClock::merge(&mut self.fragment_top, &clock);
+        self.fragments.push(FragmentNode { id, deps, clock });
     }
 
     pub(crate) fn add_change(&mut self, change: &Change, actor: usize) -> Result<(), MissingDep> {
@@ -759,6 +868,8 @@ impl ChangeGraphCols {
             }
         }
 
+        graph.cache_fragments();
+
         graph
     }
 
@@ -859,6 +970,8 @@ impl ChangeGraphCols {
         let clock_cache = HashMap::default();
         let hashes = vec![];
         let nodes_by_hash = HashMap::new();
+        let fragments = vec![];
+        let fragment_top = SeqClock::new(num_actors);
 
         Ok(ChangeGraphCols(ChangeGraph {
             edges,
@@ -877,6 +990,8 @@ impl ChangeGraphCols {
             nodes_by_hash,
             clock_cache,
             seq_index,
+            fragments,
+            fragment_top,
         }))
     }
 }
@@ -1067,6 +1182,183 @@ mod tests {
             }
             graph
         }
+
+        fn all_hashes(&self) -> Vec<ChangeHash> {
+            self.changes.iter().map(|c| c.hash()).collect()
+        }
+    }
+
+    #[test]
+    fn fragments_cover_all_changes() {
+        // Create a long linear chain — with ~1000 changes, we expect several
+        // with fragment_level >= 1 (roughly 1 in 256).
+        let mut builder = TestGraphBuilder::new();
+        let actor = builder.actor();
+        let mut prev = vec![];
+        for _ in 0..1000 {
+            let h = builder.change(&actor, 1, &prev);
+            prev = vec![h];
+        }
+        let graph = builder.build();
+        let all_hashes: BTreeSet<_> = builder.all_hashes().into_iter().collect();
+        let heads: Vec<_> = graph.heads().collect();
+
+        let fragments: Vec<_> = graph.fragments(&heads).collect();
+
+        // Collect all content hashes across all fragments
+        // (hashes may appear in multiple fragments — this is expected)
+        let mut covered: BTreeSet<ChangeHash> = BTreeSet::new();
+        for f in &fragments {
+            for h in &f.content {
+                covered.insert(*h);
+            }
+        }
+
+        // Every change must appear in at least one fragment
+        let missing: Vec<_> = all_hashes.difference(&covered).collect();
+        assert!(
+            missing.is_empty(),
+            "changes not covered by any fragment: {:?}",
+            missing,
+        );
+    }
+
+    fn assert_fragment_invariants(fragments: &[Fragment]) {
+        for f in fragments {
+            // level must match the fragment_level of the id hash
+            assert_eq!(
+                f.level,
+                f.id.fragment_level(),
+                "fragment level mismatch for {:?}",
+                f.id
+            );
+
+            // id must be in content
+            assert!(
+                f.content.contains(&f.id),
+                "fragment id {:?} not found in its own content",
+                f.id
+            );
+
+            // deps must be equal or higher level than the fragment
+            for dep in &f.deps {
+                assert!(
+                    dep.fragment_level() >= f.level,
+                    "fragment {:?} (level {}) has dep {:?} with lower level {}",
+                    f.id,
+                    f.level,
+                    dep,
+                    dep.fragment_level(),
+                );
+            }
+
+            // content must not contain a hash with a higher level than the id
+            for h in &f.content {
+                assert!(
+                    h.fragment_level() <= f.level,
+                    "fragment {:?} (level {}) contains {:?} with higher level {}",
+                    f.id,
+                    f.level,
+                    h,
+                    h.fragment_level(),
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn fragment_id_and_level_consistent() {
+        let mut builder = TestGraphBuilder::new();
+        let actor = builder.actor();
+        let mut prev = vec![];
+        for _ in 0..1000 {
+            let h = builder.change(&actor, 1, &prev);
+            prev = vec![h];
+        }
+        let graph = builder.build();
+        let heads: Vec<_> = graph.heads().collect();
+        let fragments: Vec<_> = graph.fragments(&heads).collect();
+
+        assert_fragment_invariants(&fragments);
+    }
+
+    #[test]
+    fn fragments_work_with_concurrent_actors() {
+        let mut builder = TestGraphBuilder::new();
+        let actor1 = builder.actor();
+        let actor2 = builder.actor();
+
+        // Build two concurrent chains that merge periodically
+        let root = builder.change(&actor1, 1, &[]);
+        let mut tip1 = root;
+        let mut tip2 = root;
+        for i in 0..500 {
+            tip1 = builder.change(&actor1, 1, &[tip1]);
+            tip2 = builder.change(&actor2, 1, &[tip2]);
+            if i % 50 == 49 {
+                // merge
+                let merge = builder.change(&actor1, 1, &[tip1, tip2]);
+                tip1 = merge;
+                tip2 = merge;
+            }
+        }
+        let graph = builder.build();
+        let all_hashes: BTreeSet<_> = builder.all_hashes().into_iter().collect();
+        let heads: Vec<_> = graph.heads().collect();
+        let fragments: Vec<_> = graph.fragments(&heads).collect();
+
+        let mut covered: BTreeSet<ChangeHash> = BTreeSet::new();
+        for f in &fragments {
+            for h in &f.content {
+                covered.insert(*h);
+            }
+        }
+
+        let missing: Vec<_> = all_hashes.difference(&covered).collect();
+        assert!(
+            missing.is_empty(),
+            "changes not covered by any fragment: {:?}",
+            missing,
+        );
+
+        assert_fragment_invariants(&fragments);
+    }
+
+    #[test]
+    fn fragment_deps_reference_known_hashes() {
+        let mut builder = TestGraphBuilder::new();
+        let actor = builder.actor();
+        let mut prev = vec![];
+        for _ in 0..1000 {
+            let h = builder.change(&actor, 1, &prev);
+            prev = vec![h];
+        }
+        let graph = builder.build();
+        let all_hashes: BTreeSet<_> = builder.all_hashes().into_iter().collect();
+        let heads: Vec<_> = graph.heads().collect();
+        let fragments: Vec<_> = graph.fragments(&heads).collect();
+        let fragment_ids: BTreeSet<_> = fragments.iter().map(|f| f.id).collect();
+
+        for f in &fragments {
+            for dep in &f.deps {
+                assert!(
+                    all_hashes.contains(dep),
+                    "fragment {:?} has dep {:?} not in change graph",
+                    f.id,
+                    dep
+                );
+                // Deps of cached fragments (level > 0) should point to other fragment ids
+                // Deps of loose fragments (level == 0) point to change-level parents
+                if f.level > 0 {
+                    assert!(
+                        fragment_ids.contains(dep) || dep.fragment_level() == 0,
+                        "cached fragment {:?} has dep {:?} that is not a fragment id",
+                        f.id,
+                        dep
+                    );
+                }
+            }
+        }
     }
 }
 
@@ -1189,6 +1481,41 @@ impl<'a> Iterator for ChangeIter<'a> {
             builder: 0,
         })
     }
+}
+
+#[derive(Debug, PartialEq, Clone)]
+struct FragmentNode {
+    id: NodeIdx,
+    deps: Vec<NodeIdx>,
+    clock: SeqClock,
+}
+
+impl FragmentNode {
+    fn export(&self, graph: &ChangeGraph) -> Fragment {
+        let id = graph.hashes[self.id.0 as usize];
+        let level = id.fragment_level();
+        let deps = self
+            .deps
+            .iter()
+            .map(|d| graph.hashes[d.0 as usize])
+            .collect();
+        let clock = graph.calculate_clock(self.deps.clone());
+        let content = graph.fragment_content(self.id, &clock).collect();
+        Fragment {
+            id,
+            level,
+            deps,
+            content,
+        }
+    }
+}
+
+#[derive(Debug, PartialEq, Clone)]
+pub struct Fragment {
+    pub id: ChangeHash,
+    pub level: usize,
+    pub deps: Vec<ChangeHash>,
+    pub content: Vec<ChangeHash>,
 }
 
 #[rustfmt::skip]

--- a/rust/automerge/src/change_graph.rs
+++ b/rust/automerge/src/change_graph.rs
@@ -1360,6 +1360,198 @@ mod tests {
             }
         }
     }
+
+    // ─── depth_fragments tests ───────────────────────────────────────────
+
+    fn assert_depth_fragment_invariants(fragments: &[DepthFragment]) {
+        for f in fragments {
+            // level matches head's leading-zero-byte count.
+            assert_eq!(
+                f.level,
+                f.head.fragment_level(),
+                "DepthFragment level mismatch for {:?}",
+                f.head
+            );
+
+            // Heads are never depth 0.
+            assert!(f.level > 0, "DepthFragment head must have level > 0");
+
+            // head appears in members.
+            assert!(
+                f.members.contains(&f.head),
+                "DepthFragment head {:?} must be in its own members",
+                f.head
+            );
+
+            // Every member has level strictly less than head.level, OR is the head itself.
+            for m in &f.members {
+                if m == &f.head {
+                    continue;
+                }
+                assert!(
+                    m.fragment_level() < f.level,
+                    "DepthFragment {:?} (level {}) has member {:?} with level >= head level",
+                    f.head,
+                    f.level,
+                    m
+                );
+            }
+
+            // Checkpoints ⊆ members, and 0 < checkpoint.level < head.level.
+            let members_set: BTreeSet<_> = f.members.iter().collect();
+            for c in &f.checkpoints {
+                assert!(
+                    members_set.contains(c),
+                    "DepthFragment {:?}: checkpoint {:?} not in members",
+                    f.head,
+                    c
+                );
+                let cl = c.fragment_level();
+                assert!(
+                    cl > 0 && cl < f.level,
+                    "DepthFragment {:?} (level {}): checkpoint {:?} has invalid level {}",
+                    f.head,
+                    f.level,
+                    c,
+                    cl
+                );
+            }
+
+            // Boundary level is always >= head.level.
+            for b in &f.boundary {
+                assert!(
+                    b.fragment_level() >= f.level,
+                    "DepthFragment {:?} (level {}) has boundary {:?} with level < head level",
+                    f.head,
+                    f.level,
+                    b
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn depth_fragments_linear_invariants() {
+        let mut builder = TestGraphBuilder::new();
+        let actor = builder.actor();
+        let mut prev = vec![];
+        for _ in 0..1000 {
+            let h = builder.change(&actor, 1, &prev);
+            prev = vec![h];
+        }
+        let graph = builder.build();
+        let heads: Vec<_> = graph.heads().collect();
+        let fragments = graph.depth_fragments(&heads);
+        assert_depth_fragment_invariants(&fragments);
+    }
+
+    #[test]
+    fn depth_fragments_cover_all_changes() {
+        let mut builder = TestGraphBuilder::new();
+        let actor = builder.actor();
+        let mut prev = vec![];
+        for _ in 0..1000 {
+            let h = builder.change(&actor, 1, &prev);
+            prev = vec![h];
+        }
+        let graph = builder.build();
+        let all_hashes: BTreeSet<_> = builder.all_hashes().into_iter().collect();
+        let heads: Vec<_> = graph.heads().collect();
+        let fragments = graph.depth_fragments(&heads);
+
+        // Every depth-0 change appears in some fragment's members
+        // (or there are no fragments and the doc is purely loose commits).
+        let mut covered: BTreeSet<ChangeHash> = BTreeSet::new();
+        for f in &fragments {
+            for h in &f.members {
+                covered.insert(*h);
+            }
+        }
+        // Heads with level == 0 won't be in any fragment — they're loose commits.
+        // But for a 1000-change linear chain we expect ~3-4 depth>=1 fragments and
+        // every change between them should be a member.
+        assert!(
+            !fragments.is_empty(),
+            "expected at least one depth>=1 fragment in 1000 commits"
+        );
+
+        // Every change with level >= 1 must be a head of some fragment OR a
+        // checkpoint of some fragment.
+        let heads_set: BTreeSet<_> = fragments.iter().map(|f| f.head).collect();
+        let checkpoints_set: BTreeSet<_> = fragments
+            .iter()
+            .flat_map(|f| f.checkpoints.iter().copied())
+            .collect();
+        for h in &all_hashes {
+            if h.fragment_level() == 0 {
+                continue;
+            }
+            assert!(
+                heads_set.contains(h) || checkpoints_set.contains(h) || covered.contains(h),
+                "depth>=1 change {:?} (level {}) not represented anywhere",
+                h,
+                h.fragment_level()
+            );
+        }
+    }
+
+    #[test]
+    fn depth_fragments_concurrent_actors_invariants() {
+        let mut builder = TestGraphBuilder::new();
+        let actor1 = builder.actor();
+        let actor2 = builder.actor();
+
+        let root = builder.change(&actor1, 1, &[]);
+        let mut tip1 = root;
+        let mut tip2 = root;
+        for i in 0..500 {
+            tip1 = builder.change(&actor1, 1, &[tip1]);
+            tip2 = builder.change(&actor2, 1, &[tip2]);
+            if i % 50 == 49 {
+                let merge = builder.change(&actor1, 1, &[tip1, tip2]);
+                tip1 = merge;
+                tip2 = merge;
+            }
+        }
+        let graph = builder.build();
+        let heads: Vec<_> = graph.heads().collect();
+        let fragments = graph.depth_fragments(&heads);
+        assert_depth_fragment_invariants(&fragments);
+    }
+
+    #[test]
+    fn depth_fragments_boundary_chains_to_next_level() {
+        // Property: every boundary hash is either a fragment head we also
+        // emitted, or a hash whose level is >= the boundary holder's level.
+        // (Together with the level-≥ property above this means: boundaries
+        // are always either deeper fragment heads or unreachable from the
+        // initial heads, which in a fully-connected graph means they should
+        // also have been emitted as fragments.)
+        let mut builder = TestGraphBuilder::new();
+        let actor = builder.actor();
+        let mut prev = vec![];
+        for _ in 0..2000 {
+            let h = builder.change(&actor, 1, &prev);
+            prev = vec![h];
+        }
+        let graph = builder.build();
+        let heads: Vec<_> = graph.heads().collect();
+        let fragments = graph.depth_fragments(&heads);
+        let heads_set: BTreeSet<_> = fragments.iter().map(|f| f.head).collect();
+
+        for f in &fragments {
+            for b in &f.boundary {
+                // Every boundary hash should itself be the head of some
+                // fragment we emitted (since we walk boundaries level-by-level).
+                assert!(
+                    heads_set.contains(b),
+                    "boundary {:?} of fragment {:?} not emitted as a fragment head",
+                    b,
+                    f.head
+                );
+            }
+        }
+    }
 }
 
 fn to_vec<'a, I, T>(iter: I) -> Result<Vec<T>, PackError>
@@ -1516,6 +1708,176 @@ pub struct Fragment {
     pub level: usize,
     pub deps: Vec<ChangeHash>,
     pub content: Vec<ChangeHash>,
+}
+
+// ─── depth-stratified fragmenter ──────────────────────────────────────────
+//
+// `DepthFragment` and `ChangeGraph::depth_fragments` are an alternative
+// fragmenter that follows the sedimentree spec rather than the clock-based
+// approximation in the prototype above.
+//
+// Differences vs. `Fragment`:
+//
+// - Stop predicate is depth (leading-zero bytes of `ChangeHash`), not a
+//   `SeqClock`. A walk from a fragment head H of level L stops at any
+//   ancestor whose level is >= L; that ancestor becomes part of the
+//   fragment's _boundary_ rather than its members.
+// - `members` includes the head and every shallow ancestor visited;
+//   `checkpoints` is the subset of members with `0 < level < head_level`
+//   (intermediate fragment heads contained in this one).
+// - There is no eager cache and no `supercede` of dominated fragments —
+//   `Automerge::depth_fragments` recomputes on demand. Caching/minimization
+//   are downstream concerns left to the consumer (see `Sedimentree::minimize`).
+//
+// The algorithm matches `sedimentree_core::commit::CommitStore::fragment`
+// structurally, modulo: we walk via the in-memory change graph rather than a
+// generic store, and we omit the `known_fragment_states` deduplication (which
+// is dead code for a single-call build because shallower fragments are built
+// before their deeper boundaries — see notes in `commit.rs:142-151`).
+
+/// A spec-correct fragment derived from a depth-stratified BFS.
+///
+/// Built by [`Automerge::depth_fragments`](crate::Automerge::depth_fragments).
+/// Mirrors the `(head, members, checkpoints, boundary)` shape of
+/// `sedimentree_core::commit::FragmentState`.
+#[derive(Debug, PartialEq, Clone)]
+pub struct DepthFragment {
+    /// Head change; the newest commit in the fragment, with `level > 0`.
+    pub head: ChangeHash,
+
+    /// `ChangeHash::fragment_level()` of `head` (number of leading zero bytes).
+    pub level: usize,
+
+    /// Every change reachable from `head` whose level is strictly less than
+    /// `level`. Always includes `head` itself.
+    pub members: Vec<ChangeHash>,
+
+    /// Subset of `members` with `0 < level < head.level` — intermediate
+    /// fragment heads contained inside this fragment. Used by
+    /// `Fragment::supports` in `sedimentree_core` to determine when a
+    /// shallower fragment is fully contained in this one.
+    pub checkpoints: Vec<ChangeHash>,
+
+    /// Ancestors whose level is `>= head.level`, encountered during the
+    /// walk but _not_ expanded. They delimit the fragment and become heads
+    /// for the next (deeper) level when building a complete fragment store.
+    pub boundary: Vec<ChangeHash>,
+}
+
+impl ChangeGraph {
+    /// Build all spec-correct fragments reachable from `heads`, level by level.
+    ///
+    /// Returns a `Vec` in build order (shallowest level first; within a level,
+    /// LIFO over the input heads — same DFS-style order used by
+    /// `sedimentree_core::CommitStore::build_fragment_store`).
+    ///
+    /// Heads with `level == 0` are loose commits, not fragment heads;
+    /// they are skipped, but their parents are still walked so that
+    /// deeper-level ancestors are discovered and emitted as fragment heads.
+    ///
+    /// This recomputes from scratch on every call. There is no eager
+    /// per-change cache (in contrast to the `fragments` API exposed by
+    /// [`Automerge::fragments`](crate::Automerge::fragments)).
+    pub(crate) fn depth_fragments(&self, heads: &[ChangeHash]) -> Vec<DepthFragment> {
+        let mut out = Vec::new();
+        let mut emitted: HashSet<NodeIdx> = HashSet::new();
+        let mut visited: HashSet<NodeIdx> = HashSet::new();
+        let mut queue: VecDeque<NodeIdx> = heads
+            .iter()
+            .filter_map(|h| self.nodes_by_hash.get(h).copied())
+            .collect();
+        for &n in &queue {
+            visited.insert(n);
+        }
+
+        while let Some(head) = queue.pop_back() {
+            // pop_back = LIFO/DFS; matches spec's `Vec::pop`.
+            if emitted.contains(&head) {
+                continue;
+            }
+            let head_hash = self.hashes[head.0 as usize];
+            let head_level = head_hash.fragment_level();
+
+            if head_level == 0 {
+                // Loose commit: not a fragment head, but walk parents so
+                // deeper-level ancestors enter the queue.
+                for p in self.parents(head) {
+                    if visited.insert(p) {
+                        queue.push_back(p);
+                    }
+                }
+                emitted.insert(head);
+                continue;
+            }
+
+            let frag = self.build_one_depth_fragment(head, head_level);
+
+            // Boundary nodes become next-level heads.
+            for b_hash in &frag.boundary {
+                if let Some(&b_idx) = self.nodes_by_hash.get(b_hash) {
+                    if visited.insert(b_idx) {
+                        queue.push_back(b_idx);
+                    }
+                }
+            }
+
+            emitted.insert(head);
+            out.push(frag);
+        }
+
+        out
+    }
+
+    /// BFS from `head` through parent edges, classifying each visited node
+    /// as a member, checkpoint, or boundary based on its level relative to
+    /// `head_level`.
+    fn build_one_depth_fragment(&self, head: NodeIdx, head_level: usize) -> DepthFragment {
+        debug_assert!(head_level > 0, "depth-0 commit cannot head a fragment");
+
+        let mut visited: HashSet<NodeIdx> = HashSet::new();
+        let mut members: Vec<NodeIdx> = Vec::new();
+        let mut checkpoints: Vec<NodeIdx> = Vec::new();
+        let mut boundary: Vec<NodeIdx> = Vec::new();
+        let mut queue: VecDeque<NodeIdx> = VecDeque::new();
+
+        visited.insert(head);
+        members.push(head);
+        queue.push_back(head);
+
+        while let Some(n) = queue.pop_front() {
+            for p in self.parents(n) {
+                if !visited.insert(p) {
+                    continue;
+                }
+                let p_level = self.hashes[p.0 as usize].fragment_level();
+                if p_level >= head_level {
+                    // Same or deeper: boundary, do not expand.
+                    boundary.push(p);
+                } else {
+                    members.push(p);
+                    if p_level > 0 {
+                        // 0 < p_level < head_level: intermediate fragment head.
+                        checkpoints.push(p);
+                    }
+                    queue.push_back(p);
+                }
+            }
+        }
+
+        let to_hashes = |idxs: Vec<NodeIdx>| -> Vec<ChangeHash> {
+            idxs.into_iter()
+                .map(|n| self.hashes[n.0 as usize])
+                .collect()
+        };
+
+        DepthFragment {
+            head: self.hashes[head.0 as usize],
+            level: head_level,
+            members: to_hashes(members),
+            checkpoints: to_hashes(checkpoints),
+            boundary: to_hashes(boundary),
+        }
+    }
 }
 
 #[rustfmt::skip]

--- a/rust/automerge/src/clock.rs
+++ b/rust/automerge/src/clock.rs
@@ -54,6 +54,15 @@ impl SeqClock {
             }
         }
     }
+
+    pub(crate) fn covers(&self, other: &SeqClock) -> bool {
+        assert_eq!(self.0.len(), other.0.len());
+        std::iter::zip(self.0.iter(), other.0.iter()).all(|(a, b)| match (a, b) {
+            (_, None) => true,
+            (Some(s1), Some(s2)) => s1 >= s2,
+            _ => false,
+        })
+    }
 }
 
 #[derive(Debug, Clone, PartialEq)]

--- a/rust/automerge/src/lib.rs
+++ b/rust/automerge/src/lib.rs
@@ -295,6 +295,7 @@ pub use crate::automerge::{Automerge, LoadOptions, OnPartialLoad, SaveOptions, S
 pub use autocommit::AutoCommit;
 pub use autoserde::AutoSerde;
 pub use change::{Change, LoadError as LoadChangeError};
+pub use change_graph::{DepthFragment, Fragment};
 pub use cursor::{Cursor, CursorPosition, MoveCursor, OpCursor};
 pub use error::AutomergeError;
 pub use error::InvalidActorId;

--- a/rust/automerge/src/types.rs
+++ b/rust/automerge/src/types.rs
@@ -676,6 +676,10 @@ impl ChangeHash {
     pub(crate) fn checksum(&self) -> [u8; 4] {
         [self.0[0], self.0[1], self.0[2], self.0[3]]
     }
+
+    pub(crate) fn fragment_level(&self) -> usize {
+        self.0.iter().rev().take_while(|&&b| b == 0).count()
+    }
 }
 
 impl AsRef<[u8]> for ChangeHash {

--- a/rust/automerge/src/types.rs
+++ b/rust/automerge/src/types.rs
@@ -678,7 +678,7 @@ impl ChangeHash {
     }
 
     pub(crate) fn fragment_level(&self) -> usize {
-        self.0.iter().rev().take_while(|&&b| b == 0).count()
+        self.0.iter().take_while(|&&b| b == 0).count()
     }
 }
 


### PR DESCRIPTION
Related #1326 

This PR was originally an experiment, but turns out that it actually may be worth merging. I was curious to see how much worse the performance would be to use hash walks for the DFS over the hand-tuned clock based ranges. The clock-based version was creating different fragments with different members — basically breaking the doc up differently. Sedimentree defines a particular fragmentation strategy with semantics that are important for doing distributed set reconciliation (which I won't go into here).

Why an experiment? If the hash version performed significantly worse, we may have had to reconsider how Sedimentree worked, but the non-compliant version was so much faster than our existing naive JS version by leveraging internals that I was hopeful that we could eat into some of that performance and still be reasonably fast.

Strategy:

* Leave existing implementation from #1326
* Bench that :point_up: 
* [Have Opus] write a spec-compliant implementation (called `Depth` below)
* Bench them head-to-head

The results were... surprising [machine generated output below]

# Fragmenter benchmark: depth-stratified vs. clock-based

**Bench:** `cargo bench -p automerge --bench fragments`
**Hardware:** AMD Ryzen AI 9 HX 370 (12c/24t @ 5.16 GHz boost) · 30 GiB · NixOS 25.11 / Linux 7.0.2 · rustc 1.89.0
**Bench Config**: single run, 100 samples/case, criterion defaults
**Topologies:**

- `linear` — one actor, one transaction per change.
- `concurrent2` — two actors making half the changes each on independent forks, then merged.
- `wide8` — eight actors making concurrent changes on independent forks, then merged.

## Query cost (head-to-head)

The only group where both strategies do work along the comparable critical path. Both start from the same prebuilt `Automerge` doc (the clock-based eager fragment cache already populated); we time `doc.fragments()` versus `doc.depth_fragments()`.

| Topology | Size | Clock-based mean (µs) | Clock-based 95% CI | Depth mean (µs) | Depth 95% CI | Speedup |
|---|---:|---:|:---|---:|:---|---:|
| linear | 1000 | 58.93 | [57.58, 60.54] | 31.28 | [31.06, 31.56] | 1.88× |
| linear | 10000 | 570.92 | [567.94, 574.34] | 239.78 | [238.86, 241.17] | 2.38× |
| concurrent2 | 1000 | 39.97 | [39.77, 40.19] | 25.32 | [25.26, 25.38] | 1.58× |
| concurrent2 | 10000 | 506.25 | [492.68, 524.80] | 252.35 | [243.28, 264.08] | 2.01× |
| wide8 | 1000 | 74.40 | [73.89, 75.22] | 38.91 | [38.66, 39.21] | 1.91× |
| wide8 | 10000 | 507.69 | [504.93, 510.76] | 287.80 | [285.18, 291.09] | 1.76× |

Depth is **1.58×–2.38× faster** on every topology and size. CIs do not overlap on any case.

## Fragment counts (semantic divergence)

Sampled during the bench run on prebuilt docs.

| Topology | Size | Heads | Clock-based fragments | Depth fragments |
|---|---:|---:|---:|---:|
| linear | 1000 | 1 | ~21 | ~4 |
| linear | 10000 | 1 | ~138 | ~46 |
| concurrent2 | 1000 | 2 | ~67 | ~5 |
| concurrent2 | 10000 | 2 | ~487 | ~45 |
| wide8 | 1000 | 8 | ~775 | ~6 |
| wide8 | 10000 | 8 | ~2649 | ~41 |

The clock-based design emits one `Fragment` per visited node above `fragment_top` (loose) and one per cached `FragmentNode`. Depth's spec-correct strategy emits one per commit with `fragment_level >= 1`, matching theory's ~1/256 rate. Numbers are approximate because `ChangeHash` content depends on per-run actor IDs.

## Why is this strategy faster?

It isn't because depth checks beat clock checks at the per-node level —
both are roughly O(1) reads (a leading-zero-byte count vs a per-actor
clock slot lookup). The win is structural.

The clock-based design emits one `Fragment` per cached `FragmentNode`
plus one per depth-0 commit above `fragment_top`. Each Fragment is
exported by running an independent `bfs_until_clock` (allocating a
fresh `HashSet`, `VecDeque`, and result `Vec`) and, for cached
fragments, a `calculate_clock(deps)` walk on top. On `wide8/10k` that
means ~2 600 small BFSes for ~10 000 nodes of work — per-BFS setup
dominates total cost.

The depth strategy emits one fragment per commit with `fragment_level >= 1`.
The same ~10 000 nodes are visited, but partitioned into ~50 BFSes
instead of ~2 600. The hot loop's `HashSet` stays warm through a
fragment-sized walk, parent-edge cache lines amortise across more
work, and we make ~100 result-`Vec` allocations instead of ~5 000.
Net effect: equal per-node cost × ≈50× fewer per-BFS setups + far
fewer small allocations = 1.5–2.5× speedup, even though the depth
path is lazy and the clock path is reading from a precomputed cache.