### PR TITLE
benchmark: Add benchmark exercising `Automerge::from` code path

### DIFF
--- a/rust/benchmark-battery/src/lib.rs
+++ b/rust/benchmark-battery/src/lib.rs
@@ -1,10 +1,13 @@
 use rand::distr::Alphanumeric;
 use rand::{rng, Rng, RngExt};
+use std::collections::HashMap;
 use std::fmt::{Display, Error, Formatter};
 
 pub use automerge;
 
-pub use automerge::{transaction::Transactable, Automerge, ObjType, ScalarValue, ROOT};
+pub use automerge::{
+    hydrate, transaction::Transactable, AutoCommit, Automerge, ObjType, ScalarValue, ROOT,
+};
 
 pub struct TestItem<T> {
     pub label: String,
@@ -138,6 +141,56 @@ pub fn deep_history_doc(n: u64) -> Automerge {
         tx.commit();
     }
 
+    doc
+}
+
+/// Build a [`hydrate::Map`] document that consists of a single `records` list of `n` maps.
+/// Each map has an `id`, a `name`, a list of `tags`, and a nested `payload` map.
+///
+/// When expanded by `Automerge::from` (and in turn,
+/// `Transactable::init_root_from_hydrate`), it will produce roughly 11 ops per
+/// record. So, `n` records produce on the order of `11 * n` ops.
+#[inline(never)]
+pub fn build_hydrate_map(n: u64) -> hydrate::Map {
+    let mut records: Vec<hydrate::Value> = Vec::with_capacity(n as usize);
+    for i in 0..n {
+        let tags = hydrate::List::from(vec![
+            hydrate::Value::from(format!("t{}", i % 7).as_str()),
+            hydrate::Value::from(format!("t{}", i % 13).as_str()),
+            hydrate::Value::from(format!("t{}", i % 17).as_str()),
+        ]);
+        let payload = hydrate::Map::from(HashMap::<String, hydrate::Value>::from([
+            ("value".to_string(), hydrate::Value::from(i as f64 * 0.5)),
+            (
+                "note".to_string(),
+                hydrate::Value::scalar(format!("some text for record number {i} ").repeat(3)),
+            ),
+            ("active".to_string(), hydrate::Value::scalar(i % 2 == 0)),
+        ]));
+        let record = hydrate::Map::from(HashMap::<String, hydrate::Value>::from([
+            ("id".to_string(), hydrate::Value::from(i as i64)),
+            (
+                "name".to_string(),
+                hydrate::Value::scalar(format!("record-{i}")),
+            ),
+            ("tags".to_string(), hydrate::Value::from(tags)),
+            ("payload".to_string(), hydrate::Value::from(payload)),
+        ]));
+        records.push(hydrate::Value::from(record));
+    }
+    hydrate::Map::from(HashMap::<String, hydrate::Value>::from([(
+        "records".to_string(),
+        hydrate::Value::from(hydrate::List::from(records)),
+    )]))
+}
+
+/// Build a document from a pre-built `hydrate::Map` via
+/// [`Transactable::init_root_from_hydrate`], the exact core entry point used by
+/// the JavaScript `Automerge.from()` API.
+#[inline(never)]
+pub fn from_hydrate(map: &hydrate::Map) -> AutoCommit {
+    let mut doc = AutoCommit::new();
+    doc.init_root_from_hydrate(map).unwrap();
     doc
 }
 

--- a/rust/benchmark-battery/src/scenarios/from.rs
+++ b/rust/benchmark-battery/src/scenarios/from.rs
@@ -1,0 +1,33 @@
+use super::{Benchmark, SampledBenchmark};
+use benchmark_battery::{build_hydrate_map, from_hydrate, hydrate};
+use std::hint::black_box;
+
+// Number of records in the generated hydrated document.
+//
+// Each record expands to roughly 11 ops, so 10,000 records is on the order of
+// ~110k ops, comparable to the other size-parameterised benchmarks in this
+// suite.
+const SIZES: [u64; 2] = [1_000, 10_000];
+
+pub fn benchmarks() -> Vec<Benchmark> {
+    SIZES
+        .into_iter()
+        .map(|n| {
+            SampledBenchmark::batched(
+                "from",
+                name(n),
+                move || build_hydrate_map(n),
+                run_from_hydrate,
+            )
+            .into()
+        })
+        .collect()
+}
+
+fn run_from_hydrate(map: hydrate::Map) {
+    black_box(from_hydrate(black_box(&map)));
+}
+
+fn name(n: u64) -> &'static str {
+    Box::leak(format!("from/init_root_from_hydrate/{n}").into_boxed_str())
+}

--- a/rust/benchmark-battery/src/scenarios/memory.rs
+++ b/rust/benchmark-battery/src/scenarios/memory.rs
@@ -5,7 +5,9 @@ use super::MemoryMeasurement;
 #[cfg(feature = "memory")]
 use benchmark_battery::automerge::Automerge;
 #[cfg(feature = "memory")]
-use benchmark_battery::{big_paste_doc, poorly_simulated_typing_doc, text_splice_100};
+use benchmark_battery::{
+    big_paste_doc, build_hydrate_map, from_hydrate, poorly_simulated_typing_doc, text_splice_100,
+};
 #[cfg(feature = "memory")]
 use std::path::Path;
 
@@ -18,9 +20,17 @@ enum Workload {
     BigPaste,
     TextSplice100,
     Fixture(&'static str),
+    /// `Autocommit::init_root_from_hydrate` applied to a document with the
+    /// given number of N records.
+    FromHydrate(u64),
 }
 
-const BENCHMARKS: [(&str, Workload); 10] = [
+const BENCHMARKS: [(&str, Workload); 12] = [
+    ("memory/from/hydrate_map/1000", Workload::FromHydrate(1_000)),
+    (
+        "memory/from/hydrate_map/10000",
+        Workload::FromHydrate(10_000),
+    ),
     ("memory/load/typing", Workload::Typing),
     ("memory/load/big-paste", Workload::BigPaste),
     ("memory/load/text-splice-100", Workload::TextSplice100),
@@ -58,8 +68,14 @@ pub fn benchmarks() -> Vec<MemoryBenchmark> {
             }
             #[cfg(not(feature = "memory"))]
             {
-                if let Workload::Fixture(filename) = workload {
-                    let _ = filename;
+                match workload {
+                    Workload::Fixture(filename) => {
+                        let _ = filename;
+                    }
+                    Workload::FromHydrate(n) => {
+                        let _ = n;
+                    }
+                    _ => {}
                 }
                 MemoryBenchmark::unavailable("memory", name)
             }
@@ -74,7 +90,16 @@ fn setup(workload: Workload) -> Box<dyn FnMut() -> MemoryMeasurement> {
         Workload::BigPaste => load_data(big_paste_doc(N).save()),
         Workload::TextSplice100 => load_data(text_splice_100(N).save()),
         Workload::Fixture(filename) => load_fixture(filename),
+        Workload::FromHydrate(n) => from_hydrate_measure(n),
     }
+}
+
+#[cfg(feature = "memory")]
+fn from_hydrate_measure(n: u64) -> Box<dyn FnMut() -> MemoryMeasurement> {
+    // Building the hydrate map is setup and excluded from the measurement; only
+    // the `init_root_from_hydrate` expansion is measured.
+    let map = build_hydrate_map(n);
+    Box::new(move || crate::memory::measure(|| from_hydrate(&map)))
 }
 
 #[cfg(feature = "memory")]

--- a/rust/benchmark-battery/src/scenarios/mod.rs
+++ b/rust/benchmark-battery/src/scenarios/mod.rs
@@ -4,6 +4,7 @@ pub mod build;
 pub mod diff;
 pub mod edit_trace;
 pub mod egwalker_paper;
+pub mod from;
 pub mod length;
 pub mod list;
 pub mod load_save;
@@ -261,6 +262,7 @@ pub fn benchmarks() -> Vec<Benchmark> {
     benchmarks.extend(build::benchmarks().into_iter().map(Into::into));
     benchmarks.extend(diff::benchmarks().into_iter().map(Into::into));
     benchmarks.extend(edit_trace::benchmarks().into_iter().map(Into::into));
+    benchmarks.extend(from::benchmarks());
     benchmarks.extend(egwalker_paper::benchmarks().into_iter().map(Into::into));
     benchmarks.extend(length::benchmarks().into_iter().map(Into::into));
     benchmarks.extend(list::benchmarks().into_iter().map(Into::into));


### PR DESCRIPTION
LLM Disclaimer: An LLM was used to generate the majority of this benchmark. It has been reviewed and modified by the author.

Problem: In [#644], it is noted that using `Automerge::from` can result in a large amount of CPU and RAM being used. This happens through the code path `init_root_from_hydrate`, using a `hydrate::Map`.

Benchmark: Exercise this code path to measure the memory and time usage with reasonable sizes. This can be used to measure any improvements made to the code path.

[#644]: https://github.com/automerge/automerge/issues/644