### PR TITLE
rust/deny: Warn on multiple versions

### DIFF
--- a/rust/deny.toml
+++ b/rust/deny.toml
@@ -153,7 +153,7 @@ deny = [
 ]
 # Certain crates/versions that will be skipped when doing duplicate detection.
 skip = [
-{ crate = "itertools@0.13.0", reason = "this is brought in by criterion-plot, which we only use in benchmarks" },
+    { crate = "itertools@0.13.0", reason = "this is brought in by criterion-plot, which we only use in benchmarks" },
     { crate = "winnow@0.7.15", reason = "brought in by toml via cbindgen; 1.0.0 brought in by toml_parser via the same path" },
     { crate = "syn@2.0.119", reason = "pulled in by cbindgen, divan, test-log and thiserror 1.0 (via prettytable); the rest of the tree uses syn 3.0" },
     { crate = "wit-bindgen@0.57.1", reason = "pulled in by wasip2 via getrandom 0.3 (only present with older lockfiles; newer getrandom uses wasip3 with wit-bindgen 0.51)" },
@@ -161,6 +161,7 @@ skip = [
     # is still on roxmltree 0.20; both come from resvg, used by
     # benchmark-battery to render benchmark graphs
     { crate = "roxmltree@0.20.0", reason = "brought in by fontconfig-parser via resvg; usvg uses 0.21" },
+    { crate = "miniz_oxide@0.8.9", reason = "brought in by benchmark-battery via resvg@0.48.1" },
 ]
 # Similarly to `skip` allows you to skip certain crates during duplicate
 # detection. Unlike skip, it also includes the entire tree of transitive

--- a/rust/deny.toml
+++ b/rust/deny.toml
@@ -156,7 +156,6 @@ skip = [
     { crate = "itertools@0.13.0", reason = "this is brought in by criterion-plot, which we only use in benchmarks" },
     { crate = "winnow@0.7.15", reason = "brought in by toml via cbindgen; 1.0.0 brought in by toml_parser via the same path" },
     { crate = "syn@2.0.119", reason = "pulled in by cbindgen, divan, test-log and thiserror 1.0 (via prettytable); the rest of the tree uses syn 3.0" },
-    { crate = "wit-bindgen@0.57.1", reason = "pulled in by wasip2 via getrandom 0.3 (only present with older lockfiles; newer getrandom uses wasip3 with wit-bindgen 0.51)" },
     # usvg depends on roxmltree 0.21 while its fontconfig-parser dependency
     # is still on roxmltree 0.20; both come from resvg, used by
     # benchmark-battery to render benchmark graphs


### PR DESCRIPTION
Problem: `cargo deny` can detect when multiple versions of the same dependency are used. This can be intractable when these dependencies are transitive, and their versions are not controlled by this project.

Solution: Rather than `deny`, use `warn` so that the project is aware of them and can fix any ones that are possible to fix.