### PR TITLE
rust: fix perf regression in large transactions

### DIFF
--- a/rust/automerge/src/transaction/inner.rs
+++ b/rust/automerge/src/transaction/inner.rs
@@ -100,7 +100,9 @@ impl TransactionInner {
 
     fn exid_to_obj(&self, doc: &Automerge, id: &ExId) -> Result<ObjMeta, AutomergeError> {
         let obj = doc.exid_to_obj(id)?;
-        let created_in_transaction = self.pending.iter().any(|op| op.id() == obj.id.0);
+        let created_in_transaction = obj.id.0.actor() == self.actor
+            && obj.id.0.counter() >= self.start_op.get()
+            && obj.id.0.counter() < self.start_op.get() + self.pending_ops() as u64;
         if !obj.id.is_root()
             && !created_in_transaction
             && self


### PR DESCRIPTION
Problem: in transaction methods which accept an object ID (i.e. basically any method which modifies the document) we check that the object ID in question is in the history of the transaction. This check includes a scan over the pending ops of the transaction. For large transaction this is an expensive O(number of ops in transaction) scan.

Solution: instead of scanning the pending ops just check that the op counter is within the start op of the transaction and the max op

Closes #1530 