### PR TITLE
Add an  anonymizer

### DIFF
--- a/javascript/src/implementation.ts
+++ b/javascript/src/implementation.ts
@@ -341,6 +341,47 @@ export function clone<T>(
   return handle.applyPatches(doc, { ...stateSansHeads, handle })
 }
 
+/**
+ * Return a copy of an Automerge document with its private data anonymized.
+ *
+ * The complete change history is retained, but actor IDs, map keys, mark names,
+ * scalar values, change metadata, and extra bytes are replaced. The resulting
+ * document still exposes structural information including its change graph,
+ * object and value types, collection sizes, string lengths, and whitespace.
+ * Review the result before publishing it.
+ *
+ * The returned document has an unknown schema because its map keys and values
+ * no longer correspond to those of the input document.
+ */
+export function anonymize<T>(doc: Doc<T>): Doc<Record<string, unknown>> {
+  const state = _state(doc)
+  if (_is_proxy(doc)) {
+    throw new RangeError("Calls to Automerge.anonymize cannot be nested")
+  }
+  let source = state.handle
+  let temporarySource = false
+  if (state.heads !== undefined) {
+    source = state.handle.fork(undefined, state.heads)
+    temporarySource = true
+  }
+
+  let handle: Automerge
+  try {
+    handle = source.anonymize()
+  } finally {
+    if (temporarySource) {
+      source.free()
+    }
+  }
+
+  handle.enableFreeze(state.freeze)
+  return handle.materialize("/", undefined, {
+    handle,
+    heads: undefined,
+    freeze: state.freeze,
+  }) as Doc<Record<string, unknown>>
+}
+
 /** Explicity free the memory backing a document. Note that this is note
  * necessary in environments which support
  * [`FinalizationRegistry`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/FinalizationRegistry)

--- a/javascript/test/anonymize_test.ts
+++ b/javascript/test/anonymize_test.ts
@@ -1,0 +1,69 @@
+import { default as assert } from "assert"
+import * as Automerge from "../src/entrypoints/fullfat_node.js"
+
+describe("anonymize", () => {
+  it("returns a loadable document with anonymized data and matching history shape", () => {
+    let source = Automerge.from(
+      {
+        privateName: "Alice",
+        privateNotes: ["Monday meeting", "secret follow-up"],
+      },
+      { actor: "01020304" },
+    )
+    source = Automerge.change(
+      source,
+      { message: "private commit message", time: 1_700_000_000 },
+      doc => {
+        doc.privateName = "Bob"
+        doc.privateNotes.push("confidential")
+      },
+    )
+
+    const anonymized = Automerge.anonymize(source)
+
+    assert.deepStrictEqual(source, {
+      privateName: "Bob",
+      privateNotes: ["Monday meeting", "secret follow-up", "confidential"],
+    })
+    assert.notDeepStrictEqual(anonymized, source)
+    assert(!Object.keys(anonymized).includes("privateName"))
+    assert(!Object.keys(anonymized).includes("privateNotes"))
+
+    const sourceChanges = Automerge.getAllChanges(source).map(
+      Automerge.decodeChange,
+    )
+    const anonymizedChanges = Automerge.getAllChanges(anonymized).map(
+      Automerge.decodeChange,
+    )
+    assert.strictEqual(anonymizedChanges.length, sourceChanges.length)
+    assert.deepStrictEqual(
+      anonymizedChanges.map(change => change.ops.length),
+      sourceChanges.map(change => change.ops.length),
+    )
+    assert.deepStrictEqual(
+      anonymizedChanges.map(change => change.deps.length),
+      sourceChanges.map(change => change.deps.length),
+    )
+    for (const [changeIndex, sourceChange] of sourceChanges.entries()) {
+      for (const [opIndex, sourceOp] of sourceChange.ops.entries()) {
+        const anonymizedOp = anonymizedChanges[changeIndex].ops[opIndex]
+        if (
+          typeof sourceOp.value === "string" &&
+          sourceOp.value.trim().length > 0
+        ) {
+          assert.notStrictEqual(anonymizedOp.value, sourceOp.value)
+        }
+      }
+    }
+    assert(
+      anonymizedChanges.every(
+        (change, index) =>
+          sourceChanges[index].message === null ||
+          change.message !== sourceChanges[index].message,
+      ),
+    )
+
+    const reloaded = Automerge.load(Automerge.save(anonymized))
+    assert.deepStrictEqual(reloaded, anonymized)
+  })
+})

--- a/rust/automerge-cli/Cargo.toml
+++ b/rust/automerge-cli/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["Alex Good <alex@memoryandthought.me>"]
 edition = "2021"
 license = "MIT"
 rust-version = "1.90.0"
+readme = "README.md"
 
 [[bin]]
 name = "automerge"

--- a/rust/automerge-cli/README.md
+++ b/rust/automerge-cli/README.md
@@ -1,0 +1,13 @@
+# Automerge CLI
+
+## Anonymize a document
+
+The `anonymize` command replaces document data while retaining its history and structural shape:
+
+```sh
+cargo run -p automerge-cli -- anonymize input.automerge --out output.automerge
+```
+
+Input and output can instead be piped through stdin and stdout. The result still reveals metadata
+such as the change graph, object and value types, collection sizes, string lengths, and whitespace.
+Review it before publishing.

--- a/rust/automerge-cli/src/anonymize.rs
+++ b/rust/automerge-cli/src/anonymize.rs
@@ -1,0 +1,39 @@
+use std::collections::BTreeSet;
+use std::io::Read;
+
+use anyhow::{Context, Result};
+
+pub(crate) struct AnonymizedDocument {
+    pub(crate) bytes: Vec<u8>,
+    pub(crate) change_count: usize,
+    pub(crate) operation_count: usize,
+    pub(crate) actor_count: usize,
+}
+
+pub(crate) fn anonymize(mut input: impl Read) -> Result<AnonymizedDocument> {
+    let mut bytes = Vec::new();
+    input
+        .read_to_end(&mut bytes)
+        .context("failed to read Automerge document")?;
+    let document =
+        automerge::Automerge::load(&bytes).context("failed to load Automerge document")?;
+    let changes = document.get_changes(&[]);
+    let change_count = changes.len();
+    let operation_count = changes.iter().map(automerge::Change::len).sum();
+    let actor_count = changes
+        .iter()
+        .flat_map(automerge::Change::actors)
+        .collect::<BTreeSet<_>>()
+        .len();
+    let bytes = document
+        .anonymize()
+        .context("failed to anonymize Automerge document")?
+        .save();
+
+    Ok(AnonymizedDocument {
+        bytes,
+        change_count,
+        operation_count,
+        actor_count,
+    })
+}

--- a/rust/automerge-cli/src/main.rs
+++ b/rust/automerge-cli/src/main.rs
@@ -1,4 +1,9 @@
-use std::{fs::File, io::IsTerminal, path::PathBuf, str::FromStr};
+use std::{
+    fs::File,
+    io::{IsTerminal, Write},
+    path::{Path, PathBuf},
+    str::FromStr,
+};
 
 use anyhow::{anyhow, Result};
 use clap::{
@@ -6,6 +11,7 @@ use clap::{
     Parser,
 };
 
+mod anonymize;
 mod color_json;
 mod examine;
 mod examine_sync;
@@ -120,6 +126,16 @@ enum Command {
     /// Read an automerge sync messaage and print a JSON representation of it
     ExamineSync { input_file: Option<PathBuf> },
 
+    /// Replace private document data while retaining history and structural shape
+    Anonymize {
+        /// The Automerge document to anonymize. If omitted, reads from stdin
+        input_file: Option<PathBuf>,
+
+        /// The file to write to. If omitted, writes to stdout
+        #[clap(long("out"), short('o'))]
+        output_file: Option<PathBuf>,
+    },
+
     /// Read one or more automerge documents and output a merged, compacted version of them
     Merge {
         /// The file to write to. If omitted assumes stdout
@@ -132,29 +148,29 @@ enum Command {
 }
 
 fn open_file_or_stdin(maybe_path: Option<PathBuf>) -> Result<Box<dyn std::io::Read>> {
-    if std::io::stdin().is_terminal() {
-        if let Some(path) = maybe_path {
-            Ok(Box::new(File::open(path).unwrap()))
-        } else {
-            Err(anyhow!(
-                "Must provide file path if not providing input via stdin"
-            ))
-        }
+    if let Some(path) = maybe_path {
+        Ok(Box::new(File::open(path)?))
+    } else if std::io::stdin().is_terminal() {
+        Err(anyhow!(
+            "Must provide file path if not providing input via stdin"
+        ))
     } else {
         Ok(Box::new(std::io::stdin()))
     }
 }
 
 fn create_file_or_stdout(maybe_path: Option<PathBuf>) -> Result<Box<dyn std::io::Write>> {
-    if std::io::stdout().is_terminal() {
-        if let Some(path) = maybe_path {
-            Ok(Box::new(File::create(path).unwrap()))
-        } else {
-            Err(anyhow!("Must provide file path if not piping to stdout"))
-        }
+    if let Some(path) = maybe_path {
+        Ok(Box::new(File::create(path)?))
+    } else if std::io::stdout().is_terminal() {
+        Err(anyhow!("Must provide file path if not piping to stdout"))
     } else {
         Ok(Box::new(std::io::stdout()))
     }
+}
+
+fn paths_refer_to_same_file(input: &Path, output: &Path) -> Result<bool> {
+    Ok(input == output || (output.exists() && input.canonicalize()? == output.canonicalize()?))
 }
 
 fn main() -> Result<()> {
@@ -226,6 +242,32 @@ fn main() -> Result<()> {
                     eprintln!("Error: {:?}", e);
                 }
             }
+            Ok(())
+        }
+        Command::Anonymize {
+            input_file,
+            output_file,
+        } => {
+            if let (Some(input), Some(output)) = (&input_file, &output_file) {
+                if paths_refer_to_same_file(input, output)? {
+                    return Err(anyhow!("input and output paths must differ"));
+                }
+            }
+
+            let input = open_file_or_stdin(input_file)?;
+            // Do not truncate an existing output until the input has loaded and anonymization has
+            // succeeded.
+            let anonymized = anonymize::anonymize(input)?;
+            let mut output = create_file_or_stdout(output_file)?;
+            output.write_all(&anonymized.bytes)?;
+            output.flush()?;
+            eprintln!(
+                "anonymized {} change(s), {} operation(s), and {} actor(s)",
+                anonymized.change_count, anonymized.operation_count, anonymized.actor_count
+            );
+            eprintln!(
+                "review the output before publishing; document structure and lengths are retained"
+            );
             Ok(())
         }
         Command::Merge { input, output_file } => {

--- a/rust/automerge-cli/tests/integration.rs
+++ b/rust/automerge-cli/tests/integration.rs
@@ -61,6 +61,29 @@ fn import_export_isomorphic() {
     assert_eq!(stdout, json_bytes);
 }
 
+#[test]
+fn anonymize_scrubs_a_document_from_stdin() {
+    use automerge::transaction::Transactable;
+    use automerge::{AutoCommit, Automerge, ReadDoc, ROOT};
+
+    let bin = env!("CARGO_BIN_EXE_automerge");
+    let mut source = AutoCommit::new();
+    source.put(ROOT, "private-key", "private value").unwrap();
+    let source_bytes = source.save();
+
+    let output = cmd!(bin, "anonymize")
+        .stdin_bytes(source_bytes.clone())
+        .stdout_capture()
+        .stderr_capture()
+        .run()
+        .unwrap();
+    let anonymized = Automerge::load(&output.stdout).unwrap();
+
+    assert_eq!(anonymized.get_changes(&[]).len(), 1);
+    assert!(anonymized.get(ROOT, "private-key").unwrap().is_none());
+    assert_ne!(output.stdout, source_bytes);
+}
+
 /*
 #[test]
 fn import_change_export() {

--- a/rust/automerge-wasm/src/lib.rs
+++ b/rust/automerge-wasm/src/lib.rs
@@ -476,6 +476,16 @@ impl Automerge {
         Ok(())
     }
 
+    /// Return a copy of this document with its data anonymized while retaining its history and
+    /// structural shape.
+    pub fn anonymize(&mut self) -> Result<Automerge, error::Anonymize> {
+        Ok(Automerge {
+            doc: self.doc.anonymize()?,
+            freeze: self.freeze,
+            external_types: self.external_types.clone(),
+        })
+    }
+
     #[allow(clippy::should_implement_trait)]
     pub fn clone(&mut self, actor: Option<String>) -> Result<Automerge, error::BadActorId> {
         let mut automerge = Automerge {
@@ -2233,7 +2243,7 @@ pub fn read_bundle(bundle: Uint8Array) -> Result<JsValue, error::ReadBundle> {
 }
 
 pub mod error {
-    use automerge::{AutomergeError, ObjType};
+    use automerge::{AnonymizeError, AutomergeError, ObjType};
     use js_sys::RangeError;
     use wasm_bindgen::JsValue;
 
@@ -2241,6 +2251,16 @@ pub mod error {
         self,
         error::{BadChangeHash, BadChangeHashes, BadJSChanges, BadUint8Array, GetProp},
     };
+
+    #[derive(Debug, thiserror::Error)]
+    #[error(transparent)]
+    pub struct Anonymize(#[from] AnonymizeError);
+
+    impl From<Anonymize> for JsValue {
+        fn from(error: Anonymize) -> Self {
+            RangeError::new(&error.to_string()).into()
+        }
+    }
 
     #[derive(Debug, thiserror::Error)]
     #[error("could not parse Actor ID as a hex string: {0}")]

--- a/rust/automerge-wasm/test/test.mts
+++ b/rust/automerge-wasm/test/test.mts
@@ -57,6 +57,20 @@ describe("Automerge", () => {
       doc.commit();
     });
 
+    it("should anonymize a document without modifying the source", () => {
+      const doc = create({ actor: "01020304" });
+      doc.put("_root", "private-key", "secret value");
+      doc.commit("private commit message", 1_700_000_000);
+
+      const anonymized = doc.anonymize();
+
+      assert.deepEqual(doc.get("_root", "private-key"), "secret value");
+      assert.deepEqual(anonymized.get("_root", "private-key"), undefined);
+      assert.equal(anonymized.keys("_root").length, 1);
+      assert.equal(anonymized.getChanges([]).length, doc.getChanges([]).length);
+      assert.doesNotThrow(() => load(anonymized.save()));
+    });
+
     it("getting a nonexistent prop does not throw an error", () => {
       const doc = create();
       const root = "_root";

--- a/rust/automerge/src/anonymize.rs
+++ b/rust/automerge/src/anonymize.rs
@@ -1,0 +1,558 @@
+use crate::legacy::{ElementId, Key, MarkData, ObjectId, OpId, OpType};
+use crate::{ActorId, Automerge, AutomergeError, Change, ChangeHash, ScalarValue};
+use rand::rngs::StdRng;
+use rand::seq::SliceRandom;
+use rand::RngExt;
+use std::collections::{BTreeSet, HashMap};
+
+const SYNTHETIC_TEXT: &[u8] = b"loremipsumdolorsitametconsecteturadipiscingelit";
+
+/// An error encountered while anonymizing a document.
+#[derive(Debug, thiserror::Error)]
+pub enum AnonymizeError {
+    /// A change appeared before one of its dependencies.
+    #[error("change {change} appeared before dependency {dependency}")]
+    MissingDependency {
+        /// The change being anonymized.
+        change: ChangeHash,
+        /// The dependency which has not yet been anonymized.
+        dependency: ChangeHash,
+    },
+    /// The rewritten changes could not be applied.
+    #[error(transparent)]
+    Apply(#[from] AutomergeError),
+}
+
+/// Return a new document anonymized with a fresh random seed.
+pub fn anonymize(document: &Automerge) -> Result<Automerge, AnonymizeError> {
+    Anonymization::new(rand::make_rng()).anonymize(document)
+}
+
+struct Anonymization {
+    rng: StdRng,
+    structural_permutations: StructuralPermutations,
+    content_permutations: StructuralPermutations,
+    synthetic_text: Vec<u8>,
+    synthetic_position: usize,
+}
+
+impl Anonymization {
+    fn new(mut rng: StdRng) -> Self {
+        let mut synthetic_text = SYNTHETIC_TEXT.to_vec();
+        synthetic_text.shuffle(&mut rng);
+        let synthetic_position = rng.random_range(0..synthetic_text.len());
+        Self {
+            rng,
+            structural_permutations: StructuralPermutations::default(),
+            content_permutations: StructuralPermutations::default(),
+            synthetic_text,
+            synthetic_position,
+        }
+    }
+
+    #[cfg(test)]
+    fn from_seed(seed: [u8; 32]) -> Self {
+        use rand::SeedableRng as _;
+
+        Self::new(StdRng::from_seed(seed))
+    }
+
+    fn anonymize(mut self, document: &Automerge) -> Result<Automerge, AnonymizeError> {
+        let changes = document.get_changes(&[]);
+        let actor_map = self.actor_map(&changes);
+        let mut change_hashes = HashMap::<ChangeHash, ChangeHash>::new();
+        let mut anonymized = Automerge::new_with_encoding(document.text_encoding());
+
+        for change in changes {
+            let old_hash = change.hash();
+            let mut expanded = change.decode();
+            expanded.hash = None;
+            expanded.deps = expanded
+                .deps
+                .iter()
+                .map(|dependency| {
+                    change_hashes.get(dependency).copied().ok_or(
+                        AnonymizeError::MissingDependency {
+                            change: old_hash,
+                            dependency: *dependency,
+                        },
+                    )
+                })
+                .collect::<Result<Vec<_>, _>>()?;
+            expanded.actor_id = mapped_actor(&actor_map, &expanded.actor_id);
+            expanded.time = self.random_i64_other_than(expanded.time);
+            expanded.message = expanded
+                .message
+                .as_deref()
+                .map(|message| self.anonymize_content_string(message));
+            expanded.extra_bytes = self.anonymize_bytes(&expanded.extra_bytes);
+
+            for operation in &mut expanded.operations {
+                self.anonymize_operation(operation, &actor_map);
+            }
+
+            let anonymized_change = Change::from(expanded);
+            let anonymized_hash = anonymized_change.hash();
+            anonymized.apply_changes([anonymized_change])?;
+            change_hashes.insert(old_hash, anonymized_hash);
+        }
+
+        Ok(anonymized)
+    }
+
+    fn actor_map(&mut self, changes: &[Change]) -> HashMap<ActorId, ActorId> {
+        let actors = changes
+            .iter()
+            .flat_map(Change::actors)
+            .cloned()
+            .collect::<BTreeSet<_>>();
+
+        loop {
+            let prefix = self.rng.random::<[u8; 8]>();
+            let mapped = actors
+                .iter()
+                .enumerate()
+                .map(|(rank, actor)| {
+                    let mut anonymized = [0_u8; 16];
+                    anonymized[..8].copy_from_slice(&prefix);
+                    anonymized[8..].copy_from_slice(&(rank as u64).to_be_bytes());
+                    (actor.clone(), ActorId::from(anonymized))
+                })
+                .collect::<HashMap<_, _>>();
+            if mapped.values().all(|actor| !actors.contains(actor)) {
+                return mapped;
+            }
+        }
+    }
+
+    fn anonymize_operation(
+        &mut self,
+        operation: &mut crate::legacy::Op,
+        actors: &HashMap<ActorId, ActorId>,
+    ) {
+        map_object_id(&mut operation.obj, actors);
+        match &mut operation.key {
+            Key::Map(key) => *key = self.anonymize_structural_string(key).into(),
+            Key::Seq(ElementId::Id(id)) => map_op_id(id, actors),
+            Key::Seq(ElementId::Head) => {}
+        }
+        operation.pred = operation
+            .pred
+            .iter()
+            .cloned()
+            .map(|mut predecessor| {
+                map_op_id(&mut predecessor, actors);
+                predecessor
+            })
+            .collect();
+
+        match &mut operation.action {
+            OpType::Put(value) => *value = self.anonymize_scalar(value),
+            OpType::Increment(value) => *value = self.random_i64_other_than(*value),
+            OpType::MarkBegin(MarkData { name, value, .. }) => {
+                *name = self.anonymize_structural_string(name).into();
+                *value = self.anonymize_scalar(value);
+            }
+            OpType::Make(_) | OpType::Delete | OpType::MarkEnd(_) => {}
+        }
+    }
+
+    fn anonymize_scalar(&mut self, value: &ScalarValue) -> ScalarValue {
+        match value {
+            ScalarValue::Bytes(bytes) => ScalarValue::Bytes(self.anonymize_bytes(bytes)),
+            ScalarValue::Str(value) => {
+                ScalarValue::from(self.anonymize_content_string(value.as_str()))
+            }
+            ScalarValue::Int(value) => ScalarValue::Int(self.random_i64_other_than(*value)),
+            ScalarValue::Uint(value) => ScalarValue::Uint(self.random_u64_other_than(*value)),
+            ScalarValue::F64(value) => ScalarValue::F64(self.random_f64_other_than(*value)),
+            ScalarValue::Counter(value) => {
+                ScalarValue::counter(self.random_i64_other_than(i64::from(value)))
+            }
+            ScalarValue::Timestamp(value) => {
+                ScalarValue::Timestamp(self.random_i64_other_than(*value))
+            }
+            ScalarValue::Boolean(_) => ScalarValue::Boolean(self.rng.random()),
+            ScalarValue::Unknown { type_code, bytes } => ScalarValue::Unknown {
+                type_code: *type_code,
+                bytes: self.anonymize_bytes(bytes),
+            },
+            ScalarValue::Null => ScalarValue::Null,
+        }
+    }
+
+    fn random_i64_other_than(&mut self, original: i64) -> i64 {
+        loop {
+            // Signed integer columns use delta encoding. Sampling from the i32 domain keeps the
+            // difference between any two generated values representable as an i64 while still
+            // producing independent, varied values for run-length and delta encoding.
+            let replacement = i64::from(self.rng.random::<i32>());
+            if replacement != original {
+                return replacement;
+            }
+        }
+    }
+
+    fn random_u64_other_than(&mut self, original: u64) -> u64 {
+        loop {
+            let replacement = self.rng.random();
+            if replacement != original {
+                return replacement;
+            }
+        }
+    }
+
+    fn random_f64_other_than(&mut self, original: f64) -> f64 {
+        loop {
+            // `rand` samples finite values from 0..1, avoiding NaNs and infinities while still
+            // producing independently encoded values for each occurrence.
+            let replacement = self.rng.random::<f64>();
+            if replacement.to_bits() != original.to_bits() {
+                return replacement;
+            }
+        }
+    }
+
+    fn anonymize_structural_string(&mut self, value: &str) -> String {
+        value
+            .chars()
+            .map(|character| {
+                self.structural_permutations
+                    .replace(character, &mut self.rng)
+            })
+            .collect()
+    }
+
+    fn anonymize_content_string(&mut self, value: &str) -> String {
+        let mut result = String::with_capacity(value.len());
+        for character in value.chars() {
+            if character.is_whitespace() || character.is_ascii_control() {
+                result.push(character);
+            } else if character.is_ascii() {
+                result.push(char::from(self.random_synthetic_byte(character as u8)));
+            } else {
+                result.push(self.content_permutations.replace(character, &mut self.rng));
+            }
+        }
+        result
+    }
+
+    fn anonymize_bytes(&mut self, value: &[u8]) -> Vec<u8> {
+        value
+            .iter()
+            .map(|source| self.random_synthetic_byte(*source))
+            .collect()
+    }
+
+    fn random_synthetic_byte(&mut self, original: u8) -> u8 {
+        loop {
+            let replacement = self.synthetic_text[self.synthetic_position];
+            self.synthetic_position = (self.synthetic_position + 1) % self.synthetic_text.len();
+            if replacement != original {
+                return replacement;
+            }
+        }
+    }
+}
+
+/// Lazily generated, seeded substitution tables for each character encoding class.
+///
+/// The rank conversion helpers below are deterministic, but they only index these tables. The
+/// source rank is mapped through a randomly shuffled derangement before being converted back into a
+/// character. This deliberately preserves character equality patterns and is consequently a
+/// substitution cipher, not cryptographic protection.
+#[derive(Default)]
+struct StructuralPermutations {
+    printable_ascii: Option<Vec<u32>>,
+    ascii_control: Option<Vec<u32>>,
+    two_byte: Option<Vec<u32>>,
+    three_byte: Option<Vec<u32>>,
+    four_byte: Option<Vec<u32>>,
+}
+
+impl StructuralPermutations {
+    fn replace(&mut self, character: char, rng: &mut StdRng) -> char {
+        let (alphabet, source_rank, alphabet_size) = structural_character_rank(character);
+        let permutation = match alphabet {
+            StructuralAlphabet::PrintableAscii => &mut self.printable_ascii,
+            StructuralAlphabet::AsciiControl => &mut self.ascii_control,
+            StructuralAlphabet::TwoByte => &mut self.two_byte,
+            StructuralAlphabet::ThreeByte => &mut self.three_byte,
+            StructuralAlphabet::FourByte => &mut self.four_byte,
+        }
+        .get_or_insert_with(|| random_derangement(alphabet_size, rng));
+        let replacement_rank = permutation[source_rank as usize];
+        structural_character_from_rank(character, replacement_rank)
+    }
+}
+
+#[derive(Clone, Copy)]
+enum StructuralAlphabet {
+    PrintableAscii,
+    AsciiControl,
+    TwoByte,
+    ThreeByte,
+    FourByte,
+}
+
+fn random_derangement(count: u32, rng: &mut StdRng) -> Vec<u32> {
+    debug_assert!(count > 1);
+    loop {
+        let mut permutation = (0..count).collect::<Vec<_>>();
+        permutation.shuffle(rng);
+        if permutation
+            .iter()
+            .enumerate()
+            .all(|(index, replacement)| index as u32 != *replacement)
+        {
+            return permutation;
+        }
+    }
+}
+
+// Locate a character within an alphabet whose members have the same encoded width. Randomization
+// happens when `StructuralPermutations::replace` maps this rank through a seeded permutation.
+fn structural_character_rank(character: char) -> (StructuralAlphabet, u32, u32) {
+    let codepoint = character as u32;
+    match character.len_utf8() {
+        1 if (0x20..=0x7e).contains(&codepoint) => (
+            StructuralAlphabet::PrintableAscii,
+            codepoint - 0x20,
+            0x7e - 0x20 + 1,
+        ),
+        1 if codepoint < 0x20 => (StructuralAlphabet::AsciiControl, codepoint, 0x21),
+        1 => (StructuralAlphabet::AsciiControl, 0x20, 0x21),
+        2 => (StructuralAlphabet::TwoByte, codepoint - 0x80, 0x800 - 0x80),
+        3 if codepoint < 0xd800 => (
+            StructuralAlphabet::ThreeByte,
+            codepoint - 0x800,
+            0xd800 - 0x800 + 0x2000,
+        ),
+        3 => (
+            StructuralAlphabet::ThreeByte,
+            0xd800 - 0x800 + codepoint - 0xe000,
+            0xd800 - 0x800 + 0x2000,
+        ),
+        4 => (
+            StructuralAlphabet::FourByte,
+            codepoint - 0x10000,
+            0x110000 - 0x10000,
+        ),
+        _ => unreachable!("Rust char values use one to four UTF-8 bytes"),
+    }
+}
+
+fn structural_character_from_rank(original: char, rank: u32) -> char {
+    let codepoint = match original.len_utf8() {
+        1 if (' '..='~').contains(&original) => 0x20 + rank,
+        1 if original < ' ' => rank,
+        1 => {
+            if rank < 0x20 {
+                rank
+            } else {
+                0x7f
+            }
+        }
+        2 => 0x80 + rank,
+        3 if rank < 0xd800 - 0x800 => 0x800 + rank,
+        3 => 0xe000 + rank - (0xd800 - 0x800),
+        4 => 0x10000 + rank,
+        _ => unreachable!("Rust char values use one to four UTF-8 bytes"),
+    };
+    char::from_u32(codepoint).expect("character rank should map to a valid Unicode scalar")
+}
+
+fn mapped_actor(actors: &HashMap<ActorId, ActorId>, actor: &ActorId) -> ActorId {
+    actors
+        .get(actor)
+        .expect("every referenced actor should be present in the change actor table")
+        .clone()
+}
+
+fn map_op_id(id: &mut OpId, actors: &HashMap<ActorId, ActorId>) {
+    id.1 = mapped_actor(actors, &id.1);
+}
+
+fn map_object_id(id: &mut ObjectId, actors: &HashMap<ActorId, ActorId>) {
+    if let ObjectId::Id(id) = id {
+        map_op_id(id, actors);
+    }
+}
+
+#[cfg(test)]
+mod fuzz;
+#[cfg(test)]
+mod shape;
+
+#[cfg(test)]
+mod tests {
+    use super::{shape::ShapeSignature, Anonymization, Key, OpType};
+    use crate::transaction::{CommitOptions, Transactable};
+    use crate::{AutoCommit, Automerge, ObjType, ReadDoc, ScalarValue, ROOT};
+    use std::collections::{HashMap, HashSet};
+
+    #[test]
+    fn repeated_numeric_values_receive_varied_replacements() {
+        let mut anonymization = Anonymization::from_seed([2; 32]);
+
+        let signed = (0..16)
+            .map(|_| anonymization.random_i64_other_than(42))
+            .collect::<HashSet<_>>();
+        let unsigned = (0..16)
+            .map(|_| anonymization.random_u64_other_than(42))
+            .collect::<HashSet<_>>();
+        let floats = (0..16)
+            .map(|_| anonymization.random_f64_other_than(42.0).to_bits())
+            .collect::<HashSet<_>>();
+
+        assert!(signed.len() > 1 && !signed.contains(&42));
+        assert!(unsigned.len() > 1 && !unsigned.contains(&42));
+        assert!(floats.len() > 1 && !floats.contains(&42.0_f64.to_bits()));
+    }
+
+    #[test]
+    fn structural_strings_are_seeded_unique_and_preserve_encoded_lengths() {
+        let mut first = Anonymization::from_seed([3; 32]);
+        let mut second = Anonymization::from_seed([4; 32]);
+        let source = ["name", "email", "a", "b", "é", "界", "😀"];
+        let anonymized = source.map(|value| first.anonymize_structural_string(value));
+        let differently_anonymized = source.map(|value| second.anonymize_structural_string(value));
+
+        assert_ne!(anonymized, differently_anonymized);
+        assert_eq!(
+            anonymized
+                .iter()
+                .collect::<std::collections::HashSet<_>>()
+                .len(),
+            source.len()
+        );
+        for (source, anonymized) in source.into_iter().zip(anonymized) {
+            assert_ne!(source, anonymized);
+            assert_eq!(source.len(), anonymized.len());
+            assert_eq!(
+                source.encode_utf16().count(),
+                anonymized.encode_utf16().count()
+            );
+        }
+    }
+
+    #[test]
+    fn anonymizes_data_while_preserving_history_and_shape() {
+        let mut source = AutoCommit::new();
+        source.put(ROOT, "private-key", "secret value").unwrap();
+        source.put(ROOT, "private-bytes", vec![1, 2, 3, 4]).unwrap();
+        source.put(ROOT, "private-number", 42_i64).unwrap();
+        source
+            .put(ROOT, "private-counter", ScalarValue::counter(10))
+            .unwrap();
+        let text = source
+            .put_object(ROOT, "private-text", ObjType::Text)
+            .unwrap();
+        source
+            .splice_text(&text, 0, 0, "Meeting with Alice 👋\nTomorrow")
+            .unwrap();
+        source.commit_with(
+            CommitOptions::default()
+                .with_message("private commit message")
+                .with_time(1_700_000_000),
+        );
+        source.increment(ROOT, "private-counter", 5).unwrap();
+        source.put(ROOT, "private-key", "another secret").unwrap();
+        source.commit();
+
+        let source = Automerge::load(&source.save()).unwrap();
+        let anonymized = Anonymization::from_seed([7; 32])
+            .anonymize(&source)
+            .unwrap();
+        let anonymized_again = Anonymization::from_seed([7; 32])
+            .anonymize(&source)
+            .unwrap();
+        let differently_anonymized = Anonymization::from_seed([8; 32])
+            .anonymize(&source)
+            .unwrap();
+
+        assert_eq!(anonymized.save(), anonymized_again.save());
+        assert_ne!(anonymized.save(), differently_anonymized.save());
+        assert_ne!(anonymized.save(), source.save());
+        Automerge::load(&anonymized.save()).unwrap();
+        assert_eq!(
+            ShapeSignature::new(&source),
+            ShapeSignature::new(&anonymized)
+        );
+
+        let source_changes = source.get_changes(&[]);
+        let anonymized_changes = anonymized.get_changes(&[]);
+        assert_eq!(source_changes.len(), anonymized_changes.len());
+        let source_indices = source_changes
+            .iter()
+            .enumerate()
+            .map(|(index, change)| (change.hash(), index))
+            .collect::<HashMap<_, _>>();
+        let anonymized_indices = anonymized_changes
+            .iter()
+            .enumerate()
+            .map(|(index, change)| (change.hash(), index))
+            .collect::<HashMap<_, _>>();
+        for (source, anonymized) in source_changes.iter().zip(&anonymized_changes) {
+            assert_eq!(source.len(), anonymized.len());
+            assert_eq!(source.seq(), anonymized.seq());
+            assert_eq!(source.start_op(), anonymized.start_op());
+            assert_ne!(source.actor_id(), anonymized.actor_id());
+            let source_deps = source
+                .deps()
+                .iter()
+                .map(|hash| source_indices[hash])
+                .collect::<Vec<_>>();
+            let anonymized_deps = anonymized
+                .deps()
+                .iter()
+                .map(|hash| anonymized_indices[hash])
+                .collect::<Vec<_>>();
+            assert_eq!(source_deps, anonymized_deps);
+            if source.timestamp() != 0 {
+                assert_ne!(source.timestamp(), anonymized.timestamp());
+            }
+            if source.message().is_some() {
+                assert_ne!(source.message(), anonymized.message());
+            }
+        }
+
+        assert!(anonymized.get(ROOT, "private-key").unwrap().is_none());
+        assert!(anonymized.get(ROOT, "private-text").unwrap().is_none());
+        let text_id = anonymized
+            .keys(ROOT)
+            .find_map(|key| match anonymized.get(ROOT, key).unwrap() {
+                Some((crate::Value::Object(ObjType::Text), object)) => Some(object),
+                _ => None,
+            })
+            .unwrap();
+        let source_text = source.text(&text).unwrap();
+        let anonymized_text = anonymized.text(&text_id).unwrap();
+        assert_ne!(source_text, anonymized_text);
+        assert_eq!(source_text.len(), anonymized_text.len());
+        assert_eq!(
+            source_text.encode_utf16().count(),
+            anonymized_text.encode_utf16().count()
+        );
+
+        for change in &anonymized_changes {
+            let expanded = change.decode();
+            assert_ne!(expanded.message.as_deref(), Some("private commit message"));
+            for operation in expanded.operations {
+                if let Key::Map(key) = operation.key {
+                    assert!(!key.starts_with("private"));
+                }
+                match operation.action {
+                    OpType::Put(ScalarValue::Str(value)) => {
+                        assert_ne!(value.as_str(), "secret value");
+                        assert_ne!(value.as_str(), "another secret");
+                    }
+                    OpType::Put(ScalarValue::Bytes(value)) => {
+                        assert_ne!(value, vec![1, 2, 3, 4]);
+                    }
+                    _ => {}
+                }
+            }
+        }
+    }
+}

--- a/rust/automerge/src/anonymize/fuzz.rs
+++ b/rust/automerge/src/anonymize/fuzz.rs
@@ -1,0 +1,200 @@
+use proptest::prelude::*;
+
+use super::{
+    shape::{assert_private_data_changed, ShapeSignature},
+    Anonymization,
+};
+use crate::marks::{ExpandMark, Mark};
+use crate::transaction::{CommitOptions, Transactable};
+use crate::{ActorId, AutoCommit, Automerge, ObjId, ObjType, ReadDoc, ScalarValue, ROOT};
+
+const REPLICA_COUNT: usize = 3;
+const ROOT_KEYS: [&str; 4] = ["alpha", "beta", "gamma", "delta"];
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(64))]
+
+    #[test]
+    fn randomized_documents_retain_their_shape(
+        program in proptest::collection::vec(any::<u8>(), 0..192),
+        seed in any::<[u8; 32]>(),
+    ) {
+        let source = document_from_program(&program);
+        let source_shape = ShapeSignature::new(&source);
+        let anonymized = Anonymization::from_seed(seed).anonymize(&source).unwrap();
+
+        prop_assert_eq!(source_shape, ShapeSignature::new(&anonymized));
+        assert_private_data_changed(&source, &anonymized);
+
+        let reloaded = Automerge::load(&anonymized.save()).unwrap();
+        prop_assert_eq!(ShapeSignature::new(&anonymized), ShapeSignature::new(&reloaded));
+    }
+}
+
+fn document_from_program(program: &[u8]) -> Automerge {
+    let mut base = AutoCommit::new();
+    base.set_actor(actor(0));
+    let list = base.put_object(ROOT, "items", ObjType::List).unwrap();
+    let text = base.put_object(ROOT, "notes", ObjType::Text).unwrap();
+    base.put(ROOT, "counter", ScalarValue::counter(0)).unwrap();
+    base.commit_with(
+        CommitOptions::default()
+            .with_message("initial private data")
+            .with_time(1_700_000_000),
+    );
+
+    let mut replicas = (0..REPLICA_COUNT)
+        .map(|index| {
+            let mut replica = base.fork();
+            replica.set_actor(actor(index as u8 + 1));
+            replica
+        })
+        .collect::<Vec<_>>();
+
+    for instruction in program.chunks(6) {
+        apply_instruction(&mut replicas, &list, &text, instruction);
+    }
+
+    for index in 1..replicas.len() {
+        let mut incoming = replicas[index].fork();
+        replicas[0].merge(&mut incoming).unwrap();
+    }
+
+    Automerge::load(&replicas[0].save()).unwrap()
+}
+
+fn apply_instruction(replicas: &mut [AutoCommit], list: &ObjId, text: &ObjId, instruction: &[u8]) {
+    let byte = |index| instruction.get(index).copied().unwrap_or_default();
+    let opcode = byte(0) % 11;
+    let replica_index = byte(1) as usize % replicas.len();
+    let a = byte(2);
+    let b = byte(3);
+    let c = byte(4);
+    let d = byte(5);
+
+    if opcode == 9 {
+        let source_index = a as usize % replicas.len();
+        if source_index != replica_index {
+            let mut incoming = replicas[source_index].fork();
+            replicas[replica_index].merge(&mut incoming).unwrap();
+        }
+        return;
+    }
+
+    let document = &mut replicas[replica_index];
+    match opcode {
+        0 => {
+            document
+                .put(
+                    ROOT,
+                    ROOT_KEYS[a as usize % ROOT_KEYS.len()],
+                    scalar(b, c, d),
+                )
+                .unwrap();
+        }
+        1 => {
+            document
+                .delete(ROOT, ROOT_KEYS[a as usize % ROOT_KEYS.len()])
+                .unwrap();
+        }
+        2 => {
+            let length = document.length(list);
+            let index = a as usize % (length + 1);
+            document.insert(list, index, scalar(b, c, d)).unwrap();
+        }
+        3 => {
+            let length = document.length(list);
+            if length > 0 {
+                document
+                    .put(list, a as usize % length, scalar(b, c, d))
+                    .unwrap();
+            }
+        }
+        4 => {
+            let length = document.length(list);
+            if length > 0 {
+                document.delete(list, a as usize % length).unwrap();
+            }
+        }
+        5 => {
+            let length = document.length(text);
+            let index = a as usize % (length + 1);
+            let value = ["a", "Z", " ", "\n"][b as usize % 4];
+            document.splice_text(text, index, 0, value).unwrap();
+        }
+        6 => {
+            let length = document.length(text);
+            if length > 0 {
+                document
+                    .splice_text(text, a as usize % length, 1, "")
+                    .unwrap();
+            }
+        }
+        7 => {
+            let increment = i64::from(i8::from_ne_bytes([a]));
+            let _ = document.increment(ROOT, "counter", increment);
+        }
+        8 => {
+            let length = document.length(text);
+            if length > 0 {
+                let start = a as usize % length;
+                let end = start + 1 + b as usize % (length - start);
+                let expand = match c % 4 {
+                    0 => ExpandMark::Before,
+                    1 => ExpandMark::After,
+                    2 => ExpandMark::Both,
+                    _ => ExpandMark::None,
+                };
+                document
+                    .mark(
+                        text,
+                        Mark::new(format!("mark-{}", d % 4), scalar(b, c, d), start, end),
+                        expand,
+                    )
+                    .unwrap();
+            }
+        }
+        10 => {
+            let object_type = match b % 4 {
+                0 => ObjType::Map,
+                1 => ObjType::Table,
+                2 => ObjType::List,
+                _ => ObjType::Text,
+            };
+            document
+                .put_object(ROOT, format!("object-{}", a % 4), object_type)
+                .unwrap();
+        }
+        _ => unreachable!(),
+    }
+
+    if document.pending_ops() > 0 {
+        let mut options = CommitOptions::default().with_time(i64::from(i16::from_le_bytes([c, d])));
+        if a.is_multiple_of(2) {
+            options = options.with_message(format!("private-message-{a}-{b}"));
+        }
+        document.commit_with(options);
+    }
+}
+
+fn scalar(kind: u8, a: u8, b: u8) -> ScalarValue {
+    match kind % 10 {
+        0 => ScalarValue::from(format!("private-{a}-{b}")),
+        1 => ScalarValue::Bytes(vec![a, b, kind]),
+        2 => ScalarValue::Int(i64::from(i16::from_le_bytes([a, b]))),
+        3 => ScalarValue::Uint(u64::from(u16::from_le_bytes([a, b]))),
+        4 => ScalarValue::F64(f64::from(i16::from_le_bytes([a, b])) / 10.0),
+        5 => ScalarValue::counter(i64::from(i16::from_le_bytes([a, b]))),
+        6 => ScalarValue::Timestamp(i64::from(i16::from_le_bytes([a, b]))),
+        7 => ScalarValue::Boolean(a.is_multiple_of(2)),
+        8 => ScalarValue::Unknown {
+            type_code: 10 + a % 6,
+            bytes: vec![a, b],
+        },
+        _ => ScalarValue::Null,
+    }
+}
+
+fn actor(index: u8) -> ActorId {
+    ActorId::from(vec![index])
+}

--- a/rust/automerge/src/anonymize/shape.rs
+++ b/rust/automerge/src/anonymize/shape.rs
@@ -1,0 +1,464 @@
+use std::collections::{BTreeMap, BTreeSet, HashMap};
+
+use crate::legacy::{ElementId, Key, MarkData, ObjectId, OpId, OpType};
+use crate::{ActorId, Automerge, Change, ChangeHash, ObjType, ScalarValue, TextEncoding};
+
+/// A canonical description of the parts of a document which anonymization promises to retain.
+///
+/// Actor IDs, change hashes, operation IDs, and structural characters are replaced with canonical
+/// indices. Private scalar data is reduced to its type and encoded shape.
+#[derive(Debug, PartialEq, Eq)]
+pub(super) struct ShapeSignature {
+    text_encoding: TextEncoding,
+    actor_count: usize,
+    heads: Vec<ChangeId>,
+    changes: Vec<ChangeShape>,
+}
+
+impl ShapeSignature {
+    pub(super) fn new(document: &Automerge) -> Self {
+        ShapeBuilder::new(document).build(document)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+struct ChangeId {
+    actor: usize,
+    seq: u64,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct ChangeShape {
+    id: ChangeId,
+    start_op: u64,
+    dependencies: Vec<ChangeId>,
+    message: Option<ContentStringShape>,
+    extra_bytes: usize,
+    operations: Vec<OperationShape>,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct OperationShape {
+    object: ObjectShape,
+    key: KeyShape,
+    predecessors: Vec<CanonicalOpId>,
+    insert: bool,
+    action: ActionShape,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+enum ObjectShape {
+    Root,
+    Id(CanonicalOpId),
+}
+
+#[derive(Debug, PartialEq, Eq)]
+enum KeyShape {
+    Map(StructuralStringShape),
+    Head,
+    Element(CanonicalOpId),
+}
+
+#[derive(Debug, PartialEq, Eq)]
+enum ActionShape {
+    Make(ObjType),
+    Delete,
+    Increment,
+    Put(ScalarShape),
+    MarkBegin {
+        name: StructuralStringShape,
+        value: ScalarShape,
+        expand: bool,
+    },
+    MarkEnd(bool),
+}
+
+#[derive(Debug, PartialEq, Eq)]
+enum ScalarShape {
+    Bytes(usize),
+    String(ContentStringShape),
+    Int,
+    Uint,
+    Float,
+    Counter,
+    Timestamp,
+    Boolean,
+    Unknown { type_code: u8, bytes: usize },
+    Null,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct StructuralStringShape(Vec<StructuralCharacterShape>);
+
+#[derive(Debug, PartialEq, Eq)]
+struct StructuralCharacterShape {
+    identity: usize,
+    class: CharacterClass,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct ContentStringShape(Vec<ContentCharacterShape>);
+
+#[derive(Debug, PartialEq, Eq)]
+enum ContentCharacterShape {
+    /// Whitespace and ASCII control characters are deliberately retained verbatim.
+    Retained(char),
+    Replaced(CharacterClass),
+}
+
+#[derive(Debug, PartialEq, Eq)]
+enum CharacterClass {
+    PrintableAscii,
+    AsciiControl,
+    Unicode { utf8: u8, utf16: u8 },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+struct CanonicalOpId {
+    counter: u64,
+    actor: usize,
+}
+
+struct ShapeBuilder {
+    actors: HashMap<ActorId, usize>,
+    changes: HashMap<ChangeHash, ChangeId>,
+    structural_characters: HashMap<char, usize>,
+}
+
+impl ShapeBuilder {
+    fn new(document: &Automerge) -> Self {
+        let changes = document.get_changes(&[]);
+        let actors = actor_ranks(&changes);
+        let change_ids = changes
+            .iter()
+            .map(|change| {
+                (
+                    change.hash(),
+                    ChangeId {
+                        actor: actors[change.actor_id()],
+                        seq: change.seq(),
+                    },
+                )
+            })
+            .collect();
+        Self {
+            actors,
+            changes: change_ids,
+            structural_characters: HashMap::new(),
+        }
+    }
+
+    fn build(mut self, document: &Automerge) -> ShapeSignature {
+        let mut changes = document.get_changes(&[]);
+        changes.sort_unstable_by_key(|change| self.changes[&change.hash()]);
+
+        let changes = changes.iter().map(|change| self.change(change)).collect();
+        let mut heads = document
+            .get_heads()
+            .iter()
+            .map(|hash| self.changes[hash])
+            .collect::<Vec<_>>();
+        heads.sort_unstable();
+
+        ShapeSignature {
+            text_encoding: document.text_encoding(),
+            actor_count: self.actors.len(),
+            heads,
+            changes,
+        }
+    }
+
+    fn change(&mut self, change: &Change) -> ChangeShape {
+        let expanded = change.decode();
+        let mut dependencies = change
+            .deps()
+            .iter()
+            .map(|hash| self.changes[hash])
+            .collect::<Vec<_>>();
+        dependencies.sort_unstable();
+
+        ChangeShape {
+            id: self.changes[&change.hash()],
+            start_op: change.start_op().get(),
+            dependencies,
+            message: change.message().map(content_string_shape),
+            extra_bytes: change.extra_bytes().len(),
+            operations: expanded
+                .operations
+                .iter()
+                .map(|operation| self.operation(operation))
+                .collect(),
+        }
+    }
+
+    fn operation(&mut self, operation: &crate::legacy::Op) -> OperationShape {
+        let mut predecessors = operation
+            .pred
+            .iter()
+            .map(|id| self.op_id(id))
+            .collect::<Vec<_>>();
+        predecessors.sort_unstable();
+
+        OperationShape {
+            object: match &operation.obj {
+                ObjectId::Root => ObjectShape::Root,
+                ObjectId::Id(id) => ObjectShape::Id(self.op_id(id)),
+            },
+            key: match &operation.key {
+                Key::Map(key) => KeyShape::Map(self.structural_string(key)),
+                Key::Seq(ElementId::Head) => KeyShape::Head,
+                Key::Seq(ElementId::Id(id)) => KeyShape::Element(self.op_id(id)),
+            },
+            predecessors,
+            insert: operation.insert,
+            action: self.action(&operation.action),
+        }
+    }
+
+    fn action(&mut self, action: &OpType) -> ActionShape {
+        match action {
+            OpType::Make(object_type) => ActionShape::Make(*object_type),
+            OpType::Delete => ActionShape::Delete,
+            OpType::Increment(_) => ActionShape::Increment,
+            OpType::Put(value) => ActionShape::Put(scalar_shape(value)),
+            OpType::MarkBegin(MarkData {
+                name,
+                value,
+                expand,
+            }) => ActionShape::MarkBegin {
+                name: self.structural_string(name),
+                value: scalar_shape(value),
+                expand: *expand,
+            },
+            OpType::MarkEnd(expand) => ActionShape::MarkEnd(*expand),
+        }
+    }
+
+    fn structural_string(&mut self, value: &str) -> StructuralStringShape {
+        StructuralStringShape(
+            value
+                .chars()
+                .map(|character| {
+                    let identity =
+                        if let Some(identity) = self.structural_characters.get(&character) {
+                            *identity
+                        } else {
+                            let identity = self.structural_characters.len();
+                            self.structural_characters.insert(character, identity);
+                            identity
+                        };
+                    StructuralCharacterShape {
+                        identity,
+                        class: character_class(character),
+                    }
+                })
+                .collect(),
+        )
+    }
+
+    fn op_id(&self, id: &OpId) -> CanonicalOpId {
+        CanonicalOpId {
+            counter: id.counter(),
+            actor: self.actors[id.actor()],
+        }
+    }
+}
+
+fn scalar_shape(value: &ScalarValue) -> ScalarShape {
+    match value {
+        ScalarValue::Bytes(value) => ScalarShape::Bytes(value.len()),
+        ScalarValue::Str(value) => ScalarShape::String(content_string_shape(value)),
+        ScalarValue::Int(_) => ScalarShape::Int,
+        ScalarValue::Uint(_) => ScalarShape::Uint,
+        ScalarValue::F64(_) => ScalarShape::Float,
+        ScalarValue::Counter(_) => ScalarShape::Counter,
+        ScalarValue::Timestamp(_) => ScalarShape::Timestamp,
+        ScalarValue::Boolean(_) => ScalarShape::Boolean,
+        ScalarValue::Unknown { type_code, bytes } => ScalarShape::Unknown {
+            type_code: *type_code,
+            bytes: bytes.len(),
+        },
+        ScalarValue::Null => ScalarShape::Null,
+    }
+}
+
+fn content_string_shape(value: &str) -> ContentStringShape {
+    ContentStringShape(
+        value
+            .chars()
+            .map(|character| {
+                if character.is_whitespace() || character.is_ascii_control() {
+                    ContentCharacterShape::Retained(character)
+                } else {
+                    ContentCharacterShape::Replaced(character_class(character))
+                }
+            })
+            .collect(),
+    )
+}
+
+fn character_class(character: char) -> CharacterClass {
+    if character.is_ascii_control() {
+        CharacterClass::AsciiControl
+    } else if character.is_ascii() {
+        CharacterClass::PrintableAscii
+    } else {
+        CharacterClass::Unicode {
+            utf8: character.len_utf8() as u8,
+            utf16: character.len_utf16() as u8,
+        }
+    }
+}
+
+fn actor_ranks(changes: &[Change]) -> HashMap<ActorId, usize> {
+    changes
+        .iter()
+        .flat_map(Change::actors)
+        .cloned()
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .enumerate()
+        .map(|(index, actor)| (actor, index))
+        .collect()
+}
+
+/// Check data-bearing fields separately from [`ShapeSignature`], which deliberately erases them.
+pub(super) fn assert_private_data_changed(source: &Automerge, anonymized: &Automerge) {
+    let source_changes = canonical_changes(source);
+    let anonymized_changes = canonical_changes(anonymized);
+    assert_eq!(source_changes.len(), anonymized_changes.len());
+
+    for (id, source) in source_changes {
+        let anonymized = &anonymized_changes[&id];
+        assert_ne!(source.hash(), anonymized.hash(), "unchanged hash in {id:?}");
+        assert_ne!(
+            source.actor_id(),
+            anonymized.actor_id(),
+            "unchanged actor in {id:?}"
+        );
+        assert_ne!(
+            source.timestamp(),
+            anonymized.timestamp(),
+            "unchanged timestamp in {id:?}"
+        );
+        if let (Some(source), Some(anonymized)) = (source.message(), anonymized.message()) {
+            assert_content_changed(source, anonymized, "change message");
+        }
+        assert_bytes_changed(
+            source.extra_bytes(),
+            anonymized.extra_bytes(),
+            "change extra bytes",
+        );
+
+        let source = source.decode();
+        let anonymized = anonymized.decode();
+        assert_eq!(source.operations.len(), anonymized.operations.len());
+        for (index, (source, anonymized)) in source
+            .operations
+            .iter()
+            .zip(&anonymized.operations)
+            .enumerate()
+        {
+            if let (Key::Map(source), Key::Map(anonymized)) = (&source.key, &anonymized.key) {
+                assert_structural_string_changed(source, anonymized, "map key");
+            }
+            match (&source.action, &anonymized.action) {
+                (OpType::Put(source), OpType::Put(anonymized)) => {
+                    assert_scalar_changed(source, anonymized)
+                }
+                (OpType::Increment(source), OpType::Increment(anonymized)) => {
+                    assert_ne!(
+                        source, anonymized,
+                        "unchanged increment in {id:?} op {index}"
+                    )
+                }
+                (OpType::MarkBegin(source), OpType::MarkBegin(anonymized)) => {
+                    assert_structural_string_changed(&source.name, &anonymized.name, "mark name");
+                    assert_scalar_changed(&source.value, &anonymized.value);
+                }
+                (OpType::Make(_), OpType::Make(_))
+                | (OpType::Delete, OpType::Delete)
+                | (OpType::MarkEnd(_), OpType::MarkEnd(_)) => {}
+                _ => panic!("action shape differs in {id:?} op {index}"),
+            }
+        }
+    }
+}
+
+fn canonical_changes(document: &Automerge) -> BTreeMap<ChangeId, Change> {
+    let changes = document.get_changes(&[]);
+    let actors = actor_ranks(&changes);
+    changes
+        .into_iter()
+        .map(|change| {
+            (
+                ChangeId {
+                    actor: actors[change.actor_id()],
+                    seq: change.seq(),
+                },
+                change,
+            )
+        })
+        .collect()
+}
+
+fn assert_scalar_changed(source: &ScalarValue, anonymized: &ScalarValue) {
+    match (source, anonymized) {
+        (ScalarValue::Bytes(source), ScalarValue::Bytes(anonymized)) => {
+            assert_bytes_changed(source, anonymized, "scalar bytes")
+        }
+        (ScalarValue::Str(source), ScalarValue::Str(anonymized)) => {
+            assert_content_changed(source, anonymized, "scalar string")
+        }
+        (ScalarValue::Int(source), ScalarValue::Int(anonymized)) => {
+            assert_ne!(source, anonymized)
+        }
+        (ScalarValue::Uint(source), ScalarValue::Uint(anonymized)) => {
+            assert_ne!(source, anonymized)
+        }
+        (ScalarValue::F64(source), ScalarValue::F64(anonymized)) => {
+            assert_ne!(source.to_bits(), anonymized.to_bits())
+        }
+        (ScalarValue::Counter(source), ScalarValue::Counter(anonymized)) => {
+            assert_ne!(i64::from(source), i64::from(anonymized))
+        }
+        (ScalarValue::Timestamp(source), ScalarValue::Timestamp(anonymized)) => {
+            assert_ne!(source, anonymized)
+        }
+        // A random boolean can equal its source, and null has no alternative of the same type.
+        (ScalarValue::Boolean(_), ScalarValue::Boolean(_))
+        | (ScalarValue::Null, ScalarValue::Null) => {}
+        (
+            ScalarValue::Unknown { bytes: source, .. },
+            ScalarValue::Unknown {
+                bytes: anonymized, ..
+            },
+        ) => assert_bytes_changed(source, anonymized, "unknown scalar bytes"),
+        _ => panic!("scalar shape differs"),
+    }
+}
+
+fn assert_structural_string_changed(source: &str, anonymized: &str, label: &str) {
+    assert_eq!(source.chars().count(), anonymized.chars().count());
+    for (source, anonymized) in source.chars().zip(anonymized.chars()) {
+        assert_ne!(source, anonymized, "unchanged character in {label}");
+    }
+}
+
+fn assert_content_changed(source: &str, anonymized: &str, label: &str) {
+    assert_eq!(source.chars().count(), anonymized.chars().count());
+    for (source, anonymized) in source.chars().zip(anonymized.chars()) {
+        if source.is_whitespace() || source.is_ascii_control() {
+            assert_eq!(source, anonymized, "retained character changed in {label}");
+        } else {
+            assert_ne!(source, anonymized, "unchanged character in {label}");
+        }
+    }
+}
+
+fn assert_bytes_changed(source: &[u8], anonymized: &[u8], label: &str) {
+    assert_eq!(source.len(), anonymized.len());
+    for (source, anonymized) in source.iter().zip(anonymized) {
+        assert_ne!(source, anonymized, "unchanged byte in {label}");
+    }
+}

--- a/rust/automerge/src/autocommit.rs
+++ b/rust/automerge/src/autocommit.rs
@@ -13,7 +13,7 @@ use crate::sync::SyncDoc;
 use crate::transaction::{CommitOptions, Transactable};
 use crate::types::{ObjId, ObjMeta};
 use crate::Fragment;
-use crate::{hydrate, Bundle, OnPartialLoad, TextEncoding};
+use crate::{hydrate, AnonymizeError, Bundle, OnPartialLoad, TextEncoding};
 use crate::{sync, ObjType, Patch, ReadDoc, ScalarValue, ROOT};
 use crate::{
     transaction::TransactionInner, ActorId, Automerge, AutomergeError, Change, ChangeHash, Cursor,
@@ -104,6 +104,20 @@ impl AutoCommit {
             save_cursor: Vec::new(),
             isolation: None,
         }
+    }
+
+    /// Return a copy of this document with its data anonymized.
+    pub fn anonymize(&mut self) -> Result<Self, AnonymizeError> {
+        self.ensure_transaction_closed();
+        Ok(Self {
+            doc: self.doc.anonymize()?,
+            transaction: None,
+            patch_log: PatchLog::inactive(),
+            diff_cursor: Vec::new(),
+            diff_cache: None,
+            save_cursor: Vec::new(),
+            isolation: None,
+        })
     }
 
     pub fn load(data: &[u8]) -> Result<Self, AutomergeError> {

--- a/rust/automerge/src/automerge.rs
+++ b/rust/automerge/src/automerge.rs
@@ -228,6 +228,23 @@ impl Automerge {
         }
     }
 
+    /// Return a copy of this document with its data anonymized using a fresh random seed.
+    ///
+    // Anonymization replaces actor IDs, map keys, mark names, scalar values, change metadata, and
+    // extra bytes. It retains the change graph, operation and object types, sequence positions,
+    // scalar string and byte-value lengths, and the UTF-8/UTF-16 width of each character. The
+    // intention is to make a document that has very similar performance characteristics to the
+    // original. This makes it useful when you want to send a document which is causing performance
+    // problems to someone to diagnose.
+    //
+    // That said, the data scrubbing here is best-effort. The anonymized document still reveals
+    // a bunch of information about editing patterns. A determined adversary could probably still
+    // learn a great deal from such a document. The intended use is really for sending documents
+    // to mostly trusted parties who are helping with bug fixing (e.g. library maintainers).
+    pub fn anonymize(&self) -> Result<Self, crate::AnonymizeError> {
+        crate::anonymize::anonymize(self)
+    }
+
     /// Overwrite the keys of the root object with the values from `value`
     ///
     /// This is useful to initialize an empty document with a large initial

--- a/rust/automerge/src/lib.rs
+++ b/rust/automerge/src/lib.rs
@@ -259,6 +259,7 @@ macro_rules! __log {
      }
  }
 
+pub mod anonymize;
 mod autocommit;
 mod automerge;
 mod autoserde;
@@ -290,6 +291,7 @@ pub mod transaction;
 mod types;
 mod value;
 
+pub use crate::anonymize::AnonymizeError;
 pub use crate::automerge::{Automerge, LoadOptions, OnPartialLoad, SaveOptions, StringMigration};
 pub use autocommit::AutoCommit;
 pub use autoserde::AutoSerde;


### PR DESCRIPTION
Problem: sometimes you have a document which is causing performance problems and you want to share it with someone who can help you debug it, but you don't want to share the contents of the document.

Solution: add an Automerge::anonymize (and corresponding JS api call and CLI command) which will return a new document with the same commit graph and operation structure, but with the contents randomized. This will still reveal information, but often is sufficient for sharing problematic documents with someone who can help you debug them.