### PR TITLE
javascript/implementation: Fix documentation mention `fork`

### DIFF
--- a/javascript/src/implementation.ts
+++ b/javascript/src/implementation.ts
@@ -538,7 +538,7 @@ export type ChangeAtResult<T> = {
  * const heads = automerge.getHeads(doc)
  *
  * // fork the document make a change
- * let fork = automerge.fork(doc)
+ * let fork = automerge.clone(doc)
  * fork = automerge.change(fork, () => {...})
  * const headsOnFork = automerge.getHeads(fork)
  *


### PR DESCRIPTION
The name `fork` is the internal method for an Automerge document, however, the public API for Javascript is `clone`.

Fixes [#961].

[#961]: https://github.com/automerge/automerge/issues/961