### PR TITLE
Add opt-in WebAssembly Memory64 build target (#1107)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -81,6 +81,38 @@ jobs:
       - name: run tests
         run: ./scripts/ci/wasm_tests
 
+  build_wasm_memory64:
+    runs-on: ubuntu-latest
+    # wasm64-unknown-unknown is Tier 3 (nightly-only, no precompiled std). Don't
+    # gate other jobs on it — nightly regressions shouldn't block PRs.
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+      - uses: jetli/wasm-bindgen-action@v0.2.0
+        with:
+          version: "0.2.121"
+      - name: Install nightly toolchain with rust-src
+        run: rustup toolchain install nightly --component rust-src --profile minimal
+      - name: Build memory64 wasm
+        working-directory: rust/automerge-wasm
+        run: |
+          npm ci
+          npm run release:memory64
+      - name: Smoke test memory64 wasm in Node 24
+        working-directory: rust/automerge-wasm
+        run: |
+          node -e "
+            const wasm = require('./nodejs-memory64/automerge_wasm.cjs');
+            const d = wasm.create();
+            d.put('_root', 'k', 'v');
+            const got = d.materialize();
+            if (got.k !== 'v') { console.error('unexpected:', got); process.exit(1); }
+            console.log('memory64 smoke test passed:', got);
+          "
+
   js_tests:
     runs-on: ubuntu-latest
     needs:

--- a/javascript/package.json
+++ b/javascript/package.json
@@ -16,6 +16,7 @@
     "dist/cjs/**/*.js",
     "dist/cjs/**/*.cjs",
     "dist/cjs/**/*.wasm",
+    "dist/cjs/memory64/**/*",
     "dist/iife/**/*.js",
     "dist/mjs/**/*.js",
     "dist/mjs/**/*.cjs",
@@ -57,6 +58,15 @@
       },
       "import": "./dist/mjs/entrypoints/slim.js",
       "require": "./dist/cjs/slim.cjs"
+    },
+    "./memory64": {
+      "types": "./dist/index.d.ts",
+      "node": {
+        "import": "./dist/mjs/entrypoints/fullfat_node_memory64.js",
+        "require": "./dist/cjs/memory64/fullfat_node_memory64.cjs"
+      },
+      "import": "./dist/mjs/entrypoints/fullfat_node_memory64.js",
+      "require": "./dist/cjs/memory64/fullfat_node_memory64.cjs"
     },
     "./automerge.wasm": "./dist/automerge.wasm",
     "./automerge.wasm.base64": {

--- a/javascript/scripts/build.mjs
+++ b/javascript/scripts/build.mjs
@@ -188,6 +188,39 @@ function buildWasm(outputDir, gitHead) {
   runWasmBindgen("bundler")
   runWasmBindgen("web")
   runWasmBindgen("nodejs")
+
+  // Opt-in 64-bit memory build. Requires nightly Rust + rust-src.
+  // Enable with BUILD_MEMORY64=1 npm run build. Produces an additional
+  // "nodejs-memory64" target alongside the default 32-bit outputs.
+  if (process.env.BUILD_MEMORY64 === "1") {
+    console.log("building automerge-wasm for wasm64-unknown-unknown")
+    execSync(
+      "cargo +nightly build -Z build-std=std,panic_abort " +
+        "--target wasm64-unknown-unknown --release",
+      {
+        cwd: automergeWasmPath,
+        env: { ...process.env, GIT_HEAD: gitHead },
+      },
+    )
+
+    const wasm64BlobPath = path.join(
+      rustProjectDir,
+      "target",
+      "wasm64-unknown-unknown",
+      "release",
+      "automerge_wasm.wasm",
+    )
+
+    const target = "nodejs"
+    const outDirName = "nodejs-memory64"
+    const outputPath = path.join(outputDir, outDirName)
+    fs.mkdirSync(outputPath, { recursive: true })
+    console.log(`running wasm-bindgen for '${outDirName}' (memory64) target`)
+    execSync(
+      `wasm-bindgen ${wasm64BlobPath} --out-dir ${outputPath} --target ${target} --weak-refs`,
+      { cwd: __dirname },
+    )
+  }
 }
 
 /**
@@ -241,6 +274,22 @@ function copyAndFixupWasm(wasmBuildTarball, gitHead) {
   // Note: if you change this logic please update the note in `javascript/HACKING.md#getrandom-support`
   console.log("prepending webcrypto polyfill to 'automerge_wasm.cjs'")
   prependWebcryptoPolyfill(cjsWasmWrapperPath)
+
+  // Same treatment for the optional memory64 node target, if it was built.
+  const node64OutputPath = path.join(
+    jsProjectDir,
+    "src",
+    "wasm_bindgen_output",
+    "nodejs-memory64",
+  )
+  if (fs.existsSync(path.join(node64OutputPath, "automerge_wasm.js"))) {
+    console.log(
+      "renaming 'automerge_wasm.js' to 'automerge_wasm.cjs' in the nodejs-memory64 target",
+    )
+    const cjs64Path = path.join(node64OutputPath, "automerge_wasm.cjs")
+    fs.cpSync(path.join(node64OutputPath, "automerge_wasm.js"), cjs64Path)
+    prependWebcryptoPolyfill(cjs64Path)
+  }
 
   console.log("copying the 'web' target to 'workerd' directory")
   const webOutputPath = path.join(
@@ -383,6 +432,36 @@ async function transpileCjs() {
     platform: "node",
     outExtension: { ".js": ".cjs" },
   })
+
+  // The memory64 CJS bundle needs its own subdirectory because the wasm-bindgen
+  // generated nodejs glue looks up `${__dirname}/automerge_wasm_bg.wasm`, and
+  // dist/cjs/ already holds the 32-bit wasm for fullfat_node.cjs.
+  if (fs.existsSync(`${inDir}/entrypoints/fullfat_node_memory64.js`)) {
+    const memory64OutDir = path.join(outDir, "memory64")
+    console.log("building memory64 node CommonJS module")
+    await build({
+      absWorkingDir: distDir,
+      entryPoints: [`${inDir}/entrypoints/fullfat_node_memory64.js`],
+      outdir: memory64OutDir,
+      bundle: true,
+      packages: "external",
+      format: "cjs",
+      target: "node14",
+      platform: "node",
+      outExtension: { ".js": ".cjs" },
+    })
+    const memory64WasmSrc = path.join(
+      jsProjectDir,
+      "src",
+      "wasm_bindgen_output",
+      "nodejs-memory64",
+      "automerge_wasm_bg.wasm",
+    )
+    fs.copyFileSync(
+      memory64WasmSrc,
+      path.join(memory64OutDir, "automerge_wasm_bg.wasm"),
+    )
+  }
 
   const iifeDir = path.join(distDir, "iife")
   await build({

--- a/javascript/src/entrypoints/fullfat_node_memory64.ts
+++ b/javascript/src/entrypoints/fullfat_node_memory64.ts
@@ -1,0 +1,5 @@
+import { UseApi } from "../low_level.js"
+import * as api from "../wasm_bindgen_output/nodejs-memory64/automerge_wasm.cjs"
+UseApi(api)
+
+export * from "../index.js"

--- a/rust/.cargo/config.toml
+++ b/rust/.cargo/config.toml
@@ -1,2 +1,5 @@
 [target.wasm32-unknown-unknown]
 rustflags = ['--cfg', 'getrandom_backend="wasm_js"']
+
+[target.wasm64-unknown-unknown]
+rustflags = ['--cfg', 'getrandom_backend="wasm_js"']

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -16,3 +16,11 @@ codegen-units = 1
 
 [profile.bench]
 debug = true
+
+# getrandom 0.4.2 (latest crates.io release as of 2026-05) does not support
+# wasm64-unknown-unknown in its wasm_js backend. Upstream PR rust-random/getrandom#848
+# adds that support but is unreleased. Pin to the git rev that includes it so the
+# memory64 build target works. wasm32 builds are unaffected — the patched code
+# extends the existing wasm_js arm from target_arch=wasm32 to target_family=wasm.
+[patch.crates-io]
+getrandom = { git = "https://github.com/rust-random/getrandom", branch = "master" }

--- a/rust/automerge-wasm/.gitignore
+++ b/rust/automerge-wasm/.gitignore
@@ -3,6 +3,8 @@
 /nodejs
 /deno
 /web
+/nodejs-memory64
+/web-memory64
 Cargo.lock
 package-lock.json
 index.d.ts

--- a/rust/automerge-wasm/README.md
+++ b/rust/automerge-wasm/README.md
@@ -2,6 +2,34 @@
 
 This package is a low level interface to the [automerge rust](https://github.com/automerge/automerge/tree/main/rust/automerge) CRDT.  The api is intended to be as "close to the metal" as possible with only a few ease of use accommodations.  This library is used as the underpinnings for the [Automerge JS wrapper](https://github.com/automerge/automerge/tree/main/javascript) and can be used as is or as a basis for another higher level expression of a CRDT.
 
+### Memory64 build (experimental)
+
+The default build targets `wasm32-unknown-unknown`, which caps a single
+document/repo at 4 GB of linear memory. For sync servers and other workloads
+that exceed that limit, an opt-in **Memory64** build is also published at the
+`@automerge/automerge-wasm/memory64` sub-path.
+
+Runtime requirements:
+
+- Node 24+ (V8 13.6+), Chrome 133+, Firefox 134+. Older runtimes cannot
+  instantiate memory64 modules.
+- Some early Node 24.x releases require `--experimental-wasm-memory64`.
+  Recent V8 (Node 24.15+) loads it natively.
+
+Building the memory64 artifact locally requires **nightly Rust** with the
+`rust-src` component, because `wasm64-unknown-unknown` is a Tier 3 target with
+no precompiled `std`:
+
+```sh
+rustup toolchain install nightly --component rust-src
+cd rust/automerge-wasm
+npm ci
+npm run release:memory64
+```
+
+This produces additional `nodejs-memory64/` and `web-memory64/` outputs
+alongside the default 32-bit targets.
+
 All example code can be found in `test/readme.ts`
 
 ### Why CRDT?

--- a/rust/automerge-wasm/fixup-node-memory64-cjs.mjs
+++ b/rust/automerge-wasm/fixup-node-memory64-cjs.mjs
@@ -1,0 +1,4 @@
+import fs from "fs"
+
+fs.cpSync("nodejs-memory64/automerge_wasm.d.ts", "nodejs-memory64/automerge_wasm.d.cts")
+fs.renameSync("nodejs-memory64/automerge_wasm.js", "nodejs-memory64/automerge_wasm.cjs")

--- a/rust/automerge-wasm/package.json
+++ b/rust/automerge-wasm/package.json
@@ -24,7 +24,11 @@
     "bundler/automerge_wasm_bg.wasm",
     "web/automerge_wasm_bg.wasm",
     "web/automerge_wasm.js",
-    "web/index.js"
+    "web/index.js",
+    "nodejs-memory64/automerge_wasm.cjs",
+    "nodejs-memory64/automerge_wasm_bg.wasm",
+    "web-memory64/automerge_wasm.js",
+    "web-memory64/automerge_wasm_bg.wasm"
   ],
   "private": false,
   "types": "index.d.ts",
@@ -41,6 +45,10 @@
     "compile": "cargo build --target wasm32-unknown-unknown --profile $PROFILE",
     "bindgen": "wasm-bindgen --omit-default-module-path --weak-refs --typescript --target $TARGET --out-dir $TARGET ../target/wasm32-unknown-unknown/$TARGET_DIR/automerge_wasm.wasm",
     "opt": "echo wasm-opt -O4 $TARGET/automerge_wasm_bg.wasm -o $TARGET/automerge_wasm_bg.wasm",
+    "compile:memory64": "cargo +nightly build -Z build-std=std,panic_abort --target wasm64-unknown-unknown --profile $PROFILE",
+    "bindgen:memory64": "wasm-bindgen --omit-default-module-path --weak-refs --typescript --target $BINDGEN_TARGET --out-dir $OUT_DIR ../target/wasm64-unknown-unknown/$TARGET_DIR/automerge_wasm.wasm",
+    "target:memory64": "rimraf ./$OUT_DIR && npm run compile:memory64 && npm run bindgen:memory64",
+    "release:memory64": "cross-env PROFILE=release TARGET_DIR=release OUT_DIR=nodejs-memory64 BINDGEN_TARGET=nodejs npm run target:memory64 && node ./fixup-node-memory64-cjs.mjs && cross-env PROFILE=release TARGET_DIR=release OUT_DIR=web-memory64 BINDGEN_TARGET=web npm run target:memory64",
     "test": "tsc --noEmit && mocha --loader=ts-node/esm test/**/*.mts"
   },
   "devDependencies": {
@@ -62,10 +70,19 @@
     "uuid": "^9.0.0"
   },
   "exports": {
-    "types": "./index.d.ts",
-    "workerd": "./web/index.js",
-    "browser": "./bundler/automerge_wasm.js",
-    "require": "./nodejs/automerge_wasm.cjs",
-    "import": "./nodejs/automerge_wasm.cjs"
+    ".": {
+      "types": "./index.d.ts",
+      "workerd": "./web/index.js",
+      "browser": "./bundler/automerge_wasm.js",
+      "require": "./nodejs/automerge_wasm.cjs",
+      "import": "./nodejs/automerge_wasm.cjs"
+    },
+    "./memory64": {
+      "types": "./index.d.ts",
+      "workerd": "./web-memory64/automerge_wasm.js",
+      "browser": "./web-memory64/automerge_wasm.js",
+      "require": "./nodejs-memory64/automerge_wasm.cjs",
+      "import": "./nodejs-memory64/automerge_wasm.cjs"
+    }
   }
 }


### PR DESCRIPTION
> **Disclosure:** this PR was fully generated by an AI coding agent (Claude Code) on behalf of someone with effectively zero Rust/WASM background. It is intended as a conversation starter — to gauge appetite, surface objections, and build a little momentum on #1107 — rather than as a drop-in fix to merge as-is. The 4 GB ceiling is becoming pressing for our sync-server workload, so we are hoping to nudge things along.

## Problem

The default `automerge-wasm` build targets `wasm32-unknown-unknown`, which caps a single document/repo at 4 GB of linear memory. For sync servers and other `automerge-repo` consumers that hold many or large documents in `handleCache`, that limit is increasingly load-bearing.

Node 24 (V8 13.6+) and recent Chrome/Firefox now support the WebAssembly Memory64 proposal, raising the ceiling to ~16 GB.

Refs: #1107

## Solution

Add an **opt-in** Memory64 (`wasm64-unknown-unknown`) build alongside the existing 32-bit artifacts. The default build pipeline and existing consumers are untouched.

- `rust/automerge-wasm` gains `npm run release:memory64`, producing `nodejs-memory64/` and `web-memory64/` outputs next to today's `nodejs/ bundler/ deno/ web/`.
- A new `@automerge/automerge-wasm/memory64` sub-path export ships those artifacts.
- `@automerge/automerge` gains a matching `fullfat_node_memory64` entrypoint exposed at `@automerge/automerge/memory64`. The JS build script runs the wasm64 cargo build only when `BUILD_MEMORY64=1` is set, so the default build stays on stable Rust.
- A new `build_wasm_memory64` CI job exercises the path with `continue-on-error: true` (Tier 3 target, nightly toolchain — we don't want nightly regressions blocking PRs).

Consumers opt in with one import swap on top of `automerge-repo/slim` (no `automerge-repo` PR needed — it only depends on `@automerge/automerge/slim`):

```ts
import "@automerge/automerge/memory64"          // initializes wasm64
import { Repo } from "@automerge/automerge-repo/slim"
```

## Known caveats / open questions

These are the spots most likely to need a human eye:

1. **`wasm64-unknown-unknown` is Tier 3** — nightly Rust + `rust-src` only, no precompiled `std`, built via `-Z build-std`. Memory64 itself is still a Stage 4 proposal. The opt-in shape contains this: default users see nothing change.
2. **`getrandom` patch.** The crates.io release of `getrandom` (0.4.2) does not compile under wasm64 because its `wasm_js` backend is gated on `target_arch="wasm32"`. Upstream rust-random/getrandom#848 (merged 2026-05-18, unreleased) extends it to `target_family="wasm"`. To make the build work today the workspace `[patch.crates-io]`-pins `getrandom` to master. Before merging this almost certainly wants to be either (a) waited out until a release is cut, or (b) pinned to a specific commit.
3. **`hexane` (transitive via `automerge`'s `wasm` feature)** built fine for wasm64 on first try, but this hasn't been exercised broadly — worth keeping an eye on.
4. **No browser-side fullfat-memory64 entrypoint** was added — sync servers were the motivating use case and the `web-memory64/` artifact is published in `automerge-wasm` for anyone who wants to wire it up. Happy to add it if you want it in this PR.
5. **wasm-opt** is currently echoed-but-not-run for memory64 (same as the default pipeline). Recent `binaryen` does support memory64; could be enabled with `--enable-memory64` once turned on for the 32-bit path too.

## Test plan

What I ran locally (Node 24.15.0, macOS, nightly rustc 1.97.0):

- [x] `npm run release:memory64` in `rust/automerge-wasm` succeeds and produces `nodejs-memory64/` + `web-memory64/`.
- [x] `wasm-tools print` confirms the output is a true memory64 module: `(memory (;0;) i64 19)` (i64 index type, not i32).
- [x] The memory64 module loads & runs in Node 24 natively (no `--experimental-wasm-memory64` flag required on recent V8).
- [x] `require(\"@automerge/automerge-wasm/memory64\")` resolves and round-trips a small document.
- [x] `BUILD_MEMORY64=1 npm run build` in `javascript/` produces a working `@automerge/automerge/memory64` sub-path export. Both `require(...)` (CJS) and `import * as` (ESM) load and exercise the API end-to-end.
- [x] Default `npm run release` in `rust/automerge-wasm` and `npm run build` in `javascript/` still produce all 32-bit artifacts unchanged.
- [x] `rust/automerge-wasm` mocha suite: 155 passing.
- [x] `javascript` mocha suite: 312 passing.

What was **not** tested:

- [ ] Actually pushing past 4 GB in a real workload (didn't have a 16 GB-RAM box handy; items above prove the build target is wasm64 but not that the ceiling is gone in practice).
- [ ] Workerd / browser memory64 loading paths.
- [ ] CI Linux runner: the new `build_wasm_memory64` job is configured but has not yet executed.