### PR TITLE
Update Rust dependencies

### DIFF
--- a/rust/automerge-wasm/Cargo.toml
+++ b/rust/automerge-wasm/Cargo.toml
@@ -1,4 +1,3 @@
-# You must change these to your own details.
 [package]
 name = "automerge-wasm"
 description = "An js/wasm wrapper for the rust implementation of automerge-backend"
@@ -15,6 +14,12 @@ edition = "2021"
 license = "MIT"
 rust-version = "1.90.0"
 
+[package.metadata.wasm-pack.profile.release]
+# wasm-opt = false
+
+[package.metadata.wasm-pack.profile.profiling]
+wasm-opt = false
+
 [lib]
 crate-type = ["cdylib", "rlib"]
 bench = false
@@ -26,25 +31,19 @@ default = []
 [dependencies]
 # wee_alloc = { version = "^0.4", optional = true }
 automerge = { path = "../automerge", features = ["wasm", "utf16-indexing"] }
-js-sys = "^0.3"
-serde = "^1.0"
-serde_json = "^1.0"
-serde-wasm-bindgen = "0.6.5"
-serde_bytes = "0.11.5"
 hex = "^0.4.3"
 itertools = "0.15.0"
-thiserror = "^2.0.12"
+js-sys = "^0.3"
 rustc-hash = "^2.1.1"
+serde = "^1.0"
+serde-wasm-bindgen = "0.6.5"
+serde_bytes = "0.11.5"
+serde_json = "^1.0"
+thiserror = "^2.0.12"
 
 [dependencies.wasm-bindgen]
 version = "= 0.2.126"
 features = ["serde-serialize", "std"]
-
-[package.metadata.wasm-pack.profile.release]
-# wasm-opt = false
-
-[package.metadata.wasm-pack.profile.profiling]
-wasm-opt = false
 
 # The `web-sys` crate allows you to interact with the various browser APIs,
 # like the DOM.

--- a/rust/automerge-wasm/Cargo.toml
+++ b/rust/automerge-wasm/Cargo.toml
@@ -32,7 +32,7 @@ serde_json = "^1.0"
 serde-wasm-bindgen = "0.6.5"
 serde_bytes = "0.11.5"
 hex = "^0.4.3"
-itertools = "0.14.0"
+itertools = "0.15.0"
 thiserror = "^2.0.12"
 rustc-hash = "^2.1.1"
 

--- a/rust/automerge/Cargo.toml
+++ b/rust/automerge/Cargo.toml
@@ -18,30 +18,29 @@ utf16-indexing = []
 slow_path_assertions = ["hexane/slow_path_assertions"]
 
 [dependencies]
-hexane = { version = "1.0.0-alpha.2", path = "../hexane" }
-hex = "^0.4.3"
-itertools = "0.15.0"
-leb128 = "^0.2.5"
-sha2 = "^0.11.0-rc.5"
-thiserror = "^2.0.12"
+cfg-if = "1.0"
 # zlib-rs backend: pure Rust (works on wasm), ~25% faster inflate than the
 # default miniz_oxide backend natively and ~2x faster on wasm
 flate2 = { version = "^1.0.22", default-features = false, features = ["zlib-rs"] }
-smol_str = { version = "0.3", features = ["serde"] }
-tracing = { version = "^0.1.29" }
-rustc-hash = "^2.1.1"
-tinyvec = { version = "^1.5.1", features = ["alloc"] }
-serde = { version = "^1.0", features = ["derive"] }
-cfg-if = "1.0"
 getrandom = "0.4"
+hex = "^0.4.3"
+hexane = { version = "1.0.0-alpha.2", path = "../hexane" }
+itertools = "0.15.0"
+leb128 = "^0.2.5"
+rustc-hash = "^2.1.1"
+serde = { version = "^1.0", features = ["derive"] }
+sha2 = "^0.11.0-rc.5"
+smol_str = { version = "0.3", features = ["serde"] }
+thiserror = "^2.0.12"
+tinyvec = { version = "^1.5.1", features = ["alloc"] }
+tracing = { version = "^0.1.29" }
+unicode-segmentation = "1.10.1"
 
 # optional deps
 dot = { version = "0.1.4", optional = true }
 js-sys = { version = "^0.3", optional = true }
-wasm-bindgen = { version = "^0.2", optional = true }
 rand = { version = "^0.10", optional = false }
-
-unicode-segmentation = "1.10.1"
+wasm-bindgen = { version = "^0.2", optional = true }
 
 [dependencies.web-sys]
 version = "^0.3.55"
@@ -49,16 +48,11 @@ features = ["console"]
 optional = true
 
 [dev-dependencies]
-pretty_assertions = "1.0.0"
-proptest = { version = "^1.7.0", default-features = false, features = ["std"] }
-serde_json = { version = "^1.0.73", features = [
-    "float_roundtrip",
-], default-features = true }
-maplit = { version = "^1.0" }
-test-log = { version = "0.2.10", features = [
-    "trace",
-], default-features = false }
-tracing-subscriber = { version = "^0.3", features = ["fmt", "env-filter"] }
 automerge-test = { path = "../automerge-test" }
+maplit = { version = "^1.0" }
+pretty_assertions = "1.0.0"
 prettytable = "0.10.0"
-
+proptest = { version = "^1.7.0", default-features = false, features = ["std"] }
+serde_json = { version = "^1.0.73", features = ["float_roundtrip"], default-features = true }
+test-log = { version = "0.2.10", features = ["trace"], default-features = false }
+tracing-subscriber = { version = "^0.3", features = ["fmt", "env-filter"] }

--- a/rust/automerge/Cargo.toml
+++ b/rust/automerge/Cargo.toml
@@ -20,10 +20,10 @@ slow_path_assertions = ["hexane/slow_path_assertions"]
 [dependencies]
 hexane = { version = "1.0.0-alpha.2", path = "../hexane" }
 hex = "^0.4.3"
+itertools = "0.15.0"
 leb128 = "^0.2.5"
 sha2 = "^0.11.0-rc.5"
 thiserror = "^2.0.12"
-itertools = "0.14.0"
 # zlib-rs backend: pure Rust (works on wasm), ~25% faster inflate than the
 # default miniz_oxide backend natively and ~2x faster on wasm
 flate2 = { version = "^1.0.22", default-features = false, features = ["zlib-rs"] }


### PR DESCRIPTION
Update the `itertools` dependency, of `automerge` and `automerge-wasm`, to `0.15.0`.

I also took it upon myself to sort the entries to make it easier to find the dependencies in the future, and add new ones too.

Supersedes: https://github.com/automerge/automerge/pull/1418 and https://github.com/automerge/automerge/pull/1414