### PR TITLE
rust/automerge-wasm: Chunk splice calls when applying large list insert patches

### DIFF
--- a/javascript/test/basic_test.ts
+++ b/javascript/test/basic_test.ts
@@ -282,6 +282,33 @@ describe("Automerge", () => {
       assert.deepEqual(doc6, { list: [2, 1, 9, 100, 101, 10, 3, 11, 12] })
     })
 
+    it("can insert very large numbers of list elements in one change", function () {
+      // inserting 200k elements is slow on CI runners; the mocha default of
+      // 2s is not enough
+      this.timeout(30_000)
+      // Contiguous inserts are consolidated into a single Insert patch, which
+      // used to be applied with a single `Array.prototype.splice` call whose
+      // argument count exceeded the JS engine's stack limit (~125k args in V8),
+      // throwing "RangeError: Maximum call stack size exceeded".
+      const N = 200_000
+      const chunkSize = 10_000
+      let doc = Automerge.from<{ list: number[] }>({ list: [] })
+      doc = Automerge.change(doc, d => {
+        for (let i = 0; i < N; i += chunkSize) {
+          const chunk = Array.from({ length: chunkSize }, (_, j) => i + j)
+          Automerge.insertAt(d.list, i, ...chunk)
+        }
+      })
+      assert.equal(doc.list.length, N)
+      assert.equal(doc.list[0], 0)
+      assert.equal(doc.list[N - 1], N - 1)
+      // deleting a large range must also not overflow
+      doc = Automerge.change(doc, d => {
+        Automerge.deleteAt(d.list, 0, N - 1)
+      })
+      assert.deepEqual(doc.list, [N - 1])
+    })
+
     it("allows access to the backend", () => {
       let doc = Automerge.from({ hello: "world" })
       assert.deepEqual(Automerge.getBackend(doc).materialize(), {

--- a/rust/automerge-wasm/src/interop.rs
+++ b/rust/automerge-wasm/src/interop.rs
@@ -9,6 +9,7 @@ use automerge::marks::{MarkSet, UpdateSpansConfig};
 use automerge::ReadDoc;
 use automerge::ROOT;
 use automerge::{Change, ChangeHash, ObjType, Prop};
+use itertools::Itertools;
 use js_sys::{Array, BigInt, Function, JsString, Number, Object, Reflect, Uint8Array};
 use std::borrow::Cow;
 use std::collections::{BTreeSet, HashMap, HashSet};
@@ -1479,17 +1480,29 @@ impl Automerge {
         meta: &JsValue,
         cache: &ExportCache<'_>,
     ) -> Result<(), error::ApplyPatch> {
-        let args: Array = values
-            .into_iter()
-            .map(|v| self.maybe_wrap_object(alloc(&v.0), &v.1, meta, cache))
-            .collect::<Result<_, _>>()?;
-        args.unshift(&(num_del as u32).into());
-        args.unshift(&(index as u32).into());
+        // The arguments to a function invoked via `Reflect::apply` are passed
+        // on the JS engine's stack, which limits how many arguments a single
+        // call can take (~125k in V8). A consolidated insert patch can contain
+        // far more values than that, so we perform the deletion in one
+        // argument-free call and then insert the values in bounded chunks.
+        const MAX_SPLICE_ARGS: usize = 32_000;
         let method = js_get(o, "splice")?
             .0
             .dyn_into::<Function>()
             .map_err(error::Export::GetSplice)?;
-        Reflect::apply(&method, o, &args).map_err(error::Export::CallSplice)?;
+        if num_del > 0 {
+            let args = Array::of2(&(index as u32).into(), &(num_del as u32).into());
+            Reflect::apply(&method, o, &args).map_err(error::Export::CallSplice)?;
+        }
+        let wrapped = values
+            .into_iter()
+            .map(|v| self.maybe_wrap_object(alloc(&v.0), &v.1, meta, cache));
+        for (n, chunk) in wrapped.chunks(MAX_SPLICE_ARGS).into_iter().enumerate() {
+            let args: Array = chunk.collect::<Result<_, _>>()?;
+            args.unshift(&0_u32.into());
+            args.unshift(&((index + n * MAX_SPLICE_ARGS) as u32).into());
+            Reflect::apply(&method, o, &args).map_err(error::Export::CallSplice)?;
+        }
         Ok(())
     }
 


### PR DESCRIPTION
Problem: Applying a consolidated Insert patch used a single Array.prototype.splice call via Reflect::apply, passing one JS argument per inserted element. JS engines pass applied arguments on the stack (V8 caps out around 125k), so inserting more than ~125k list elements in one change threw 'RangeError: Maximum call stack size exceeded'.

Solution: Perform the deletion in a separate argument-free splice call and insert values in chunks of at most 32,000 arguments.

Fixes #756

Note: the original issue reported the issue on text, but this no longer applies with the newer implementation of text handling in automerge.