### PR TITLE
Use the updated `bijoux` lib with `i64` support

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -6,11 +6,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1709702368,
-        "narHash": "sha256-1YOPubkJ5M6HigdfN0gn0AZ3kx6MHboG9UbWpYpk3gM=",
+        "lastModified": 1767143937,
+        "narHash": "sha256-xs2Q4j5B5TRzGyqM+JMGXpWsXgaZnmPU3wWe04KjHOs=",
         "owner": "expede",
         "repo": "nix-command-utils",
-        "rev": "8f7179876383495b1f98311e53ebb41649ca270a",
+        "rev": "7fb663be6c86472a859231f40689f8482e5e3704",
         "type": "github"
       },
       "original": {
@@ -56,12 +56,11 @@
     },
     "nixos-unstable": {
       "locked": {
-        "lastModified": 1763333199,
-        "narHash": "sha256-vY+FWILo4v7FCLL2CgV02kppYxqJaR6U6kHQtzZdVGE=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "aaed8bfd0140fbc02afd559983cbab272939f5bf",
-        "type": "github"
+        "lastModified": 1784834273,
+        "narHash": "sha256-ARPrbHm5ReO4qHnxnIut1gGDz68gl2vyzUFTHenThz4=",
+        "rev": "7d4b60cc165478e9d2c87236a1740e09de951ded",
+        "type": "tarball",
+        "url": "https://releases.nixos.org/nixos/unstable-small/nixos-26.11pre1040699.7d4b60cc1654/nixexprs.tar.xz"
       },
       "original": {
         "id": "nixpkgs",
@@ -86,11 +85,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1763049705,
-        "narHash": "sha256-A5LS0AJZ1yDPTa2fHxufZN++n8MCmtgrJDtxFxrH4S8=",
+        "lastModified": 1767313136,
+        "narHash": "sha256-16KkgfdYqjaeRGBaYsNrhPRRENs0qzkQVUooNHtoy2w=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "3acb677ea67d4c6218f33de0db0955f116b7588c",
+        "rev": "ac62194c3917d5f474c1a844b6fd6da2db95077d",
         "type": "github"
       },
       "original": {
@@ -115,11 +114,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1763347184,
-        "narHash": "sha256-6QH8hpCYJxifvyHEYg+Da0BotUn03BwLIvYo3JAxuqQ=",
+        "lastModified": 1784784641,
+        "narHash": "sha256-F8/6twaXdW5dOHgLt1sO62fygfA3aKiYlEmnnIxzpTU=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "08895cce80433978d5bfd668efa41c5e24578cbd",
+        "rev": "19a19f3921ae195f2fbd85f5dc57e6d1df63aa0b",
         "type": "github"
       },
       "original": {

--- a/rust/hexane/Cargo.toml
+++ b/rust/hexane/Cargo.toml
@@ -15,13 +15,13 @@ bench = false
 [features]
 wasm = ["web-sys"]
 slow_path_assertions = []
-bijou64 = ["dep:bijou64"]
+bijou64 = ["dep:bijoux"]
 
 
 [dependencies]
 leb128 = "^0.2.5"
 thiserror = "^2.0.12"
-bijou64 = { version = "^0.2.1", optional = true }
+bijoux = { version = "^0.3.1", optional = true, default-features = false, features = ["u64", "i64"] }
 
 [dev-dependencies]
 proptest = { version = "^1.7", default-features = false, features = ["std"] }

--- a/rust/hexane/src/codec.rs
+++ b/rust/hexane/src/codec.rs
@@ -333,8 +333,8 @@ fn leb_bytes(bits: u64) -> u64 {
 // ── Bijou64 ─────────────────────────────────────────────────────────────────
 
 /// The [bijou64](https://github.com/inkandswitch/bijou) tag-byte codec
-/// (feature `bijou64`) — a thin [`Codec`] adapter over the `bijou64`
-/// crate, plus a zigzag mapping for signed values.
+/// (feature `bijou64`) — a thin [`Codec`] adapter over the `bijoux`
+/// crate's `u64`/`i64` formats.
 ///
 /// Unsigned values 0–247 encode as a single byte equal to the value;
 /// larger values use a tag byte `0xF8`–`0xFF` followed by 1–8 big-endian
@@ -349,10 +349,10 @@ fn leb_bytes(bits: u64) -> u64 {
 ///   bytes cannot be scanned backwards, which [`Codec`] already forbids
 ///   relying on.
 ///
-/// Signed values are zigzag-mapped (`(n << 1) ^ (n >> 63)`) onto the
-/// unsigned encoding.  Zigzag is itself a bijection, so canonicality is
-/// preserved; the 1-byte signed range is −124..=123 (vs LEB128's
-/// −64..=63).
+/// Signed values use the bijou64s format ([`bijoux::i64`]): zigzag
+/// (`(n << 1) ^ (n >> 63)`) composed with the unsigned encoding.  Zigzag
+/// is itself a bijection, so canonicality is preserved; the 1-byte
+/// signed range is −124..=123 (vs LEB128's −64..=63).
 ///
 /// [`unsigned_len`]: Codec::unsigned_len
 #[cfg(feature = "bijou64")]
@@ -364,33 +364,24 @@ mod bijou64_impl {
     use super::{Bijou64, Codec, VarBuf};
     use crate::PackError;
 
-    #[inline]
-    fn zigzag(n: i64) -> u64 {
-        ((n << 1) ^ (n >> 63)) as u64
-    }
-
-    #[inline]
-    fn unzigzag(z: u64) -> i64 {
-        ((z >> 1) as i64) ^ -((z & 1) as i64)
-    }
-
     impl Codec for Bijou64 {
         #[inline]
         fn encode_unsigned(n: u64) -> VarBuf {
-            let (bytes, len) = bijou64::encode_array(n);
             let mut out = VarBuf::new();
-            out.extend_from_slice(&bytes[..len]);
+            out.extend_from_slice(&bijoux::u64::encoded_bytes(n));
             out
         }
 
         #[inline]
         fn encode_signed(n: i64) -> VarBuf {
-            Self::encode_unsigned(zigzag(n))
+            let mut out = VarBuf::new();
+            out.extend_from_slice(&bijoux::i64::encoded_bytes(n));
+            out
         }
 
         #[inline]
         fn read_unsigned(data: &[u8]) -> Option<(usize, u64)> {
-            match bijou64::decode(data) {
+            match bijoux::u64::decode(data) {
                 Ok((v, n)) => Some((n, v)),
                 Err(_) => None,
             }
@@ -398,20 +389,24 @@ mod bijou64_impl {
 
         #[inline]
         fn read_signed(data: &[u8]) -> Option<(usize, i64)> {
-            let (n, z) = Self::read_unsigned(data)?;
-            Some((n, unzigzag(z)))
+            match bijoux::i64::decode(data) {
+                Ok((v, n)) => Some((n, v)),
+                Err(_) => None,
+            }
         }
 
         fn try_read_unsigned(data: &[u8]) -> Result<(usize, u64), PackError> {
-            match bijou64::decode(data) {
+            match bijoux::u64::decode(data) {
                 Ok((v, n)) => Ok((n, v)),
                 Err(e) => Err(PackError::InvalidValue(format!("bijou64: {e}"))),
             }
         }
 
         fn try_read_signed(data: &[u8]) -> Result<(usize, i64), PackError> {
-            let (n, z) = Self::try_read_unsigned(data)?;
-            Ok((n, unzigzag(z)))
+            match bijoux::i64::decode(data) {
+                Ok((v, n)) => Ok((n, v)),
+                Err(e) => Err(PackError::InvalidValue(format!("bijou64s: {e}"))),
+            }
         }
 
         /// Total length from the tag byte alone — no decode, no scan.
@@ -435,12 +430,12 @@ mod bijou64_impl {
 
         #[inline]
         fn unsigned_size(n: u64) -> u64 {
-            bijou64::encoded_len(n) as u64
+            bijoux::u64::encoded_len(n) as u64
         }
 
         #[inline]
         fn signed_size(n: i64) -> u64 {
-            bijou64::encoded_len(zigzag(n)) as u64
+            bijoux::i64::encoded_len(n) as u64
         }
     }
 }


### PR DESCRIPTION
Martin asked if we could add `i64` support to bijou64, and I used it as an opportunity to consolidate the crates. `bijoux` is the bijou varint crate going forward. I also landed on zigzag encoding over alternatives (looks like that's what you were already doing). Worth noting that twos compliment was often quite a bit faster but seriously increased the space required by negative numbers.