### PR TITLE
rust/automerge: Remove optree-visualisation feature

### DIFF
--- a/rust/automerge/Cargo.toml
+++ b/rust/automerge/Cargo.toml
@@ -9,7 +9,6 @@ description = "A JSON-like data structure (a CRDT) that can be modified concurre
 readme = "./README.md"
 
 [features]
-optree-visualisation = ["dot"]
 wasm = ["js-sys", "wasm-bindgen", "web-sys", "getrandom/wasm_js", "hexane/wasm"]
 utf8-indexing = []
 utf16-indexing = []
@@ -37,7 +36,6 @@ tracing = { version = "^0.1.29" }
 unicode-segmentation = "1.10.1"
 
 # optional deps
-dot = { version = "0.1.4", optional = true }
 js-sys = { version = "^0.3", optional = true }
 rand = { version = "^0.10", optional = false }
 wasm-bindgen = { version = "^0.2", optional = true }


### PR DESCRIPTION
The feature is not mentioned anywhere and this allows the removal of an optional dependency.