### PR TITLE
optimization pass on text()

### DIFF
--- a/rust/automerge/src/autocommit.rs
+++ b/rust/automerge/src/autocommit.rs
@@ -748,13 +748,21 @@ impl AutoCommit {
     fn get_scope(&self, heads: Option<&[ChangeHash]>) -> Option<Clock> {
         // heads arg takes priority
         if let Some(h) = heads {
-            return Some(self.doc.clock_at(h));
+            // the heads == current-heads shortcut (an unscoped read) is only
+            // sound with no transaction in flight: pending ops are already in
+            // the op set but not yet under the graph's heads
+            return if self.transaction.is_none() {
+                self.doc.clock_at(h)
+            } else {
+                Some(self.doc.change_graph.clock_at(h))
+            };
         }
         match (&self.isolation, &self.transaction) {
             // then look at in progress isolated transaction
             (Some(_), Some((_, t))) => t.get_scope().clone(),
-            // then look at clock for isolation
-            (Some(i), None) => Some(self.doc.clock_at(i)),
+            // then look at clock for isolation (no transaction is open, so
+            // isolation at the current heads can read unscoped)
+            (Some(i), None) => self.doc.clock_at(i),
             _ => None,
         }
     }

--- a/rust/automerge/src/automerge.rs
+++ b/rust/automerge/src/automerge.rs
@@ -1111,13 +1111,29 @@ impl Automerge {
     }
 
     pub(crate) fn clock_range(&self, before: &[ChangeHash], after: &[ChangeHash]) -> ClockRange {
-        let before = self.clock_at(before);
-        let after = self.clock_at(after);
+        let before = self.change_graph.clock_at(before);
+        let after = self.change_graph.clock_at(after);
         ClockRange::Diff(before, after)
     }
 
-    pub(crate) fn clock_at(&self, heads: &[ChangeHash]) -> Clock {
-        self.change_graph.clock_for_heads(heads)
+    /// Clock for reading the document as at `heads`.
+    ///
+    /// Returns `None` — an unscoped read of the present document — when
+    /// `heads` is exactly the current heads, so `*_at(doc.get_heads())`
+    /// takes the same indexed fast paths as the un-suffixed methods.
+    ///
+    /// The shortcut is sound here because pending transaction ops enter
+    /// the op set before the graph's heads advance, and an `Automerge`
+    /// cannot be read through `&self` while a transaction holds it
+    /// mutably. Anything reading *around* an in-flight transaction
+    /// (`AutoCommit`, the transaction types) — or needing a concrete
+    /// clock — must use [`ChangeGraph::clock_at`] instead.
+    pub(crate) fn clock_at(&self, heads: &[ChangeHash]) -> Option<Clock> {
+        if self.change_graph.heads_are_current(heads) {
+            None
+        } else {
+            Some(self.change_graph.clock_at(heads))
+        }
     }
 
     fn get_isolated_actor_index(&mut self, level: usize) -> usize {
@@ -1132,7 +1148,7 @@ impl Automerge {
 
     pub(crate) fn isolate_actor(&mut self, heads: &[ChangeHash]) -> Isolation {
         let mut actor_index = self.get_isolated_actor_index(0);
-        let mut clock = self.clock_at(heads);
+        let mut clock = self.change_graph.clock_at(heads);
 
         for i in 1.. {
             let max_op = self.change_graph.max_op_for_actor(actor_index);
@@ -1141,7 +1157,8 @@ impl Automerge {
                 break;
             }
             actor_index = self.get_isolated_actor_index(i);
-            clock = self.clock_at(heads); // need to recompute the clock b/c the actor indexes may have changed
+            // need to recompute the clock b/c the actor indexes may have changed
+            clock = self.change_graph.clock_at(heads);
         }
 
         let seq = self.change_graph.seq_for_actor(actor_index) + 1;
@@ -1438,13 +1455,36 @@ impl Automerge {
         clock: Option<Clock>,
     ) -> Result<Vec<Mark>, AutomergeError> {
         let obj = self.exid_to_obj(obj.as_ref())?;
-        let mut top_ops = self.ops().top_ops(&obj.id, clock).marks();
 
         let Some(seq_type) = obj.typ.as_sequence_type() else {
             // Really we should return an error here but we don't in order to stay
             // compatibile with older implementations
             return Ok(Vec::new());
         };
+
+        // present-time text marks come straight from the mark and text
+        // indexes — no op materialization (the text index carries text
+        // widths, so lists still take the walk below)
+        if clock.is_none() && seq_type == SequenceType::Text {
+            let fast = self.ops().calculate_marks_fast(&obj.id);
+            #[cfg(feature = "slow_path_assertions")]
+            {
+                let slow = self.calculate_marks_slow(&obj, None, seq_type);
+                assert_eq!(fast, slow, "indexed marks != walked marks");
+            }
+            return Ok(fast);
+        }
+
+        Ok(self.calculate_marks_slow(&obj, clock, seq_type))
+    }
+
+    fn calculate_marks_slow(
+        &self,
+        obj: &crate::types::ObjMeta,
+        clock: Option<Clock>,
+        seq_type: SequenceType,
+    ) -> Vec<Mark> {
+        let mut top_ops = self.ops().top_ops(&obj.id, clock).marks();
 
         let mut index = 0;
         let mut acc = MarkAccumulator::default();
@@ -1470,11 +1510,11 @@ impl Automerge {
             Some(m) if mark_len > 0 => acc.add(mark_index, mark_len, m),
             _ => (),
         }
-        Ok(acc.into_iter_no_unmark().collect())
+        acc.into_iter_no_unmark().collect()
     }
 
     pub fn hydrate(&self, heads: Option<&[ChangeHash]>) -> hydrate::Value {
-        let clock = heads.map(|heads| self.clock_at(heads));
+        let clock = heads.and_then(|heads| self.clock_at(heads));
         self.hydrate_map(&ObjId::root(), clock.as_ref())
     }
 
@@ -1484,7 +1524,7 @@ impl Automerge {
         heads: Option<&[ChangeHash]>,
     ) -> Result<hydrate::Value, AutomergeError> {
         let obj = self.exid_to_obj(obj)?;
-        let clock = heads.map(|heads| self.clock_at(heads));
+        let clock = heads.and_then(|heads| self.clock_at(heads));
         Ok(match obj.typ {
             ObjType::Map | ObjType::Table => self.hydrate_map(&obj.id, clock.as_ref()),
             ObjType::List => self.hydrate_list(&obj.id, clock.as_ref()),
@@ -1895,7 +1935,7 @@ impl ReadDoc for Automerge {
         heads: &[ChangeHash],
     ) -> Result<Parents<'_>, AutomergeError> {
         let clock = self.clock_at(heads);
-        self.parents_for(obj.as_ref(), Some(clock))
+        self.parents_for(obj.as_ref(), clock)
     }
 
     fn keys<O: AsRef<ExId>>(&self, obj: O) -> Keys<'_> {
@@ -1904,12 +1944,12 @@ impl ReadDoc for Automerge {
 
     fn keys_at<O: AsRef<ExId>>(&self, obj: O, heads: &[ChangeHash]) -> Keys<'_> {
         let clock = self.clock_at(heads);
-        self.keys_for(obj.as_ref(), Some(clock))
+        self.keys_for(obj.as_ref(), clock)
     }
 
     fn iter_at<O: AsRef<ExId>>(&self, obj: O, heads: Option<&[ChangeHash]>) -> DocIter<'_> {
         //let obj = self.exid_to_obj(obj.as_ref()).unwrap();
-        let clock = heads.map(|heads| self.clock_at(heads));
+        let clock = heads.and_then(|heads| self.clock_at(heads));
         self.iter_for(obj.as_ref(), clock)
     }
 
@@ -1928,7 +1968,7 @@ impl ReadDoc for Automerge {
         heads: &[ChangeHash],
     ) -> MapRange<'a> {
         let clock = self.clock_at(heads);
-        self.map_range_for(obj.as_ref(), range, Some(clock))
+        self.map_range_for(obj.as_ref(), range, clock)
     }
 
     fn list_range<O: AsRef<ExId>, R: RangeBounds<usize>>(&self, obj: O, range: R) -> ListRange<'_> {
@@ -1942,7 +1982,7 @@ impl ReadDoc for Automerge {
         heads: &[ChangeHash],
     ) -> ListRange<'_> {
         let clock = self.clock_at(heads);
-        self.list_range_for(obj.as_ref(), range, Some(clock))
+        self.list_range_for(obj.as_ref(), range, clock)
     }
 
     fn values<O: AsRef<ExId>>(&self, obj: O) -> Values<'_> {
@@ -1951,7 +1991,7 @@ impl ReadDoc for Automerge {
 
     fn values_at<O: AsRef<ExId>>(&self, obj: O, heads: &[ChangeHash]) -> Values<'_> {
         let clock = self.clock_at(heads);
-        self.values_for(obj.as_ref(), Some(clock))
+        self.values_for(obj.as_ref(), clock)
     }
 
     fn length<O: AsRef<ExId>>(&self, obj: O) -> usize {
@@ -1960,7 +2000,7 @@ impl ReadDoc for Automerge {
 
     fn length_at<O: AsRef<ExId>>(&self, obj: O, heads: &[ChangeHash]) -> usize {
         let clock = self.clock_at(heads);
-        self.length_for(obj.as_ref(), Some(clock))
+        self.length_for(obj.as_ref(), clock)
     }
 
     fn text<O: AsRef<ExId>>(&self, obj: O) -> Result<String, AutomergeError> {
@@ -1977,7 +2017,7 @@ impl ReadDoc for Automerge {
         heads: &[ChangeHash],
     ) -> Result<Spans<'_>, AutomergeError> {
         let clock = self.clock_at(heads);
-        self.spans_for(obj.as_ref(), Some(clock))
+        self.spans_for(obj.as_ref(), clock)
     }
 
     fn get_cursor<O: AsRef<ExId>, I: Into<CursorPosition>>(
@@ -1986,7 +2026,7 @@ impl ReadDoc for Automerge {
         position: I,
         at: Option<&[ChangeHash]>,
     ) -> Result<Cursor, AutomergeError> {
-        let clock = at.map(|heads| self.clock_at(heads));
+        let clock = at.and_then(|heads| self.clock_at(heads));
         self.get_cursor_for(obj.as_ref(), position.into(), clock, MoveCursor::After)
     }
 
@@ -1997,7 +2037,7 @@ impl ReadDoc for Automerge {
         at: Option<&[ChangeHash]>,
         move_cursor: MoveCursor,
     ) -> Result<Cursor, AutomergeError> {
-        let clock = at.map(|heads| self.clock_at(heads));
+        let clock = at.and_then(|heads| self.clock_at(heads));
         self.get_cursor_for(obj.as_ref(), position.into(), clock, move_cursor)
     }
 
@@ -2007,7 +2047,7 @@ impl ReadDoc for Automerge {
         cursor: &Cursor,
         at: Option<&[ChangeHash]>,
     ) -> Result<usize, AutomergeError> {
-        let clock = at.map(|heads| self.clock_at(heads));
+        let clock = at.and_then(|heads| self.clock_at(heads));
         self.get_cursor_position_for(obj.as_ref(), cursor, clock)
     }
 
@@ -2017,7 +2057,7 @@ impl ReadDoc for Automerge {
         heads: &[ChangeHash],
     ) -> Result<String, AutomergeError> {
         let clock = self.clock_at(heads);
-        self.text_for(obj.as_ref(), Some(clock))
+        self.text_for(obj.as_ref(), clock)
     }
 
     fn marks<O: AsRef<ExId>>(&self, obj: O) -> Result<Vec<Mark>, AutomergeError> {
@@ -2030,7 +2070,7 @@ impl ReadDoc for Automerge {
         heads: &[ChangeHash],
     ) -> Result<Vec<Mark>, AutomergeError> {
         let clock = self.clock_at(heads);
-        self.marks_for(obj.as_ref(), Some(clock))
+        self.marks_for(obj.as_ref(), clock)
     }
 
     fn hydrate<O: AsRef<ExId>>(
@@ -2039,7 +2079,7 @@ impl ReadDoc for Automerge {
         heads: Option<&[ChangeHash]>,
     ) -> Result<hydrate::Value, AutomergeError> {
         let obj = self.exid_to_obj(obj.as_ref())?;
-        let clock = heads.map(|h| self.clock_at(h));
+        let clock = heads.and_then(|h| self.clock_at(h));
         Ok(match obj.typ {
             ObjType::List => self.hydrate_list(&obj.id, clock.as_ref()),
             ObjType::Text => self.hydrate_text(&obj.id, clock.as_ref()),
@@ -2053,7 +2093,7 @@ impl ReadDoc for Automerge {
         index: usize,
         heads: Option<&[ChangeHash]>,
     ) -> Result<MarkSet, AutomergeError> {
-        let clock = heads.map(|h| self.clock_at(h));
+        let clock = heads.and_then(|h| self.clock_at(h));
         self.get_marks_for(obj.as_ref(), index, clock)
     }
 
@@ -2071,7 +2111,7 @@ impl ReadDoc for Automerge {
         prop: P,
         heads: &[ChangeHash],
     ) -> Result<Option<(Value<'_>, ExId)>, AutomergeError> {
-        let clock = Some(self.clock_at(heads));
+        let clock = self.clock_at(heads);
         self.get_for(obj.as_ref(), prop.into(), clock)
     }
 
@@ -2089,7 +2129,7 @@ impl ReadDoc for Automerge {
         prop: P,
         heads: &[ChangeHash],
     ) -> Result<Vec<(Value<'_>, ExId)>, AutomergeError> {
-        let clock = Some(self.clock_at(heads));
+        let clock = self.clock_at(heads);
         self.get_all_for(obj.as_ref(), prop.into(), clock)
     }
 

--- a/rust/automerge/src/automerge.rs
+++ b/rust/automerge/src/automerge.rs
@@ -1121,13 +1121,6 @@ impl Automerge {
     /// Returns `None` — an unscoped read of the present document — when
     /// `heads` is exactly the current heads, so `*_at(doc.get_heads())`
     /// takes the same indexed fast paths as the un-suffixed methods.
-    ///
-    /// The shortcut is sound here because pending transaction ops enter
-    /// the op set before the graph's heads advance, and an `Automerge`
-    /// cannot be read through `&self` while a transaction holds it
-    /// mutably. Anything reading *around* an in-flight transaction
-    /// (`AutoCommit`, the transaction types) — or needing a concrete
-    /// clock — must use [`ChangeGraph::clock_at`] instead.
     pub(crate) fn clock_at(&self, heads: &[ChangeHash]) -> Option<Clock> {
         if self.change_graph.heads_are_current(heads) {
             None

--- a/rust/automerge/src/change_graph.rs
+++ b/rust/automerge/src/change_graph.rs
@@ -127,6 +127,17 @@ impl ChangeGraph {
         self.heads.iter().cloned()
     }
 
+    /// Whether `heads` is exactly the set of current heads (order and
+    /// duplicates ignored).
+    pub(crate) fn heads_are_current(&self, heads: &[ChangeHash]) -> bool {
+        // duplicates can only shrink the set, so fewer entries than heads
+        // can never match
+        if heads.len() < self.heads.len() {
+            return false;
+        }
+        heads.iter().copied().collect::<BTreeSet<_>>() == self.heads
+    }
+
     pub(crate) fn head_indexes(&self) -> impl Iterator<Item = u64> + '_ {
         self.heads
             .iter()
@@ -767,7 +778,7 @@ impl ChangeGraph {
             .collect()
     }
 
-    pub(crate) fn clock_for_heads(&self, heads: &[ChangeHash]) -> Clock {
+    pub(crate) fn clock_at(&self, heads: &[ChangeHash]) -> Clock {
         let nodes = self.heads_to_nodes(heads);
         self.calculate_clock(nodes)
             .iter()

--- a/rust/automerge/src/iter/spans.rs
+++ b/rust/automerge/src/iter/spans.rs
@@ -2,7 +2,7 @@ use crate::clock::{Clock, ClockRange};
 use crate::hydrate::Value;
 use crate::iter::tools::{Diff, DiffIter, Unshift};
 use crate::marks::{MarkSet, MarkSetIter, MarkStateMachine};
-use crate::op_set2::op_set::{ActionValueIter, MarkInfoIter, OpIdIter, OpSet, SkipToTopIter};
+use crate::op_set2::op_set::{ActionValueIter, MarkInfoIter, OpIdIter, OpSet, TopIter};
 use crate::op_set2::types::{Action, MarkData, ScalarValue};
 use crate::patches::PatchLog;
 use crate::types::{ObjId, OpId, TextEncoding};
@@ -45,17 +45,17 @@ impl SpanDiff {
     }
 }
 
-// The DiffIter/SkipToTopIter iterators use the top index to jump  from one top
+// The DiffIter/TopIter iterators use the top index to jump  from one top
 // op to the next while generating a diff. In many cases this is unnecessary
 // overhead as every op in the range being iterated is already top. In this
-// case we avoid the overhead of SkipToTopIter and stream action/value columns
+// case we avoid the overhead of TopIter and stream action/value columns
 // directly.
 #[derive(Debug, Clone)]
 // Boxing the variants leads to losing a few milliseconds on some iteration benchmarks
 #[expect(clippy::large_enum_variant)]
 enum SpansActionValue<'a> {
     Current(Unshift<ActionValueIter<'a>>),
-    Diff(Unshift<DiffIter<'a, ActionValueIter<'a>, SkipToTopIter<'a>>>),
+    Diff(Unshift<DiffIter<'a, ActionValueIter<'a>, TopIter<'a>>>),
 }
 
 impl Default for SpansActionValue<'_> {

--- a/rust/automerge/src/iter/tools.rs
+++ b/rust/automerge/src/iter/tools.rs
@@ -1,6 +1,6 @@
 use crate::clock::ClockRange;
 use crate::exid::ExId;
-use crate::op_set2::op_set::{SkipToTopIter, VisIter};
+use crate::op_set2::op_set::{TopIter, VisIter};
 use crate::op_set2::OpSet;
 use crate::types::OpId;
 
@@ -61,6 +61,55 @@ pub(crate) trait Skipper: Iterator<Item = usize> {}
 
 pub(crate) trait Shiftable: Iterator + Debug {
     fn shift_next(&mut self, _range: Range<usize>) -> Option<<Self as Iterator>::Item>;
+}
+
+/// A peekable iterator that also supports repositioning.
+///
+/// Unlike [`std::iter::Peekable`] the lookahead can be discarded: [`Self::shift`]
+/// repositions the inner iterator to a new range and stores the first item
+/// of that range as the new lookahead.
+#[derive(Clone, Debug, Default)]
+pub(crate) struct PeekShift<I: Iterator> {
+    iter: I,
+    peeked: Option<I::Item>,
+}
+
+impl<I: Iterator> PeekShift<I> {
+    pub(crate) fn new(iter: I) -> Self {
+        Self { iter, peeked: None }
+    }
+
+    pub(crate) fn peek(&mut self) -> Option<&I::Item> {
+        if self.peeked.is_none() {
+            self.peeked = self.iter.next();
+        }
+        self.peeked.as_ref()
+    }
+
+    /// The next item if it satisfies `f`, leaving it as the lookahead
+    /// otherwise.
+    pub(crate) fn next_if(&mut self, f: impl FnOnce(&I::Item) -> bool) -> Option<I::Item> {
+        match self.peek() {
+            Some(item) if f(item) => self.peeked.take(),
+            _ => None,
+        }
+    }
+}
+
+impl<I: Iterator + Shiftable> PeekShift<I> {
+    /// Reposition to `range`, discarding the current lookahead; the first
+    /// item of the new range (if any) becomes the lookahead.
+    pub(crate) fn shift(&mut self, range: Range<usize>) {
+        self.peeked = self.iter.shift_next(range);
+    }
+}
+
+impl<I: Iterator> Iterator for PeekShift<I> {
+    type Item = I::Item;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.peeked.take().or_else(|| self.iter.next())
+    }
 }
 
 #[derive(Debug)]
@@ -367,15 +416,13 @@ impl<'a> DiffSkipper<VisIter<'a>> {
     }
 }
 
-impl<'a> DiffSkipper<SkipToTopIter<'a>> {
+impl<'a> DiffSkipper<TopIter<'a>> {
     fn new_top(op_set: &'a OpSet, clock: ClockRange, range: Range<usize>) -> Self {
         match clock {
-            ClockRange::Current(clock) => {
-                DiffSkipper::Current(SkipToTopIter::new(op_set, clock, range))
-            }
+            ClockRange::Current(clock) => DiffSkipper::Current(TopIter::new(op_set, clock, range)),
             ClockRange::Diff(before, after) => {
-                let before = SkipToTopIter::new(op_set, Some(before), range.clone());
-                let after = SkipToTopIter::new(op_set, Some(after), range);
+                let before = TopIter::new(op_set, Some(before), range.clone());
+                let after = TopIter::new(op_set, Some(after), range);
                 DiffSkipper::Diff(PastSkipper::new(before, after))
             }
         }
@@ -513,7 +560,7 @@ impl<'a, I: Iterator + Debug + Clone> DiffIter<'a, I, VisIter<'a>> {
     }
 }
 
-impl<'a, I: Iterator + Debug + Clone> DiffIter<'a, I, SkipToTopIter<'a>> {
+impl<'a, I: Iterator + Debug + Clone> DiffIter<'a, I, TopIter<'a>> {
     pub(crate) fn new_top(
         op_set: &'a OpSet,
         iter: I,

--- a/rust/automerge/src/op_set2/op_set.rs
+++ b/rust/automerge/src/op_set2/op_set.rs
@@ -22,6 +22,7 @@ use super::types::{Action, ActorIdx, KeyRef, MarkData, OpType, ScalarValue};
 use hexane::PackError;
 use itertools::Itertools;
 
+use std::borrow::Cow;
 use std::cmp::Ordering;
 use std::num::NonZeroUsize;
 use std::ops::{Range, RangeBounds};
@@ -50,7 +51,7 @@ pub(crate) use op_iter::{
     OpIter, ReadOpError, SuccIterIter, SuccWalker, ValueIter,
 };
 pub(crate) use op_query::{FixCounters, OpQuery, OpQueryTerm};
-pub(crate) use top_op::{SkipToTopIter, TopOps};
+pub(crate) use top_op::{TopIter, TopOps};
 pub(crate) use visible::{VisIter, VisibleOpIter};
 
 pub(crate) type InsertAcc<'a> = hexane::PrefixIter<'a, bool>;
@@ -923,21 +924,6 @@ impl OpSet {
                 .is_some_and(|delta| delta.delta == range.len())
     }
 
-    pub(crate) fn obj_id_iter_range(&self, range: &Range<usize>) -> ObjIdIter<'_> {
-        ObjIdIter::new_range(
-            self.cols.obj_actor.iter_range(range.clone()),
-            self.cols.obj_ctr.iter_range(range.clone()),
-        )
-    }
-
-    pub(crate) fn key_iter_range(&self, range: &Range<usize>) -> KeyIter<'_> {
-        KeyIter::new(
-            self.cols.key_str.iter_range(range.clone()),
-            self.cols.key_actor.iter_range(range.clone()),
-            self.cols.key_ctr.iter_range(range.clone()),
-        )
-    }
-
     pub(crate) fn key_str_iter_range(
         &self,
         range: &Range<usize>,
@@ -957,12 +943,104 @@ impl OpSet {
         SkipIter::new(iter, vis)
     }
 
-    pub(crate) fn text(&self, obj: &ObjId, clock: Option<Clock>) -> String {
-        let mut text = String::new();
-        for op in self.top_ops(obj, clock) {
-            text.push_str(op.as_str());
+    /// Like [`Self::action_value_iter`] but yielding only each element's
+    /// top (winning, visible) op — one item per element, so a conflicted
+    /// text position contributes a single character.
+    pub(crate) fn action_value_top_iter(
+        &self,
+        range: Range<usize>,
+        clock: Option<Clock>,
+    ) -> SkipIter<ActionValueIter<'_>, TopIter<'_>> {
+        let value = self.value_iter_range(&range);
+        let action = self.action_iter_range(&range);
+        let top = TopIter::new(self, clock, range);
+        let iter = ActionValueIter::new(action, value);
+        SkipIter::new(iter, top)
+    }
+
+    /// Present-time marks for a text object, read straight from the mark
+    /// and text indexes: mark boundaries are the mark index's non-null
+    /// entries and span widths come from the text index's prefix sums, so
+    /// no ops are materialized. O(boundaries x log n) plus a run-level walk
+    /// of the mark index column.
+    pub(crate) fn calculate_marks_fast(&self, obj: &ObjId) -> Vec<crate::marks::Mark> {
+        use super::op_set::mark_index::MarkIdx;
+        use crate::marks::MarkAccumulator;
+
+        let mut acc = MarkAccumulator::default();
+        if !self.cols.index.mark.has_any_marks() {
+            return vec![];
         }
-        text
+        let range = self.scope_to_obj(obj);
+        let text = &self.cols.index.text;
+        // Sequence positions are exclusive prefix sums of the text index.
+        // Boundaries arrive in ascending position order, so one forward
+        // width iterator serves them all in O(1) amortized per boundary
+        // (`get_prefix` per boundary would be O(log n) each); `pv.prefix()`
+        // is the absolute exclusive prefix at the landed position, and the
+        // iterator's construction already computed the base prefix.
+        let mut widths = text.iter_range(range.clone());
+        let base = widths.total();
+        let mut widths_at = range.start;
+
+        let mut state = RichTextQueryState::default();
+        let mut seg: Option<(usize, std::sync::Arc<MarkSet>)> = None;
+        let mut iter = self.cols.index.mark.iter_range(range.clone());
+        let mut pos = range.start;
+        while let Some(run) = iter.next_run() {
+            let Some(idx) = run.value else {
+                pos += run.count;
+                continue;
+            };
+            // distinct op ids make runs of identical Some values length 1,
+            // but stay honest about the count anyway
+            for _ in 0..run.count {
+                let seek = widths
+                    .delta_nth(pos - widths_at)
+                    .expect("mark boundary lies within the text index");
+                widths_at = pos + 1;
+                let seq = (seek.pv.prefix() - base) as usize;
+                if let Some((start, set)) = seg.take() {
+                    if seq > start {
+                        acc.add(start, seq - start, &set);
+                    }
+                }
+                match idx {
+                    MarkIdx::Start(id) => {
+                        if let Some(data) = self.cols.index.mark.mark_data(&id) {
+                            state.map.insert(id, data.clone());
+                        }
+                    }
+                    MarkIdx::End(id) => {
+                        state.map.remove(&id);
+                    }
+                }
+                if let Some(set) = MarkSet::from_query_state(&state) {
+                    seg = Some((seq, set));
+                }
+                pos += 1;
+            }
+        }
+        if let Some((start, set)) = seg {
+            let end = (text.get_prefix(range.end) - base) as usize;
+            if end > start {
+                acc.add(start, end - start, &set);
+            }
+        }
+        acc.into_iter_no_unmark().collect()
+    }
+
+    pub(crate) fn text(&self, obj: &ObjId, clock: Option<Clock>) -> String {
+        // only the action and value columns are needed: the `TopIter`
+        // skipper jumps between top ops without materializing full ops
+        let range = self.scope_to_obj(obj);
+        self.action_value_top_iter(range, clock)
+            .map(|(action, value, _)| match (action, value) {
+                (Action::Set, ScalarValue::Str(s)) => s,
+                (Action::Mark, _) => Cow::Borrowed(""),
+                (_, _) => Cow::Borrowed("\u{fffc}"),
+            })
+            .collect()
     }
 
     pub(crate) fn id_to_exid(&self, id: OpId) -> ExId {

--- a/rust/automerge/src/op_set2/op_set.rs
+++ b/rust/automerge/src/op_set2/op_set.rs
@@ -958,11 +958,6 @@ impl OpSet {
         SkipIter::new(iter, top)
     }
 
-    /// Present-time marks for a text object, read straight from the mark
-    /// and text indexes: mark boundaries are the mark index's non-null
-    /// entries and span widths come from the text index's prefix sums, so
-    /// no ops are materialized. O(boundaries x log n) plus a run-level walk
-    /// of the mark index column.
     pub(crate) fn calculate_marks_fast(&self, obj: &ObjId) -> Vec<crate::marks::Mark> {
         use super::op_set::mark_index::MarkIdx;
         use crate::marks::MarkAccumulator;
@@ -973,12 +968,10 @@ impl OpSet {
         }
         let range = self.scope_to_obj(obj);
         let text = &self.cols.index.text;
-        // Sequence positions are exclusive prefix sums of the text index.
-        // Boundaries arrive in ascending position order, so one forward
-        // width iterator serves them all in O(1) amortized per boundary
-        // (`get_prefix` per boundary would be O(log n) each); `pv.prefix()`
-        // is the absolute exclusive prefix at the landed position, and the
-        // iterator's construction already computed the base prefix.
+        // Sequence positions are exclusive prefix sums of the text index (which
+        // tracks text widths). Boundaries arrive in ascending position order,
+        // so one forward width iterator serves them all in O(1) amortized per
+        // boundary.
         let mut widths = text.iter_range(range.clone());
         let base = widths.total();
         let mut widths_at = range.start;

--- a/rust/automerge/src/op_set2/op_set/mark_index.rs
+++ b/rust/automerge/src/op_set2/op_set/mark_index.rs
@@ -234,6 +234,23 @@ impl MarkIndexColumn {
         self.data.values().iter()
     }
 
+    pub(crate) fn iter_range(
+        &self,
+        range: std::ops::Range<usize>,
+    ) -> hexane::Iter<'_, Option<MarkIdx>> {
+        self.data.values().iter_range(range)
+    }
+
+    /// Whether any mark exists anywhere in the document: the cache holds
+    /// the [`MarkData`] of every live mark-begin op.
+    pub(crate) fn has_any_marks(&self) -> bool {
+        !self.cache.is_empty()
+    }
+
+    pub(crate) fn mark_data(&self, id: &OpId) -> Option<&MarkData<'static>> {
+        self.cache.get(id)
+    }
+
     pub(crate) fn rewrite_with_new_actor(&mut self, idx: usize) {
         let new_values: Vec<Option<MarkIdx>> = self
             .data

--- a/rust/automerge/src/op_set2/op_set/top_op.rs
+++ b/rust/automerge/src/op_set2/op_set/top_op.rs
@@ -1,13 +1,15 @@
 use crate::clock::Clock;
-use crate::iter::tools::{BoolColumnSkipper, Shiftable, SkipIter, Skipper};
+use crate::iter::tools::{BoolColumnSkipper, PeekShift, Shiftable, SkipIter, Skipper};
 use crate::marks::MarkSet;
 use crate::op_set2::op::SuccCursors;
-use crate::op_set2::types::{Action, KeyRef};
-use crate::types::{ElemId, ObjId, OpId};
+use crate::op_set2::types::Action;
+#[cfg(feature = "slow_path_assertions")]
+use crate::types::ObjId;
+use crate::types::OpId;
 
 use super::{
-    ActionIter, FixCounters, InsertIter, KeyIter, ObjIdIter, OpIdIter, OpIter, OpQueryTerm, OpSet,
-    SuccIterIter, VisIter,
+    ActionIter, FixCounters, InsertIter, OpIdIter, OpIter, OpQueryTerm, OpSet, SuccIterIter,
+    VisIter,
 };
 
 use std::ops::Range;
@@ -15,7 +17,7 @@ use std::sync::Arc;
 
 #[derive(Clone, Debug)]
 pub(crate) struct TopOps<'a> {
-    inner: FixCounters<'a, SkipIter<OpIter<'a>, SkipToTopIter<'a>>>,
+    inner: FixCounters<'a, SkipIter<OpIter<'a>, TopIter<'a>>>,
     visible: VisIter<'a>,
     visible_pos: usize,
 }
@@ -26,7 +28,7 @@ impl<'a> TopOps<'a> {
         let visible = VisIter::new(op_set, clock.as_ref(), range.clone());
         let iter = SkipIter::new(
             op_set.iter_range(&range),
-            SkipToTopIter::new(op_set, clock.clone(), range),
+            TopIter::new(op_set, clock.clone(), range),
         );
         let inner = FixCounters::new(iter, clock);
         Self {
@@ -141,56 +143,60 @@ impl<'a, I: Iterator<Item = super::Op<'a>>> Iterator for SlowTopOpIter<'a, I> {
     }
 }
 
-/// An iterator which returns runs of non-top ops, this can be used with a
-/// SkipIter to skip to the next top op
+/// The `top` twin of [`VisIter`]: a [`Skipper`] which yields runs of
+/// non-top ops so a `SkipIter` can jump from one top op (each element's
+/// winning, visible op) to the next.
+///
+/// Like [`VisIter`] it comes in two flavors: `Current` reads the `top`
+/// index column directly, `Scan` recomputes topness under a historical
+/// [`Clock`] from the cheap columns only.
+///
+/// The range must be scoped to a single object: the scan flavor detects
+/// group boundaries from inserts and `key_str` changes alone, which cannot
+/// distinguish equal map keys across an object boundary.
 #[derive(Clone, Debug)]
-pub(crate) struct SkipToTopIter<'a> {
+pub(crate) struct TopIter<'a> {
     range: Range<usize>,
-    clock: Option<Clock>,
     cursor: usize,
     exhausted: bool,
-    inner: SkipToTopIterInner<'a>,
+    inner: TopIterInner<'a>,
 }
 
 #[derive(Clone, Debug)]
-enum SkipToTopIterInner<'a> {
+enum TopIterInner<'a> {
     Empty,
     Current(BoolColumnSkipper<'a>),
-    Scan {
-        iter: Box<TopScanIter<'a>>,
-        buffered: Option<Box<TopScanRow<'a>>>,
-    },
+    // peekable because the row which terminates one group is the first
+    // row of the next
+    Scan(Box<PeekShift<ScanTopIter<'a>>>),
 }
 
-impl Default for SkipToTopIter<'_> {
+impl Default for TopIter<'_> {
     fn default() -> Self {
         Self {
             range: 0..0,
-            clock: None,
             cursor: 0,
             exhausted: true,
-            inner: SkipToTopIterInner::Empty,
+            inner: TopIterInner::Empty,
         }
     }
 }
 
-impl<'a> SkipToTopIter<'a> {
+impl<'a> TopIter<'a> {
     pub(crate) fn new(op_set: &'a OpSet, clock: Option<Clock>, range: Range<usize>) -> Self {
         let cursor = range.start;
-        let inner = if clock.is_some() {
-            SkipToTopIterInner::Scan {
-                iter: Box::new(TopScanIter::new(op_set, &range)),
-                buffered: None,
-            }
+        let inner = if let Some(clock) = clock {
+            TopIterInner::Scan(Box::new(PeekShift::new(ScanTopIter::new(
+                op_set, clock, &range,
+            ))))
         } else {
-            SkipToTopIterInner::Current(BoolColumnSkipper::new(
+            TopIterInner::Current(BoolColumnSkipper::new(
                 op_set.top_index_range(&range),
                 range.clone(),
             ))
         };
         Self {
             range,
-            clock,
             cursor,
             exhausted: false,
             inner,
@@ -198,20 +204,19 @@ impl<'a> SkipToTopIter<'a> {
     }
 }
 
-impl Skipper for SkipToTopIter<'_> {}
+impl Skipper for TopIter<'_> {}
 
-impl Shiftable for SkipToTopIter<'_> {
+impl Shiftable for TopIter<'_> {
     fn shift_next(&mut self, range: Range<usize>) -> Option<<Self as Iterator>::Item> {
         self.cursor = range.start;
         self.range = range.clone();
         self.exhausted = false;
         match &mut self.inner {
-            SkipToTopIterInner::Empty => None,
-            SkipToTopIterInner::Current(iter) => iter.shift_next(range),
-            SkipToTopIterInner::Scan { iter, buffered } => {
-                *buffered = None;
-                if let Some(first) = iter.shift_next(range.clone()) {
-                    *buffered = Some(Box::new(first));
+            TopIterInner::Empty => None,
+            TopIterInner::Current(iter) => iter.shift_next(range),
+            TopIterInner::Scan(iter) => {
+                iter.shift(range.clone());
+                if iter.peek().is_some() {
                     self.next()
                 } else {
                     self.exhausted = true;
@@ -222,7 +227,7 @@ impl Shiftable for SkipToTopIter<'_> {
     }
 }
 
-impl Iterator for SkipToTopIter<'_> {
+impl Iterator for TopIter<'_> {
     type Item = usize;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -230,63 +235,54 @@ impl Iterator for SkipToTopIter<'_> {
             return None;
         }
         match &mut self.inner {
-            SkipToTopIterInner::Empty => None,
-            SkipToTopIterInner::Current(iter) => iter.next(),
-            SkipToTopIterInner::Scan { iter, buffered } => {
-                let clock = self.clock.as_ref();
-                loop {
-                    let Some(first) = buffered.take().or_else(|| iter.next().map(Box::new)) else {
-                        self.exhausted = true;
-                        let skip = self.range.end.saturating_sub(self.cursor);
-                        self.cursor = self.range.end.saturating_add(1);
-                        return Some(skip);
-                    };
-                    let obj = first.obj;
-                    let key = first.key.clone();
-                    let mut top = if first.is_visible(clock) {
-                        Some(first.pos)
-                    } else {
-                        None
-                    };
-
-                    for row in iter.by_ref() {
-                        if row.obj != obj || row.key != key {
-                            *buffered = Some(Box::new(row));
-                            break;
-                        }
-                        if row.is_visible(clock) {
-                            top = Some(row.pos);
-                        }
-                    }
-
-                    if let Some(pos) = top {
-                        let skip = pos.checked_sub(self.cursor)?;
-                        self.cursor = pos + 1;
-                        return Some(skip);
+            TopIterInner::Empty => None,
+            TopIterInner::Current(iter) => iter.next(),
+            TopIterInner::Scan(iter) => loop {
+                let Some(first) = iter.next() else {
+                    self.exhausted = true;
+                    let skip = self.range.end.saturating_sub(self.cursor);
+                    self.cursor = self.range.end.saturating_add(1);
+                    return Some(skip);
+                };
+                // a group is one map key or one list element; its ops are
+                // contiguous, and the next group starts at the next insert
+                // op (list element or mark) or `key_str` change (map key)
+                let group_key = first.key_str;
+                let mut top = first.visible.then_some(first.pos);
+                while let Some(row) = iter.next_if(|r| !r.insert && r.key_str == group_key) {
+                    if row.visible {
+                        top = Some(row.pos);
                     }
                 }
-            }
+                if let Some(pos) = top {
+                    let skip = pos.checked_sub(self.cursor)?;
+                    self.cursor = pos + 1;
+                    return Some(skip);
+                }
+            },
         }
     }
 }
 
+/// The columns [`TopIter`]'s scan flavor needs: `insert` and `key_str` for
+/// group boundaries, `id`/`action`/`succ` for visibility under the clock.
 #[derive(Clone, Debug)]
-struct TopScanIter<'a> {
+struct ScanTopIter<'a> {
     pos: usize,
-    obj: ObjIdIter<'a>,
-    key: KeyIter<'a>,
+    clock: Clock,
+    key_str: hexane::Iter<'a, Option<String>>,
     id: OpIdIter<'a>,
     insert: InsertIter<'a>,
     action: ActionIter<'a>,
     succ: SuccIterIter<'a>,
 }
 
-impl<'a> TopScanIter<'a> {
-    fn new(op_set: &'a OpSet, range: &Range<usize>) -> Self {
+impl<'a> ScanTopIter<'a> {
+    fn new(op_set: &'a OpSet, clock: Clock, range: &Range<usize>) -> Self {
         Self {
             pos: range.start,
-            obj: op_set.obj_id_iter_range(range),
-            key: op_set.key_iter_range(range),
+            clock,
+            key_str: op_set.key_str_iter_range(range),
             id: op_set.id_iter_range(range),
             insert: op_set.insert_iter_range(range),
             action: op_set.action_iter_range(range),
@@ -294,75 +290,71 @@ impl<'a> TopScanIter<'a> {
         }
     }
 
-    fn row_at(&mut self, pos: usize) -> Option<TopScanRow<'a>> {
-        let id = self.id.next()?;
-        let key = self.key.next()?;
-        let key = if self.insert.next()? {
-            KeyRef::Seq(ElemId(id))
-        } else {
-            key
-        };
-        Some(TopScanRow {
+    fn row(
+        &mut self,
+        pos: usize,
+        id: OpId,
+        key_str: Option<&'a str>,
+        insert: bool,
+        action: Action,
+        succ: SuccCursors<'a>,
+    ) -> ScanTopRow<'a> {
+        let visible = is_visible(id, action, succ, &self.clock);
+        ScanTopRow {
             pos,
-            obj: self.obj.next()?,
-            key,
-            id,
-            action: self.action.next()?,
-            succ: self.succ.next()?,
-        })
-    }
-
-    fn shift_next(&mut self, range: Range<usize>) -> Option<TopScanRow<'a>> {
-        let pos = range.start;
-        self.pos = pos + 1;
-        let id = self.id.shift_next(range.clone())?;
-        let key = self.key.shift_next(range.clone())?;
-        let key = if self.insert.shift_next(range.clone())? {
-            KeyRef::Seq(ElemId(id))
-        } else {
-            key
-        };
-        Some(TopScanRow {
-            pos,
-            obj: self.obj.shift_next(range.clone())?,
-            key,
-            id,
-            action: self.action.shift_next(range.clone())?,
-            succ: self.succ.shift_next(range)?,
-        })
+            insert,
+            key_str,
+            visible,
+        }
     }
 }
 
-impl<'a> Iterator for TopScanIter<'a> {
-    type Item = TopScanRow<'a>;
+impl<'a> Shiftable for ScanTopIter<'a> {
+    fn shift_next(&mut self, range: Range<usize>) -> Option<ScanTopRow<'a>> {
+        let pos = range.start;
+        self.pos = pos + 1;
+        let id = self.id.shift_next(range.clone())?;
+        let key_str = self.key_str.shift_next(range.clone())?;
+        let insert = self.insert.shift_next(range.clone())?;
+        let action = self.action.shift_next(range.clone())?;
+        let succ = self.succ.shift_next(range)?;
+        Some(self.row(pos, id, key_str, insert, action, succ))
+    }
+}
+
+impl<'a> Iterator for ScanTopIter<'a> {
+    type Item = ScanTopRow<'a>;
 
     fn next(&mut self) -> Option<Self::Item> {
         let pos = self.pos;
         self.pos += 1;
-        self.row_at(pos)
+        let id = self.id.next()?;
+        let key_str = self.key_str.next()?;
+        let insert = self.insert.next()?;
+        let action = self.action.next()?;
+        let succ = self.succ.next()?;
+        Some(self.row(pos, id, key_str, insert, action, succ))
     }
 }
 
+/// One op reduced to what topness needs: where its group starts and
+/// whether it is visible.
 #[derive(Clone, Debug)]
-struct TopScanRow<'a> {
+struct ScanTopRow<'a> {
     pos: usize,
-    obj: ObjId,
-    key: KeyRef<'a>,
-    id: OpId,
-    action: Action,
-    succ: SuccCursors<'a>,
+    insert: bool,
+    key_str: Option<&'a str>,
+    visible: bool,
 }
 
-impl TopScanRow<'_> {
-    fn is_visible(&self, clock: Option<&Clock>) -> bool {
-        if self.action == Action::Increment || clock.is_some_and(|clock| !clock.covers(&self.id)) {
+fn is_visible(id: OpId, action: Action, succ: SuccCursors<'_>, clock: &Clock) -> bool {
+    if action == Action::Increment || !clock.covers(&id) {
+        return false;
+    }
+    for (id, inc) in succ.with_inc() {
+        if inc.is_none() && clock.covers(&id) {
             return false;
         }
-        for (id, inc) in self.succ.clone().with_inc() {
-            if inc.is_none() && clock.map(|clock| clock.covers(&id)).unwrap_or(true) {
-                return false;
-            }
-        }
-        true
     }
+    true
 }

--- a/rust/automerge/src/patches/patch_log.rs
+++ b/rust/automerge/src/patches/patch_log.rs
@@ -508,7 +508,7 @@ impl PatchLog {
     }
 
     fn make_current_patches(&mut self, doc: &Automerge) -> Vec<Patch> {
-        let clock = self.heads.as_ref().map(|h| doc.clock_at(h));
+        let clock = self.heads.as_ref().map(|h| doc.change_graph.clock_at(h));
         let path_map = self.get_path_map();
         let text_encoding = doc.text_encoding();
         self.events

--- a/rust/automerge/src/transaction/manual_transaction.rs
+++ b/rust/automerge/src/transaction/manual_transaction.rs
@@ -112,7 +112,10 @@ impl Transaction<'_> {
 
     fn get_scope(&self, heads: Option<&[ChangeHash]>) -> Option<crate::types::Clock> {
         if let Some(h) = heads {
-            Some(self.doc.clock_at(h))
+            // a transaction is in flight: its pending ops are in the op set
+            // but not under the graph's heads, so the current-heads
+            // shortcut in `scope_at` would wrongly expose them
+            Some(self.doc.change_graph.clock_at(h))
         } else {
             self.inner.as_ref().and_then(|i| i.get_scope().clone())
         }

--- a/rust/automerge/src/transaction/owned_transaction.rs
+++ b/rust/automerge/src/transaction/owned_transaction.rs
@@ -105,7 +105,10 @@ impl OwnedTransaction {
 
     fn get_scope(&self, heads: Option<&[ChangeHash]>) -> Option<crate::types::Clock> {
         if let Some(h) = heads {
-            Some(self.doc.clock_at(h))
+            // a transaction is in flight: its pending ops are in the op set
+            // but not under the graph's heads, so the current-heads
+            // shortcut in `scope_at` would wrongly expose them
+            Some(self.doc.change_graph.clock_at(h))
         } else {
             self.inner.as_ref().and_then(|i| i.get_scope().clone())
         }

--- a/rust/hexane/src/prefix.rs
+++ b/rust/hexane/src/prefix.rs
@@ -796,6 +796,15 @@ impl<'a, T: PrefixValue> PrefixIter<'a, T> {
         self.inner.pos
     }
 
+    /// The running sum of everything consumed so far — equivalently, the
+    /// **exclusive** prefix of the next item to be yielded. Immediately
+    /// after [`PrefixColumn::iter_range`] this is the prefix at the
+    /// range's start, already paid for by the construction's tree descent.
+    #[inline]
+    pub fn total(&self) -> T::Prefix {
+        self.total.clone()
+    }
+
     #[inline]
     pub fn items_left(&self) -> usize {
         self.inner.items_left
@@ -957,6 +966,19 @@ impl<'a, T: PrefixValue> IntoIterator for &'a PrefixColumn<T> {
 #[cfg(test)]
 mod tests {
     use crate::prefix::PrefixColumn;
+
+    #[test]
+    fn iter_total_is_prefix_at_range_start() {
+        let values: Vec<u64> = (0..500).map(|i| i % 7).collect();
+        let col = PrefixColumn::<u64>::from_values(values);
+        for i in 0..=col.len() {
+            assert_eq!(
+                col.iter_range(i..col.len()).total(),
+                col.get_prefix(i),
+                "iter_range({i}..).total() != get_prefix({i})",
+            );
+        }
+    }
 
     fn parity_check(values: Vec<u64>) {
         let col = PrefixColumn::<u64>::from_values(values.clone());


### PR DESCRIPTION
There was a performance regression on text() - optimized it and a few other functions were fixed up with it.  Fixed a long standing bug where if heads were passed as an argument the slow path was used even if they equaled the current heads 