### PR TITLE
javascript/proxies: Guard on `__proto__`

### DIFF
--- a/javascript/src/proxies.ts
+++ b/javascript/src/proxies.ts
@@ -35,7 +35,12 @@ export function validateForBatchInsert(
       validateForBatchInsert(value[i], context, [...path, i])
     }
   } else if (Object.prototype.toString.call(value) === "[object Object]") {
-    for (const k in value) {
+    for (const k of Object.keys(value)) {
+      if (k === "__proto__") {
+        throw new RangeError(
+          'The key "__proto__" is not allowed in Automerge documents',
+        )
+      }
       validateForBatchInsert(value[k], context, [...path, k])
     }
   }
@@ -263,6 +268,11 @@ const MapHandler = {
   set(target: Target, key: any, val: any) {
     const { context, objectId, path } = target
     target.cache.clear() // reset cache on set
+    if (key === "__proto__") {
+      throw new RangeError(
+        'The key "__proto__" is not allowed in Automerge documents',
+      )
+    }
     if (isSameDocument(val, context)) {
       throw new RangeError(
         "Cannot create a reference to an existing document object",

--- a/javascript/test/proxies.ts
+++ b/javascript/test/proxies.ts
@@ -1,5 +1,6 @@
 import * as assert from "assert"
 import { beforeEach } from "mocha"
+import "../src/entrypoints/fullfat_node.js"
 import { type Doc, from, change } from "../src/index.js"
 
 type DocType = {
@@ -21,6 +22,43 @@ describe("Proxies", () => {
           d.doc = doc
         }, /Cannot create a reference to an existing document object/)
       })
+    })
+  })
+
+  describe("__proto__ handling", () => {
+    it("should throw a useful RangeError when assigning a scalar to __proto__ in a change callback", () => {
+      const doc = from<Record<string, unknown>>({})
+      assert.throws(() => {
+        change(doc, d => {
+          d["__proto__"] = "somestring"
+        })
+      }, /"__proto__" is not allowed/)
+    })
+
+    it("should throw and not pollute the prototype when assigning an object to __proto__", () => {
+      const doc = from<Record<string, unknown>>({})
+      assert.throws(() => {
+        change(doc, d => {
+          d["__proto__"] = { x: 1 }
+        })
+      }, /"__proto__" is not allowed/)
+      assert.strictEqual(Object.getPrototypeOf(doc), Object.prototype)
+      assert.strictEqual((doc as { x?: number }).x, undefined)
+    })
+
+    it("should throw when the initial state passed to `from` contains a __proto__ key", () => {
+      assert.throws(() => {
+        from({ ["__proto__"]: false } as Record<string, unknown>)
+      }, /"__proto__" is not allowed/)
+    })
+
+    it("should throw when a nested object assigned in a change contains a __proto__ key", () => {
+      const doc = from<Record<string, unknown>>({})
+      assert.throws(() => {
+        change(doc, d => {
+          d["nested"] = { ["__proto__"]: { x: 1 } }
+        })
+      }, /"__proto__" is not allowed/)
     })
   })
 


### PR DESCRIPTION
Problem: The `__proto__` keyword is a special attribute of Javascript objects. Currently, the keyword is allowed as a field of an Automerge object.

Solution: Guard for `__proto__` being used as a key to an Automerge object, and throw a specific error when encountered.

Fixes #860 