### PR TITLE
javascript/README: Use `../javascript` for `HACKING` link

### DIFF
--- a/javascript/README.md
+++ b/javascript/README.md
@@ -101,7 +101,7 @@ assert.deepEqual(doc2, {
 
 ## Development
 
-See [HACKING.md](./HACKING.md)
+See [HACKING.md](../javascript/HACKING.md)
 
 ## Meta
 


### PR DESCRIPTION
Problem: When browsing <https://www.npmjs.com/package/@automerge/automerge>, the `HACKING` link gets resolved incorrectly to
<https://github.com/automerge/automerge/blob/HEAD/HACKING.md>.

Solution: Use `../javascript` to correctly resolve the file whether from an editor, GitHub, or npmjs.com. This can be confirmed by navigating to <https://github.com/automerge/automerge/blob/HEAD/javascript/HACKING.md>.

Fixes https://github.com/automerge/automerge/issues/1274