### PR TITLE
rust: fix fragment clocks

### DIFF
--- a/rust/automerge/src/change_graph.rs
+++ b/rust/automerge/src/change_graph.rs
@@ -159,6 +159,10 @@ impl ChangeGraph {
         for clock in &mut self.clock_cache.values_mut() {
             clock.remove_actor(idx)
         }
+        for fragment in &mut self.fragments {
+            fragment.clock.remove_actor(idx)
+        }
+        self.fragment_top.remove_actor(idx);
     }
 
     pub(crate) fn len(&self) -> usize {

--- a/rust/automerge/src/transaction/inner.rs
+++ b/rust/automerge/src/transaction/inner.rs
@@ -1105,11 +1105,20 @@ impl TransactionInner {
                 }
             }
         }
-        for (key, new_value) in new_value.iter() {
-            if !present_keys.contains(key) {
-                self.update_value(doc, patch_log, map, key.into(), &new_value.value, None)?;
-            }
+        // Hydrated maps and the sets above are hash-based, so their iteration
+        // order varies between executions. Apply additions and deletions in key
+        // order so operation IDs and nested-object creation are deterministic.
+        // (this is useful for fuzzing, but also generally nice)
+        let mut additions = new_value
+            .iter()
+            .filter(|(key, _)| !present_keys.contains(*key))
+            .collect::<Vec<_>>();
+        additions.sort_unstable_by(|(left, _), (right, _)| left.cmp(right));
+        for (key, new_value) in additions {
+            self.update_value(doc, patch_log, map, key.into(), &new_value.value, None)?;
         }
+        let mut delenda = delenda.into_iter().collect::<Vec<_>>();
+        delenda.sort_unstable();
         for key in delenda {
             self.delete(doc, patch_log, map, key)?;
         }


### PR DESCRIPTION
Problem: Removing unused actors left fragment clocks with stale actor slots, causing clock length assertions during fragment caching. 

Solution: Remove actors from cached fragment clocks and the fragment top clock.