### PR TITLE
Prevent `AMresult` struct leakage in the ported WASM sync test suite

### DIFF
--- a/rust/automerge-c/test/ported_wasm/sync_tests.c
+++ b/rust/automerge-c/test/ported_wasm/sync_tests.c
@@ -86,6 +86,8 @@ static void sync(AMdoc* a, AMdoc* b, AMsyncState* a_sync_state, AMsyncState* b_s
                 break;
             }
         }
+        AMresultFree(a2b_msg_result);
+        AMresultFree(b2a_msg_result);
         if (++iter > MAX_ITER) {
             fail_msg(
                 "Did not synchronize within %d iterations. "


### PR DESCRIPTION
I finally noticed that the `sync()` utility function within the `run_ported_wasm_sync_tests()` suite leaks two `AMresult` structs for every iteration of its internal loop. :flushed:

This PR finally fixes that bug.
