### PR TITLE
hexane: Add i32 support for Columns

### DIFF
--- a/rust/hexane/src/lib.rs
+++ b/rust/hexane/src/lib.rs
@@ -617,6 +617,25 @@ impl RleValue for u32 {
     }
 }
 
+impl ColumnValue for i32 {
+    type Encoding<C: Codec> = RleEncoding<i32, C>;
+}
+
+impl RleValue for i32 {
+    fn try_unpack<C: Codec>(data: &[u8]) -> Result<(usize, i32), PackError> {
+        let (n, v) = C::try_read_signed(data)?;
+        let v = i32::try_from(v).map_err(|_| PackError::InvalidValue("i32 overflow".into()))?;
+        Ok((n, v))
+    }
+    fn value_len<C: Codec>(data: &[u8]) -> Option<usize> {
+        C::signed_len(data)
+    }
+    fn pack<C: Codec>(value: i32, out: &mut Vec<u8>) -> bool {
+        out.extend(C::encode_signed(value.into()));
+        true
+    }
+}
+
 impl ColumnValue for usize {
     type Encoding<C: Codec> = RleEncoding<usize, C>;
 }


### PR DESCRIPTION
There is already i64,u64,u32 implementing ColumnValue trait, add support for i32 as well.