### PR TITLE
rust: remove unused actors on transaction completion

### DIFF
--- a/javascript/package.json
+++ b/javascript/package.json
@@ -88,7 +88,7 @@
     "mocha": "^11.4.0",
     "pako": "^2.1.0",
     "prettier": "3.8.1",
-    "puppeteer": "^24.9.0",
+    "puppeteer": "^25.1.0",
     "serve-handler": "^6.1.5",
     "ts-mocha": "^11.1.0",
     "ts-node": "^10.9.1",

--- a/rust/automerge/src/autocommit.rs
+++ b/rust/automerge/src/autocommit.rs
@@ -398,11 +398,11 @@ impl AutoCommit {
     pub(crate) fn ensure_transaction_open(&mut self) {
         if self.transaction.is_none() {
             let args = self.doc.transaction_args(self.isolation.as_deref());
+            // This is AutoCommit's internal patch log, so unlike caller-supplied PatchLogs it
+            // always belongs to this document and can never mismatch.
             self.patch_log
-                .migrate_actors(&self.doc.ops().actors)
-                // This is AutoCommit's internal patch log, so unlike caller-supplied PatchLogs it
-                // should always belong to this document.
-                .unwrap();
+                .begin_transaction(&self.doc, &args)
+                .expect("AutoCommit's patch log always belongs to its document");
             let inner = TransactionInner::new(args);
             let branch = self.patch_log.branch();
             self.transaction = Some((branch, inner));
@@ -413,6 +413,7 @@ impl AutoCommit {
         if let Some((patch_log, tx)) = self.transaction.take() {
             self.patch_log.merge(patch_log);
             let hash = tx.commit(&mut self.doc, None, None);
+            self.patch_log.finish_transaction(&self.doc.ops().actors);
             if self.isolation.is_some() && hash.is_some() {
                 self.isolation = hash.map(|h| vec![h])
             }
@@ -654,6 +655,7 @@ impl AutoCommit {
         let (patch_log, tx) = self.transaction.take().unwrap();
         self.patch_log.merge(patch_log);
         let hash = tx.commit(&mut self.doc, options.message, options.time);
+        self.patch_log.finish_transaction(&self.doc.ops().actors);
         if self.isolation.is_some() && hash.is_some() {
             self.isolation = hash.map(|h| vec![h])
         }
@@ -664,7 +666,11 @@ impl AutoCommit {
     pub fn rollback(&mut self) -> usize {
         self.transaction
             .take()
-            .map(|(_, tx)| tx.rollback(&mut self.doc))
+            .map(|(_, tx)| {
+                let num = tx.rollback(&mut self.doc);
+                self.patch_log.finish_transaction(&self.doc.ops().actors);
+                num
+            })
             .unwrap_or(0)
     }
 
@@ -680,7 +686,14 @@ impl AutoCommit {
     pub fn empty_change(&mut self, options: CommitOptions) -> ChangeHash {
         self.ensure_transaction_closed();
         let args = self.doc.transaction_args(None);
-        TransactionInner::empty(&mut self.doc, args, options.message, options.time)
+        // This is AutoCommit's internal patch log, so unlike caller-supplied PatchLogs it
+        // always belongs to this document and can never mismatch.
+        self.patch_log
+            .begin_transaction(&self.doc, &args)
+            .expect("AutoCommit's patch log always belongs to its document");
+        let result = TransactionInner::empty(&mut self.doc, args, options.message, options.time);
+        self.patch_log.finish_transaction(&self.doc.ops.actors);
+        result
     }
 
     /// An implementation of [`crate::sync::SyncDoc`] for this autocommit

--- a/rust/automerge/src/automerge.rs
+++ b/rust/automerge/src/automerge.rs
@@ -354,9 +354,9 @@ impl Automerge {
 
     /// Start a transaction.
     pub fn transaction(&mut self) -> Transaction<'_> {
+        let patch_log = PatchLog::inactive();
         let args = self.transaction_args(None);
-        Transaction::new(self, args, PatchLog::inactive())
-            .expect("inactive patch log should not mismatch")
+        Transaction::new(self, args, patch_log)
     }
 
     /// Start a transaction which records changes in a [`PatchLog`]
@@ -366,10 +366,11 @@ impl Automerge {
     /// another document.
     pub fn transaction_log_patches(
         &mut self,
-        patch_log: PatchLog,
+        mut patch_log: PatchLog,
     ) -> Result<Transaction<'_>, crate::PatchLogMismatch> {
         let args = self.transaction_args(None);
-        Transaction::new(self, args, patch_log)
+        patch_log.begin_transaction(self, &args)?;
+        Ok(Transaction::new(self, args, patch_log))
     }
 
     /// Start a transaction isolated at a given heads
@@ -379,11 +380,12 @@ impl Automerge {
     /// another document.
     pub fn transaction_at(
         &mut self,
-        patch_log: PatchLog,
+        mut patch_log: PatchLog,
         heads: &[ChangeHash],
     ) -> Result<Transaction<'_>, crate::PatchLogMismatch> {
         let args = self.transaction_args(Some(heads));
-        Transaction::new(self, args, patch_log)
+        patch_log.begin_transaction(self, &args)?;
+        Ok(Transaction::new(self, args, patch_log))
     }
 
     /// Start a transaction that owns the document, consuming `self`.
@@ -438,6 +440,7 @@ impl Automerge {
         // SAFETY: this unwrap is safe as we always add 1
         let start_op = NonZeroU64::new(self.change_graph.max_op() + 1).unwrap();
         let checkpoint = self.ops.save_checkpoint();
+
         TransactionArgs {
             actor_index,
             seq,
@@ -558,6 +561,7 @@ impl Automerge {
     /// The main reason to do this is if you want to create a "merge commit", which is a change
     /// that has all the current heads of the document as dependencies.
     pub fn empty_commit(&mut self, opts: CommitOptions) -> ChangeHash {
+        // No patch log is recorded for an empty change, so migrate a throwaway one.
         let args = self.transaction_args(None);
         Transaction::empty(self, args, opts)
     }

--- a/rust/automerge/src/patches/patch_log.rs
+++ b/rust/automerge/src/patches/patch_log.rs
@@ -3,6 +3,7 @@ use crate::exid::ExId;
 use crate::hydrate::Value;
 use crate::marks::{MarkAccumulator, MarkSet};
 use crate::op_set2::PropRef;
+use crate::transaction::TransactionArgs;
 use crate::types::{ActorId, Clock, ObjId, ObjType, OpId, Prop, TextEncoding};
 use crate::{ChangeHash, Patch};
 use std::collections::{BTreeMap, BTreeSet, HashSet};
@@ -47,6 +48,10 @@ pub struct PatchLog {
     path_hint: usize,
     pub(crate) heads: Option<Vec<ChangeHash>>,
     pub(crate) actors: Vec<ActorId>,
+    /// Actors which were speculatively added to `actors` when a transaction was opened. If the
+    /// transaction produces no ops the actor is removed from the document again on commit/rollback,
+    /// so these must be removed from the patch log too (see [`PatchLog::finish_transaction`]).
+    speculative_actor: Option<ActorId>,
 }
 
 #[derive(Clone, PartialEq, Debug)]
@@ -151,6 +156,60 @@ impl Event {
             event => event,
         }
     }
+
+    // Re-index this event after the actor at `idx` has been removed from the actor list.
+    //
+    // This may only be called for actors which are not referenced by the event (e.g. an actor
+    // which was speculatively added when opening a transaction but ended up making no ops). If the
+    // event _does_ reference the removed actor this returns `None`.
+    pub(crate) fn without_actor(self, idx: usize) -> Option<Self> {
+        Some(match self {
+            Self::PutMap {
+                key,
+                value,
+                id,
+                conflict,
+            } => Self::PutMap {
+                key,
+                value,
+                id: id.without_actor(idx)?,
+                conflict,
+            },
+            Self::PutSeq {
+                index,
+                value,
+                id,
+                conflict,
+            } => Self::PutSeq {
+                index,
+                value,
+                id: id.without_actor(idx)?,
+                conflict,
+            },
+            Self::Insert {
+                index,
+                value,
+                id,
+                conflict,
+            } => Self::Insert {
+                index,
+                value,
+                id: id.without_actor(idx)?,
+                conflict,
+            },
+            Self::IncrementMap { key, n, id } => Self::IncrementMap {
+                key,
+                n,
+                id: id.without_actor(idx)?,
+            },
+            Self::IncrementSeq { index, n, id } => Self::IncrementSeq {
+                index,
+                n,
+                id: id.without_actor(idx)?,
+            },
+            event => event,
+        })
+    }
 }
 
 impl PatchLog {
@@ -173,6 +232,7 @@ impl PatchLog {
             path_map: Default::default(),
             path_hint: 0,
             actors: vec![],
+            speculative_actor: None,
         }
     }
 
@@ -433,6 +493,7 @@ impl PatchLog {
             path_hint: 0,
             heads: None,
             actors: self.actors.clone(),
+            speculative_actor: None,
         }
     }
 
@@ -450,30 +511,95 @@ impl PatchLog {
             .collect();
     }
 
-    // if a new actor is added to an opset, the id's inside the patch log need to be re-ordered
-    // this is an uncommon operation so this seems preferable to storing ExId's in place
-    // for every objid and opid
+    fn remove_actor(&mut self, index: usize) {
+        self.actors.remove(index);
+
+        let dirty = std::mem::take(&mut self.events);
+        self.events = dirty
+            .into_iter()
+            .filter_map(|(o, e)| Some((o.without_actor(index)?, e.without_actor(index)?)))
+            .collect();
+
+        let dirty = std::mem::take(&mut self.expose);
+        self.expose = dirty
+            .into_iter()
+            .filter_map(|id| id.without_actor(index))
+            .collect();
+    }
+
+    /// Notify the patch log that we are beginning a new transaction
+    ///
+    /// This is necessary because the transaction may be creating a new actor,
+    /// which needs to be tracked as speculative until the transaction is
+    /// committed or rolled back so that if the transaction produces no ops the
+    /// actor can be removed from the document in [`Self::finish_transaction`]
+    pub(crate) fn begin_transaction(
+        &mut self,
+        doc: &Automerge,
+        args: &TransactionArgs,
+    ) -> Result<(), crate::PatchLogMismatch> {
+        self.migrate_actors(&doc.ops.actors)?;
+        // If this is the actor's first change then the actor was (potentially)
+        // just added to the document. It should be removed again on
+        // commit/rollback if the transaction produces no ops, so flag it as
+        // speculative.
+        if let Some(speculative_actor) =
+            (args.seq == 1).then(|| doc.ops.actors[args.actor_index].clone())
+        {
+            assert!(
+                self.speculative_actor.is_none(),
+                "beginning a transaction when a speculative actor is already present"
+            );
+            self.speculative_actor = Some(speculative_actor);
+        }
+        Ok(())
+    }
+
+    /// Notify the patch log that the transaction has finished
+    ///
+    /// This allows the patch log to clean up any speculative actors that were added
+    /// when the transaction began. This method should be called after the transaction
+    /// has been committed or rolled back.
+    pub(crate) fn finish_transaction(&mut self, doc_actors: &[ActorId]) {
+        let Some(speculative_actor) = self.speculative_actor.take() else {
+            return;
+        };
+        if !doc_actors.contains(&speculative_actor) {
+            if let Ok(index) = self.actors.binary_search(&speculative_actor) {
+                self.remove_actor(index);
+            }
+        }
+        debug_assert_eq!(self.actors.as_slice(), doc_actors);
+    }
+
+    // Re-align this patch log's actor list (and the event indices into it) with the document's
+    // actor list (`others`).
+    //
+    // The document's actor list can grow between uses of a patch log (e.g. applying changes adds
+    // new actors). Because actor lists are sorted, inserting a new actor shifts the indices of the
+    // actors after it, so the event ids stored in the patch log have to be re-indexed to match.
     pub(crate) fn migrate_actors(
         &mut self,
-        others: &Vec<ActorId>,
+        others: &[ActorId],
     ) -> Result<(), crate::PatchLogMismatch> {
-        if &self.actors != others {
-            if self.actors.is_empty() {
-                self.actors = others.clone();
-                return Ok(());
-            }
-            for i in 0..others.len() {
-                match (self.actors.get(i), others.get(i)) {
-                    (Some(a), Some(b)) if a == b => {}
-                    (Some(a), Some(b)) if b < a => {
-                        self.actors.insert(i, b.clone());
-                        self.migrate_actor(i);
-                    }
-                    (None, Some(b)) => {
-                        self.actors.insert(i, b.clone());
-                    }
-                    _ => return Err(crate::PatchLogMismatch),
+        if self.actors.as_slice() == others {
+            return Ok(());
+        }
+        if self.actors.is_empty() {
+            self.actors = others.to_vec();
+            return Ok(());
+        }
+        for i in 0..others.len() {
+            match (self.actors.get(i), others.get(i)) {
+                (Some(a), Some(b)) if a == b => {}
+                (Some(a), Some(b)) if b < a => {
+                    self.actors.insert(i, b.clone());
+                    self.migrate_actor(i);
                 }
+                (None, Some(b)) => {
+                    self.actors.insert(i, b.clone());
+                }
+                _ => return Err(crate::PatchLogMismatch),
             }
         }
         Ok(())

--- a/rust/automerge/src/transaction/inner.rs
+++ b/rust/automerge/src/transaction/inner.rs
@@ -89,7 +89,7 @@ impl TransactionInner {
     /// Commit the operations performed in this transaction, returning the hashes corresponding to
     /// the new heads.
     ///
-    /// Returns `None` if there were no operations to commit
+    /// Returns `None` if there were no operations to commit.
     #[tracing::instrument(skip(self, doc))]
     pub(crate) fn commit(
         self,

--- a/rust/automerge/src/transaction/manual_transaction.rs
+++ b/rust/automerge/src/transaction/manual_transaction.rs
@@ -1,7 +1,7 @@
 use crate::exid::ExId;
 use crate::patches::PatchLog;
 use crate::ChangeHash;
-use crate::{automerge::Automerge, AutomergeError, PatchLogMismatch};
+use crate::{automerge::Automerge, AutomergeError};
 
 use super::{CommitOptions, TransactionArgs, TransactionInner};
 
@@ -27,19 +27,12 @@ pub struct Transaction<'a> {
 }
 
 impl<'a> Transaction<'a> {
-    pub(crate) fn new(
-        doc: &'a mut Automerge,
-        args: TransactionArgs,
-        mut patch_log: PatchLog,
-    ) -> Result<Self, PatchLogMismatch> {
-        patch_log
-            .migrate_actors(&doc.ops().actors)
-            .map_err(|_| PatchLogMismatch)?;
-        Ok(Self {
+    pub(crate) fn new(doc: &'a mut Automerge, args: TransactionArgs, patch_log: PatchLog) -> Self {
+        Self {
             inner: Some(TransactionInner::new(args)),
             doc,
             patch_log,
-        })
+        }
     }
 
     /// Get the hash of the change that contains the given opid.
@@ -74,6 +67,7 @@ impl Transaction<'_> {
     pub fn commit(mut self) -> (Option<ChangeHash>, PatchLog) {
         let tx = self.inner.take().unwrap();
         let hash = tx.commit(self.doc, None, None);
+        self.patch_log.finish_transaction(&self.doc.ops().actors);
         // TODO - remove this clone
         (hash, self.patch_log.clone())
     }
@@ -97,6 +91,7 @@ impl Transaction<'_> {
     pub fn commit_with(mut self, options: CommitOptions) -> (Option<ChangeHash>, PatchLog) {
         let tx = self.inner.take().unwrap();
         let hash = tx.commit(self.doc, options.message, options.time);
+        self.patch_log.finish_transaction(&self.doc.ops().actors);
         // TODO - remove this clone
         (hash, self.patch_log.clone())
     }
@@ -104,6 +99,7 @@ impl Transaction<'_> {
     /// Undo the operations added in this transaction, returning the number of cancelled
     /// operations.
     pub fn rollback(mut self) -> usize {
+        self.patch_log.finish_transaction(&self.doc.ops().actors);
         self.inner.take().unwrap().rollback(self.doc)
     }
 

--- a/rust/automerge/src/transaction/owned_transaction.rs
+++ b/rust/automerge/src/transaction/owned_transaction.rs
@@ -41,9 +41,7 @@ impl OwnedTransaction {
     ) -> Result<Self, PatchLogMismatch> {
         let args = doc.transaction_args(heads);
         let mut patch_log = patch_log.unwrap_or_else(PatchLog::inactive);
-        patch_log
-            .migrate_actors(&doc.ops().actors)
-            .map_err(|_| PatchLogMismatch)?;
+        patch_log.begin_transaction(&doc, &args)?;
         Ok(Self {
             inner: Some(TransactionInner::new(args)),
             patch_log,
@@ -72,6 +70,7 @@ impl OwnedTransaction {
     pub fn commit(mut self) -> (Automerge, Option<ChangeHash>, PatchLog) {
         let tx = self.inner.take().unwrap();
         let hash = tx.commit(&mut self.doc, None, None);
+        self.patch_log.finish_transaction(&self.doc.ops().actors);
         (self.doc, hash, self.patch_log)
     }
 
@@ -82,12 +81,14 @@ impl OwnedTransaction {
     ) -> (Automerge, Option<ChangeHash>, PatchLog) {
         let tx = self.inner.take().unwrap();
         let hash = tx.commit(&mut self.doc, options.message, options.time);
+        self.patch_log.finish_transaction(&self.doc.ops().actors);
         (self.doc, hash, self.patch_log)
     }
 
     /// Rollback the transaction, returning the document and number of cancelled ops.
     pub fn rollback(mut self) -> (Automerge, usize) {
         let cancelled = self.inner.take().unwrap().rollback(&mut self.doc);
+        self.patch_log.finish_transaction(&self.doc.ops().actors);
         (self.doc, cancelled)
     }
 

--- a/rust/automerge/tests/test.rs
+++ b/rust/automerge/tests/test.rs
@@ -2666,3 +2666,59 @@ fn reproduce_clock_cache_bug() {
 
     assert!(base.get_changes(&heads).is_empty());
 }
+
+#[test]
+fn merge_panic_after_putting_value_equal_to_initial_value() {
+    // Regression test for https://github.com/automerge/automerge/issues/1390
+    //
+    // Putting a value equal to the existing value is a no-op, so the transaction produces no ops
+    // and the actor that was speculatively added when the transaction was opened is removed again
+    // on commit. This used to leave the AutoCommit's internal patch log with an actor that the
+    // document no longer had, causing a panic (later a `PatchLogMismatch`) on the next merge.
+    let mut base = AutoCommit::new().with_actor(ActorId::from(b"base".as_slice()));
+    base.put(ROOT, "a", 1i64).unwrap();
+
+    let mut left = base.fork().with_actor(ActorId::from(b"left".as_slice()));
+    let mut right = base.fork().with_actor(ActorId::from(b"right".as_slice()));
+
+    // Equal to the initial value -> no-op
+    left.put(ROOT, "a", 1i64).unwrap();
+    right.put(ROOT, "a", 0i64).unwrap();
+
+    left.merge(&mut right).unwrap();
+
+    // "right" wins the conflict (higher actor id), so "a" should be 0.
+    assert_eq!(left.get(ROOT, "a").unwrap().unwrap().0, Value::int(0));
+
+    // Diffing produces a consistent set of patches without panicking and the document state
+    // matches a freshly loaded copy.
+    left.diff_incremental();
+    let reloaded = AutoCommit::load(&left.save()).unwrap();
+    assert_eq!(reloaded.get(ROOT, "a").unwrap().unwrap().0, Value::int(0));
+}
+
+#[test]
+fn merge_after_noop_then_real_put() {
+    // A no-op transaction followed by a real transaction must leave the patch log's actor list
+    // consistent with the document so that a subsequent merge does not error.
+    // Related to https://github.com/automerge/automerge/issues/1390
+    let mut base = AutoCommit::new().with_actor(ActorId::from(b"base".as_slice()));
+    base.put(ROOT, "a", 1i64).unwrap();
+
+    let mut left = base.fork().with_actor(ActorId::from(b"left".as_slice()));
+    let mut right = base.fork().with_actor(ActorId::from(b"right".as_slice()));
+
+    // No-op (equal value) then a real change in a separate commit on the same actor.
+    left.put(ROOT, "a", 1i64).unwrap();
+    left.commit();
+    left.put(ROOT, "b", "hello").unwrap();
+    left.commit();
+
+    right.put(ROOT, "a", 0i64).unwrap();
+
+    left.merge(&mut right).unwrap();
+    left.diff_incremental();
+
+    assert_eq!(left.get(ROOT, "a").unwrap().unwrap().0, Value::int(0));
+    assert_eq!(left.get(ROOT, "b").unwrap().unwrap().0, Value::str("hello"));
+}


### PR DESCRIPTION
Problem: In issue #1390[0] a bug is reproduced where merging a document after making a no-op change to it panics complaining that the patch log doesn't match. 

To understand this we need to know something about the `PatchLog`. The `PatchLog` carries around a bunch of operations which can be turned into patches by passing them to `Automerge::make_patches`. This avoids materializing paths and whatnot until the caller wants them. The operation IDs are lamport timestamps which refer to actor IDs via an _index_ into a `Vec<ActorId>` on the document. The `PatchLog` isn't part of the document though and this means that the actor indexes in the document can get out of sync with the indexes in the `PatchLog`. To deal with this the `PatchLog` also has a `Vec<ActorId>` on it and whenever we pass the `PatchLog` to the document we add any new actors which have appeared to the `PatchLog` in `PatchLog::migrate_actors`. The actor IDs generally only ever grow, so if `PatchLog::actors` is ever larger than `OpSet::actors` we throw an error - which turns into a panic in some internal code paths.

Unfortunately there is _one_ valid code path where the actor IDs array can shrink. This is when an actor is added to the document when beginning a transaction, but they are then removed because the transaction is rolled back or is a no-op. #1390 was firing because the no-op transaction added an actor to the `PatchLog` which was then not removed. 

Solution: Add `PatchLog::begin_transaction` and
`PatchLog::finish_transaction` which take care of tracking a "speculative actor" in cases where we are creating a transaction for a new actor and then removing that actor if `finish_transaction` is called and the speculative actor is not in the document.

This is actually quite an unsatisfying solution as it requires being quite careful to make sure these two methods are called. I have a much more satisfying solution in the works - but until that lands this should fix the bug.

[0]: https://github.com/automerge/automerge/issues/1390

Fixes #1390 