### PR TITLE
javascript/proxies: Use Map instead of object for cache 

### DIFF
--- a/javascript/src/proxies.ts
+++ b/javascript/src/proxies.ts
@@ -67,7 +67,7 @@ type Target = {
   context: Automerge
   objectId: ObjID
   path: Array<Prop>
-  cache: object
+  cache: Map<Prop | symbol, AutomergeValue | undefined>
   trace?: any
 }
 
@@ -245,7 +245,7 @@ const MapHandler = {
   get<T extends Target>(
     target: T,
     key: any,
-  ): AutomergeValue | ObjID | boolean | { handle: Automerge } {
+  ): AutomergeValue | ObjID | boolean | { handle: Automerge } | undefined {
     const { context, objectId, cache } = target
     if (key === Symbol.toStringTag) {
       return target[Symbol.toStringTag]
@@ -254,15 +254,15 @@ const MapHandler = {
     if (key === IS_PROXY) return true
     if (key === TRACE) return target.trace
     if (key === STATE) return { handle: context }
-    if (!cache[key]) {
-      cache[key] = valueAt(target, key)
+    if (!cache.has(key)) {
+      cache.set(key, valueAt(target, key))
     }
-    return cache[key]
+    return cache.get(key)
   },
 
   set(target: Target, key: any, val: any) {
     const { context, objectId, path } = target
-    target.cache = {} // reset cache on set
+    target.cache.clear() // reset cache on set
     if (isSameDocument(val, context)) {
       throw new RangeError(
         "Cannot create a reference to an existing document object",
@@ -296,7 +296,7 @@ const MapHandler = {
 
   deleteProperty(target: Target, key: any) {
     const { context, objectId } = target
-    target.cache = {} // reset cache on delete
+    target.cache.clear() // reset cache on delete
     context.delete(objectId, key)
     return true
   },
@@ -466,7 +466,7 @@ export function mapProxy(
     context,
     objectId,
     path: path || [],
-    cache: {},
+    cache: new Map(),
   }
   const proxied = {}
   Object.assign(proxied, target)
@@ -484,7 +484,7 @@ export function listProxy(
     context,
     objectId,
     path: path || [],
-    cache: {},
+    cache: new Map(),
   }
   const proxied = []
   Object.assign(proxied, target)

--- a/javascript/test/proxies.ts
+++ b/javascript/test/proxies.ts
@@ -184,4 +184,51 @@ describe("Proxies", () => {
       assert.deepEqual(doc, { map: { key: "value", number: 2 } })
     })
   })
+
+  // Ensure that falsy values are respected when checking their values in the
+  // proxy implementation.
+  describe("Falsy values are respected", () => {
+    type FalsyDoc = {
+      zero?: number
+      empty?: string
+      flag?: boolean
+      nothing?: null
+    }
+
+    it("should read back zero", () => {
+      const doc = from({} as FalsyDoc)
+      change(doc, d => {
+        d.zero = 0
+        assert.strictEqual(d.zero, 0)
+        assert.strictEqual(d.zero, 0)
+      })
+    })
+
+    it("should read back empty", () => {
+      const doc = from({} as FalsyDoc)
+      change(doc, d => {
+        d.empty = ""
+        assert.strictEqual(d.empty, "")
+        assert.strictEqual(d.empty, "")
+      })
+    })
+
+    it("should read back flag", () => {
+      const doc = from({} as FalsyDoc)
+      change(doc, d => {
+        d.flag = false
+        assert.strictEqual(d.flag, false)
+        assert.strictEqual(d.flag, false)
+      })
+    })
+
+    it("should read back nothing", () => {
+      const doc = from({} as FalsyDoc)
+      change(doc, d => {
+        d.nothing = null
+        assert.strictEqual(d.nothing, null)
+        assert.strictEqual(d.nothing, null)
+      })
+    })
+  })
 })

--- a/javascript/test/proxies.ts
+++ b/javascript/test/proxies.ts
@@ -231,4 +231,77 @@ describe("Proxies", () => {
       })
     })
   })
+
+  describe("Object.prototype toString, valueOf, and hasOwnProperty properties", () => {
+    // TS sees `{}` as having Object.prototype's toString(), which clashes
+    // with our declared `toString?: { x: number }`.
+    //
+    // To instantiate a new `PropDoc`, you must cast the object:
+    //     const doc = from({} as PropDoc)
+    type PropDoc = {
+      toString?: { x: number }
+      valueOf?: { x: number }
+      hasOwnProperty?: { x: number }
+    }
+
+    it("should respect `in` and Object.keys for toString", () => {
+      const doc = from({} as PropDoc)
+      change(doc, d => {
+        assert.equal("toString" in d, false)
+        assert.deepEqual(Object.keys(d), [])
+        d.toString = { x: 1 }
+        assert.equal("toString" in d, true)
+        assert.deepEqual(Object.keys(d), ["toString"])
+      })
+    })
+
+    it("should respect `in` and Object.keys for valueOf", () => {
+      const doc = from({} as PropDoc)
+      change(doc, d => {
+        assert.equal("valueOf" in d, false)
+        assert.deepEqual(Object.keys(d), [])
+        d.valueOf = { x: 1 }
+        assert.equal("valueOf" in d, true)
+        assert.deepEqual(Object.keys(d), ["valueOf"])
+      })
+    })
+
+    it("should respect `in` and Object.keys for hasOwnProperty", () => {
+      const doc = from({} as PropDoc)
+      change(doc, d => {
+        assert.equal("hasOwnProperty" in d, false)
+        assert.deepEqual(Object.keys(d), [])
+        d.hasOwnProperty = { x: 1 }
+        assert.equal("hasOwnProperty" in d, true)
+        assert.deepEqual(Object.keys(d), ["hasOwnProperty"])
+      })
+    })
+
+    it("should read back the assigned toString inside and outside change()", () => {
+      let doc = from({} as PropDoc)
+      doc = change(doc, d => {
+        d.toString = { x: 1 }
+        assert.deepEqual(d.toString, { x: 1 })
+      })
+      assert.deepEqual(doc.toString, { x: 1 })
+    })
+
+    it("should read back the assigned valueOf inside and outside change()", () => {
+      let doc = from({} as PropDoc)
+      doc = change(doc, d => {
+        d.valueOf = { x: 1 }
+        assert.deepEqual(d.valueOf, { x: 1 })
+      })
+      assert.deepEqual(doc.valueOf, { x: 1 })
+    })
+
+    it("should read back the assigned hasOwnProperty inside and outside change()", () => {
+      let doc = from({} as PropDoc)
+      doc = change(doc, d => {
+        d.hasOwnProperty = { x: 1 }
+        assert.deepEqual(d.hasOwnProperty, { x: 1 })
+      })
+      assert.deepEqual(doc.hasOwnProperty, { x: 1 })
+    })
+  })
 })


### PR DESCRIPTION
Reads in the map proxy's `get` trap were cached in a plain object and guarded by
`!cache[key]`.

For keys that shadow `Object.prototype` members such as `toString`, `valueOf`,
and `hasOwnProperty`, the lookup fell through the cache's prototype chain and
returned the inherited function instead of the document's value, so reads inside
`change()` disagreed with the materialized document (https://github.com/automerge/automerge/issues/1415).

The same truthiness check also treated cached falsy values as misses,
re-fetching them on every read.

A `Map` has no prototype chain to fall through, and `Map.has` checks key presence
rather than value truthiness, fixing both. It also forced the `get` trap's return
type to honestly include `undefined`.

Fixes https://github.com/automerge/automerge/issues/1415.