### PR TITLE
rust: use top ops not visible ops when computing spans

### DIFF
--- a/rust/automerge/src/automerge.rs
+++ b/rust/automerge/src/automerge.rs
@@ -1386,12 +1386,7 @@ impl Automerge {
         clock: Option<Clock>,
     ) -> Result<Vec<Mark>, AutomergeError> {
         let obj = self.exid_to_obj(obj.as_ref())?;
-        let mut top_ops = self
-            .ops()
-            .iter_obj(&obj.id)
-            .visible_slow(clock)
-            .top_ops()
-            .marks();
+        let mut top_ops = self.ops().top_ops(&obj.id, clock).marks();
 
         let Some(seq_type) = obj.typ.as_sequence_type() else {
             // Really we should return an error here but we don't in order to stay
@@ -1729,12 +1724,7 @@ impl Automerge {
         clock: Option<Clock>,
     ) -> Result<MarkSet, AutomergeError> {
         let obj = self.exid_to_obj(obj.as_ref())?;
-        let mut iter = self
-            .ops
-            .iter_obj(&obj.id)
-            .visible_slow(clock)
-            .top_ops()
-            .marks();
+        let mut iter = self.ops.top_ops(&obj.id, clock).marks();
         iter.nth(index);
         match iter.get_marks() {
             Some(arc) => Ok(arc.as_ref().clone().without_unmarks()),

--- a/rust/automerge/src/iter/keys.rs
+++ b/rust/automerge/src/iter/keys.rs
@@ -1,12 +1,12 @@
 #[cfg(test)]
 use crate::op_set2::Op;
-use crate::op_set2::{OpIter, OpSet, TopOpIter, VisibleOpIter};
+use crate::op_set2::{OpSet, TopOps};
 
 use std::fmt::Debug;
 
 #[derive(Clone, Debug, Default)]
 pub struct Keys<'a> {
-    pub(crate) iter: Option<(&'a OpSet, TopOpIter<'a, VisibleOpIter<'a, OpIter<'a>>>)>,
+    pub(crate) iter: Option<(&'a OpSet, TopOps<'a>)>,
 }
 
 impl Iterator for Keys<'_> {
@@ -20,10 +20,7 @@ impl Iterator for Keys<'_> {
 }
 
 impl<'a> Keys<'a> {
-    pub(crate) fn new(
-        op_set: &'a OpSet,
-        iter: TopOpIter<'a, VisibleOpIter<'a, OpIter<'a>>>,
-    ) -> Self {
+    pub(crate) fn new(op_set: &'a OpSet, iter: TopOps<'a>) -> Self {
         Self {
             iter: Some((op_set, iter)),
         }

--- a/rust/automerge/src/iter/spans.rs
+++ b/rust/automerge/src/iter/spans.rs
@@ -2,7 +2,7 @@ use crate::clock::{Clock, ClockRange};
 use crate::hydrate::Value;
 use crate::iter::tools::{Diff, DiffIter, Unshift};
 use crate::marks::{MarkSet, MarkSetIter, MarkStateMachine};
-use crate::op_set2::op_set::{ActionValueIter, MarkInfoIter, OpIdIter, OpSet};
+use crate::op_set2::op_set::{ActionValueIter, MarkInfoIter, OpIdIter, OpSet, SkipToTopIter};
 use crate::op_set2::types::{Action, MarkData, ScalarValue};
 use crate::patches::PatchLog;
 use crate::types::{ObjId, OpId, TextEncoding};
@@ -45,9 +45,69 @@ impl SpanDiff {
     }
 }
 
+// The DiffIter/SkipToTopIter iterators use the top index to jump  from one top
+// op to the next while generating a diff. In many cases this is unnecessary
+// overhead as every op in the range being iterated is already top. In this
+// case we avoid the overhead of SkipToTopIter and stream action/value columns
+// directly.
+#[derive(Debug, Clone)]
+// Boxing the variants leads to losing a few milliseconds on some iteration benchmarks
+#[expect(clippy::large_enum_variant)]
+enum SpansActionValue<'a> {
+    Current(Unshift<ActionValueIter<'a>>),
+    Diff(Unshift<DiffIter<'a, ActionValueIter<'a>, SkipToTopIter<'a>>>),
+}
+
+impl Default for SpansActionValue<'_> {
+    fn default() -> Self {
+        Self::Diff(Default::default())
+    }
+}
+
+impl<'a> SpansActionValue<'a> {
+    fn new(op_set: &'a OpSet, clock: &ClockRange, range: Range<usize>) -> Self {
+        let value = op_set.value_iter_range(&range);
+        let action = op_set.action_iter_range(&range);
+        let iter = ActionValueIter::new(action, value);
+        if matches!(clock, ClockRange::Current(None)) && op_set.all_of_range_is_top(&range) {
+            Self::Current(Unshift::new(iter))
+        } else {
+            Self::Diff(Unshift::new(DiffIter::new_top(
+                op_set,
+                iter,
+                clock.clone(),
+                range,
+            )))
+        }
+    }
+
+    fn shift(&mut self, op_set: &'a OpSet, clock: &ClockRange, range: Range<usize>) {
+        if matches!(self, Self::Current(_)) && !op_set.all_of_range_is_top(&range) {
+            *self = Self::new(op_set, clock, range);
+        } else {
+            match self {
+                Self::Current(iter) => iter.shift(range),
+                Self::Diff(iter) => iter.shift(range),
+            }
+        }
+    }
+}
+
+impl<'a> Iterator for SpansActionValue<'a> {
+    type Item = (Diff, (Action, ScalarValue<'a>, usize));
+
+    #[inline(always)]
+    fn next(&mut self) -> Option<Self::Item> {
+        match self {
+            Self::Current(iter) => Some((Diff::Add, iter.next()?)),
+            Self::Diff(iter) => iter.next(),
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 pub(crate) struct SpansDiff<'a> {
-    action_value: Unshift<DiffIter<'a, ActionValueIter<'a>>>,
+    action_value: SpansActionValue<'a>,
     mark_info: MarkInfoIter<'a>,
     op_id: OpIdIter<'a>,
     marks: RichTextDiff<'a>,
@@ -60,6 +120,7 @@ pub(crate) struct SpansDiff<'a> {
 impl Iterator for SpansDiff<'_> {
     type Item = SpanDiff;
 
+    #[inline(always)]
     fn next(&mut self) -> Option<Self::Item> {
         if let Some(span) = self.state.pop() {
             return Some(span);
@@ -90,7 +151,8 @@ impl<'a> SpansDiff<'a> {
     pub(crate) fn shift_next(&mut self, range: Range<usize>) -> Option<<Self as Iterator>::Item> {
         self.mark_info.set_max(range.end);
         self.op_id.set_max(range.end);
-        self.action_value.shift(range);
+        self.action_value
+            .shift(self.op_set?, &self.clock, range.clone());
 
         self.marks = Default::default();
         self.state = SpanState::empty(self.state.encoding);
@@ -107,14 +169,7 @@ impl<'a> SpansDiff<'a> {
         let op_id = op_set.id_iter_range(&range);
         let mark_info = op_set.mark_info_iter_range(&range);
 
-        let skip = {
-            let value = op_set.value_iter_range(&range);
-            let action = op_set.action_iter_range(&range);
-            let iter = ActionValueIter::new(action, value);
-            DiffIter::new(op_set, iter, clock.clone(), range)
-        };
-
-        let action_value = Unshift::new(skip);
+        let action_value = SpansActionValue::new(op_set, &clock, range.clone());
         let marks = Default::default();
         let state = SpanState::empty(encoding);
         let op_set = Some(op_set);
@@ -162,6 +217,7 @@ impl<'a> SpansDiff<'a> {
         self.state.push_marks(current);
     }
 
+    #[inline(always)]
     fn process_action_val_diff(
         &mut self,
         diff: Diff,
@@ -169,6 +225,9 @@ impl<'a> SpansDiff<'a> {
     ) -> Option<SpanDiff> {
         self.pos = av.2;
         match av {
+            (Action::Set, ScalarValue::Str(s), _) if diff == Diff::Add => {
+                self.state.push_unmarked_add_str(&s)
+            }
             (Action::Set, ScalarValue::Str(s), _) => self.state.push_str(diff, &s),
             (Action::MakeMap, _, _) => self.push_block(diff),
             (Action::Mark, value, _) => {
@@ -429,6 +488,7 @@ impl SpanState {
         }
     }
 
+    #[inline(always)]
     fn push_str(&mut self, diff: Diff, s: &str) -> Option<SpanDiff> {
         debug_assert!(self.next_diff.is_none());
 
@@ -448,6 +508,29 @@ impl SpanState {
         next_text.len += self.encoding.width(s);
 
         span
+    }
+
+    // Avoid mark/diff comparisons in the common path of appending unmarked
+    // current text to an existing text span.
+    #[inline(always)]
+    fn push_unmarked_add_str(&mut self, s: &str) -> Option<SpanDiff> {
+        debug_assert!(self.next_diff.is_none());
+        if matches!(self.marks, MarkDiff::Nothing) {
+            if let Some(next) = &mut self.next_text {
+                if next.diff == Diff::Add && matches!(next.marks, MarkDiff::Nothing) {
+                    next.buff.push_str(s);
+                    next.len += self.encoding.width(s);
+                    return None;
+                }
+            } else {
+                let mut next = NextText::new(Diff::Add, &self.marks);
+                next.buff.push_str(s);
+                next.len += self.encoding.width(s);
+                self.next_text = Some(next);
+                return None;
+            }
+        }
+        self.push_str(Diff::Add, s)
     }
 
     fn diff_width(&self, diff: Diff, s: &str) -> usize {

--- a/rust/automerge/src/iter/tools.rs
+++ b/rust/automerge/src/iter/tools.rs
@@ -1,6 +1,6 @@
 use crate::clock::ClockRange;
 use crate::exid::ExId;
-use crate::op_set2::op_set::VisIter;
+use crate::op_set2::op_set::{SkipToTopIter, VisIter};
 use crate::op_set2::OpSet;
 use crate::types::OpId;
 
@@ -107,6 +107,10 @@ impl<I: Iterator + Debug + Clone, S: Skipper> SkipIter<I, S> {
     pub(crate) fn new(iter: I, skip: S) -> Self {
         Self { iter, skip }
     }
+
+    pub(crate) fn inner(&self) -> &I {
+        &self.iter
+    }
 }
 
 impl<I: Iterator + Debug + Clone + Shiftable, S: Skipper + Shiftable> Shiftable for SkipIter<I, S> {
@@ -123,8 +127,11 @@ impl<I: Iterator + Debug + Clone, S: Skipper> Iterator for SkipIter<I, S> {
 
     fn next(&mut self) -> Option<Self::Item> {
         let skip = self.skip.next()?;
-        let item = self.iter.nth(skip)?;
-        Some(item)
+        if skip == 0 {
+            self.iter.next()
+        } else {
+            self.iter.nth(skip)
+        }
     }
 }
 
@@ -247,26 +254,105 @@ where
     }
 }
 
+/// A [`BoolColumnSkipper`] is an iterator that iterates over usize values
+/// represnting ranges of `false` values in a boolean column. This can then
+/// be used by other iterators to skip past elements for which the boolean
+/// column is false
 #[derive(Clone, Default, Debug)]
-struct PastSkipper<'a> {
-    before: VisIter<'a>,
-    after: VisIter<'a>,
+pub(crate) struct BoolColumnSkipper<'a> {
+    iter: hexane::Iter<'a, bool>,
+    range: Range<usize>,
+    cursor: usize,
+    pending: usize,
+    exhausted: bool,
+}
+
+impl<'a> BoolColumnSkipper<'a> {
+    pub(crate) fn new(iter: hexane::Iter<'a, bool>, range: Range<usize>) -> Self {
+        let cursor = range.start;
+        Self {
+            iter,
+            range,
+            cursor,
+            pending: 0,
+            exhausted: false,
+        }
+    }
+}
+
+impl Skipper for BoolColumnSkipper<'_> {}
+
+impl Shiftable for BoolColumnSkipper<'_> {
+    fn shift_next(&mut self, range: Range<usize>) -> Option<<Self as Iterator>::Item> {
+        self.range = range.clone();
+        self.cursor = range.start;
+        self.pending = 0;
+        self.exhausted = false;
+
+        let Some(value) = self.iter.shift_next(range.clone()) else {
+            self.exhausted = true;
+            return Some(range.end.saturating_sub(range.start));
+        };
+
+        self.cursor = range.start + 1;
+        if value {
+            Some(0)
+        } else {
+            Some(1 + self.next().unwrap_or(0))
+        }
+    }
+}
+
+impl Iterator for BoolColumnSkipper<'_> {
+    type Item = usize;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.exhausted {
+            return None;
+        }
+        if self.pending > 0 {
+            self.pending -= 1;
+            self.cursor += 1;
+            Some(0)
+        } else {
+            let mut skipped = 0;
+            while let Some(run) = self.iter.next_run() {
+                if run.value && run.count > 0 {
+                    self.pending = run.count - 1;
+                    let pos = self.cursor + skipped;
+                    self.cursor = pos + 1;
+                    return Some(skipped);
+                }
+                skipped += run.count;
+            }
+            self.exhausted = true;
+            let skip = self.range.end.saturating_sub(self.cursor);
+            self.cursor = self.range.end.saturating_add(1);
+            Some(skip)
+        }
+    }
+}
+
+#[derive(Clone, Default, Debug)]
+struct PastSkipper<S> {
+    before: S,
+    after: S,
     state: (Diff, usize),
 }
 
 #[derive(Clone, Debug)]
-enum DiffSkipper<'a> {
-    Diff(PastSkipper<'a>),
-    Current(VisIter<'a>),
+enum DiffSkipper<S> {
+    Diff(PastSkipper<S>),
+    Current(S),
 }
 
-impl Default for DiffSkipper<'_> {
+impl<S: Default> Default for DiffSkipper<S> {
     fn default() -> Self {
-        Self::Current(VisIter::default())
+        Self::Current(S::default())
     }
 }
 
-impl<'a> DiffSkipper<'a> {
+impl<'a> DiffSkipper<VisIter<'a>> {
     fn new(op_set: &'a OpSet, clock: ClockRange, range: Range<usize>) -> Self {
         match clock {
             ClockRange::Current(clock) => {
@@ -281,8 +367,23 @@ impl<'a> DiffSkipper<'a> {
     }
 }
 
-impl<'a> PastSkipper<'a> {
-    fn new(before: VisIter<'a>, after: VisIter<'a>) -> Self {
+impl<'a> DiffSkipper<SkipToTopIter<'a>> {
+    fn new_top(op_set: &'a OpSet, clock: ClockRange, range: Range<usize>) -> Self {
+        match clock {
+            ClockRange::Current(clock) => {
+                DiffSkipper::Current(SkipToTopIter::new(op_set, clock, range))
+            }
+            ClockRange::Diff(before, after) => {
+                let before = SkipToTopIter::new(op_set, Some(before), range.clone());
+                let after = SkipToTopIter::new(op_set, Some(after), range);
+                DiffSkipper::Diff(PastSkipper::new(before, after))
+            }
+        }
+    }
+}
+
+impl<S: Skipper> PastSkipper<S> {
+    fn new(before: S, after: S) -> Self {
         Self {
             before,
             after,
@@ -326,7 +427,10 @@ impl<'a> PastSkipper<'a> {
     }
 }
 
-impl Iterator for DiffSkipper<'_> {
+impl<S> Iterator for DiffSkipper<S>
+where
+    S: Skipper,
+{
     type Item = (Diff, usize);
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -337,7 +441,10 @@ impl Iterator for DiffSkipper<'_> {
     }
 }
 
-impl Iterator for PastSkipper<'_> {
+impl<S> Iterator for PastSkipper<S>
+where
+    S: Skipper,
+{
     type Item = (Diff, usize);
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -347,7 +454,10 @@ impl Iterator for PastSkipper<'_> {
     }
 }
 
-impl Shiftable for DiffSkipper<'_> {
+impl<S> Shiftable for DiffSkipper<S>
+where
+    S: Skipper + Shiftable + Debug,
+{
     fn shift_next(&mut self, range: Range<usize>) -> Option<(Diff, usize)> {
         match self {
             Self::Current(iter) => Some((Diff::Add, iter.shift_next(range)?)),
@@ -356,7 +466,10 @@ impl Shiftable for DiffSkipper<'_> {
     }
 }
 
-impl Shiftable for PastSkipper<'_> {
+impl<S> Shiftable for PastSkipper<S>
+where
+    S: Skipper + Shiftable + Debug,
+{
     fn shift_next(&mut self, range: Range<usize>) -> Option<(Diff, usize)> {
         let skip_before = self.before.shift_next(range.clone());
         let skip_after = self.after.shift_next(range.clone());
@@ -366,30 +479,60 @@ impl Shiftable for PastSkipper<'_> {
 }
 
 #[derive(Clone, Debug)]
-pub(crate) struct DiffIter<'a, I: Iterator + Debug + Clone> {
+pub(crate) struct DiffIter<'a, I: Iterator + Debug + Clone, S = VisIter<'a>>
+where
+    S: Skipper,
+{
     iter: I,
-    skipper: DiffSkipper<'a>,
+    skipper: DiffSkipper<S>,
+    _phantom: std::marker::PhantomData<&'a ()>,
 }
 
-impl<I: Iterator + Debug + Clone + Default> Default for DiffIter<'_, I> {
+impl<I, S> Default for DiffIter<'_, I, S>
+where
+    I: Iterator + Debug + Clone + Default,
+    S: Skipper + Default,
+    DiffSkipper<S>: Default,
+{
     fn default() -> Self {
         Self {
             iter: I::default(),
             skipper: DiffSkipper::default(),
+            _phantom: Default::default(),
         }
     }
 }
 
-impl<'a, I: Iterator + Debug + Clone> DiffIter<'a, I> {
+impl<'a, I: Iterator + Debug + Clone> DiffIter<'a, I, VisIter<'a>> {
     pub(crate) fn new(op_set: &'a OpSet, iter: I, clock: ClockRange, range: Range<usize>) -> Self {
         Self {
             iter,
             skipper: DiffSkipper::new(op_set, clock, range),
+            _phantom: Default::default(),
         }
     }
 }
 
-impl<I: Iterator + Debug + Clone + Shiftable> Shiftable for DiffIter<'_, I> {
+impl<'a, I: Iterator + Debug + Clone> DiffIter<'a, I, SkipToTopIter<'a>> {
+    pub(crate) fn new_top(
+        op_set: &'a OpSet,
+        iter: I,
+        clock: ClockRange,
+        range: Range<usize>,
+    ) -> Self {
+        Self {
+            iter,
+            skipper: DiffSkipper::new_top(op_set, clock, range),
+            _phantom: Default::default(),
+        }
+    }
+}
+
+impl<I, S> Shiftable for DiffIter<'_, I, S>
+where
+    I: Iterator + Debug + Clone + Shiftable,
+    S: Skipper + Shiftable + Debug,
+{
     fn shift_next(&mut self, range: Range<usize>) -> Option<<Self as Iterator>::Item> {
         let (diff, skip) = self.skipper.shift_next(range.clone())?;
         let start = range.start + skip;
@@ -398,12 +541,21 @@ impl<I: Iterator + Debug + Clone + Shiftable> Shiftable for DiffIter<'_, I> {
     }
 }
 
-impl<I: Iterator + Debug + Clone> Iterator for DiffIter<'_, I> {
+impl<I, S> Iterator for DiffIter<'_, I, S>
+where
+    I: Iterator + Debug + Clone,
+    S: Skipper,
+{
     type Item = (Diff, I::Item);
 
     fn next(&mut self) -> Option<Self::Item> {
         let (diff, skip) = self.skipper.next()?;
-        let item = self.iter.nth(skip);
+        // nth(0) is noticeably slower for column iterators than next().
+        let item = if skip == 0 {
+            self.iter.next()
+        } else {
+            self.iter.nth(skip)
+        };
         Some((diff, item?))
     }
 }

--- a/rust/automerge/src/op_set2.rs
+++ b/rust/automerge/src/op_set2.rs
@@ -13,6 +13,4 @@ pub(crate) use types::{ActorIdx, KeyRef, MarkData, OpType, PropRef};
 pub use types::{ChangeMetadata, ScalarValue, ValueRef};
 
 pub(crate) use meta::ValueMeta;
-pub(crate) use op_set::{
-    OpIter, OpQuery, OpQueryTerm, OpSet, ReadOpError, TopOpIter, VisibleOpIter,
-};
+pub(crate) use op_set::{OpQuery, OpQueryTerm, OpSet, ReadOpError, TopOps};

--- a/rust/automerge/src/op_set2/op_set.rs
+++ b/rust/automerge/src/op_set2/op_set.rs
@@ -49,8 +49,8 @@ pub(crate) use op_iter::{
     ActionIter, ActionValueIter, CtrWalker, InsertIter, KeyIter, MarkInfoIter, ObjIdIter, OpIdIter,
     OpIter, ReadOpError, SuccIterIter, SuccWalker, ValueIter,
 };
-pub(crate) use op_query::{OpQuery, OpQueryTerm};
-pub(crate) use top_op::TopOpIter;
+pub(crate) use op_query::{FixCounters, OpQuery, OpQueryTerm};
+pub(crate) use top_op::{SkipToTopIter, TopOps};
 pub(crate) use visible::{VisIter, VisibleOpIter};
 
 pub(crate) type InsertAcc<'a> = hexane::PrefixIter<'a, bool>;
@@ -374,8 +374,7 @@ impl OpSet {
     }
 
     pub(crate) fn keys<'a>(&'a self, obj: &ObjId, clock: Option<Clock>) -> Keys<'a> {
-        let iter = self.iter_obj(obj).visible_slow(clock).top_ops();
-        Keys::new(self, iter)
+        Keys::new(self, self.top_ops(obj, clock))
     }
 
     pub(crate) fn spans(&self, obj: &ObjId, clock: Option<Clock>) -> SpansInternal<'_> {
@@ -903,6 +902,42 @@ impl OpSet {
         self.cols.insert.iter_range(range.clone())
     }
 
+    pub(crate) fn insert_iter_range(&self, range: &Range<usize>) -> InsertIter<'_> {
+        InsertIter::new(self.cols.insert.values().iter_range(range.clone()))
+    }
+
+    pub(crate) fn top_index_range(&self, range: &Range<usize>) -> hexane::Iter<'_, bool> {
+        self.cols.index.top.values().iter_range(range.clone())
+    }
+
+    /// Checks whether every op in the given range is "top" (i.e. every op has
+    /// no successor and there are no conflicts).
+    pub(crate) fn all_of_range_is_top(&self, range: &Range<usize>) -> bool {
+        // Lets span iteration skip top-filtering entirely for dense current docs.
+        range.is_empty()
+            || self
+                .cols
+                .index
+                .top
+                .delta(range.start, range.end)
+                .is_some_and(|delta| delta.delta == range.len())
+    }
+
+    pub(crate) fn obj_id_iter_range(&self, range: &Range<usize>) -> ObjIdIter<'_> {
+        ObjIdIter::new_range(
+            self.cols.obj_actor.iter_range(range.clone()),
+            self.cols.obj_ctr.iter_range(range.clone()),
+        )
+    }
+
+    pub(crate) fn key_iter_range(&self, range: &Range<usize>) -> KeyIter<'_> {
+        KeyIter::new(
+            self.cols.key_str.iter_range(range.clone()),
+            self.cols.key_actor.iter_range(range.clone()),
+            self.cols.key_ctr.iter_range(range.clone()),
+        )
+    }
+
     pub(crate) fn key_str_iter_range(
         &self,
         range: &Range<usize>,
@@ -961,12 +996,12 @@ impl OpSet {
         })
     }
 
-    pub(crate) fn top_ops<'a>(
-        &'a self,
-        obj: &ObjId,
-        clock: Option<Clock>,
-    ) -> TopOpIter<'a, VisibleOpIter<'a, OpIter<'a>>> {
-        self.iter_obj(obj).visible_slow(clock).top_ops()
+    pub(crate) fn top_ops<'a>(&'a self, obj: &ObjId, clock: Option<Clock>) -> TopOps<'a> {
+        let range = self.scope_to_obj(obj);
+        let fast = TopOps::new(self, clock.clone(), range);
+        #[cfg(feature = "slow_path_assertions")]
+        top_op::assert_matches_slow(self, obj, clock, fast.clone());
+        fast
     }
 
     pub(crate) fn to_string<E: Exportable>(&self, id: E) -> String {
@@ -1889,8 +1924,10 @@ mod tests {
             let ops = iter.collect::<Vec<_>>();
             assert_eq!(&test_ops[3..6], ops.as_slice());
 
-            let iter = opset.iter_obj(&ObjId(OpId::new(1, 1)));
-            let ops = iter.top_ops().collect::<Vec<_>>();
+            let clock = [None, Some(9), Some(9)].into_iter().collect::<Clock>();
+            let ops = opset
+                .top_ops(&ObjId(OpId::new(1, 1)), Some(clock.clone()))
+                .collect::<Vec<_>>();
             assert_eq!(&test_ops[2], &ops[0]);
             assert_eq!(&test_ops[5], &ops[1]);
             assert_eq!(&test_ops[7], &ops[2]);
@@ -1926,8 +1963,9 @@ mod tests {
             assert_eq!(&test_ops[7..8], key3);
             assert!(key4.is_none());
 
-            let iter = opset.iter_obj(&ObjId(OpId::new(1, 1)));
-            let ops = iter.visible_slow(None).top_ops().collect::<Vec<_>>();
+            let ops = opset
+                .top_ops(&ObjId(OpId::new(1, 1)), Some(clock))
+                .collect::<Vec<_>>();
             assert_eq!(&test_ops[2], &ops[0]);
             assert_eq!(&test_ops[5], &ops[1]);
             assert_eq!(&test_ops[7], &ops[2]);

--- a/rust/automerge/src/op_set2/op_set/op_iter.rs
+++ b/rust/automerge/src/op_set2/op_set/op_iter.rs
@@ -433,6 +433,12 @@ impl<'a> InsertIter<'a> {
     }
 }
 
+impl Shiftable for InsertIter<'_> {
+    fn shift_next(&mut self, range: Range<usize>) -> Option<Self::Item> {
+        self.iter.shift_next(range)
+    }
+}
+
 impl Iterator for InsertIter<'_> {
     type Item = bool;
 
@@ -519,6 +525,15 @@ impl<'a> KeyIter<'a> {
             key_actor: self.key_actor.suspend(),
             key_ctr: self.key_ctr.suspend(),
         }
+    }
+}
+
+impl<'a> Shiftable for KeyIter<'a> {
+    fn shift_next(&mut self, range: Range<usize>) -> Option<Self::Item> {
+        let key_str = self.key_str.shift_next(range.clone())?;
+        let key_actor = self.key_actor.shift_next(range.clone())?;
+        let key_ctr = self.key_ctr.shift_next(range)?;
+        KeyRef::try_load(key_str, key_actor, key_ctr.map(i64::from)).ok()
     }
 }
 
@@ -612,6 +627,14 @@ impl<'a> ObjIdIter<'a> {
             obj_actor: self.obj_actor.suspend(),
             obj_ctr: self.obj_ctr.suspend(),
         }
+    }
+}
+
+impl Shiftable for ObjIdIter<'_> {
+    fn shift_next(&mut self, range: Range<usize>) -> Option<Self::Item> {
+        let actor = self.obj_actor.shift_next(range.clone())?;
+        let ctr = self.obj_ctr.shift_next(range)?;
+        ObjId::try_load(actor, ctr.map(i64::from)).ok()
     }
 }
 
@@ -725,6 +748,7 @@ impl<'a> ActionValueIter<'a> {
 impl<'a> Iterator for ActionValueIter<'a> {
     type Item = (Action, ScalarValue<'a>, usize);
 
+    #[inline(always)]
     fn next(&mut self) -> Option<Self::Item> {
         let action = self.action.next();
         let value = self.value.next();
@@ -732,6 +756,7 @@ impl<'a> Iterator for ActionValueIter<'a> {
         Some((action?, value?, pos - 1))
     }
 
+    #[inline(always)]
     fn nth(&mut self, n: usize) -> Option<Self::Item> {
         let action = self.action.nth(n);
         let value = self.value.nth(n);
@@ -842,6 +867,7 @@ impl<'a> ValueIter<'a> {
         Self { meta, raw }
     }
 
+    #[inline(always)]
     pub(crate) fn try_next(&mut self) -> Result<ScalarValue<'a>, ReadOpError> {
         let meta = self
             .meta
@@ -878,6 +904,7 @@ impl<'a> ValueIter<'a> {
 impl<'a> Iterator for ValueIter<'a> {
     type Item = ScalarValue<'a>;
 
+    #[inline(always)]
     fn next(&mut self) -> Option<Self::Item> {
         self.try_next().ok()
     }

--- a/rust/automerge/src/op_set2/op_set/op_query.rs
+++ b/rust/automerge/src/op_set2/op_set/op_query.rs
@@ -1,5 +1,5 @@
 use super::visible::VisIter;
-use super::{MarkIter, NoMarkIter, Op, OpIter, OpSet, TopOpIter, VisibleOpIter};
+use super::{MarkIter, NoMarkIter, Op, OpIter, OpSet, VisibleOpIter};
 use crate::iter::tools::SkipIter;
 use crate::marks::MarkSet;
 use crate::types::Clock;
@@ -26,10 +26,6 @@ pub(crate) trait OpQuery<'a>: OpQueryTerm<'a> + Clone {
         NoMarkIter::new(self)
     }
 
-    fn top_ops(self) -> TopOpIter<'a, Self> {
-        TopOpIter::new(self)
-    }
-
     #[cfg(test)]
     fn key_ops(self) -> KeyOpIter<'a, Self> {
         KeyOpIter::new(self)
@@ -39,9 +35,13 @@ pub(crate) trait OpQuery<'a>: OpQueryTerm<'a> + Clone {
         VisibleOpIter::new(self, clock)
     }
 
-    fn visible(self, op_set: &'a OpSet, clock: Option<&Clock>) -> FixCounters<'a, Self> {
+    fn visible(
+        self,
+        op_set: &'a OpSet,
+        clock: Option<&Clock>,
+    ) -> FixCounters<'a, SkipIter<Self, VisIter<'a>>> {
         let vis = VisIter::new(op_set, clock, self.range());
-        FixCounters::new(SkipIter::new(self, vis), clock)
+        FixCounters::new(SkipIter::new(self, vis), clock.cloned())
     }
 }
 
@@ -55,28 +55,67 @@ impl<'a> OpQueryTerm<'a> for OpIter<'a> {
     }
 }
 
-impl<'a, I: OpQueryTerm<'a> + Clone> OpQuery<'a> for I {}
+impl<'a, I, S> OpQueryTerm<'a> for SkipIter<I, S>
+where
+    I: OpQueryTerm<'a> + Clone,
+    S: crate::iter::tools::Skipper + std::fmt::Debug,
+{
+    fn get_marks(&self) -> Option<&Arc<MarkSet>> {
+        None
+    }
 
-pub(crate) struct FixCounters<'a, T: OpQuery<'a>> {
-    iter: SkipIter<T, VisIter<'a>>,
-    clock: Option<Clock>,
+    fn range(&self) -> Range<usize> {
+        self.inner().range()
+    }
 }
 
-impl<'a, T: OpQuery<'a>> FixCounters<'a, T> {
-    fn new(iter: SkipIter<T, VisIter<'a>>, clock: Option<&Clock>) -> Self {
+impl<'a, I: OpQueryTerm<'a> + Clone> OpQuery<'a> for I {}
+
+#[derive(Clone, Debug)]
+pub(crate) struct FixCounters<'a, I> {
+    iter: I,
+    clock: Option<Clock>,
+    _phantom: std::marker::PhantomData<&'a ()>,
+}
+
+impl<'a, I> FixCounters<'a, I> {
+    pub(crate) fn new(iter: I, clock: Option<Clock>) -> Self {
         Self {
             iter,
-            clock: clock.cloned(),
+            clock,
+            _phantom: Default::default(),
         }
     }
 }
 
-impl<'a, T: OpQuery<'a>> Iterator for FixCounters<'a, T> {
+impl<I: Default> Default for FixCounters<'_, I> {
+    fn default() -> Self {
+        Self::new(I::default(), None)
+    }
+}
+
+impl<'a, I> Iterator for FixCounters<'a, I>
+where
+    I: Iterator<Item = Op<'a>>,
+{
     type Item = Op<'a>;
 
     fn next(&mut self) -> Option<Self::Item> {
         let mut op = self.iter.next()?;
         op.fix_counter(self.clock.as_ref());
         Some(op)
+    }
+}
+
+impl<'a, I> OpQueryTerm<'a> for FixCounters<'a, I>
+where
+    I: OpQueryTerm<'a>,
+{
+    fn get_marks(&self) -> Option<&Arc<MarkSet>> {
+        self.iter.get_marks()
+    }
+
+    fn range(&self) -> Range<usize> {
+        self.iter.range()
     }
 }

--- a/rust/automerge/src/op_set2/op_set/top_op.rs
+++ b/rust/automerge/src/op_set2/op_set/top_op.rs
@@ -1,19 +1,120 @@
+use crate::clock::Clock;
+use crate::iter::tools::{BoolColumnSkipper, Shiftable, SkipIter, Skipper};
 use crate::marks::MarkSet;
+use crate::op_set2::op::SuccCursors;
+use crate::op_set2::types::{Action, KeyRef};
+use crate::types::{ElemId, ObjId, OpId};
 
-use super::{Op, OpQueryTerm};
+use super::{
+    ActionIter, FixCounters, InsertIter, KeyIter, ObjIdIter, OpIdIter, OpIter, OpQueryTerm, OpSet,
+    SuccIterIter, VisIter,
+};
 
-use std::fmt::Debug;
 use std::ops::Range;
 use std::sync::Arc;
 
 #[derive(Clone, Debug)]
-pub(crate) struct TopOpIter<'a, I: Iterator<Item = Op<'a>>> {
-    iter: I,
-    last_op: Option<Op<'a>>,
+pub(crate) struct TopOps<'a> {
+    inner: FixCounters<'a, SkipIter<OpIter<'a>, SkipToTopIter<'a>>>,
+    visible: VisIter<'a>,
+    visible_pos: usize,
 }
 
-impl<'a, I: Iterator<Item = Op<'a>>> TopOpIter<'a, I> {
-    pub(crate) fn new(iter: I) -> Self {
+impl<'a> TopOps<'a> {
+    pub(crate) fn new(op_set: &'a OpSet, clock: Option<Clock>, range: Range<usize>) -> Self {
+        let visible_pos = range.start;
+        let visible = VisIter::new(op_set, clock.as_ref(), range.clone());
+        let iter = SkipIter::new(
+            op_set.iter_range(&range),
+            SkipToTopIter::new(op_set, clock.clone(), range),
+        );
+        let inner = FixCounters::new(iter, clock);
+        Self {
+            inner,
+            visible,
+            visible_pos,
+        }
+    }
+}
+
+impl<'a> Iterator for TopOps<'a> {
+    type Item = super::Op<'a>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let mut op = self.inner.next()?;
+        let mut conflict = false;
+        loop {
+            let skip = self.visible.next().expect("a top op must also be visible");
+            let pos = self.visible_pos + skip;
+            self.visible_pos = pos + 1;
+            assert!(
+                pos <= op.pos,
+                "visible op at {pos} advanced past top op at {}",
+                op.pos
+            );
+            if pos == op.pos {
+                break;
+            }
+            conflict = true;
+        }
+        op.conflict = conflict;
+        Some(op)
+    }
+}
+
+impl<'a> OpQueryTerm<'a> for TopOps<'a> {
+    fn get_marks(&self) -> Option<&Arc<MarkSet>> {
+        self.inner.get_marks()
+    }
+
+    fn range(&self) -> Range<usize> {
+        self.inner.range()
+    }
+}
+
+#[cfg(feature = "slow_path_assertions")]
+pub(super) fn assert_matches_slow(
+    op_set: &OpSet,
+    obj: &ObjId,
+    clock: Option<Clock>,
+    mut fast: TopOps<'_>,
+) {
+    use super::OpQuery;
+
+    let mut slow = SlowTopOpIter::new(op_set.iter_obj(obj).visible_slow(clock));
+    let mut index = 0;
+    loop {
+        match (fast.next(), slow.next()) {
+            (Some(fast), Some(slow)) => {
+                assert_eq!(fast.id, slow.id, "fast and slow top op IDs differ at {index}");
+                assert_eq!(
+                    fast.value, slow.value,
+                    "fast and slow top op values differ at {index}"
+                );
+                assert_eq!(
+                    fast.conflict, slow.conflict,
+                    "fast and slow top op conflict flags differ at {index}"
+                );
+            }
+            (None, None) => break,
+            (fast, slow) => panic!(
+                "fast and slow top op iterator lengths differ at {index}: fast={fast:?}, slow={slow:?}"
+            ),
+        }
+        index += 1;
+    }
+}
+
+#[cfg(feature = "slow_path_assertions")]
+#[derive(Clone, Debug)]
+struct SlowTopOpIter<'a, I: Iterator<Item = super::Op<'a>>> {
+    iter: I,
+    last_op: Option<super::Op<'a>>,
+}
+
+#[cfg(feature = "slow_path_assertions")]
+impl<'a, I: Iterator<Item = super::Op<'a>>> SlowTopOpIter<'a, I> {
+    fn new(iter: I) -> Self {
         Self {
             iter,
             last_op: None,
@@ -21,8 +122,9 @@ impl<'a, I: Iterator<Item = Op<'a>>> TopOpIter<'a, I> {
     }
 }
 
-impl<'a, I: Iterator<Item = Op<'a>>> Iterator for TopOpIter<'a, I> {
-    type Item = Op<'a>;
+#[cfg(feature = "slow_path_assertions")]
+impl<'a, I: Iterator<Item = super::Op<'a>>> Iterator for SlowTopOpIter<'a, I> {
+    type Item = super::Op<'a>;
 
     fn next(&mut self) -> Option<Self::Item> {
         for mut next in self.iter.by_ref() {
@@ -30,9 +132,8 @@ impl<'a, I: Iterator<Item = Op<'a>>> Iterator for TopOpIter<'a, I> {
                 if next.obj != last.obj || next.elemid_or_key() != last.elemid_or_key() {
                     self.last_op = Some(next);
                     return Some(last);
-                } else {
-                    next.conflict = true;
                 }
+                next.conflict = true;
             }
             self.last_op = Some(next);
         }
@@ -40,11 +141,228 @@ impl<'a, I: Iterator<Item = Op<'a>>> Iterator for TopOpIter<'a, I> {
     }
 }
 
-impl<'a, I: OpQueryTerm<'a>> OpQueryTerm<'a> for TopOpIter<'a, I> {
-    fn get_marks(&self) -> Option<&Arc<MarkSet>> {
-        self.iter.get_marks()
+/// An iterator which returns runs of non-top ops, this can be used with a
+/// SkipIter to skip to the next top op
+#[derive(Clone, Debug)]
+pub(crate) struct SkipToTopIter<'a> {
+    range: Range<usize>,
+    clock: Option<Clock>,
+    cursor: usize,
+    exhausted: bool,
+    inner: SkipToTopIterInner<'a>,
+}
+
+#[derive(Clone, Debug)]
+enum SkipToTopIterInner<'a> {
+    Empty,
+    Current(BoolColumnSkipper<'a>),
+    Scan {
+        iter: Box<TopScanIter<'a>>,
+        buffered: Option<Box<TopScanRow<'a>>>,
+    },
+}
+
+impl Default for SkipToTopIter<'_> {
+    fn default() -> Self {
+        Self {
+            range: 0..0,
+            clock: None,
+            cursor: 0,
+            exhausted: true,
+            inner: SkipToTopIterInner::Empty,
+        }
     }
-    fn range(&self) -> Range<usize> {
-        self.iter.range()
+}
+
+impl<'a> SkipToTopIter<'a> {
+    pub(crate) fn new(op_set: &'a OpSet, clock: Option<Clock>, range: Range<usize>) -> Self {
+        let cursor = range.start;
+        let inner = if clock.is_some() {
+            SkipToTopIterInner::Scan {
+                iter: Box::new(TopScanIter::new(op_set, &range)),
+                buffered: None,
+            }
+        } else {
+            SkipToTopIterInner::Current(BoolColumnSkipper::new(
+                op_set.top_index_range(&range),
+                range.clone(),
+            ))
+        };
+        Self {
+            range,
+            clock,
+            cursor,
+            exhausted: false,
+            inner,
+        }
+    }
+}
+
+impl Skipper for SkipToTopIter<'_> {}
+
+impl Shiftable for SkipToTopIter<'_> {
+    fn shift_next(&mut self, range: Range<usize>) -> Option<<Self as Iterator>::Item> {
+        self.cursor = range.start;
+        self.range = range.clone();
+        self.exhausted = false;
+        match &mut self.inner {
+            SkipToTopIterInner::Empty => None,
+            SkipToTopIterInner::Current(iter) => iter.shift_next(range),
+            SkipToTopIterInner::Scan { iter, buffered } => {
+                *buffered = None;
+                if let Some(first) = iter.shift_next(range.clone()) {
+                    *buffered = Some(Box::new(first));
+                    self.next()
+                } else {
+                    self.exhausted = true;
+                    Some(range.end.saturating_sub(range.start))
+                }
+            }
+        }
+    }
+}
+
+impl Iterator for SkipToTopIter<'_> {
+    type Item = usize;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.exhausted {
+            return None;
+        }
+        match &mut self.inner {
+            SkipToTopIterInner::Empty => None,
+            SkipToTopIterInner::Current(iter) => iter.next(),
+            SkipToTopIterInner::Scan { iter, buffered } => {
+                let clock = self.clock.as_ref();
+                loop {
+                    let Some(first) = buffered.take().or_else(|| iter.next().map(Box::new)) else {
+                        self.exhausted = true;
+                        let skip = self.range.end.saturating_sub(self.cursor);
+                        self.cursor = self.range.end.saturating_add(1);
+                        return Some(skip);
+                    };
+                    let obj = first.obj;
+                    let key = first.key.clone();
+                    let mut top = if first.is_visible(clock) {
+                        Some(first.pos)
+                    } else {
+                        None
+                    };
+
+                    for row in iter.by_ref() {
+                        if row.obj != obj || row.key != key {
+                            *buffered = Some(Box::new(row));
+                            break;
+                        }
+                        if row.is_visible(clock) {
+                            top = Some(row.pos);
+                        }
+                    }
+
+                    if let Some(pos) = top {
+                        let skip = pos.checked_sub(self.cursor)?;
+                        self.cursor = pos + 1;
+                        return Some(skip);
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+struct TopScanIter<'a> {
+    pos: usize,
+    obj: ObjIdIter<'a>,
+    key: KeyIter<'a>,
+    id: OpIdIter<'a>,
+    insert: InsertIter<'a>,
+    action: ActionIter<'a>,
+    succ: SuccIterIter<'a>,
+}
+
+impl<'a> TopScanIter<'a> {
+    fn new(op_set: &'a OpSet, range: &Range<usize>) -> Self {
+        Self {
+            pos: range.start,
+            obj: op_set.obj_id_iter_range(range),
+            key: op_set.key_iter_range(range),
+            id: op_set.id_iter_range(range),
+            insert: op_set.insert_iter_range(range),
+            action: op_set.action_iter_range(range),
+            succ: op_set.succ_iter_range(range),
+        }
+    }
+
+    fn row_at(&mut self, pos: usize) -> Option<TopScanRow<'a>> {
+        let id = self.id.next()?;
+        let key = self.key.next()?;
+        let key = if self.insert.next()? {
+            KeyRef::Seq(ElemId(id))
+        } else {
+            key
+        };
+        Some(TopScanRow {
+            pos,
+            obj: self.obj.next()?,
+            key,
+            id,
+            action: self.action.next()?,
+            succ: self.succ.next()?,
+        })
+    }
+
+    fn shift_next(&mut self, range: Range<usize>) -> Option<TopScanRow<'a>> {
+        let pos = range.start;
+        self.pos = pos + 1;
+        let id = self.id.shift_next(range.clone())?;
+        let key = self.key.shift_next(range.clone())?;
+        let key = if self.insert.shift_next(range.clone())? {
+            KeyRef::Seq(ElemId(id))
+        } else {
+            key
+        };
+        Some(TopScanRow {
+            pos,
+            obj: self.obj.shift_next(range.clone())?,
+            key,
+            id,
+            action: self.action.shift_next(range.clone())?,
+            succ: self.succ.shift_next(range)?,
+        })
+    }
+}
+
+impl<'a> Iterator for TopScanIter<'a> {
+    type Item = TopScanRow<'a>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let pos = self.pos;
+        self.pos += 1;
+        self.row_at(pos)
+    }
+}
+
+#[derive(Clone, Debug)]
+struct TopScanRow<'a> {
+    pos: usize,
+    obj: ObjId,
+    key: KeyRef<'a>,
+    id: OpId,
+    action: Action,
+    succ: SuccCursors<'a>,
+}
+
+impl TopScanRow<'_> {
+    fn is_visible(&self, clock: Option<&Clock>) -> bool {
+        if self.action == Action::Increment || clock.is_some_and(|clock| !clock.covers(&self.id)) {
+            return false;
+        }
+        for (id, inc) in self.succ.clone().with_inc() {
+            if inc.is_none() && clock.map(|clock| clock.covers(&id)).unwrap_or(true) {
+                return false;
+            }
+        }
+        true
     }
 }

--- a/rust/automerge/src/op_set2/op_set/visible.rs
+++ b/rust/automerge/src/op_set2/op_set/visible.rs
@@ -9,7 +9,7 @@ use std::fmt::Debug;
 use std::ops::Range;
 use std::sync::Arc;
 
-use crate::iter::tools::{Shiftable, Skipper};
+use crate::iter::tools::{BoolColumnSkipper, Shiftable, Skipper};
 
 impl Shiftable for VisIter<'_> {
     fn shift_next(&mut self, range: Range<usize>) -> Option<usize> {
@@ -37,13 +37,7 @@ impl Shiftable for ScanVisIter<'_> {
 
 impl Shiftable for IndexedVisIter<'_> {
     fn shift_next(&mut self, range: Range<usize>) -> Option<usize> {
-        let val = self.iter.shift_next(range)?;
-        self.vis = 0;
-        if val {
-            Some(0)
-        } else {
-            Some(1 + self.next().unwrap_or(0))
-        }
+        self.iter.shift_next(range)
     }
 }
 
@@ -86,14 +80,15 @@ impl Iterator for VisIter<'_> {
 
 #[derive(Clone, Default, Debug)]
 pub(crate) struct IndexedVisIter<'a> {
-    iter: hexane::Iter<'a, bool>,
-    vis: usize,
+    iter: BoolColumnSkipper<'a>,
 }
 
 impl<'a> IndexedVisIter<'a> {
     fn new(op_set: &'a OpSet, range: Range<usize>) -> Self {
-        let iter = op_set.cols.index.visible.iter_range(range);
-        Self { iter, vis: 0 }
+        let iter = op_set.cols.index.visible.iter_range(range.clone());
+        Self {
+            iter: BoolColumnSkipper::new(iter, range),
+        }
     }
 }
 
@@ -101,21 +96,7 @@ impl Iterator for IndexedVisIter<'_> {
     type Item = usize;
 
     fn next(&mut self) -> Option<Self::Item> {
-        if self.vis > 0 {
-            self.vis -= 1;
-            Some(0)
-        } else {
-            let mut skip = 0;
-            while let Some(run) = self.iter.next_run() {
-                if run.value && run.count > 0 {
-                    self.vis = run.count - 1;
-                    break;
-                } else {
-                    skip += run.count;
-                }
-            }
-            Some(skip)
-        }
+        self.iter.next()
     }
 }
 

--- a/rust/automerge/src/op_set2/types.rs
+++ b/rust/automerge/src/op_set2/types.rs
@@ -301,6 +301,7 @@ impl<'a> ScalarValue<'a> {
         }
     }
 
+    #[inline(always)]
     pub(crate) fn from_raw(
         meta: super::meta::ValueMeta,
         raw: &'a [u8],

--- a/rust/automerge/tests/test.rs
+++ b/rust/automerge/tests/test.rs
@@ -302,6 +302,147 @@ fn load_incremental_into_empty_doc_preserves_utf8_text_encoding() {
 }
 
 #[test]
+fn spans_match_text_after_merge_of_conflicting_text_overwrites_from_fuzz_trace() {
+    // A text element is concurrently overwritten by two strings. The visible
+    // text reconstructed from spans() should match text(), i.e. spans() should
+    // not emit the losing side of the conflict.
+    let mut doc = AutoCommit::new();
+    doc.set_actor(ActorId::from(vec![0]));
+    let text = doc.put_object(ROOT, "text", ObjType::Text).unwrap();
+    doc.insert(&text, 0, "base").unwrap();
+    doc.commit();
+
+    let mut left = doc.fork();
+    left.set_actor(ActorId::from(vec![1]));
+    left.put(&text, 0, "left").unwrap();
+    left.commit();
+
+    let mut right = doc.fork();
+    right.set_actor(ActorId::from(vec![2]));
+    right.put(&text, 0, "right").unwrap();
+    right.commit();
+
+    left.merge(&mut right).unwrap();
+
+    let from_text = left.text(&text).unwrap();
+    let from_spans = left
+        .spans(&text)
+        .unwrap()
+        .filter_map(|span| match span {
+            automerge::iter::Span::Text { text, .. } => Some(text),
+            automerge::iter::Span::Block(_) => None,
+        })
+        .collect::<String>();
+
+    assert_eq!(from_spans, from_text);
+}
+
+#[test]
+fn doc_iter_spans_skip_losing_conflicting_text_overwrites_after_object_shift() {
+    // DocIter reuses one SpansDiff while shifting between objects. The fast
+    // all-top path for the root object must not be reused for a conflicted text
+    // object reached later.
+    let mut doc = AutoCommit::new();
+    doc.set_actor(ActorId::from(vec![0]));
+    let text = doc.put_object(ROOT, "text", ObjType::Text).unwrap();
+    doc.insert(&text, 0, "base").unwrap();
+    doc.commit();
+
+    let mut left = doc.fork();
+    left.set_actor(ActorId::from(vec![1]));
+    left.put(&text, 0, "left").unwrap();
+    left.commit();
+
+    let mut right = doc.fork();
+    right.set_actor(ActorId::from(vec![2]));
+    right.put(&text, 0, "right").unwrap();
+    right.commit();
+
+    left.merge(&mut right).unwrap();
+
+    let from_text = left.text(&text).unwrap();
+    let from_doc_iter = left
+        .iter()
+        .filter_map(|item| match item.item {
+            automerge::iter::DocItem::Text(automerge::iter::Span::Text { text, .. }) => Some(text),
+            _ => None,
+        })
+        .collect::<String>();
+
+    assert_eq!(from_doc_iter, from_text);
+}
+
+#[test]
+fn diff_spans_preserve_marks_on_inserted_text() {
+    // Historical top scanning must group inserted ops by elemid_or_key(), not
+    // raw key, so mark ops sharing an insertion key with text ops are retained.
+    let mut doc = AutoCommit::new();
+    let text = doc.put_object(ROOT, "text", ObjType::Text).unwrap();
+    doc.commit();
+    let before = doc.get_heads();
+
+    doc.splice_text(&text, 0, 0, "abc").unwrap();
+    doc.mark(
+        &text,
+        Mark {
+            start: 0,
+            end: 3,
+            name: "bold".into(),
+            value: ScalarValue::from(1),
+        },
+        ExpandMark::After,
+    )
+    .unwrap();
+    let after = doc.get_heads();
+
+    let patches = doc.diff(&before, &after);
+    let has_marked_splice = patches.iter().any(|patch| {
+        matches!(
+            &patch.action,
+            PatchAction::SpliceText { marks: Some(_), .. }
+        )
+    });
+
+    assert!(has_marked_splice);
+}
+
+#[test]
+fn diff_spans_skip_losing_conflicting_text_overwrites() {
+    // The diff path uses SpansDiff rather than SpansInternal. It should apply
+    // the same top-op filtering and avoid emitting the losing text value.
+    let mut doc = AutoCommit::new();
+    doc.set_actor(ActorId::from(vec![0]));
+    let text = doc.put_object(ROOT, "text", ObjType::Text).unwrap();
+    doc.insert(&text, 0, "base").unwrap();
+    doc.commit();
+    let before = doc.get_heads();
+
+    let mut left = doc.fork();
+    left.set_actor(ActorId::from(vec![1]));
+    left.put(&text, 0, "left").unwrap();
+    left.commit();
+
+    let mut right = doc.fork();
+    right.set_actor(ActorId::from(vec![2]));
+    right.put(&text, 0, "right").unwrap();
+    right.commit();
+
+    left.merge(&mut right).unwrap();
+    let after = left.get_heads();
+
+    let spliced_text = left
+        .diff(&before, &after)
+        .into_iter()
+        .filter_map(|patch| match patch.action {
+            PatchAction::SpliceText { value, .. } => Some(value.make_string()),
+            _ => None,
+        })
+        .collect::<String>();
+
+    assert_eq!(spliced_text, left.text(&text).unwrap());
+}
+
+#[test]
 fn no_conflict_on_repeated_assignment() {
     let mut doc = AutoCommit::new();
     doc.put(&automerge::ROOT, "foo", 1).unwrap();


### PR DESCRIPTION
Problem: spans and diff spans walked were using the visible ops index which meant that if there were conflicting elements in a text object (which admittedly we discourage in the API) then the spans would include all the conflicting insertions whereas `Automerge::text()` just shows the winning insertions.

Solution: use the top-ops index when computing spans and likewise scan for top ops when computing historical spans. This is became a little more involved than initially intended because I took the opportunity to consolidate the logic for reading top ops from the top index. Specifically, the `OpSet::top_ops` iterator now uses a skipping iterator similar to the `VisIter`. This has improved our performance across the board on the automerge-battery benchmarks, here's the highlights:

| Benchmark                           |  Before |   After |     Change |
| ----------------------------------- | ------: | ------: | ---------: |
| `egwalker_paper/get_text/A1.am`     | 55.9 ms | 3.42 ms | **−93.9%** |
| `egwalker_paper/get_text/S3.am#2`   |  133 ms | 9.15 ms | **−93.1%** |
| `egwalker_paper/get_text/S3.am`     |  133 ms | 9.15 ms | **−93.1%** |
| `egwalker_paper/get_text/A2.am`     | 58.7 ms | 18.3 ms | **−68.8%** |
| `bestiary/iter/moby-dick.automerge` | 47.1 ms | 15.9 ms | **−66.1%** |