### PR TITLE
`PatchLog` Improvements

### DIFF
--- a/javascript/test/change_at.ts
+++ b/javascript/test/change_at.ts
@@ -114,5 +114,34 @@ describe("Automerge", () => {
         ])
       })
     })
+
+    // Regression test for issue #1270:
+    // clone() + changeAt() with a splice should not produce duplicate content
+    it("should not duplicate splice results with clone + changeAt", () => {
+      let doc = Automerge.change(
+        Automerge.init<{ text: string }>(),
+        doc => {
+          doc.text = ""
+        },
+      )
+      const heads = Automerge.getHeads(doc)
+      doc = Automerge.change(doc, doc =>
+        Automerge.splice(doc, ["text"], 0, 0, "def"),
+      )
+
+      const result = Automerge.changeAt(
+        Automerge.clone(doc),
+        heads,
+        doc => {
+          Automerge.splice(doc, ["text"], 0, 0, "abc")
+        },
+      )
+
+      assert.strictEqual(
+        result.newDoc.text,
+        "abcdef",
+        `Expected "abcdef" but got "${result.newDoc.text}"`,
+      )
+    })
   })
 })

--- a/rust/automerge/src/autocommit.rs
+++ b/rust/automerge/src/autocommit.rs
@@ -814,13 +814,9 @@ impl AutoCommit {
     }
 
     fn patch_to(&mut self, after: &[ChangeHash]) {
-        // Establish actor baseline in the patch log before logging events.
-        // Without this, if a new actor that sorts before existing actors is
-        // inserted later, migrate_actors() cannot properly migrate the events
-        // logged below (it early-returns when actors is empty). See issue #1270.
-        if self.patch_log.is_active() && self.patch_log.actors.is_empty() {
-            self.patch_log.actors = self.doc.ops().actors.clone();
-        }
+        // Establish the actor baseline before logging events (issue #1270);
+        // see `PatchLog::seed_actors`.
+        self.patch_log.seed_actors(&self.doc.ops().actors);
 
         // we may be isolated so we dont use self.doc.get_heads()
         let before = self.get_heads();

--- a/rust/automerge/src/autocommit.rs
+++ b/rust/automerge/src/autocommit.rs
@@ -814,6 +814,14 @@ impl AutoCommit {
     }
 
     fn patch_to(&mut self, after: &[ChangeHash]) {
+        // Establish actor baseline in the patch log before logging events.
+        // Without this, if a new actor that sorts before existing actors is
+        // inserted later, migrate_actors() cannot properly migrate the events
+        // logged below (it early-returns when actors is empty). See issue #1270.
+        if self.patch_log.is_active() && self.patch_log.actors.is_empty() {
+            self.patch_log.actors = self.doc.ops().actors.clone();
+        }
+
         // we may be isolated so we dont use self.doc.get_heads()
         let before = self.get_heads();
         if before.as_slice() != after {

--- a/rust/automerge/src/automerge.rs
+++ b/rust/automerge/src/automerge.rs
@@ -1074,6 +1074,12 @@ impl Automerge {
         patch_log: &mut PatchLog,
         recursive: bool,
     ) {
+        // Establish the actor baseline before logging events: the caller's
+        // patch log may outlive changes to this document's actor table
+        // (issue #1270 variant: `load_incremental_log_patches` on an empty
+        // document followed by a transaction with a smaller actor). See
+        // `PatchLog::seed_actors`.
+        patch_log.seed_actors(&self.ops.actors);
         let clock = ClockRange::default();
         let path_map = DiffIter::log(self, obj, clock, patch_log, recursive);
         patch_log.path_hint(path_map);

--- a/rust/automerge/src/patches/patch_builder.rs
+++ b/rust/automerge/src/patches/patch_builder.rs
@@ -84,13 +84,7 @@ impl PatchBuilder<'_> {
                 //marks,
             } => {
                 let opid = doc.id_to_exid(*id);
-                self.insert(
-                    exid,
-                    *index,
-                    (value.into(), opid),
-                    *conflict,
-                    //marks.clone(),
-                );
+                self.insert(exid, *index, (value.into(), opid), *conflict);
             }
             Event::DeleteSeq { index, num } => {
                 self.delete_seq(exid, *index, *num);

--- a/rust/automerge/src/patches/patch_log.rs
+++ b/rust/automerge/src/patches/patch_log.rs
@@ -245,6 +245,7 @@ impl PatchLog {
         Self::new(false)
     }
 
+    /// An alternative name for [`PatchLog::inactive`].
     pub fn null() -> Self {
         Self::new(false)
     }

--- a/rust/automerge/src/patches/patch_log.rs
+++ b/rust/automerge/src/patches/patch_log.rs
@@ -655,6 +655,18 @@ impl PatchLog {
             return Ok(());
         }
         if self.actors.is_empty() {
+            // An empty baseline together with buffered events is
+            // unmigratable: we no longer know which actor table the events'
+            // indices refer to, so adopting `others` silently corrupts any
+            // event whose actor index was shifted (issue #1270). Every
+            // ingestion path must establish the baseline (see
+            // [`Self::seed_actors`]) before logging events.
+            debug_assert!(
+                self.events.is_empty() && self.expose.is_empty(),
+                "patch log has buffered events but no actor baseline; \
+                 events were logged without seeding the baseline first \
+                 (see issue #1270)"
+            );
             self.actors = others.to_vec();
             return Ok(());
         }

--- a/rust/automerge/src/patches/patch_log.rs
+++ b/rust/automerge/src/patches/patch_log.rs
@@ -641,6 +641,26 @@ impl PatchLog {
         debug_assert_eq!(self.actors.as_slice(), doc_actors);
     }
 
+    /// Record the actor table that subsequently logged events will be indexed
+    /// against.
+    ///
+    /// This must be called before events are logged into a patch log which can
+    /// outlive changes to the document's actor table (e.g. `AutoCommit`'s
+    /// internal log, or a caller-held log passed to
+    /// `load_incremental_log_patches`). Without a baseline,
+    /// [`Self::migrate_actors`] cannot re-index buffered events when a new
+    /// actor is inserted before existing ones, producing corrupted patches
+    /// (issue #1270).
+    ///
+    /// Logs which are filled and drained against a single document state
+    /// (e.g. `Automerge::diff`) never migrate and do not need a baseline,
+    /// though seeding them is harmless.
+    pub(crate) fn seed_actors(&mut self, actors: &[ActorId]) {
+        if self.is_active() && self.actors.is_empty() {
+            self.actors = actors.to_vec();
+        }
+    }
+
     // Re-align this patch log's actor list (and the event indices into it) with the document's
     // actor list (`others`).
     //

--- a/rust/automerge/src/patches/patch_log.rs
+++ b/rust/automerge/src/patches/patch_log.rs
@@ -265,8 +265,24 @@ impl PatchLog {
         self.active
     }
 
+    /// Record an [`Event`] in the [`PatchLog`] with the given [`ObjId`].
+    ///
+    /// All events should be recorded using [`PatchLog::push_event`] since it
+    /// checks for [`PatchLog::is_active`].
     fn push_event(&mut self, obj: ObjId, event: Event) {
-        self.events.push((obj, event));
+        if self.is_active() {
+            self.events.push((obj, event));
+        }
+    }
+
+    /// Record an [`OpId`] in the [`PatchLog`] to be in the exposed set.
+    ///
+    /// All exposed operations should be recorded using [`PatchLog::push_expose`]
+    /// since it checks for [`PatchLog::is_active`].
+    fn push_expose(&mut self, id: OpId) {
+        if self.is_active() {
+            self.expose.insert(id);
+        }
     }
 
     fn events_len(&self) -> usize {
@@ -318,14 +334,14 @@ impl PatchLog {
     }
 
     pub(crate) fn increment_map(&mut self, obj: ObjId, key: &str, n: i64, id: OpId) {
-        self.events.push((
+        self.push_event(
             obj,
             Event::IncrementMap {
                 key: key.into(),
                 n,
                 id,
             },
-        ))
+        )
     }
 
     pub(crate) fn increment_seq(&mut self, obj: ObjId, index: usize, n: i64, id: OpId) {
@@ -372,9 +388,9 @@ impl PatchLog {
         expose: bool,
     ) {
         if expose && value.is_object() {
-            self.expose.insert(id);
+            self.push_expose(id);
         }
-        self.events.push((
+        self.push_event(
             obj,
             Event::PutMap {
                 key: key.into(),
@@ -382,7 +398,7 @@ impl PatchLog {
                 id,
                 conflict,
             },
-        ))
+        )
     }
 
     pub(crate) fn put_seq(
@@ -395,9 +411,9 @@ impl PatchLog {
         expose: bool,
     ) {
         if expose && value.is_object() {
-            self.expose.insert(id);
+            self.push_expose(id);
         }
-        self.events.push((
+        self.push_event(
             obj,
             Event::PutSeq {
                 index,
@@ -405,7 +421,7 @@ impl PatchLog {
                 id,
                 conflict,
             },
-        ))
+        )
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -442,14 +458,14 @@ impl PatchLog {
         text: &str,
         marks: Option<Arc<MarkSet>>,
     ) {
-        self.events.push((
+        self.push_event(
             obj,
             Event::Splice {
                 index,
                 text: text.to_string(),
                 marks,
             },
-        ))
+        )
     }
 
     pub(crate) fn mark(&mut self, obj: ObjId, index: usize, len: usize, marks: &Arc<MarkSet>) {
@@ -472,7 +488,7 @@ impl PatchLog {
         expose: bool,
     ) {
         if expose && value.is_object() {
-            self.expose.insert(id);
+            self.push_expose(id);
         }
         self.insert(obj, index, value, id, conflict)
     }
@@ -659,14 +675,31 @@ impl PatchLog {
     }
 
     pub(crate) fn merge(&mut self, other: Self) {
-        self.completed_patches.extend(other.completed_patches);
-        self.events.extend(other.events);
-        self.expose.extend(other.expose);
+        // The usage of `merge` has always been through the path of first
+        // branching (see [`Self::branch`]) the `PatchLog`, which inherits the
+        // `active` flag.
+        // The flag cannot change, since doings closes the transaction first.
+        // This means that the flags should always agree.
+        debug_assert_eq!(
+            self.active, other.active,
+            "merging a patch log branch whose active flag disagrees with its parent"
+        );
+        if self.active {
+            self.completed_patches.extend(other.completed_patches);
+            self.events.extend(other.events);
+            self.expose.extend(other.expose);
+        }
     }
 
     pub(crate) fn path_hint(&mut self, hint: BTreeMap<ObjId, (Prop, ObjId)>) {
-        self.path_map = hint;
-        self.path_hint = self.events_len();
+        // An inactive log accumulates no state (see [`Self::push_event`]).
+        // Note a stored path map would survive `get_path_map`'s staleness
+        // check in an inactive log (0 events == 0 hint), so this gate is
+        // load-bearing, not just tidiness.
+        if self.active {
+            self.path_map = hint;
+            self.path_hint = self.events_len();
+        }
     }
 }
 

--- a/rust/automerge/tests/issue_1270_variants.rs
+++ b/rust/automerge/tests/issue_1270_variants.rs
@@ -1,0 +1,88 @@
+//! Evidence-gathering tests for the class of bug behind issue #1270.
+//!
+//! Hypothesis: the root problem is not specific to `fork()` + `isolate()`
+//! (which PR #1295 patches at the `patch_to` call site). The underlying
+//! invariant is that a `PatchLog` may not buffer events without recording the
+//! actor table those events were indexed against. Any path which logs events
+//! into a *persistent* patch log whose `actors` baseline is empty exhibits the
+//! same corruption when a lexicographically-smaller actor is later inserted.
+//!
+//! This test exercises a different public entry point:
+//! `Automerge::load_incremental_log_patches` on an empty document, which calls
+//! `log_current_state` into the caller's patch log (seeding events but not the
+//! baseline), followed by `transaction_log_patches` with a smaller actor.
+
+use automerge::{
+    transaction::Transactable, ActorId, AutoCommit, Automerge, ObjType, PatchAction, PatchLog,
+    ReadDoc, ROOT,
+};
+
+/// Apply SpliceText/DeleteSeq patches for the "text" object to a string,
+/// mimicking how a materialized view (e.g. the JS wrapper) consumes patches.
+fn apply_text_patches(initial: &str, patches: &[automerge::Patch]) -> String {
+    let mut text = String::from(initial);
+    for patch in patches {
+        match &patch.action {
+            PatchAction::SpliceText { index, value, .. } => {
+                let s = value.make_string();
+                let byte_idx = text
+                    .char_indices()
+                    .nth(*index)
+                    .map(|(i, _)| i)
+                    .unwrap_or(text.len());
+                text.insert_str(byte_idx, &s);
+            }
+            PatchAction::DeleteSeq { index, length } => {
+                let start = text.char_indices().nth(*index).map(|(i, _)| i).unwrap();
+                let end = text
+                    .char_indices()
+                    .nth(index + length)
+                    .map(|(i, _)| i)
+                    .unwrap_or(text.len());
+                text.replace_range(start..end, "");
+            }
+            // Object creation (PutMap for "text") etc. — irrelevant to the text content.
+            _ => {}
+        }
+    }
+    text
+}
+
+#[test]
+fn load_incremental_then_transact_with_smaller_actor() {
+    // A saved document authored by actor "2222" containing "def".
+    let mut doc1 = AutoCommit::new().with_actor(ActorId::from(&b"2222"[..]));
+    let txt = doc1.put_object(&ROOT, "text", ObjType::Text).unwrap();
+    doc1.splice_text(&txt, 0, 0, "def").unwrap();
+    let saved = doc1.save();
+
+    // An empty document with a persistent, caller-held patch log — the
+    // documented usage pattern for PatchLog.
+    let mut doc2 = Automerge::new().with_actor(ActorId::from(&b"1111"[..]));
+    let mut log = PatchLog::active();
+
+    // Empty-doc fast path: log_current_state fills `log` with events indexed
+    // against the loaded actor table ["2222"], while log.actors stays [].
+    doc2.load_incremental_log_patches(&saved, &mut log).unwrap();
+
+    // A transaction by actor "1111" (sorts before "2222"): the actor table
+    // becomes ["1111", "2222"], shifting "2222" to index 1. begin_transaction
+    // -> migrate_actors sees an empty baseline and adopts without migrating
+    // the already-buffered events.
+    let mut tx = doc2.transaction_log_patches(log).unwrap();
+    let txt2 = tx.get(&ROOT, "text").unwrap().unwrap().1;
+    tx.splice_text(&txt2, 0, 0, "abc").unwrap();
+    let (_, mut log) = tx.commit();
+
+    // The document itself is correct...
+    assert_eq!(doc2.text(&txt).unwrap(), "abcdef", "document state wrong");
+
+    // ...but are the patches?
+    let patches = doc2.make_patches(&mut log);
+    let text = apply_text_patches("", &patches);
+    assert_eq!(
+        text, "abcdef",
+        "patches produced wrong result; patches were: {:#?}",
+        patches
+    );
+}

--- a/rust/automerge/tests/patch_log/main.rs
+++ b/rust/automerge/tests/patch_log/main.rs
@@ -1,0 +1,1 @@
+mod properties;

--- a/rust/automerge/tests/patch_log/properties/caller_held.rs
+++ b/rust/automerge/tests/patch_log/properties/caller_held.rs
@@ -1,0 +1,138 @@
+//! Property test for the patch-stream contract for externally (caller) held
+//! [`PatchLog`]s.
+//!
+//! Ensure that the a [`PatchLog`] remains consistent to a document's state when
+//! the [`PatchLog`] is exercised through the caller-held pattern.
+//! This refers to the use of the Automerge API through:
+//!   * [`Automerge::transaction_log_patches`],
+//!   * [`Automerge::transaction_at`],
+//!   * [`Automerge::make_patches`],
+//!   * And [`Automerge::load_incremental_log_patches`].
+//!
+//! Operations are generated with raw values and clamped/interpreted at
+//! execution time so that every generated sequence is valid (this also gives
+//! good shrinking behaviour).
+
+use automerge::{
+    transaction::Transactable, AutoCommit, Automerge, ObjType, PatchLog, ReadDoc, ROOT,
+};
+use proptest::prelude::*;
+
+use crate::properties::{actor, apply_patches, gen_text};
+
+#[derive(Debug, Clone)]
+enum Op {
+    /// A transaction with a fresh actor via [`Automerge::transaction_log_patches`].
+    Transact {
+        sort_byte: u8,
+        pos: usize,
+        text: String,
+    },
+    /// An isolated transaction at earlier heads via [`Automerge::transaction_at`].
+    ///
+    /// NOT currently generated: [`Automerge::transaction_at`] with a shared
+    /// patch log is a known defect — isolation-relative events are mixed with
+    /// current-view-relative events. Re-enable in [`gen_op`] once fixed.
+    #[allow(dead_code)]
+    TransactAt {
+        sort_byte: u8,
+        heads_idx: usize,
+        pos: usize,
+        text: String,
+    },
+    /// Drain via make_patches and check the view against the document.
+    Sync,
+}
+
+fn gen_op() -> impl Strategy<Value = Op> {
+    prop_oneof![
+        4 => (any::<u8>(), any::<usize>(), gen_text())
+            .prop_map(|(sort_byte, pos, text)| Op::Transact { sort_byte, pos, text }),
+        2 => Just(Op::Sync),
+    ]
+}
+
+fn run(ops: Vec<Op>) -> Result<(), TestCaseError> {
+    let mut uniq = 0u32;
+
+    // Simulate a saved document that is documented elsewhere.
+    let mut origin = AutoCommit::new().with_actor(actor(128, &mut uniq));
+    let txt = origin.put_object(&ROOT, "text", ObjType::Text).unwrap();
+    origin.splice_text(&txt, 0, 0, "seed").unwrap();
+    let saved = origin.save();
+
+    // The saved document is loaded into an empty document with the caller-held
+    // patch log.
+    let mut doc = Automerge::new();
+    let mut log = PatchLog::active();
+    doc.load_incremental_log_patches(&saved, &mut log).unwrap();
+
+    let mut history = vec![doc.get_heads()];
+
+    // `make_patches` does not drain the log, so each Sync rebuilds the view
+    // from scratch from the cumulative patch list.
+    let check = |doc: &Automerge, log: &mut PatchLog| -> Result<(), TestCaseError> {
+        let patches = doc.make_patches(log);
+        let mut model = String::new();
+        apply_patches(&mut model, &patches);
+        let actual = doc.text(&txt).unwrap();
+        prop_assert_eq!(
+            &model,
+            &actual,
+            "external-log view diverged from document: {:#?}",
+            patches
+        );
+        Ok(())
+    };
+
+    for op in ops {
+        match op {
+            Op::Transact {
+                sort_byte,
+                pos,
+                text,
+            } => {
+                let a = actor(sort_byte, &mut uniq);
+                doc.set_actor(a);
+                let mut tx = doc.transaction_log_patches(log).unwrap();
+                let len = tx.text(&txt).unwrap().chars().count();
+                let pos = pos % (len + 1);
+                tx.splice_text(&txt, pos, 0, &text).unwrap();
+                let (_, l) = tx.commit();
+                log = l;
+                history.push(doc.get_heads());
+            }
+            Op::TransactAt {
+                sort_byte,
+                heads_idx,
+                pos,
+                text,
+            } => {
+                let a = actor(sort_byte, &mut uniq);
+                doc.set_actor(a);
+                let heads = history[heads_idx % history.len()].clone();
+                let mut tx = doc.transaction_at(log, &heads).unwrap();
+                let len = tx.text(&txt).unwrap().chars().count();
+                let pos = pos % (len + 1);
+                tx.splice_text(&txt, pos, 0, &text).unwrap();
+                let (_, l) = tx.commit();
+                log = l;
+                history.push(doc.get_heads());
+            }
+            Op::Sync => check(&doc, &mut log)?,
+        }
+    }
+
+    check(&doc, &mut log)
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(256))]
+
+    #[test]
+    fn external_patch_log_view_matches_document(
+        ops in proptest::collection::vec(gen_op(), 1..30)
+    ) {
+        run(ops)?;
+    }
+}

--- a/rust/automerge/tests/patch_log/properties/internal_held.rs
+++ b/rust/automerge/tests/patch_log/properties/internal_held.rs
@@ -1,0 +1,223 @@
+//! Property test for the patch-stream contract for internally held
+//! [`PatchLog`]s.
+//!
+//! A materialized view maintained by only applying the patches emitted by
+//! [`Automerge::diff_incremental`] must always equl the document's actual
+//! state. In other words, the set of patches should never drift, e.g.,
+//! duplicated patch, missing patch.
+//! The Javascript wrapper relies on this contract, and it is the contract that
+//! is being violated by a bug class witnessed with stale actor indices.
+//!
+//! Operations are generated with raw values and clamped/interpreted at
+//! execution time so that every generated sequence is valid (this also gives
+//! good shrinking behaviour).
+
+use automerge::{transaction::Transactable, AutoCommit, ObjType, ReadDoc, ROOT};
+use proptest::prelude::*;
+
+use crate::properties::{actor, apply_patches, gen_text};
+
+#[derive(Debug, Clone)]
+enum Op {
+    /// Splice into the text object in a normal transaction.
+    Splice {
+        pos: usize,
+        del: usize,
+        text: String,
+    },
+    /// Change the actor used for subsequent transactions.
+    SetActor {
+        /// Determines where the new actor sorts relative to others.
+        sort_byte: u8,
+    },
+
+    /// Simulates the `changeAt` pattern in JS, which is composed of:
+    ///   1. Isolate at some earlier heads,
+    ///   2. Splice,
+    ///   3. And integrate.
+    ChangeAt {
+        heads_idx: usize,
+        pos: usize,
+        text: String,
+    },
+    /// Simulates the `clone` pattern in JS, which is composed of:
+    ///   1. Fork with a fresh actor,
+    ///   2. Abandon the original,
+    ///   3. And, re-materialize the view.
+    Fork {
+        /// Determines where the new actor sorts relative to others.
+        sort_byte: u8,
+    },
+    /// Fork off a concurrent peer document with a fresh actor.
+    SpawnPeer {
+        /// Determines where the new actor sorts relative to others.
+        sort_byte: u8,
+    },
+    /// A peer makes a concurrent edit (not yet visible to the main doc).
+    PeerSplice {
+        peer: usize,
+        pos: usize,
+        text: String,
+    },
+    /// Merge a peer's changes into the main doc, exercising the batch apply
+    /// path.
+    MergePeer { peer: usize },
+    /// Apply a peer's changes via:
+    ///   1. [`Autocommit::save`],
+    ///   2. And [`Autocommit::load_incremental`].
+    LoadIncrementalPeer { peer: usize },
+    /// Save the doc and reload it from bytes, re-materializing the view.
+    SaveLoad {
+        /// Determines where the new actor sorts relative to others.
+        sort_byte: u8,
+    },
+    /// Drain patches and check the view against the document.
+    Sync,
+}
+
+fn gen_op() -> impl Strategy<Value = Op> {
+    prop_oneof![
+        4 => (any::<usize>(), any::<usize>(), gen_text())
+            .prop_map(|(pos, del, text)| Op::Splice { pos, del, text }),
+        1 => any::<u8>().prop_map(|sort_byte| Op::SetActor { sort_byte }),
+        3 => (any::<usize>(), any::<usize>(), gen_text())
+            .prop_map(|(heads_idx, pos, text)| Op::ChangeAt { heads_idx, pos, text }),
+        2 => any::<u8>().prop_map(|sort_byte| Op::Fork { sort_byte }),
+        2 => any::<u8>().prop_map(|sort_byte| Op::SpawnPeer { sort_byte }),
+        3 => (any::<usize>(), any::<usize>(), gen_text())
+            .prop_map(|(peer, pos, text)| Op::PeerSplice { peer, pos, text }),
+        2 => any::<usize>().prop_map(|peer| Op::MergePeer { peer }),
+        1 => any::<usize>().prop_map(|peer| Op::LoadIncrementalPeer { peer }),
+        1 => any::<u8>().prop_map(|sort_byte| Op::SaveLoad { sort_byte }),
+        3 => Just(Op::Sync),
+    ]
+}
+
+fn run(ops: Vec<Op>) -> Result<(), TestCaseError> {
+    let mut uniq = 0u32;
+
+    // Set up: a document with a text object, then activate the patch log the
+    // way the JS wrapper does.
+    let mut doc = AutoCommit::new().with_actor(actor(128, &mut uniq));
+    let txt = doc.put_object(&ROOT, "text", ObjType::Text).unwrap();
+    doc.update_diff_cursor();
+    let mut model = doc.text(&txt).unwrap();
+
+    // Heads history for ChangeAt targets; concurrent peers for merge ops.
+    let mut history = vec![doc.get_heads()];
+    let mut peers: Vec<AutoCommit> = Vec::new();
+
+    for op in ops {
+        match op {
+            Op::Splice { pos, del, text } => {
+                let cur = doc.text(&txt).unwrap();
+                let len = cur.chars().count();
+                let pos = pos % (len + 1);
+                let del = del % (len - pos + 1);
+                doc.splice_text(&txt, pos, del as isize, &text).unwrap();
+                history.push(doc.get_heads());
+            }
+            Op::SetActor { sort_byte } => {
+                let a = actor(sort_byte, &mut uniq);
+                doc.set_actor(a);
+            }
+            Op::ChangeAt {
+                heads_idx,
+                pos,
+                text,
+            } => {
+                let heads = history[heads_idx % history.len()].clone();
+                doc.isolate(&heads);
+                // Reads are scoped to the isolation point.
+                let cur = doc.text(&txt).unwrap();
+                let len = cur.chars().count();
+                let pos = pos % (len + 1);
+                doc.splice_text(&txt, pos, 0, &text).unwrap();
+                doc.integrate();
+                history.push(doc.get_heads());
+            }
+            Op::Fork { sort_byte } => {
+                let a = actor(sort_byte, &mut uniq);
+                doc = doc.fork().with_actor(a);
+                // As the JS wrapper does after clone(): fresh cursor, fresh
+                // materialized view.
+                doc.update_diff_cursor();
+                model = doc.text(&txt).unwrap();
+            }
+            Op::SpawnPeer { sort_byte } => {
+                let a = actor(sort_byte, &mut uniq);
+                peers.push(doc.fork().with_actor(a));
+            }
+            Op::PeerSplice { peer, pos, text } => {
+                if peers.is_empty() {
+                    continue;
+                }
+                let n = peers.len();
+                let peer = &mut peers[peer % n];
+                let cur = peer.text(&txt).unwrap();
+                let len = cur.chars().count();
+                let pos = pos % (len + 1);
+                peer.splice_text(&txt, pos, 0, &text).unwrap();
+            }
+            Op::MergePeer { peer } => {
+                if peers.is_empty() {
+                    continue;
+                }
+                let n = peers.len();
+                doc.merge(&mut peers[peer % n]).unwrap();
+                history.push(doc.get_heads());
+            }
+            Op::LoadIncrementalPeer { peer } => {
+                if peers.is_empty() {
+                    continue;
+                }
+                let n = peers.len();
+                let bytes = peers[peer % n].save();
+                doc.load_incremental(&bytes).unwrap();
+                history.push(doc.get_heads());
+            }
+            Op::SaveLoad { sort_byte } => {
+                let bytes = doc.save();
+                doc = AutoCommit::load(&bytes).unwrap();
+                doc.set_actor(actor(sort_byte, &mut uniq));
+                // Fresh document, fresh cursor, fresh view.
+                doc.update_diff_cursor();
+                model = doc.text(&txt).unwrap();
+            }
+            Op::Sync => {
+                let patches = doc.diff_incremental();
+                apply_patches(&mut model, &patches);
+                let actual = doc.text(&txt).unwrap();
+                prop_assert_eq!(
+                    &model,
+                    &actual,
+                    "view diverged from document after applying patches: {:#?}",
+                    patches
+                );
+            }
+        }
+    }
+
+    // Final drain and check.
+    let patches = doc.diff_incremental();
+    apply_patches(&mut model, &patches);
+    let actual = doc.text(&txt).unwrap();
+    prop_assert_eq!(
+        &model,
+        &actual,
+        "view diverged from document at end of scenario: {:#?}",
+        patches
+    );
+    Ok(())
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(256))]
+
+    #[test]
+    fn document_and_patches_parity(
+        ops in proptest::collection::vec(gen_op(), 1..40)
+    ) {
+        run(ops)?;
+    }
+}

--- a/rust/automerge/tests/patch_log/properties/mod.rs
+++ b/rust/automerge/tests/patch_log/properties/mod.rs
@@ -1,0 +1,50 @@
+use automerge::{ActorId, Patch, PatchAction, Prop};
+use proptest::prelude::Strategy;
+
+mod caller_held;
+mod internal_held;
+
+/// A unique actor whose first byte controls its sort position. The trailing
+/// counter guarantees uniqueness so that forked lineages never share an actor
+/// (concurrent changes by the same actor are illegal in automerge).
+pub fn actor(sort_byte: u8, uniq: &mut u32) -> ActorId {
+    *uniq += 1;
+    let mut bytes = vec![sort_byte];
+    bytes.extend_from_slice(&uniq.to_be_bytes());
+    ActorId::from(bytes.as_slice())
+}
+
+/// Generate random text for use within generated operations.
+pub fn gen_text() -> impl Strategy<Value = String> {
+    proptest::string::string_regex("[a-z]{1,4}").unwrap()
+}
+
+/// Apply patches to the model string the way a materialized view would.
+/// Only patches addressing ROOT."text" matter for the model; a PutMap of
+/// "text" (re)creates the object, resetting the view of it.
+pub fn apply_patches(model: &mut String, patches: &[Patch]) {
+    for patch in patches {
+        let at_text =
+            patch.path.len() == 1 && matches!(&patch.path[0].1, Prop::Map(k) if k == "text");
+        match &patch.action {
+            PatchAction::PutMap { key, .. } if patch.path.is_empty() && key == "text" => {
+                model.clear();
+            }
+            PatchAction::SpliceText { index, value, .. } if at_text => {
+                let at = char_index(model, *index);
+                model.insert_str(at, &value.make_string());
+            }
+            PatchAction::DeleteSeq { index, length } if at_text => {
+                let start = char_index(model, *index);
+                let end = char_index(model, index + length);
+                model.replace_range(start..end, "");
+            }
+            _ => {}
+        }
+    }
+}
+
+/// Get the character index based on a provided `idx`, accounting for non-ASCII text.
+fn char_index(s: &str, idx: usize) -> usize {
+    s.char_indices().nth(idx).map(|(i, _)| i).unwrap_or(s.len())
+}

--- a/rust/automerge/tests/patch_log/properties/patch_view_property.proptest-regressions
+++ b/rust/automerge/tests/patch_log/properties/patch_view_property.proptest-regressions
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 160dc9c9e832d98f4e69c6ce81f8b0b94bc3d060119b314d7bc212e1a4383408 # shrinks to ops = [Splice { pos: 0, del: 0, text: "a" }, Fork { sort_byte: 0 }, ChangeAt { heads_idx: 2364357902384590476, pos: 0, text: "a" }]

--- a/rust/automerge/tests/test.rs
+++ b/rust/automerge/tests/test.rs
@@ -2615,6 +2615,53 @@ fn can_isolate() -> Result<(), AutomergeError> {
     Ok(())
 }
 
+// Regression test for issue #1270:
+// When fork() + isolate() is used with a new actor ID that is lexicographically
+// smaller than the existing actor, the diff_incremental patches contain stale
+// actor indices, causing incorrect patches (e.g. duplicate splices).
+#[test]
+fn isolate_diff_incremental_patches_are_correct() -> Result<(), AutomergeError> {
+    let actor1 = ActorId::from(&b"2222"[..]);
+    let mut doc1 = AutoCommit::new().with_actor(actor1);
+    let txt = doc1.put_object(&ROOT, "text", ObjType::Text)?;
+    let heads = doc1.get_heads();
+    doc1.splice_text(&txt, 0, 0, "def")?;
+
+    let actor2 = ActorId::from(&b"1111"[..]);
+    let mut doc2 = doc1.fork().with_actor(actor2);
+
+    // Activate patch log — this is what the JS binding does after clone()
+    doc2.update_diff_cursor();
+
+    doc2.isolate(&heads);
+    doc2.splice_text(&txt, 0, 0, "abc")?;
+    doc2.integrate();
+
+    let patches = doc2.diff_incremental();
+
+    // Apply patches to "def" (the state at the diff cursor) — should give "abcdef"
+    let mut text = String::from("def");
+    for patch in &patches {
+        match &patch.action {
+            PatchAction::SpliceText { index, value, .. } => {
+                let s = value.make_string();
+                text.replace_range(*index..*index, &s);
+            }
+            PatchAction::DeleteSeq { index, length } => {
+                text.replace_range(*index..(*index + *length), "");
+            }
+            _ => {}
+        }
+    }
+
+    assert_eq!(
+        text, "abcdef",
+        "Applying diff_incremental patches to 'def' should give 'abcdef', got '{}'",
+        text
+    );
+    Ok(())
+}
+
 #[test]
 fn inserting_text_near_deleted_marks() {
     let mut doc = Automerge::new();

--- a/rust/automerge/tests/transaction_at_probe.rs
+++ b/rust/automerge/tests/transaction_at_probe.rs
@@ -1,0 +1,87 @@
+//! Known defect (found by the `tests/patch_log/properties/caller_held.rs`):
+//! [`Automerge::transaction_at`] with a caller-held patch log produces
+//! incorrect patches.
+//!
+//! The patch log has a second, undocumented reference-frame invariant
+//! besides the actor baseline: all buffered events must be relative to the
+//! same document view. Crossing views requires finalizing the current view
+//! first (see [`PatchLog::finish_current_view`], whose doc comment describes
+//! exactly this hazard).
+//!
+//! [`AutoCommit::isolate`]/[`AutoCommit::integrate`] honor this via `patch_to`
+//! (finalize + rewind/replay diffs); [`Autocommit::transaction_at`] does not:
+//! its isolation-relative events are sorted and coalesced together with
+//! current-view-relative events, producing a self-consistent but wrong view.
+//!
+//! All actors here are strictly ascending (0x10, 0x20, 0x30), so the actor
+//! table never shifts and migrate_actors is a no-op.
+
+use automerge::{
+    transaction::Transactable, ActorId, AutoCommit, Automerge, ObjType, PatchAction, PatchLog,
+    ReadDoc, ROOT,
+};
+
+#[test]
+#[ignore = "known defect: transaction_at mixes isolation-relative and \
+            current-view-relative events in a shared patch log; see module \
+            docs and docs/plans/patch-log-actor-interning.md finding #4"]
+fn transaction_at_probe_ascending_actors() {
+    let mut origin = AutoCommit::new().with_actor(ActorId::from(&[0x10][..]));
+    let txt = origin.put_object(&ROOT, "text", ObjType::Text).unwrap();
+    origin.splice_text(&txt, 0, 0, "seed").unwrap();
+    let saved = origin.save();
+
+    let mut doc = Automerge::new();
+    let mut log = PatchLog::active();
+    doc.load_incremental_log_patches(&saved, &mut log).unwrap();
+    let heads0 = doc.get_heads();
+
+    // Regular transaction: prepend "aa" (actor 0x20, sorts after 0x10).
+    doc.set_actor(ActorId::from(&[0x20][..]));
+    let mut tx = doc.transaction_log_patches(log).unwrap();
+    tx.splice_text(&txt, 0, 0, "aa").unwrap();
+    let (_, l) = tx.commit();
+    log = l;
+
+    // Isolated transaction at the pre-"aa" heads: insert "X" at index 1 of
+    // "seed" (actor 0x30, sorts after everything).
+    doc.set_actor(ActorId::from(&[0x30][..]));
+    let mut tx = doc.transaction_at(log, &heads0).unwrap();
+    tx.splice_text(&txt, 1, 0, "X").unwrap();
+    let (_, l) = tx.commit();
+    log = l;
+
+    let actual = doc.text(&txt).unwrap();
+
+    let patches = doc.make_patches(&mut log);
+    let mut model = String::new();
+    for patch in &patches {
+        match &patch.action {
+            PatchAction::PutMap { key, .. } if key == "text" => model.clear(),
+            PatchAction::SpliceText { index, value, .. } => {
+                let at = model
+                    .char_indices()
+                    .nth(*index)
+                    .map(|(i, _)| i)
+                    .unwrap_or(model.len());
+                model.insert_str(at, &value.make_string());
+            }
+            PatchAction::DeleteSeq { index, length } => {
+                let start = model.char_indices().nth(*index).map(|(i, _)| i).unwrap();
+                let end = model
+                    .char_indices()
+                    .nth(index + length)
+                    .map(|(i, _)| i)
+                    .unwrap_or(model.len());
+                model.replace_range(start..end, "");
+            }
+            _ => {}
+        }
+    }
+
+    assert_eq!(
+        model, actual,
+        "patch-built view diverged from document; patches: {:#?}",
+        patches
+    );
+}


### PR DESCRIPTION
Works on top of the changes from #1295, but shows that those fixes were not enough to plug the holes that were present in `PatchLog`.

This set of changes takes this further, and adds property tests to ensure that the changes were safe to make. I'd recommend reviewing per commit.