### PR TITLE
ci: update to use nix

### DIFF
--- a/.github/workflows/advisory-cron.yaml
+++ b/.github/workflows/advisory-cron.yaml
@@ -12,7 +12,5 @@ jobs:
           - bans licenses sources
     steps:
       - uses: actions/checkout@v7
-      - uses: EmbarkStudios/cargo-deny-action@v2
-        with:
-          manifest-path: './rust/Cargo.toml'
-          command: check ${{ matrix.checks }}
+      - uses: cachix/install-nix-action@v31
+      - run: nix run .#ci-cargo-deny -- ${{ matrix.checks }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,46 +11,23 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: "1.90"
-          default: true
-          components: rustfmt
-      - uses: Swatinem/rust-cache@v2
-      - run: ./scripts/ci/fmt
-        shell: bash
+      - uses: cachix/install-nix-action@v31
+      - run: nix run .#ci-fmt
 
   lint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: "1.90"
-          default: true
-          components: clippy
-      - uses: Swatinem/rust-cache@v2
-      - run: ./scripts/ci/lint
-        shell: bash
+      - uses: cachix/install-nix-action@v31
+      - run: nix run .#ci-lint
 
   docs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: "1.90"
-          default: true
-      - uses: Swatinem/rust-cache@v2
-      - name: Build rust docs
-        run: ./scripts/ci/rust-docs
-        shell: bash
-      - name: Install doxygen
-        run: sudo apt-get install -y doxygen
-        shell: bash
+      - uses: cachix/install-nix-action@v31
+      - name: Build Rust docs
+        run: nix run .#ci-rust-docs
 
   cargo-deny:
     runs-on: ubuntu-latest
@@ -62,54 +39,26 @@ jobs:
     continue-on-error: ${{ matrix.checks == 'advisories' }}
     steps:
       - uses: actions/checkout@v7
-      - uses: EmbarkStudios/cargo-deny-action@v2
-        with:
-          manifest-path: "./rust/Cargo.toml"
-          command: check ${{ matrix.checks }}
+      - uses: cachix/install-nix-action@v31
+      - run: nix run .#ci-cargo-deny -- ${{ matrix.checks }}
 
   build_wasm:
     runs-on: ubuntu-latest
-    env:
-      # Pinned for reproducible wasm builds; the wasm build needs nightly for
-      # -Zbuild-std (panic=unwind). Bump deliberately when needed.
-      WASM_TOOLCHAIN: nightly-2026-04-25
     steps:
       - uses: actions/checkout@v7
-      - uses: jetli/wasm-bindgen-action@v0.2.0
-        with:
-          # Optional version of wasm-bindgen to install(eg. '0.2.83', 'latest')
-          version: "0.2.127"
-      - name: Install pinned nightly + wasm32 target + rust-src
-        run: |
-          rustup toolchain install "$WASM_TOOLCHAIN" --profile minimal
-          rustup component add rust-src --toolchain "$WASM_TOOLCHAIN"
-          rustup target add --toolchain "$WASM_TOOLCHAIN" wasm32-unknown-unknown
-      - name: run tests
-        run: ./scripts/ci/wasm_tests
+      - uses: cachix/install-nix-action@v31
+      - name: Run WASM tests
+        run: nix run .#ci-wasm-tests
 
   js_tests:
     runs-on: ubuntu-latest
     needs:
       - build_wasm
-    env:
-      WASM_TOOLCHAIN: nightly-2026-04-25
-
     steps:
       - uses: actions/checkout@v7
-      - uses: actions/setup-node@v7
-        with:
-          node-version: "24"
-      - uses: jetli/wasm-bindgen-action@v0.2.0
-        with:
-          # Optional version of wasm-bindgen to install(eg. '0.2.83', 'latest')
-          version: "0.2.127"
-      - name: Install pinned nightly + wasm32 target + rust-src
-        run: |
-          rustup toolchain install "$WASM_TOOLCHAIN" --profile minimal
-          rustup component add rust-src --toolchain "$WASM_TOOLCHAIN"
-          rustup target add --toolchain "$WASM_TOOLCHAIN" wasm32-unknown-unknown
-      - name: run tests
-        run: ./scripts/ci/js_tests
+      - uses: cachix/install-nix-action@v31
+      - name: Run JS tests
+        run: nix run .#ci-js-tests
 
   # This test is necessary because we want to make sure that the webcrypto polyfill
   # for node 18 works correctly. See the notes in javascript/HACKING.md#getrandom-support
@@ -117,65 +66,33 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - build_wasm
-    env:
-      WASM_TOOLCHAIN: nightly-2026-04-25
-
     steps:
       - uses: actions/checkout@v7
-      - uses: actions/setup-node@v7
-        with:
-          node-version: "18"
-      - uses: jetli/wasm-bindgen-action@v0.2.0
-        with:
-          # Optional version of wasm-bindgen to install(eg. '0.2.83', 'latest')
-          version: "0.2.127"
-      - name: Install pinned nightly + wasm32 target + rust-src
-        run: |
-          rustup toolchain install "$WASM_TOOLCHAIN" --profile minimal
-          rustup component add rust-src --toolchain "$WASM_TOOLCHAIN"
-          rustup target add --toolchain "$WASM_TOOLCHAIN" wasm32-unknown-unknown
-      - name: run tests
-        run: ./scripts/ci/node_18_packaging_test
+      - uses: cachix/install-nix-action@v31
+      - name: Run Node 18 packaging test
+        run: nix run .#ci-node18-packaging-test
 
   linux:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        toolchain:
-          - "1.90"
     steps:
       - uses: actions/checkout@v7
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: ${{ matrix.toolchain }}
-          default: true
-      - uses: Swatinem/rust-cache@v2
-      - run: ./scripts/ci/build-test
-        shell: bash
+      - uses: cachix/install-nix-action@v31
+      - run: nix run .#ci-build-test
 
   macos:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: "1.90"
-          default: true
-      - uses: Swatinem/rust-cache@v2
-      - run: ./scripts/ci/build-test
-        shell: bash
+      - uses: cachix/install-nix-action@v31
+      - run: nix run .#ci-build-test
 
+  # Nix does not provide a native Windows environment. Keep this job native so
+  # that it continues to test Windows rather than Linux under WSL.
   windows:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: "1.90"
-          default: true
+      - uses: dtolnay/rust-toolchain@1.90.0
       - uses: Swatinem/rust-cache@v2
       - run: ./scripts/ci/build-test
         shell: bash

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,71 +6,36 @@ on:
 jobs:
   publish-js:
     runs-on: ubuntu-latest
-    env:
-      # Pinned for reproducible wasm builds; bump deliberately when needed.
-      WASM_TOOLCHAIN: nightly-2026-04-25
-    defaults:
-      run:
-        working-directory: ./javascript
     steps:
       - uses: actions/checkout@v7
-      - uses: actions/setup-node@v7
-        with:
-          node-version: "20.x"
-          registry-url: "https://registry.npmjs.org"
-      - uses: jetli/wasm-bindgen-action@v0.2.0
-        with:
-          # Optional version of wasm-bindgen to install(eg. '0.2.83', 'latest')
-          version: "0.2.127"
-      - name: Install pinned nightly + wasm32 target + rust-src
+      - uses: cachix/install-nix-action@v31
+      - name: Build JS package
+        run: nix run .#release-js-build
+      - name: Configure npm authentication
         run: |
-          rustup toolchain install "$WASM_TOOLCHAIN" --profile minimal
-          rustup component add rust-src --toolchain "$WASM_TOOLCHAIN"
-          rustup target add --toolchain "$WASM_TOOLCHAIN" wasm32-unknown-unknown
-      - name: npm install
-        run: npm install
-      - name: build js
-        run: node ./scripts/build.mjs
+          printf '%s\n' "//registry.npmjs.org/:_authToken=\${NODE_AUTH_TOKEN}" \
+            > "$RUNNER_TEMP/.npmrc"
       - name: "npm publish pre-release"
-        if: "github.event.release.prerelease"
-        run: npm publish --tag next --access public
+        if: github.event.release.prerelease
+        run: nix run .#release-js-publish -- --tag next --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_CONFIG_USERCONFIG: ${{ runner.temp }}/.npmrc
       - name: "npm publish release"
         if: "!github.event.release.prerelease"
-        run: npm publish --access public
+        run: nix run .#release-js-publish -- --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_CONFIG_USERCONFIG: ${{ runner.temp }}/.npmrc
 
   publish-js-docs:
     runs-on: ubuntu-latest
     if: "!github.event.release.prerelease"
-    env:
-      WASM_TOOLCHAIN: nightly-2026-04-25
-    defaults:
-      run:
-        working-directory: ./javascript
     steps:
       - uses: actions/checkout@v7
-      - uses: actions/setup-node@v7
-        with:
-          node-version: "20.x"
-          registry-url: "https://registry.npmjs.org"
-      - name: Install wasm-bindgen-cli
-        run: cargo install wasm-bindgen-cli wasm-opt
-      - name: Install pinned nightly + wasm32 target + rust-src
-        run: |
-          rustup toolchain install "$WASM_TOOLCHAIN" --profile minimal
-          rustup component add rust-src --toolchain "$WASM_TOOLCHAIN"
-          rustup target add --toolchain "$WASM_TOOLCHAIN" wasm32-unknown-unknown
-      - name: npm install
-        run: npm install
-      - name: build js
-        run: node ./scripts/build.mjs
-      - name: build js docs
-        id: build_release
-        run: |
-          npx typedoc --out api-docs
+      - uses: cachix/install-nix-action@v31
+      - name: Build JS docs
+        run: nix run .#release-js-docs
       - name: Deploy 🚀
         uses: JamesIves/github-pages-deploy-action@v4
         with:

--- a/README.md
+++ b/README.md
@@ -166,6 +166,26 @@ $ rustc --version
 rustc 1.82.0 (f6e511eec 2024-10-15) # latest at time of writing
 ```
 
+CI entry points are also exposed by the flake. GitHub Actions invokes these
+same commands, so on Linux the complete non-Windows CI suite can be run with:
+
+```console
+$ nix run .#ci
+```
+
+Individual jobs can be run while iterating, for example:
+
+```console
+$ nix run .#ci-fmt
+$ nix run .#ci-lint
+$ nix run .#ci-js-tests
+$ nix run .#ci-node18-packaging-test
+```
+
+On macOS, `nix run .#ci` runs the native host test used by the macOS CI job.
+The native Windows job remains separate because Nix under WSL would test Linux
+rather than Windows.
+
 ## Contributing
 
 Please try and split your changes up into relatively independent commits which

--- a/flake.lock
+++ b/flake.lock
@@ -83,6 +83,21 @@
         "type": "indirect"
       }
     },
+    "nixpkgs-node18": {
+      "locked": {
+        "lastModified": 1720535198,
+        "narHash": "sha256-zwVvxrdIzralnSbcpghA92tWu2DV2lwv89xZc8MTrbg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "205fd4226592cc83fd4c0885a3e4c9c400efabb5",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "ref": "nixos-23.11",
+        "type": "indirect"
+      }
+    },
     "nixpkgs_2": {
       "locked": {
         "lastModified": 1783856661,
@@ -103,6 +118,7 @@
         "flake-utils": "flake-utils_2",
         "nixos-unstable": "nixos-unstable",
         "nixpkgs": "nixpkgs_2",
+        "nixpkgs-node18": "nixpkgs-node18",
         "rust-overlay": "rust-overlay"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -3,6 +3,8 @@
 
   inputs = {
     nixpkgs.url = "nixpkgs/nixos-26.05";
+    # Retain Node 18 for compatibility tests and Node 20 for release builds.
+    nixpkgs-node18.url = "nixpkgs/nixos-23.11";
     nixos-unstable.url = "nixpkgs/nixos-unstable-small";
 
     command-utils.url = "github:expede/nix-command-utils";
@@ -17,6 +19,7 @@
   outputs = {
     self,
     nixpkgs,
+    nixpkgs-node18,
     nixos-unstable,
     command-utils,
     flake-utils,
@@ -29,9 +32,25 @@
         ];
 
         pkgs = import nixpkgs {inherit system overlays;};
+        node18-pkgs = import nixpkgs-node18 {
+          inherit system;
+          # This package is deliberately used to exercise the supported Node 18
+          # compatibility path, even though Node 18 itself is end-of-life.
+          config.allowInsecurePredicate = package:
+            pkgs.lib.hasPrefix "nodejs-18" (pkgs.lib.getName package);
+        };
         unstable = import nixos-unstable {inherit system overlays;};
 
         nodejs = pkgs.nodejs_26;
+        ci-nodejs = pkgs.nodejs_24;
+        nodejs-18 = node18-pkgs.nodejs_18;
+        # Node 20 is also retained to preserve the release build's runtime.
+        release-nodejs = node18-pkgs.nodejs_20;
+
+        ci-rust-toolchain = (pkgs.rust-bin.fromRustupToolchainFile ./rust/rust-toolchain.toml).override {
+          extensions = ["clippy" "rustfmt"];
+        };
+
         rust-toolchain = (pkgs.rust-bin.fromRustupToolchainFile ./rust/rust-toolchain.toml).override {
           extensions = [
             "cargo"
@@ -262,6 +281,153 @@
         command_menu =
           command-utils.commands.${system}
           (release // build // bench // lint // watch // test // docs);
+
+        # Keep the CI entry points in the flake so local development and GitHub
+        # Actions invoke the same commands with the same pinned tools.
+        mk-ci-command = name: runtimeInputs: text:
+          pkgs.writeShellApplication {
+            inherit name;
+            runtimeInputs = [pkgs.git] ++ runtimeInputs;
+            text = ''
+              repo_root="$(${pkgs.git}/bin/git rev-parse --show-toplevel)"
+              cd "$repo_root"
+              ${pkgs.lib.optionalString pkgs.stdenv.isDarwin ''
+                # Rust's Darwin standard library links libiconv. Unlike mkShell,
+                # writeShellApplication does not apply libiconv's setup hooks,
+                # so make its library path explicit for the Nix linker wrapper.
+                export NIX_LDFLAGS="-L${pkgs.libiconv}/lib ''${NIX_LDFLAGS:-}"
+                export LIBRARY_PATH="${pkgs.libiconv}/lib''${LIBRARY_PATH:+:$LIBRARY_PATH}"
+              ''}
+              ${text}
+            '';
+          };
+
+        ci-fmt = mk-ci-command "ci-fmt" [ci-rust-toolchain] ''
+          exec ./scripts/ci/fmt
+        '';
+
+        # The stdenv compiler wrapper also supplies the current macOS SDK when
+        # evaluated on Darwin; avoid the legacy apple_sdk framework stubs here.
+        native-ci-inputs = [pkgs.stdenv.cc];
+
+        ci-lint = mk-ci-command "ci-lint" ([ci-rust-toolchain pkgs.findutils] ++ native-ci-inputs) ''
+          exec ./scripts/ci/lint
+        '';
+
+        ci-rust-docs = mk-ci-command "ci-rust-docs" ([ci-rust-toolchain] ++ native-ci-inputs) ''
+          exec ./scripts/ci/rust-docs
+        '';
+
+        ci-cargo-deny = mk-ci-command "ci-cargo-deny" [unstable.cargo-deny] ''
+          exec ./scripts/ci/advisory "$@"
+        '';
+
+        ci-build-test = mk-ci-command "ci-build-test" ([ci-rust-toolchain] ++ native-ci-inputs) ''
+          exec ./scripts/ci/build-test
+        '';
+
+        wasm-ci-inputs =
+          [
+            wasm-rust-toolchain
+            wasm-cargo
+            wasm-bindgen-cli
+            pkgs.binaryen
+            pkgs.gnutar
+            pkgs.gzip
+          ]
+          ++ native-ci-inputs;
+
+        ci-wasm-tests = mk-ci-command "ci-wasm-tests" ([release-nodejs] ++ wasm-ci-inputs) ''
+          export WASM_CARGO=wasm-cargo
+          export PUPPETEER_SKIP_DOWNLOAD=1
+          exec ./scripts/ci/wasm_tests
+        '';
+
+        ci-js-tests = mk-ci-command "ci-js-tests" ([ci-nodejs pkgs.chromium] ++ wasm-ci-inputs) ''
+          export WASM_CARGO=wasm-cargo
+          export PUPPETEER_SKIP_DOWNLOAD=1
+          export PUPPETEER_EXECUTABLE_PATH=${pkgs.chromium}/bin/chromium
+          # Chromium's crash handler requires a writable configuration home.
+          export XDG_CONFIG_HOME="$repo_root/target/ci-xdg-config"
+          mkdir -p "$XDG_CONFIG_HOME"
+          exec ./scripts/ci/js_tests
+        '';
+
+        ci-node18-packaging-test = mk-ci-command "ci-node18-packaging-test" ([nodejs-18] ++ wasm-ci-inputs) ''
+          export WASM_CARGO=wasm-cargo
+          export PUPPETEER_SKIP_DOWNLOAD=1
+          exec ./scripts/ci/node_18_packaging_test
+        '';
+
+        release-js-build = mk-ci-command "release-js-build" ([release-nodejs] ++ wasm-ci-inputs) ''
+          export WASM_CARGO=wasm-cargo
+          export PUPPETEER_SKIP_DOWNLOAD=1
+          cd ./javascript
+          npm install
+          exec node ./scripts/build.mjs
+        '';
+
+        release-js-docs = mk-ci-command "release-js-docs" ([release-nodejs] ++ wasm-ci-inputs) ''
+          export WASM_CARGO=wasm-cargo
+          export PUPPETEER_SKIP_DOWNLOAD=1
+          cd ./javascript
+          npm install
+          node ./scripts/build.mjs
+          exec npm exec -- typedoc --out api-docs
+        '';
+
+        release-js-publish = mk-ci-command "release-js-publish" [release-nodejs] ''
+          cd ./javascript
+          exec npm publish "$@"
+        '';
+
+        ci-linux =
+          mk-ci-command "ci" [
+            ci-fmt
+            ci-lint
+            ci-rust-docs
+            ci-cargo-deny
+            ci-build-test
+            ci-wasm-tests
+            ci-js-tests
+            ci-node18-packaging-test
+          ] ''
+            ci-fmt
+            ci-lint
+            ci-rust-docs
+            # Match the pull-request workflow: advisories are informative,
+            # while the policy checks are required.
+            ci-cargo-deny advisories || true
+            ci-cargo-deny bans licenses sources
+            ci-build-test
+            ci-wasm-tests
+            ci-js-tests
+            ci-node18-packaging-test
+          '';
+
+        ci-host = mk-ci-command "ci" [ci-build-test] ''
+          exec ci-build-test
+        '';
+
+        ci-packages = {
+          ci =
+            if pkgs.stdenv.isLinux
+            then ci-linux
+            else ci-host;
+          inherit
+            ci-build-test
+            ci-cargo-deny
+            ci-fmt
+            ci-js-tests
+            ci-lint
+            ci-node18-packaging-test
+            ci-rust-docs
+            ci-wasm-tests
+            release-js-build
+            release-js-docs
+            release-js-publish
+            ;
+        };
       in rec {
         devShells.default = pkgs.mkShell {
           name = "automerge";
@@ -318,6 +484,16 @@
 
           shellHook = "menu";
         };
+
+        packages = ci-packages;
+
+        apps =
+          builtins.mapAttrs (name: package: {
+            type = "app";
+            program = "${package}/bin/${name}";
+            meta.description = "Run the ${name} repository command";
+          })
+          ci-packages;
 
         formatter = pkgs.alejandra;
       }

--- a/javascript/HACKING.md
+++ b/javascript/HACKING.md
@@ -39,7 +39,9 @@ The build also passes `-C llvm-args=-wasm-use-legacy-eh`. Current nightlies
 otherwise emit modern (`exnref`) exception handling; legacy EH lets
 wasm-bindgen provide its `WebAssembly.JSTag` polyfill on runtimes such as Node
 20 that do not provide `JSTag` natively. `WASM_TOOLCHAIN` can select a specific
-nightly when a reproducible build is required.
+nightly when a reproducible build is required. Environments without rustup can
+set `WASM_CARGO` to a Cargo executable that already selects the required
+nightly; the repository's Nix flake uses this mechanism.
 
 Any time you change the rust code in `../rust/*` you'll need to re-run the
 `npm run build` command.
@@ -212,5 +214,6 @@ module. This prepending is achieved in the `javascript/build.mjs` script in a
 function called `prependWebcryptoPolyfill`.
 
 This unfortunately requires some slightly more complicated testing to make sure
-it continues to work. In `scripts/ci/node_18_packaging_test` there is some code
-which uses `fnm` to run the node_cjs_fullfat` test in a Node 18 environment.
+it continues to work. `scripts/ci/node_18_packaging_test` runs the
+`node_cjs_fullfat` test when Node 18 is active, or uses `fnm` to select Node 18.
+The `nix run .#ci-node18-packaging-test` entry point supplies Node 18 directly.

--- a/rust/automerge-wasm/README.md
+++ b/rust/automerge-wasm/README.md
@@ -464,7 +464,9 @@ EH lets wasm-bindgen provide its `WebAssembly.JSTag` polyfill on runtimes such
 as Node 20 that do not provide `JSTag` natively. `WASM_TOOLCHAIN` can select a
 specific nightly for reproducible builds. The rest of the workspace still
 builds with the pinned stable toolchain in `rust/rust-toolchain.toml`; nightly
-is only used for this wasm build.
+is only used for this wasm build. Environments without rustup can set
+`WASM_CARGO` to a Cargo executable that already selects the required nightly;
+the repository's Nix flake uses this mechanism.
 
 ### Appendix: WASM and Memory Allocation
 

--- a/rust/automerge-wasm/scripts/compile.mjs
+++ b/rust/automerge-wasm/scripts/compile.mjs
@@ -15,9 +15,12 @@ import { spawnSync } from "node:child_process"
 
 const profile = process.env.PROFILE ?? "dev"
 const toolchain = process.env.WASM_TOOLCHAIN ?? "nightly"
+// `cargo +<toolchain>` requires rustup. Nix supplies a cargo executable which
+// already selects the pinned nightly toolchain via WASM_CARGO.
+const cargo = process.env.WASM_CARGO ?? "cargo"
 
 const args = [
-  `+${toolchain}`,
+  ...(process.env.WASM_CARGO ? [] : [`+${toolchain}`]),
   "build",
   "--target",
   "wasm32-unknown-unknown",
@@ -32,7 +35,7 @@ const env = { ...process.env }
 const extra = "-C panic=unwind -C llvm-args=-wasm-use-legacy-eh"
 env.RUSTFLAGS = env.RUSTFLAGS ? `${env.RUSTFLAGS} ${extra}` : extra
 
-const result = spawnSync("cargo", args, { stdio: "inherit", env })
+const result = spawnSync(cargo, args, { stdio: "inherit", env })
 if (result.error) {
   console.error(result.error)
   process.exit(1)

--- a/scripts/ci/advisory
+++ b/scripts/ci/advisory
@@ -3,7 +3,11 @@ set -eoux pipefail
 
 cd rust
 cargo deny --version
-cargo deny check advisories
-cargo deny check licenses
-cargo deny check bans
-cargo deny check sources
+if [ "$#" -gt 0 ]; then
+    cargo deny check "$@"
+else
+    cargo deny check advisories
+    cargo deny check licenses
+    cargo deny check bans
+    cargo deny check sources
+fi


### PR DESCRIPTION
Problem: CI is currently heavily tied to Github Actions. This means it's very hard to reproduce CI failures locally.

Solution: extend the use of the existing nix tooling and make Github Actions mostly just call nix. The main downside of this approach is that nix is not available for windows, so for windows we use the existing approach.